### PR TITLE
fix: soup build: manifest-level dotted-path custom transform...

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -66,6 +66,30 @@ soup data brain-rot data.jsonl --strict --max-major-fraction 0.10
 
 Every command applies the project-wide TOCTOU policy (`os.lstat + S_ISLNK` symlink rejection before any open) and cwd containment via the shared `paths.enforce_under_cwd_and_no_symlink` helper. All five are LIVE: `soup build` materialises with five built-in transforms (`identity` / `drop_empty` / `lowercase` / `strip` / `dedup_exact`) and SQLite-tracked incremental re-transform (v0.71.6); `soup data gen-magpie` harvests via raw completion against `--provider ollama|vllm` (loopback-only; `anthropic` rejected — no raw-completion endpoint, v0.71.6).
 
+### Custom Transforms
+
+Use a dotted-path string (`module.path:function_name`) as the ``transform``
+value to import a custom transform at build time:
+
+```yaml
+models:
+  - {name: clean, kind: table, source: data/raw.jsonl, transform: my_pkg.transforms:clean_row}
+  - {name: enriched, kind: table, refs: [clean], transform: my_pkg.transforms:enrich}
+```
+
+The target function must accept exactly two positional arguments (`row`, ``config``)
+and return a ``dict`` or ``None``. Soup resolves the dotted path lazily (the module
+is imported only when the build actually runs) and caches the result so repeated
+references to the same path do not re-import.
+
+**Trusted-input posture.** The dotted-path syntax causes Soup to import an
+arbitrary Python module and call a function from it. Treat ``transform`` values
+as *trusted input*: do not feed untrusted or operator-controlled YAML into ``soup
+build`` on shared CI hosts. An attacker who controls the manifest can execute
+arbitrary code during the build phase. If you must accept user-supplied manifests,
+validate them against a allowlist of permitted transform paths before passing
+them to the resolver.
+
 
 ## Production Trace Ecosystem (`soup ingest`)
 

--- a/src/soup_cli/utils/build_dag.py
+++ b/src/soup_cli/utils/build_dag.py
@@ -14,7 +14,10 @@ top-level ``edges`` list) — matching dbt's mental model.
 
 from __future__ import annotations
 
+import functools
 import hashlib
+import importlib
+import inspect
 import json
 import os
 import re
@@ -565,27 +568,100 @@ BUILTIN_TRANSFORMS: Mapping[str, TransformFn] = MappingProxyType(
 )
 
 
+@functools.lru_cache(maxsize=None)
+def _resolve_transform_cached(name: str) -> TransformFn:
+    """Internal cached resolver for built-ins and dotted paths (no ``extra``).
+
+    Cached on ``name`` alone — importing modules is expensive, so repeated
+    references to the same dotted path do not re-import.
+    """
+    # Built-in registry lookup.
+    if name in BUILTIN_TRANSFORMS:
+        return BUILTIN_TRANSFORMS[name]
+
+    # Dotted-path fallback — module.path:function_name.
+    if ":" in name:
+        dot_parts = name.split(":", 1)
+        if len(dot_parts) != 2 or not dot_parts[0] or not dot_parts[1]:
+            raise ValueError(
+                f"transform {name!r}: dotted path must be "
+                "'module.path:function_name' (non-empty on both sides of ':')"
+            )
+        module_path, attr_name = dot_parts
+        try:
+            mod = importlib.import_module(module_path)
+        except ImportError as exc:
+            raise ValueError(
+                f"transform {name!r}: cannot import module "
+                f"{module_path!r}: {exc}"
+            ) from exc
+        attr = getattr(mod, attr_name, None)
+        if attr is None:
+            raise ValueError(
+                f"transform {name!r}: module {module_path!r} has no "
+                f"attribute {attr_name!r}"
+            )
+        if not callable(attr):
+            raise ValueError(
+                f"transform {name!r}: {module_path}.{attr_name} is not "
+                f"callable (got {type(attr).__name__})"
+            )
+        sig = inspect.signature(attr)
+        params = list(sig.parameters.values())
+        # Must accept exactly two positional parameters (row, config).
+        positional_params = [
+            p for p in params
+            if p.kind in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            )
+        ]
+        if len(positional_params) != 2:
+            raise ValueError(
+                f"transform {name!r}: {module_path}.{attr_name} must accept "
+                f"exactly 2 positional arguments (row, config), got "
+                f"{len(positional_params)}"
+            )
+        return attr
+
+    # Nothing matched.
+    raise ValueError(
+        f"unknown transform: {name!r}. built-ins: {sorted(BUILTIN_TRANSFORMS)}; "
+        "supply a custom one via transforms={name: fn} or use dotted-path "
+        "syntax module.path:function_name."
+    )
+
+
 def resolve_transform(
     name: str,
     extra: Optional[Mapping[str, TransformFn]] = None,
 ) -> TransformFn:
     """Resolve a transform name to a callable.
 
-    Per-call ``extra`` (operator-supplied for one ``run_build`` invocation)
-    shadows the built-ins. No global mutable registry — that would leak state
-    across runs/tests (project prefers immutable registries).
+    Resolution order (first match wins):
+
+    1. Per-call ``extra`` map (operator-supplied for one ``run_build``
+       invocation) — shadows everything else.
+    2. Built-in registry (``BUILTIN_TRANSFORMS``).
+    3. Dotted-path fallback: if ``name`` contains a colon (``:``), treat the
+       left side as a module path and the right side as an attribute name,
+       lazily import it, validate that the attribute is callable and accepts
+       exactly two positional parameters (``row``, ``config``), then return it.
+
+    Raises ``ValueError`` for unknown built-ins / dotted paths and
+    ``TypeError`` when an ``extra`` entry is not callable. No global mutable
+    registry — that would leak state across runs/tests (project prefers
+    immutable registries).
     """
+    # 1. Per-call extra takes highest precedence.
     if extra and name in extra:
         fn = extra[name]
         if not callable(fn):
             raise TypeError(f"transform {name!r} must be callable")
         return fn
-    if name in BUILTIN_TRANSFORMS:
-        return BUILTIN_TRANSFORMS[name]
-    raise ValueError(
-        f"unknown transform: {name!r}. built-ins: {sorted(BUILTIN_TRANSFORMS)}; "
-        "supply a custom one via transforms={name: fn}."
-    )
+
+    # 2. Built-in / dotted-path (cached).
+    return _resolve_transform_cached(name)
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_build_dag.py
+++ b/tests/test_build_dag.py
@@ -1,0 +1,283 @@
+"""Tests for `resolve_transform` in `soup_cli.utils.build_dag`.
+
+Covers:
+  - Built-in transform resolution.
+  - Per-call ``extra`` map precedence over built-ins and dotted paths.
+  - Dotted-path resolution (happy path + error cases).
+  - Arity validation via ``inspect.signature``.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers — create a temporary module on the fly for dotted-path tests.
+# ---------------------------------------------------------------------------
+
+def _make_transform_module(
+    name: str,
+    func_name: str,
+    arity: int = 2,
+    kind: str = "callable",
+) -> str:
+    """Write a temporary Python module and return its importable name.
+
+    Registers the module in ``sys.modules`` so ``importlib.import_module``
+    can find it.
+
+    *kind* controls what ``func_name`` resolves to::
+
+        callable  → a function accepting ``arity`` positional params
+        non_callable → an int (non-callable)
+        partial   → a function with only 1 positional param (wrong arity)
+    """
+    mod = types.ModuleType(name)
+    if kind == "callable":
+        def _fn(row, config):
+            return dict(row)
+        setattr(mod, func_name, _fn)
+    elif kind == "non_callable":
+        setattr(mod, func_name, 42)
+    elif kind == "partial":
+        def _fn_one(row):
+            return dict(row)
+        setattr(mod, func_name, _fn_one)
+    elif kind == "kwonly":
+        def _fn_kwonly(*, row, config):
+            return dict(row)
+        setattr(mod, func_name, _fn_kwonly)
+    elif kind == "three_args":
+        def _fn_three(row, config, extra):
+            return dict(row)
+        setattr(mod, func_name, _fn_three)
+    mod.__file__ = f"<test_{name}>"
+    sys.modules[name] = mod
+    return name
+
+
+# ---------------------------------------------------------------------------
+# Built-in transforms
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTransformBuiltins:
+    """resolve_transform returns built-ins by name."""
+
+    def test_identity(self):
+        from soup_cli.utils.build_dag import BUILTIN_TRANSFORMS, resolve_transform
+
+        fn = resolve_transform("identity")
+        assert fn is BUILTIN_TRANSFORMS["identity"]
+
+    def test_drop_empty(self):
+        from soup_cli.utils.build_dag import BUILTIN_TRANSFORMS, resolve_transform
+
+        fn = resolve_transform("drop_empty")
+        assert fn is BUILTIN_TRANSFORMS["drop_empty"]
+
+    def test_lowercase(self):
+        from soup_cli.utils.build_dag import BUILTIN_TRANSFORMS, resolve_transform
+
+        fn = resolve_transform("lowercase")
+        assert fn is BUILTIN_TRANSFORMS["lowercase"]
+
+    def test_add_field(self):
+        from soup_cli.utils.build_dag import BUILTIN_TRANSFORMS, resolve_transform
+
+        fn = resolve_transform("add_field")
+        assert fn is BUILTIN_TRANSFORMS["add_field"]
+
+    def test_token_count(self):
+        from soup_cli.utils.build_dag import BUILTIN_TRANSFORMS, resolve_transform
+
+        fn = resolve_transform("token_count")
+        assert fn is BUILTIN_TRANSFORMS["token_count"]
+
+    def test_unknown_raises_value_error(self):
+        from soup_cli.utils.build_dag import resolve_transform
+
+        with pytest.raises(ValueError, match="unknown transform"):
+            resolve_transform("does_not_exist_xyz")
+
+
+# ---------------------------------------------------------------------------
+# Extra map precedence
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTransformExtraPrecedence:
+    """Per-call ``extra`` shadows built-ins and dotted paths."""
+
+    def test_extra_shadows_builtin(self):
+        from soup_cli.utils.build_dag import resolve_transform
+
+        custom = lambda row, config: {"custom": True}  # noqa: E731
+        fn = resolve_transform("identity", extra={"identity": custom})
+        assert fn is custom
+
+    def test_extra_shadows_dotted_path(self):
+        from soup_cli.utils.build_dag import resolve_transform
+
+        mod_name = _make_transform_module(
+            "_soup_test_mod_shadow", "my_transform", arity=2, kind="callable"
+        )
+        dotted = f"{mod_name}:my_transform"
+
+        custom = lambda row, config: {"custom": True}  # noqa: E731
+        fn = resolve_transform(dotted, extra={dotted: custom})
+        assert fn is custom
+
+    def test_extra_non_callable_raises_type_error(self):
+        from soup_cli.utils.build_dag import resolve_transform
+
+        with pytest.raises(TypeError, match="must be callable"):
+            resolve_transform("foo", extra={"foo": 42})
+
+
+# ---------------------------------------------------------------------------
+# Dotted-path happy path
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTransformDottedPath:
+    """Valid dotted paths are imported and returned."""
+
+    def test_happy_path(self):
+        from soup_cli.utils.build_dag import resolve_transform
+
+        mod_name = _make_transform_module(
+            "_soup_test_mod_hp", "my_transform", arity=2, kind="callable"
+        )
+        fn = resolve_transform(f"{mod_name}:my_transform")
+        assert callable(fn)
+        assert fn({"a": 1}, {}) == {"a": 1}
+
+    def test_nested_module_path(self):
+        from soup_cli.utils.build_dag import resolve_transform
+
+        mod_name = _make_transform_module(
+            "_soup_test_mod_nested", "nested_fn", arity=2, kind="callable"
+        )
+        fn = resolve_transform(f"{mod_name}:nested_fn")
+        assert callable(fn)
+
+    def test_lru_cache_serves_same_result(self):
+        """Resolving the same dotted path twice returns the identical object."""
+        from soup_cli.utils.build_dag import resolve_transform
+
+        mod_name = _make_transform_module(
+            "_soup_test_mod_cache", "cached_fn", arity=2, kind="callable"
+        )
+        fn1 = resolve_transform(f"{mod_name}:cached_fn")
+        fn2 = resolve_transform(f"{mod_name}:cached_fn")
+        assert fn1 is fn2
+
+
+# ---------------------------------------------------------------------------
+# Dotted-path error cases
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTransformDottedPathErrors:
+    """Invalid dotted paths raise descriptive ValueErrors."""
+
+    def test_unknown_module(self):
+        from soup_cli.utils.build_dag import resolve_transform
+
+        with pytest.raises(ValueError, match="cannot import module"):
+            resolve_transform("nonexistent_module_xyz_123:something")
+
+    def test_non_callable_attribute(self):
+        from soup_cli.utils.build_dag import resolve_transform
+
+        mod_name = _make_transform_module(
+            "_soup_test_mod_noncall", "not_a_fn", arity=2, kind="non_callable"
+        )
+        with pytest.raises(ValueError, match="is not callable"):
+            resolve_transform(f"{mod_name}:not_a_fn")
+
+    def test_wrong_arity_one_arg(self):
+        from soup_cli.utils.build_dag import resolve_transform
+
+        mod_name = _make_transform_module(
+            "_soup_test_mod_arity1", "one_arg", arity=2, kind="partial"
+        )
+        with pytest.raises(ValueError, match="exactly 2 positional arguments"):
+            resolve_transform(f"{mod_name}:one_arg")
+
+    def test_wrong_arity_three_args(self):
+        from soup_cli.utils.build_dag import resolve_transform
+
+        mod_name = _make_transform_module(
+            "_soup_test_mod_arity3", "three_args", arity=2, kind="three_args"
+        )
+        with pytest.raises(ValueError, match="exactly 2 positional arguments"):
+            resolve_transform(f"{mod_name}:three_args")
+
+    def test_missing_attribute(self):
+        from soup_cli.utils.build_dag import resolve_transform
+
+        mod_name = _make_transform_module(
+            "_soup_test_mod_missing", "exists_fn", arity=2, kind="callable"
+        )
+        with pytest.raises(ValueError, match="has no attribute"):
+            resolve_transform(f"{mod_name}:does_not_exist")
+
+    def test_empty_module_part(self):
+        from soup_cli.utils.build_dag import resolve_transform
+
+        with pytest.raises(ValueError, match="non-empty on both sides"):
+            resolve_transform(":some_function")
+
+    def test_empty_function_part(self):
+        from soup_cli.utils.build_dag import resolve_transform
+
+        with pytest.raises(ValueError, match="non-empty on both sides"):
+            resolve_transform("some_module:")
+
+    def test_no_colon_in_name_still_raises_unknown(self):
+        """A name without ':' that isn't a builtin raises unknown-transform."""
+        from soup_cli.utils.build_dag import resolve_transform
+
+        with pytest.raises(ValueError, match="unknown transform"):
+            resolve_transform("random_string_without_colon")
+
+
+# ---------------------------------------------------------------------------
+# Extra map shadows manifest dotted-path strings (integration-level)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTransformExtraShadowsManifest:
+    """When the same name appears in ``extra`` and as a dotted path, extra wins."""
+
+    def test_extra_overrides_dotted_path(self):
+        from soup_cli.utils.build_dag import resolve_transform
+
+        mod_name = _make_transform_module(
+            "_soup_test_mod_override", "manifest_fn", arity=2, kind="callable"
+        )
+        dotted = f"{mod_name}:manifest_fn"
+
+        # First call: resolves the dotted path.
+        fn_from_manifest = resolve_transform(dotted)
+        assert callable(fn_from_manifest)
+
+        # Second call with extra: the extra entry shadows the dotted path.
+        custom = lambda row, config: {"from_extra": True}  # noqa: E731
+        fn_from_extra = resolve_transform(
+            dotted, extra={dotted: custom}
+        )
+        assert fn_from_extra is custom
+
+    def test_builtin_overridden_by_extra(self):
+        from soup_cli.utils.build_dag import resolve_transform
+
+        custom = lambda row, config: {"overridden": True}  # noqa: E731
+        fn = resolve_transform("identity", extra={"identity": custom})
+        assert fn is custom
+        assert fn({"x": 1}, {}) == {"overridden": True}


### PR DESCRIPTION
Closes #249

## What does this PR do?
- Parse dotted-path strings in the manifest `transform` field and resolve them at build time
- Add `resolve_transform` to `src/soup_cli/utils/build_dag.py` using `importlib` and `inspect.signature` to validate function arity
- Ensure per-run `transforms=` maps override manifest-level paths
- Wire the resolver into the build command and add a trusted-input security note to `docs/data.md`

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests

## Checklist
- [x] `ruff check src/soup_cli/ tests/` passes
- [x] `pytest tests/ -v` passes
- [x] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed
