### PR TITLE
Feature: add "soup cost" command for cloud GPU training cost estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1869,6 +1869,8 @@ soup data registry                           List all registered datasets
 soup profile --config soup.yaml              Estimate memory/speed before training
 soup profile --config soup.yaml --gpu a100   Estimate for specific GPU
 soup profile --config soup.yaml --json       Machine-readable output
+soup cost --config soup.yaml                 Estimate training cost in USD across providers
+soup cost --config soup.yaml --gpu H100      Estimate training cost for specific GPU
 soup adapters list ./output/                 Scan for LoRA adapters
 soup adapters info ./output/checkpoint-500/  Show adapter metadata
 soup adapters compare adapter1/ adapter2/    Compare two adapters

--- a/soup_cli/cli.py
+++ b/soup_cli/cli.py
@@ -12,6 +12,7 @@ from soup_cli.commands import (
     bench,
     can,
     chat,
+    cost,
     data,
     deploy,
     diff,
@@ -56,6 +57,7 @@ app = typer.Typer(
 app.command()(init.init)
 app.command()(train.train)
 app.command()(chat.chat)
+app.command()(cost.cost)
 app.command()(push.push)
 app.command(name="export")(export.export)
 app.command()(merge.merge)

--- a/soup_cli/commands/cost.py
+++ b/soup_cli/commands/cost.py
@@ -1,0 +1,156 @@
+"""soup cost — estimate training cost in USD."""
+
+import json
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from soup_cli.utils.gpu import model_size_from_name
+from soup_cli.utils.profiler import (
+    estimate_speed,
+    estimate_training_time,
+)
+
+console = Console()
+
+# GPU pricing and speed multipliers (relative to A100)
+GPU_PRICING = [
+    {"provider": "RunPod", "gpu": "A100 80G", "cost_per_hr": 1.89, "speed_mult": 1.0},
+    {"provider": "Lambda", "gpu": "A100 40G", "cost_per_hr": 1.10, "speed_mult": 1.0},
+    {"provider": "Modal", "gpu": "H100", "cost_per_hr": 5.92, "speed_mult": 2.5},
+    {"provider": "Vast.ai", "gpu": "RTX 4090", "cost_per_hr": 0.35, "speed_mult": 0.7},
+    {"provider": "CoreWeave", "gpu": "A100 80G", "cost_per_hr": 2.21, "speed_mult": 1.0},
+]
+
+
+def _get_dataset_size(cfg) -> int:
+    """Estimate dataset size."""
+    train_path = cfg.data.train
+    path = Path(train_path)
+
+    # Local file
+    if path.exists():
+        from soup_cli.data.loader import load_raw_data
+        try:
+            data = load_raw_data(path)
+            # If val_split is used, training set is smaller
+            split = 1.0 - cfg.data.val_split
+            return int(len(data) * split)
+        except Exception:
+            pass
+
+    # Try HF dataset (only if not a local file path with extension)
+    if not path.suffix:
+        try:
+            from datasets import load_dataset_builder
+            builder = load_dataset_builder(train_path)
+            size = builder.info.splits["train"].num_examples
+            split = 1.0 - cfg.data.val_split
+            return int(size * split)
+        except Exception:
+            pass
+
+    # Fallback default
+    return 10000
+
+
+def cost(
+    config: str = typer.Option(
+        "soup.yaml", "--config", "-c", help="Path to soup.yaml config file"
+    ),
+    gpu: str = typer.Option(
+        None, "--gpu", "-g",
+        help="Filter by specific GPU (e.g., A100, H100, RTX 4090)",
+    ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Output as JSON for scripting"
+    ),
+):
+    """Estimate training cost in USD."""
+    from soup_cli.config.loader import load_config
+
+    config_path = Path(config)
+    if not config_path.exists():
+        console.print(f"[red]Config file not found:[/] {config}")
+        raise typer.Exit(1)
+
+    cfg = load_config(config_path)
+    model_params_b = model_size_from_name(cfg.base)
+
+    batch_size = cfg.training.batch_size
+    if batch_size == "auto":
+        batch_size = 4
+    else:
+        batch_size = int(batch_size)
+
+    dataset_size = _get_dataset_size(cfg)
+    epochs = cfg.training.epochs
+
+    # Base speed (A100)
+    base_tokens_per_sec = estimate_speed(
+        model_params_b, cfg.training.quantization, batch_size
+    )
+    base_samples_per_sec = base_tokens_per_sec / max(cfg.data.max_length, 1)
+
+    results = []
+
+    for provider_info in GPU_PRICING:
+        if gpu:
+            gpu_norm = gpu.lower().replace(" ", "")
+            p_gpu_norm = provider_info["gpu"].lower().replace(" ", "")
+            if gpu_norm not in p_gpu_norm:
+                continue
+
+        speed_mult = provider_info["speed_mult"]
+        samples_per_sec = base_samples_per_sec * speed_mult
+
+        # Duration in minutes
+        duration_mins = estimate_training_time(dataset_size, epochs, samples_per_sec)
+        duration_hrs = duration_mins / 60.0
+
+        total_cost = duration_hrs * provider_info["cost_per_hr"]
+
+        results.append({
+            "provider": provider_info["provider"],
+            "gpu": provider_info["gpu"],
+            "cost_per_hr": provider_info["cost_per_hr"],
+            "duration_hrs": duration_hrs,
+            "total_cost": total_cost,
+        })
+
+    if not results:
+        console.print(f"[red]No matching GPUs found for:[/] {gpu}")
+        raise typer.Exit(1)
+
+    if json_output:
+        console.print(json.dumps(results, indent=2))
+        return
+
+    # Render table
+    table = Table(title="Training Cost Estimate", title_justify="left", box=None, padding=(0, 2))
+    table.add_column("Provider", style="cyan")
+    table.add_column("GPU", style="green")
+    table.add_column("$/hr", justify="right")
+    table.add_column("Total Cost", justify="right")
+
+    for r in results:
+        cost_str = f"~${r['total_cost']:.2f}"
+
+        # Format duration to match example, e.g. (4h) or (1.5h)
+        # If it's very small, maybe (<1h)
+        if r['duration_hrs'] < 1.0:
+            dur_str = "(<1h)"
+        else:
+            dur_str = f"({r['duration_hrs']:.0f}h)"
+
+        table.add_row(
+            r["provider"],
+            r["gpu"],
+            f"${r['cost_per_hr']:.2f}",
+            f"{cost_str} [dim]{dur_str}[/dim]"
+        )
+
+    console.print(table)
+    console.print()

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -1,0 +1,99 @@
+"""Tests for soup cost command."""
+
+import json
+
+from typer.testing import CliRunner
+
+from soup_cli.cli import app
+
+runner = CliRunner()
+
+
+def test_cost_with_config_file(tmp_path):
+    """Test basic cost table output."""
+    config_file = tmp_path / "soup.yaml"
+    config_file.write_text(
+        "base: meta-llama/Llama-3.1-8B-Instruct\n"
+        "task: sft\n"
+        "data:\n"
+        "  train: ./data/train.jsonl\n"
+        "  max_length: 2048\n"
+        "training:\n"
+        "  epochs: 3\n"
+        "  batch_size: 4\n"
+        "  quantization: 4bit\n"
+        "  lora:\n"
+        "    r: 64\n"
+        "output: ./output\n"
+    )
+    result = runner.invoke(app, ["cost", "--config", str(config_file)])
+    assert result.exit_code == 0
+    assert "Training Cost Estimate" in result.output
+    assert "Provider" in result.output
+    assert "RunPod" in result.output
+
+
+def test_cost_json_output(tmp_path):
+    """Test JSON output for automation."""
+    config_file = tmp_path / "soup.yaml"
+    config_file.write_text(
+        "base: meta-llama/Llama-3.1-8B-Instruct\n"
+        "task: sft\n"
+        "data:\n"
+        "  train: ./data/train.jsonl\n"
+        "  max_length: 2048\n"
+        "training:\n"
+        "  batch_size: 4\n"
+        "output: ./output\n"
+    )
+    result = runner.invoke(app, ["cost", "--config", str(config_file), "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert isinstance(data, list)
+    assert len(data) > 0
+    assert "total_cost" in data[0]
+    assert "provider" in data[0]
+
+
+def test_cost_with_gpu_filter(tmp_path):
+    """Test filtering by specific GPU."""
+    config_file = tmp_path / "soup.yaml"
+    config_file.write_text(
+        "base: meta-llama/Llama-3.1-8B-Instruct\n"
+        "task: sft\n"
+        "data:\n"
+        "  train: ./data/train.jsonl\n"
+        "  max_length: 2048\n"
+        "training:\n"
+        "  batch_size: 4\n"
+        "output: ./output\n"
+    )
+    result = runner.invoke(app, ["cost", "--config", str(config_file), "--gpu", "H100"])
+    assert result.exit_code == 0
+    assert "H100" in result.output
+    # Assuming the mock data only has RTX 4090 and we filtered to H100
+    assert "RTX 4090" not in result.output
+
+
+def test_cost_with_unknown_gpu(tmp_path):
+    """Test filtering by unknown GPU."""
+    config_file = tmp_path / "soup.yaml"
+    config_file.write_text(
+        "base: meta-llama/Llama-3.1-8B-Instruct\n"
+        "task: sft\n"
+        "data:\n"
+        "  train: ./data/train.jsonl\n"
+        "  max_length: 2048\n"
+        "training:\n"
+        "  batch_size: 4\n"
+        "output: ./output\n"
+    )
+    result = runner.invoke(app, ["cost", "--config", str(config_file), "--gpu", "nonexistent"])
+    assert result.exit_code == 1
+    assert "No matching GPUs found" in result.output
+
+
+def test_cost_missing_config():
+    """Test cost fails gracefully when config doesn't exist."""
+    result = runner.invoke(app, ["cost", "--config", "nonexistent.yaml"])
+    assert result.exit_code != 0


### PR DESCRIPTION
## What does this PR do?

I've added a new `soup cost` command to help users estimate their actual training costs before committing to a long cloud GPU run. It builds nicely on top of the existing `soup profile` infrastructure to calculate the expected training duration (tokens/sec, total steps) and cross-references it with hardcoded hourly rates from popular providers like RunPod, Lambda Labs, Modal, Vast.ai, and CoreWeave. 

When you run it against your `soup.yaml` config, it outputs a clean Rich table showing a per-provider breakdown of costs and estimated duration. I've also added a `--gpu` flag to let users filter the table for specific hardware (e.g., just `H100` or `RTX 4090`), and `--json` support for folks who want to script around it. Finally, I threw in a suite of unit tests and updated the README. 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [x] Tests

## Checklist

- [x] `ruff check soup_cli/ tests/` passes
- [x] `pytest tests/ -v` passes
- [x] Updated relevant docs (README, CLAUDE.md) if needed


ref issue #13 