### PR TITLE
FEATURE: add --prompts-file option to bench command for custom test suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -871,6 +871,10 @@ soup bench ./output
 
 # Customizing benchmarking parameters
 soup bench ./output --num-prompts 5 --max-tokens 256
+
+# Use custom prompts from a text file (one per line) or JSONL
+soup bench ./output --prompts-file my_prompts.txt
+soup bench ./output --prompts-file bench_suite.jsonl
 ```
 
 This acts as a built-in "speedometer," outputting Tokens-Per-Second (TPS), Total Latency, and Peak VRAM allocations into a clean status table.

--- a/soup_cli/commands/bench.py
+++ b/soup_cli/commands/bench.py
@@ -32,7 +32,7 @@ def bench(
         3,
         "--num-prompts",
         "-n",
-        help="Number of prompts to run for averaging",
+        help="Number of prompts to run for averaging (ignored when --prompts-file is set)",
     ),
     prompts_file: Optional[str] = typer.Option(
         None,
@@ -58,33 +58,6 @@ def bench(
             "[yellow]Warning:[/] Running on CPU. Inference speed is typically "
             "10-100x slower than GPU -- results will not reflect production TPS."
         )
-
-    console.print(
-        Panel(
-            f"Model:    [bold]{model_path}[/]\n"
-            f"Device:   [bold]{device}[/]\n"
-            f"Prompts:  [bold]{num_prompts}[/]\n"
-            f"Tokens/P: [bold]{max_tokens}[/]",
-            title="Benchmarking Configuration",
-        )
-    )
-
-    console.print("[dim]Loading model to measure resource usage...[/]")
-
-    # Reset peak stats before load -- "Max VRAM" reflects total footprint
-    # (model load + inference), i.e. what users need for deployment planning.
-    if torch.cuda.is_available():
-        torch.cuda.reset_peak_memory_stats()
-
-    start_load = time.time()
-    try:
-        model_obj, tokenizer = _load_model(str(model_path), base, device)
-    except (OSError, ImportError, RuntimeError, ValueError) as exc:
-        console.print(f"[red]Failed to load model:[/] {exc}")
-        raise typer.Exit(1) from exc
-
-    load_time = time.time() - start_load
-    console.print(f"[green]Model loaded in {load_time:.2f}s.[/]\n")
 
     if prompts_file:
         import json
@@ -126,14 +99,7 @@ def bench(
             console.print("[red]No prompts found in file.[/]")
             raise typer.Exit(1)
 
-        # If user provided a custom file but didn't explicitly override num_prompts (default 3),
-        # we assume they want to run all prompts in the file.
-        # However, to avoid parsing typer args manually, if len(prompts) > num_prompts, we'll
-        # just use len(prompts) as the default behavior, unless they want fewer?
-        # Actually, let's just set num_prompts to the length of the file if it's larger than 3.
-        # Or better: we just construct test_prompts directly.
-        # But wait, what if they want to run 100 prompts by repeating a 5-prompt file?
-        # Then test_prompts logic handles it. Let's just keep the existing logic.
+        # If --prompts-file is provided, we use all prompts in the file and ignore num_prompts.
     else:
         prompts = [
             "Explain the theory of relativity briefly.",
@@ -143,10 +109,35 @@ def bench(
             "Describe how a database index works under the hood.",
         ]
 
-    # If using custom prompts and default num_prompts (3) is smaller, run all custom prompts
-    # unless they explicitly want exactly 3. Since we can't easily check if it's default,
-    # we'll use max(num_prompts, len(prompts)) when custom prompts are provided.
-    actual_num_prompts = max(num_prompts, len(prompts)) if prompts_file else num_prompts
+    actual_num_prompts = len(prompts) if prompts_file else num_prompts
+
+    console.print(
+        Panel(
+            f"Model:    [bold]{model_path}[/]\n"
+            f"Device:   [bold]{device}[/]\n"
+            f"Prompts:  [bold]{actual_num_prompts}[/]\n"
+            f"Tokens/P: [bold]{max_tokens}[/]",
+            title="Benchmarking Configuration",
+        )
+    )
+
+    console.print("[dim]Loading model to measure resource usage...[/]")
+
+    # Reset peak stats before load -- "Max VRAM" reflects total footprint
+    # (model load + inference), i.e. what users need for deployment planning.
+    if torch.cuda.is_available():
+        torch.cuda.reset_peak_memory_stats()
+
+    start_load = time.time()
+    try:
+        model_obj, tokenizer = _load_model(str(model_path), base, device)
+    except (OSError, ImportError, RuntimeError, ValueError) as exc:
+        console.print(f"[red]Failed to load model:[/] {exc}")
+        raise typer.Exit(1) from exc
+
+    load_time = time.time() - start_load
+    console.print(f"[green]Model loaded in {load_time:.2f}s.[/]\n")
+
     test_prompts = (prompts * (actual_num_prompts // len(prompts) + 1))[:actual_num_prompts]
 
     # Warmup run: first inference includes CUDA kernel JIT compilation,

--- a/soup_cli/commands/bench.py
+++ b/soup_cli/commands/bench.py
@@ -34,6 +34,11 @@ def bench(
         "-n",
         help="Number of prompts to run for averaging",
     ),
+    prompts_file: Optional[str] = typer.Option(
+        None,
+        "--prompts-file",
+        help="Path to custom prompts file (.txt or .jsonl)",
+    ),
 ) -> None:
     """Run an inference benchmark (speed and memory) on a loaded model."""
     import torch
@@ -81,14 +86,66 @@ def bench(
     load_time = time.time() - start_load
     console.print(f"[green]Model loaded in {load_time:.2f}s.[/]\n")
 
-    prompts = [
-        "Explain the theory of relativity briefly.",
-        "Write a short Python function to calculate fibonacci numbers.",
-        "What are the main consequences of the Industrial Revolution?",
-        "Compose a poem about a wandering space traveler.",
-        "Describe how a database index works under the hood.",
-    ]
-    test_prompts = (prompts * (num_prompts // len(prompts) + 1))[:num_prompts]
+    if prompts_file:
+        import json
+        p_path = Path(prompts_file).resolve()
+        
+        try:
+            p_path.relative_to(Path.cwd())
+        except ValueError:
+            console.print(f"[red]Security Error:[/] Path {p_path} is outside the current working directory.")
+            raise typer.Exit(1)
+            
+        if not p_path.is_file():
+            console.print(f"[red]Prompts file not found:[/] {p_path}")
+            raise typer.Exit(1)
+            
+        prompts = []
+        try:
+            if p_path.suffix == ".jsonl":
+                with open(p_path, "r", encoding="utf-8") as f:
+                    for line in f:
+                        line = line.strip()
+                        if line:
+                            data = json.loads(line)
+                            if "prompt" in data:
+                                prompts.append(data["prompt"])
+            else:
+                with open(p_path, "r", encoding="utf-8") as f:
+                    for line in f:
+                        line = line.strip()
+                        if line:
+                            prompts.append(line)
+        except Exception as e:
+            console.print(f"[red]Failed to read prompts file:[/] {e}")
+            raise typer.Exit(1)
+            
+        if not prompts:
+            console.print("[red]No prompts found in file.[/]")
+            raise typer.Exit(1)
+            
+        # If user provided a custom file but didn't explicitly override num_prompts (default 3),
+        # we assume they want to run all prompts in the file.
+        # However, to avoid parsing typer args manually, if len(prompts) > num_prompts, we'll
+        # just use len(prompts) as the default behavior, unless they want fewer?
+        # Actually, let's just set num_prompts to the length of the file if it's larger than 3.
+        # Or better: we just construct test_prompts directly.
+        # But wait, what if they want to run 100 prompts by repeating a 5-prompt file? 
+        # Then test_prompts logic handles it. Let's just keep the existing logic.
+    else:
+        prompts = [
+            "Explain the theory of relativity briefly.",
+            "Write a short Python function to calculate fibonacci numbers.",
+            "What are the main consequences of the Industrial Revolution?",
+            "Compose a poem about a wandering space traveler.",
+            "Describe how a database index works under the hood.",
+        ]
+        
+    # If using custom prompts and default num_prompts (3) is smaller, run all custom prompts
+    # unless they explicitly want exactly 3. Since we can't easily check if it's default,
+    # we'll use max(num_prompts, len(prompts)) when custom prompts are provided.
+    actual_num_prompts = max(num_prompts, len(prompts)) if prompts_file else num_prompts
+    test_prompts = (prompts * (actual_num_prompts // len(prompts) + 1))[:actual_num_prompts]
 
     # Warmup run: first inference includes CUDA kernel JIT compilation,
     # which would skew the average. Discarded from timing.
@@ -102,7 +159,7 @@ def bench(
     total_tokens = 0
     total_latency = 0.0
 
-    console.print(f"[bold]Running {num_prompts} test inferences...[/]")
+    console.print(f"[bold]Running {len(test_prompts)} test inferences...[/]")
 
     for i, prompt_text in enumerate(test_prompts):
         messages = [{"role": "user", "content": prompt_text}]

--- a/soup_cli/commands/bench.py
+++ b/soup_cli/commands/bench.py
@@ -89,7 +89,7 @@ def bench(
     if prompts_file:
         import json
         p_path = Path(prompts_file).resolve()
-        
+
         try:
             p_path.relative_to(Path.cwd())
         except ValueError:
@@ -97,11 +97,11 @@ def bench(
                 f"[red]Security Error:[/] Path {p_path} is outside the current working directory."
             )
             raise typer.Exit(1)
-            
+
         if not p_path.is_file():
             console.print(f"[red]Prompts file not found:[/] {p_path}")
             raise typer.Exit(1)
-            
+
         prompts = []
         try:
             if p_path.suffix == ".jsonl":
@@ -121,18 +121,18 @@ def bench(
         except Exception as e:
             console.print(f"[red]Failed to read prompts file:[/] {e}")
             raise typer.Exit(1)
-            
+
         if not prompts:
             console.print("[red]No prompts found in file.[/]")
             raise typer.Exit(1)
-            
+
         # If user provided a custom file but didn't explicitly override num_prompts (default 3),
         # we assume they want to run all prompts in the file.
         # However, to avoid parsing typer args manually, if len(prompts) > num_prompts, we'll
         # just use len(prompts) as the default behavior, unless they want fewer?
         # Actually, let's just set num_prompts to the length of the file if it's larger than 3.
         # Or better: we just construct test_prompts directly.
-        # But wait, what if they want to run 100 prompts by repeating a 5-prompt file? 
+        # But wait, what if they want to run 100 prompts by repeating a 5-prompt file?
         # Then test_prompts logic handles it. Let's just keep the existing logic.
     else:
         prompts = [
@@ -142,7 +142,7 @@ def bench(
             "Compose a poem about a wandering space traveler.",
             "Describe how a database index works under the hood.",
         ]
-        
+
     # If using custom prompts and default num_prompts (3) is smaller, run all custom prompts
     # unless they explicitly want exactly 3. Since we can't easily check if it's default,
     # we'll use max(num_prompts, len(prompts)) when custom prompts are provided.

--- a/soup_cli/commands/bench.py
+++ b/soup_cli/commands/bench.py
@@ -93,7 +93,9 @@ def bench(
         try:
             p_path.relative_to(Path.cwd())
         except ValueError:
-            console.print(f"[red]Security Error:[/] Path {p_path} is outside the current working directory.")
+            console.print(
+                f"[red]Security Error:[/] Path {p_path} is outside the current working directory."
+            )
             raise typer.Exit(1)
             
         if not p_path.is_file():

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -51,6 +51,8 @@ def test_bench_custom_prompts(tmp_path, monkeypatch):
         assert "Running 3 test inferences" in result.output
         
         # Test 3: Path outside CWD
-        result = runner.invoke(app, ["bench", str(dummy_model), "--prompts-file", str(outside_file)])
+        result = runner.invoke(
+            app, ["bench", str(dummy_model), "--prompts-file", str(outside_file)]
+        )
         assert result.exit_code == 1
         assert "Security Error" in result.output

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -43,12 +43,12 @@ def test_bench_custom_prompts(tmp_path, monkeypatch):
         # Test 1: TXT
         result = runner.invoke(app, ["bench", str(dummy_model), "--prompts-file", "prompts.txt"])
         assert result.exit_code == 0
-        assert "Running 3 test inferences" in result.output
+        assert "Running 2 test inferences" in result.output
 
         # Test 2: JSONL
         result = runner.invoke(app, ["bench", str(dummy_model), "--prompts-file", "prompts.jsonl"])
         assert result.exit_code == 0
-        assert "Running 3 test inferences" in result.output
+        assert "Running 2 test inferences" in result.output
 
         # Test 3: Path outside CWD
         result = runner.invoke(

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -16,40 +16,40 @@ def test_bench_model_not_found():
 def test_bench_custom_prompts(tmp_path, monkeypatch):
     """Test using custom prompts from a text file and JSONL."""
     monkeypatch.chdir(tmp_path)
-    
+
     dummy_model = tmp_path / "dummy_model"
     dummy_model.mkdir()
-    
+
     # Text file
     prompts_txt = tmp_path / "prompts.txt"
     prompts_txt.write_text("Custom prompt 1\nCustom prompt 2\n")
-    
+
     # JSONL file
     prompts_jsonl = tmp_path / "prompts.jsonl"
     prompts_jsonl.write_text('{"prompt": "JSON prompt 1"}\n{"prompt": "JSON prompt 2"}\n')
-    
+
     # Path traversal
     outside_file = tmp_path.parent / "outside.txt"
     outside_file.write_text("Outside\n")
-    
+
     from unittest.mock import patch
-    
+
     with patch("soup_cli.commands.bench._load_model") as mock_load, \
          patch("soup_cli.commands.bench._generate") as mock_generate:
-        
+
         mock_load.return_value = ("mock_model", "mock_tokenizer")
         mock_generate.return_value = (None, 10)
-        
+
         # Test 1: TXT
         result = runner.invoke(app, ["bench", str(dummy_model), "--prompts-file", "prompts.txt"])
         assert result.exit_code == 0
         assert "Running 3 test inferences" in result.output
-        
+
         # Test 2: JSONL
         result = runner.invoke(app, ["bench", str(dummy_model), "--prompts-file", "prompts.jsonl"])
         assert result.exit_code == 0
         assert "Running 3 test inferences" in result.output
-        
+
         # Test 3: Path outside CWD
         result = runner.invoke(
             app, ["bench", str(dummy_model), "--prompts-file", str(outside_file)]

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -12,3 +12,45 @@ def test_bench_model_not_found():
     result = runner.invoke(app, ["bench", "nonexistent_model_path"])
     assert result.exit_code == 1
     assert "not found" in result.output.lower()
+
+def test_bench_custom_prompts(tmp_path, monkeypatch):
+    """Test using custom prompts from a text file and JSONL."""
+    monkeypatch.chdir(tmp_path)
+    
+    dummy_model = tmp_path / "dummy_model"
+    dummy_model.mkdir()
+    
+    # Text file
+    prompts_txt = tmp_path / "prompts.txt"
+    prompts_txt.write_text("Custom prompt 1\nCustom prompt 2\n")
+    
+    # JSONL file
+    prompts_jsonl = tmp_path / "prompts.jsonl"
+    prompts_jsonl.write_text('{"prompt": "JSON prompt 1"}\n{"prompt": "JSON prompt 2"}\n')
+    
+    # Path traversal
+    outside_file = tmp_path.parent / "outside.txt"
+    outside_file.write_text("Outside\n")
+    
+    from unittest.mock import patch
+    
+    with patch("soup_cli.commands.bench._load_model") as mock_load, \
+         patch("soup_cli.commands.bench._generate") as mock_generate:
+        
+        mock_load.return_value = ("mock_model", "mock_tokenizer")
+        mock_generate.return_value = (None, 10)
+        
+        # Test 1: TXT
+        result = runner.invoke(app, ["bench", str(dummy_model), "--prompts-file", "prompts.txt"])
+        assert result.exit_code == 0
+        assert "Running 3 test inferences" in result.output
+        
+        # Test 2: JSONL
+        result = runner.invoke(app, ["bench", str(dummy_model), "--prompts-file", "prompts.jsonl"])
+        assert result.exit_code == 0
+        assert "Running 3 test inferences" in result.output
+        
+        # Test 3: Path outside CWD
+        result = runner.invoke(app, ["bench", str(dummy_model), "--prompts-file", str(outside_file)])
+        assert result.exit_code == 1
+        assert "Security Error" in result.output

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -34,8 +34,8 @@ def test_bench_custom_prompts(tmp_path, monkeypatch):
 
     from unittest.mock import patch
 
-    with patch("soup_cli.commands.bench._load_model") as mock_load, \
-         patch("soup_cli.commands.bench._generate") as mock_generate:
+    with patch("soup_cli.commands.infer._load_model") as mock_load, \
+         patch("soup_cli.commands.infer._generate") as mock_generate:
 
         mock_load.return_value = ("mock_model", "mock_tokenizer")
         mock_generate.return_value = (None, 10)


### PR DESCRIPTION
## What does this PR do?

I implemented the `--prompts-file` option for the `soup bench` command, which was a follow-up from #24 / #25. I wanted to make the benchmarking more realistic, so I added support for loading custom prompts from either `.txt` (one per line) or `.jsonl` (extracting the `"prompt"` key) files. 

I made sure to include path resolution and validation so that the file must stay under the current working directory for security. I also updated the `bench` logic to scale the number of test runs automatically if a larger file is provided, while keeping the original behavior intact if no file is specified. Lastly, I added comprehensive tests in `test_bench.py` covering both formats and the security constraints, and updated the `README.md` with usage examples.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [x] Tests

## Checklist

- [x] `ruff check soup_cli/ tests/` passes
- [x] `pytest tests/ -v` passes
- [x] Updated relevant docs (README, CLAUDE.md) if needed


Ref #27 