### PR TITLE
feat(recipes): add ready-made SFT recipe for Qwen2.5-Coder-7B-Instruct

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ src/soup_cli/
   experiment/         - SQLite experiment tracking
   eval/               - Eval platform (custom tasks, LLM judge, human eval, leaderboard)
   migrate/            - Config migration (LLaMA-Factory, Axolotl, Unsloth)
-  recipes/            - Ready-made configs for popular models (133 recipes)
+  recipes/            - Ready-made configs for popular models (134 recipes)
   autopilot/          - Zero-config decision engine (v0.25.0)
   registry/           - Model Registry (hashing, store, diff, attach) (v0.26.0 + v0.33.0)
   cans/               - Shareable .can artifact format + run/publish orchestrator (v0.26.0 + v0.33.0)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -129,7 +129,7 @@ soup migrate --from llamafactory config.yaml  Import config from LLaMA-Factory
 soup migrate --from axolotl config.yml        Import config from Axolotl
 soup migrate --from unsloth notebook.ipynb    Import config from Unsloth notebook
 soup migrate --from llamafactory c.yaml --dry-run  Preview without writing
-soup recipes list                             List all 133 ready-made recipes
+soup recipes list                             List all 134 ready-made recipes
 soup recipes show llama3.1-8b-sft            Print recipe YAML
 soup recipes use llama3.1-8b-sft             Copy recipe to soup.yaml
 soup recipes search "reasoning"              Search by keyword/task/size

--- a/docs/serving-and-export.md
+++ b/docs/serving-and-export.md
@@ -418,7 +418,7 @@ soup ui
 
 **Pages:**
 - **Dashboard** — view all experiment runs, loss charts, system info, multi-run comparison
-- **New Training** — create configs from templates or 133 ready-made recipes, validate, start training with live SSE log streaming and progress bar
+- **New Training** — create configs from templates or 134 ready-made recipes, validate, start training with live SSE log streaming and progress bar
 - **Data Explorer** — browse and inspect datasets (JSONL, JSON, CSV, Parquet)
 - **Model Chat** — chat with streaming responses, configurable temperature/top_p/max_tokens, system prompt, adapter selection, markdown rendering, chat export
 
@@ -427,7 +427,7 @@ soup ui
 - **Enhanced Metrics** — 2x2 chart grid (loss, LR, grad_norm, throughput) + GPU memory chart, eval results table
 - **Multi-Run Compare** — overlay loss curves from up to 5 runs side-by-side
 - **Chat Upgrade** — SSE streaming via proxy, typing indicator, cancel button, markdown renderer (bold, italic, code blocks), chat export as JSON
-- **Config Builder** — recipe dropdown (133 recipes), config schema API for dynamic form generation
+- **Config Builder** — recipe dropdown (134 recipes), config schema API for dynamic form generation
 
 **Security:** The Web UI generates a random auth token at startup (printed to console). All mutating endpoints (start/stop training, delete runs, inspect data, validate config) require `Authorization: Bearer <token>` header. CORS is restricted to the served origin. Data inspection is sandboxed to the working directory.
 

--- a/src/soup_cli/recipes/catalog.py
+++ b/src/soup_cli/recipes/catalog.py
@@ -48,7 +48,7 @@ def search_recipes(
 
 
 # ---------------------------------------------------------------------------
-# Recipe catalog (133 recipes)
+# Recipe catalog (134 recipes)
 # ---------------------------------------------------------------------------
 
 RECIPES: Dict[str, RecipeMeta] = {
@@ -251,6 +251,34 @@ training:
     alpha: 16
     target_modules: auto
   quantization: 8bit
+
+output: ./output
+""",
+    ),
+    "qwen2.5-coder-7b-sft": RecipeMeta(
+        model="Qwen/Qwen2.5-Coder-7B-Instruct",
+        task="sft",
+        size="7B",
+        tags=("qwen", "qwen2.5", "coder", "code", "sft"),
+        description="Qwen 2.5 Coder 7B instruction tuning with LoRA",
+        yaml_str="""\
+base: Qwen/Qwen2.5-Coder-7B-Instruct
+task: sft
+
+data:
+  train: ./data/train.jsonl
+  format: auto
+  max_length: 2048
+
+training:
+  epochs: 3
+  lr: 2e-4
+  batch_size: auto
+  lora:
+    r: 16
+    alpha: 32
+    target_modules: auto
+  quantization: 4bit
 
 output: ./output
 """,

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -260,7 +260,7 @@ class TestV025NewRecipes:
             assert cfg.base == recipe.model
             assert cfg.task == recipe.task
 
-    def test_catalog_size_is_133(self):
+    def test_catalog_size_is_134(self):
         """Total catalog size — grew with each release.
 
         v0.25.0 shipped 43 recipes (29 + 9 Part A + 2 Part B tools + 3 Part E MLX).
@@ -271,10 +271,11 @@ class TestV025NewRecipes:
         v0.53.5 added 1 (deepseek-v3-reasoning) -> 113.
         v0.62.0 added 3 (raft-llama3-8b, ra-dit-retriever, ra-dit-llama3-8b) -> 116.
         v0.71.24 added 17 (2026 model-family expansion) -> 133.
+        v0.71.25 added 1 (qwen2.5-coder-7b-sft) -> 134.
         """
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 133
+        assert len(RECIPES) == 134
 
     def test_new_recipes_searchable(self):
         """Search returns the new recipes via keyword/task filter."""

--- a/tests/test_v07124.py
+++ b/tests/test_v07124.py
@@ -264,13 +264,13 @@ class TestGlm5RepoIdFix:
 
 
 # ---------------------------------------------------------------------------
-# Catalog count — 116 -> 133
+# Catalog count — 116 -> 134
 # ---------------------------------------------------------------------------
 
 
 class TestCatalogCount:
-    def test_total_recipe_count_is_133(self) -> None:
-        assert len(RECIPES) == 133
+    def test_total_recipe_count_is_134(self) -> None:
+        assert len(RECIPES) == 134
 
     def test_list_recipes_matches_dict(self) -> None:
         assert len(list_recipes()) == len(RECIPES)


### PR DESCRIPTION
## What does this PR do?

Ref #271 

This PR adds a new ready-made SFT training recipe for the popular code-specialist model `Qwen/Qwen2.5-Coder-7B-Instruct` to the declarative recipes catalog. It also updates the recipe catalog count from 133 to 134 across all tests and documentation files to keep the catalog references in sync.

- Added the `qwen2.5-coder-7b-sft` recipe to `src/soup_cli/recipes/catalog.py`.
- Bumped the total count assertions in `tests/test_recipes.py` and `tests/test_v07124.py`.
- Bumped the total count references in `CONTRIBUTING.md`, `docs/commands.md`, and `docs/serving-and-export.md`.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [x] Tests

## Checklist

- [x] `ruff check src/soup_cli/ tests/` passes
- [x] `pytest tests/ -v` passes
- [x] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed
