### PR TITLE
Fix vocabulary expansion during SFT trainer initialization

### DIFF
--- a/src/soup_cli/trainer/sft.py
+++ b/src/soup_cli/trainer/sft.py
@@ -720,7 +720,13 @@ class SFTTrainerWrapper:
                 console.print(f"[green]FlashAttention enabled:[/] {attn_impl}")
 
         self.model = AutoModelForCausalLM.from_pretrained(cfg.base, **model_kwargs)
+        from soup_cli.utils.data_pipeline import apply_vocab_expansion
 
+        apply_vocab_expansion(
+        self.tokenizer,
+        self.model,
+        cfg.data,
+        )
         # Long-context — apply RoPE scaling after model load
         if tcfg.rope_scaling_type:
             from soup_cli.utils.long_context import apply_long_context_config

--- a/src/soup_cli/utils/data_pipeline.py
+++ b/src/soup_cli/utils/data_pipeline.py
@@ -417,6 +417,53 @@ def validate_new_tokens(value: Optional[List[str]]) -> Optional[List[str]]:
     return cleaned
 
 
+def apply_vocab_expansion(tokenizer: Any, model: Any, data_cfg: Any) -> int:
+    """Add configured tokens to ``tokenizer`` and resize ``model`` embeddings.
+
+    The helper is intentionally shared by every text trainer so
+    ``data.add_new_tokens`` / ``data.new_special_tokens`` are applied in one
+    place. It is safe to call even when no expansion is configured.
+
+    Returns:
+        Number of tokens added to the tokenizer.
+    """
+    regular = list(dict.fromkeys(getattr(data_cfg, "add_new_tokens", None) or []))
+    special = list(
+        dict.fromkeys(getattr(data_cfg, "new_special_tokens", None) or [])
+    )
+    if not regular and not special:
+        return 0
+
+    existing = set()
+    if hasattr(tokenizer, "get_vocab"):
+        try:
+            existing = set(tokenizer.get_vocab().keys())
+        except Exception:
+            existing = set()
+
+    # Special tokens take precedence if the same string appears in both lists.
+    special = [token for token in special if token not in existing]
+    special_set = set(special)
+    regular = [
+        token for token in regular
+        if token not in existing and token not in special_set
+    ]
+
+    added = 0
+    if regular and hasattr(tokenizer, "add_tokens"):
+        result = tokenizer.add_tokens(regular)
+        added += int(result or 0)
+    if special and hasattr(tokenizer, "add_special_tokens"):
+        result = tokenizer.add_special_tokens(
+            {"additional_special_tokens": special}
+        )
+        added += int(result or 0)
+
+    if added > 0 and hasattr(model, "resize_token_embeddings"):
+        model.resize_token_embeddings(len(tokenizer))
+    return added
+
+
 # --- Part E: Custom prompt strategies -------------------------------------
 
 # Module:fn syntax allowlist — mirrors how Axolotl exposes user transforms.

--- a/tests/test_trainer_init.py
+++ b/tests/test_trainer_init.py
@@ -45,6 +45,125 @@ class TestSFTTrainerInit:
         )
         assert wrapper.deepspeed_config == "/path/to/ds.json"
 
+    def test_transformers_vocab_expansion_adds_tokens_and_resizes(
+        self, monkeypatch
+    ):
+        """data.add_new_tokens/new_special_tokens must affect text trainers."""
+        import sys
+        import types
+        from types import SimpleNamespace
+
+        from soup_cli.trainer.sft import SFTTrainerWrapper
+
+        cfg = _make_config(
+            data={
+                "train": "./data.jsonl",
+                "format": "alpaca",
+                "add_new_tokens": ["<new_a>", "<old>"],
+                "new_special_tokens": ["<special_a>"],
+                "resize_vocab": True,
+            },
+            training={"quantization": "none"},
+        )
+        calls = {"add_tokens": None, "add_special_tokens": None, "resize": None}
+
+        class _Tokenizer:
+            pad_token = None
+            eos_token = "<eos>"
+
+            def __init__(self):
+                self.vocab = {"<old>": 0}
+
+            def add_tokens(self, tokens):
+                calls["add_tokens"] = list(tokens)
+                added = 0
+                for token in tokens:
+                    if token not in self.vocab:
+                        self.vocab[token] = len(self.vocab)
+                        added += 1
+                return added
+
+            def add_special_tokens(self, data):
+                tokens = list(data["additional_special_tokens"])
+                calls["add_special_tokens"] = tokens
+                added = 0
+                for token in tokens:
+                    if token not in self.vocab:
+                        self.vocab[token] = len(self.vocab)
+                        added += 1
+                return added
+
+            def __len__(self):
+                return len(self.vocab)
+
+        class _Model:
+            config = SimpleNamespace()
+
+            def resize_token_embeddings(self, size):
+                calls["resize"] = size
+
+            def parameters(self):
+                return []
+
+        tokenizer = _Tokenizer()
+        model = _Model()
+
+        fake_transformers = types.SimpleNamespace(
+            AutoTokenizer=types.SimpleNamespace(
+                from_pretrained=lambda *args, **kwargs: tokenizer
+            ),
+            AutoModelForCausalLM=types.SimpleNamespace(
+                from_pretrained=lambda *args, **kwargs: model
+            ),
+        )
+        fake_peft = types.SimpleNamespace(
+            LoraConfig=lambda **kwargs: SimpleNamespace(**kwargs),
+            TaskType=SimpleNamespace(CAUSAL_LM="CAUSAL_LM"),
+            get_peft_model=lambda model_obj, _cfg: model_obj,
+            prepare_model_for_kbit_training=lambda model_obj: model_obj,
+        )
+        monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+        monkeypatch.setitem(sys.modules, "peft", fake_peft)
+        monkeypatch.setattr(
+            "soup_cli.utils.quant_menu.build_quantization_config_for_loader",
+            lambda **kwargs: None,
+        )
+        monkeypatch.setattr("soup_cli.utils.moe.detect_moe_model", lambda _m: False)
+        monkeypatch.setattr("soup_cli.utils.moe.get_moe_target_modules", lambda _m: [])
+        monkeypatch.setattr(
+            "soup_cli.utils.block_expansion.apply_block_expansion_if_configured",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "soup_cli.utils.moe_quant.apply_moe_expert_quant_if_configured",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "soup_cli.utils.peft_wiring.apply_pre_lora_patches",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "soup_cli.utils.peft_wiring.apply_post_lora_patches",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "soup_cli.utils.v028_features.apply_v028_speed_memory",
+            lambda *args, **kwargs: None,
+        )
+
+        wrapper = object.__new__(SFTTrainerWrapper)
+        wrapper.config = cfg
+        wrapper.device = "cpu"
+        wrapper._trust_remote_code = False
+        wrapper.model = None
+        wrapper.tokenizer = None
+
+        wrapper._setup_transformers(cfg, cfg.training)
+
+        assert calls["add_tokens"] == ["<new_a>", "<old>"]
+        assert calls["add_special_tokens"] == ["<special_a>"]
+        assert calls["resize"] == len(tokenizer)
+
 
 class TestDPOTrainerInit:
     """Test DPOTrainerWrapper constructor."""


### PR DESCRIPTION
Fixes #289 
## What does this PR do?

Fixes an issue where `data.add_new_tokens` and `data.new_special_tokens`
were accepted by the configuration but were never applied during
`SFTTrainerWrapper` initialization.

This PR:

- adds a shared `apply_vocab_expansion()` helper
- applies configured vocabulary expansion immediately after tokenizer/model initialization
- adds a regression test covering the SFT initialization path

The regression test fails on the original implementation and passes after this fix.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Tests

## Validation

Verified with the following tests:

- [x] `tests/test_trainer_init.py` (19 passed)
- [x] `tests/test_audio.py` (27 passed)
- [x] `tests/test_deepspeed.py` (19 passed)

Additionally, the new regression test demonstrates the original failure and passes after the fix.

## Checklist

- [ ] `ruff check src/soup_cli/ tests/` passes *(not run)*
- [x] `pytest tests/ -v` *(relevant test suites)* passes
- [ ] Updated relevant docs (not required)