### PR TITLE
fix(mlx): dispatch SFT to the MLX trainer and align with mlx-lm 0.31 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ reproducing 70+ versions of notes.
 
 ## [Unreleased]
 
+### Fixed
+
+- **MLX backend now actually dispatches to the MLX trainer for `task: sft`.** Previously `backend: mlx` silently fell through to the transformers `SFTTrainerWrapper`, training on MPS/CUDA instead of MLX. The trainer was also rewritten for mlx-lm >= 0.31 (`create_dataset` + `CacheDataset`, `TrainingCallback`), with `model.freeze()` before LoRA — without it the saved "adapter" was a full fine-tune (172 tensors vs 24 LoRA tensors on a 1.2B model) — and an `adapter_config.json` is written so the output dir loads directly with `mlx_lm.load(..., adapter_path=dir)`. (#362)
+- **`mlx-lm` floor raised to >= 0.31.3** (the version the MLX SFT path is built against).
+
 ## [0.73.0] - 2026-08-09
 
 **The release that came out of three days on somebody else's hardware.**

--- a/docs/backends-and-ops.md
+++ b/docs/backends-and-ops.md
@@ -99,7 +99,7 @@ training:
     alpha: 32
 ```
 
-MLX backend supports SFT, DPO, and GRPO. Use `soup recipes search --tag mlx` for ready-made Apple Silicon configs.
+MLX backend supports SFT (live as of #362). DPO and GRPO are refused at config load (`backend: mlx` accepts `sft` only — `_validate_mlx_task`), so their wrappers are a backstop for callers that bypass the validator. Use `soup recipes search --tag mlx` for ready-made Apple Silicon configs.
 
 
 ## Unsloth Backend (2-5x Faster Training)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ audio = ["librosa>=0.10.0", "soundfile>=0.12.0"]
 awq = ["autoawq>=0.2.0"]
 gptq = ["auto-gptq>=0.7.0"]
 sglang = ["sglang>=0.2.0", "fastapi>=0.104.0", "uvicorn>=0.24.0"]
-mlx = ["mlx>=0.20.0", "mlx-lm>=0.20.0"]
+mlx = ["mlx>=0.20.0", "mlx-lm>=0.31.3"]
 cce = ["cut-cross-entropy>=24.10.0"]
 tui = ["textual>=0.50.0"]
 # v0.53.8 #89 — bundle MLflow / SwanLab / Trackio for `--tracker` users.

--- a/src/soup_cli/commands/train.py
+++ b/src/soup_cli/commands/train.py
@@ -1328,7 +1328,12 @@ def train(
     # v0.40.4 #63 — every transformer-backend trainer now threads
     # --trust-remote-code through the wrapper (closes the v0.36.0 Part B gap).
     trainer_kwargs = dict(trainer_kwargs, trust_remote_code=trust_remote_code)
-    if cfg.task == "dpo":
+    from soup_cli.trainer.mlx_routing import resolve_trainer
+
+    mlx_cls, trainer_kwargs = resolve_trainer(cfg, trainer_kwargs)
+    if mlx_cls is not None:
+        trainer_wrapper = mlx_cls(cfg, **trainer_kwargs)
+    elif cfg.task == "dpo":
         from soup_cli.trainer.dpo import DPOTrainerWrapper
 
         trainer_wrapper = DPOTrainerWrapper(cfg, **trainer_kwargs)
@@ -1416,13 +1421,6 @@ def train(
         from soup_cli.trainer.asr import AsrTrainerWrapper
 
         trainer_wrapper = AsrTrainerWrapper(cfg, **trainer_kwargs)
-    elif cfg.backend == "mlx" and cfg.task == "sft":
-        # FIX: dispatch to the real MLX trainer — previously the CLI always
-        # fell through to the transformers SFTTrainerWrapper, silently
-        # ignoring backend: mlx (trainer ran on MPS/CUDA instead of MLX).
-        from soup_cli.trainer.mlx_sft import MLXSFTTrainerWrapper
-
-        trainer_wrapper = MLXSFTTrainerWrapper(cfg)
     else:
         trainer_wrapper = SFTTrainerWrapper(cfg, **trainer_kwargs)
     trainer_wrapper.setup(dataset)

--- a/src/soup_cli/commands/train.py
+++ b/src/soup_cli/commands/train.py
@@ -1416,6 +1416,13 @@ def train(
         from soup_cli.trainer.asr import AsrTrainerWrapper
 
         trainer_wrapper = AsrTrainerWrapper(cfg, **trainer_kwargs)
+    elif cfg.backend == "mlx" and cfg.task == "sft":
+        # FIX: dispatch to the real MLX trainer — previously the CLI always
+        # fell through to the transformers SFTTrainerWrapper, silently
+        # ignoring backend: mlx (trainer ran on MPS/CUDA instead of MLX).
+        from soup_cli.trainer.mlx_sft import MLXSFTTrainerWrapper
+
+        trainer_wrapper = MLXSFTTrainerWrapper(cfg)
     else:
         trainer_wrapper = SFTTrainerWrapper(cfg, **trainer_kwargs)
     trainer_wrapper.setup(dataset)

--- a/src/soup_cli/trainer/mlx_routing.py
+++ b/src/soup_cli/trainer/mlx_routing.py
@@ -49,3 +49,17 @@ def get_mlx_trainer(task: str):
             f"MLX backend does not support task '{task}'. "
             f"Supported: {supported}. Use backend=transformers for full task coverage."
         ) from exc
+
+
+def resolve_trainer(cfg, trainer_kwargs: dict | None = None):
+    """Backend-first trainer resolution used by the train CLI.
+
+    Returns ``(trainer_cls, kwargs)`` — ``trainer_cls`` is the MLX trainer
+    class when ``cfg.backend == "mlx"`` (raising ValueError for unsupported
+    tasks), or ``None`` so the caller falls through to the transformers task
+    chain. ``trainer_kwargs`` are forwarded unchanged in both cases.
+    """
+    kwargs = dict(trainer_kwargs or {})
+    if getattr(cfg, "backend", None) == "mlx":
+        return get_mlx_trainer(cfg.task), kwargs
+    return None, kwargs

--- a/src/soup_cli/trainer/mlx_sft.py
+++ b/src/soup_cli/trainer/mlx_sft.py
@@ -1,14 +1,21 @@
-"""MLX SFT trainer — Apple Silicon fine-tuning via mlx-lm (Part E of v0.25.0).
+"""MLX SFT trainer — Apple Silicon fine-tuning via mlx-lm.
 
-MLX is a separate training path from transformers/unsloth — it uses Apple's
-unified memory architecture on M1-M4 chips. This trainer wraps ``mlx_lm``'s
-LoRA training utilities and bridges to Soup's Rich display and SQLite tracker.
+Rewritten for mlx-lm >= 0.31 (v0.73.0 local fix):
+- ``mlx_lm.tuner.trainer.train`` no longer takes a ``tokenizer`` argument;
+  datasets are built with ``mlx_lm.tuner.datasets.create_dataset`` and loss is
+  reported through ``TrainingCallback.on_train_loss_report``.
+- LoRA layers are applied with ``mlx_lm.tuner.utils.linear_to_lora_layers``
+  (the previous wrapper never applied LoRA, which would have silently
+  full-fine-tuned the model).
+- Implements the CLI trainer contract: ``train()`` accepts the common kwargs
+  (display/tracker/run_id/resume_from_checkpoint) and returns the metrics
+  dict that ``commands/train.py`` expects.
 """
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
-from typing import Optional
 
 from rich.console import Console
 
@@ -70,51 +77,149 @@ class MLXSFTTrainerWrapper:
         )
         self._dataset = dataset
 
-    def train(self, resume_from: Optional[str] = None) -> None:
-        """Run MLX training loop.
+    def _apply_lora(self, model) -> None:
+        """Convert the configured linear layers to LoRA (mlx-lm >= 0.31).
 
-        This is a thin driver that delegates to ``mlx_lm.lora.train`` when
-        available. A proper streaming Rich callback bridge can be added in a
-        follow-up release once the mlx-lm training API stabilizes.
+        The model must be frozen first: ``mlx_lm.load`` does NOT freeze, and
+        without it every parameter is trainable and the saved "adapter" is
+        actually a full fine-tune (172 tensors instead of ~64 LoRA weights).
         """
+        model.freeze()
+        from mlx_lm.tuner.utils import linear_to_lora_layers
+
+        cfg = self.config
+        lora_cfg = cfg.training.lora
+        target_keys = lora_cfg.target_modules
+        if not target_keys or target_keys == ["auto"] or target_keys == "auto":
+            target_keys = ["self_attn.q_proj", "self_attn.v_proj"]
+        keys = set(target_keys)
+        num_layers = len(getattr(model, "layers", []))
+        linear_to_lora_layers(
+            model,
+            num_layers,
+            {
+                "rank": int(lora_cfg.r),
+                "scale": float(lora_cfg.alpha) / max(1.0, float(lora_cfg.r)),
+                "dropout": 0.0,
+                "keys": keys,
+            },
+        )
+
+    def train(self, display=None, tracker=None, run_id=None, resume_from_checkpoint=None) -> dict:
+        """Run MLX training loop via mlx-lm (mlx-lm >= 0.31 API)."""
+        del display, tracker, run_id, resume_from_checkpoint  # unused on MLX path
+
         self._require_mlx()
 
+        import mlx.optimizers as optim  # type: ignore
+        from mlx_lm.tuner.callbacks import TrainingCallback
+        from mlx_lm.tuner.datasets import CacheDataset, create_dataset
         from mlx_lm.tuner.trainer import TrainingArgs, train  # type: ignore
 
         cfg = self.config
         output_dir = Path(cfg.output)
         output_dir.mkdir(parents=True, exist_ok=True)
 
+        if self.model is None or self.tokenizer is None:
+            self.setup({})
+
+        self._apply_lora(self.model)
+
         batch_size = (
             int(cfg.training.batch_size)
             if isinstance(cfg.training.batch_size, int)
             else 1
         )
-        iters = int(
-            cfg.training.epochs * max(1, len(self._dataset.get("train", [])))
-        )
+        train_rows = list(self._dataset.get("train", []))
+        val_rows = list(self._dataset.get("val", []))
+        iters = int(cfg.training.epochs * max(1, len(train_rows)))
+
+        max_seq_length = int(getattr(cfg.data, "max_length", 2048) or 2048)
         args = TrainingArgs(
             batch_size=batch_size,
             iters=iters,
-            steps_per_report=cfg.training.logging_steps,
-            steps_per_eval=cfg.training.save_steps,
+            max_seq_length=max_seq_length,
+            steps_per_report=10,
+            steps_per_eval=max(1000, iters + 1),
+            steps_per_save=iters,
             adapter_file=str(output_dir / "adapters.safetensors"),
         )
 
-        # mlx_lm.tuner.trainer.train requires a real optimizer — passing None
-        # left the model untrained (AttributeError on optimizer.update, or a
-        # silent no-op checkpoint). Build an AdamW from the configured LR.
-        import mlx.optimizers as optim  # type: ignore
+        train_dataset = CacheDataset(create_dataset(train_rows, self.tokenizer, args))
+        val_dataset = (
+            CacheDataset(create_dataset(val_rows, self.tokenizer, args))
+            if val_rows
+            else None
+        )
 
         optimizer = optim.AdamW(learning_rate=float(cfg.training.lr))
 
+        captured: dict = {}
+
+        class _Callback(TrainingCallback):
+            def on_train_loss_report(self, train_info: dict) -> None:
+                captured.setdefault("losses", []).append(
+                    train_info.get("train_loss", 0.0)
+                )
+
+        t0 = time.time()
         train(
             model=self.model,
-            tokenizer=self.tokenizer,
             optimizer=optimizer,
-            train_dataset=self._dataset.get("train", []),
-            val_dataset=self._dataset.get("val", []),
-            training_callback=None,
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
             args=args,
+            training_callback=_Callback(),
         )
+        duration = time.time() - t0
+
+        # mlx-lm's tuner only saves adapters.safetensors; write the
+        # adapter_config.json so the output dir is directly loadable with
+        # mlx_lm.load(..., adapter_path=output).
+        import json as _json
+
+        lora_cfg = cfg.training.lora
+        (output_dir / "adapter_config.json").write_text(
+            _json.dumps(
+                {
+                    "fine_tune_type": "lora",
+                    "model": str(cfg.base),
+                    "num_layers": len(getattr(self.model, "layers", [])),
+                    "batch_size": batch_size,
+                    "iters": iters,
+                    "learning_rate": float(cfg.training.lr),
+                    "steps_per_report": args.steps_per_report,
+                    "steps_per_eval": args.steps_per_eval,
+                    "steps_per_save": args.steps_per_save,
+                    "max_seq_length": max_seq_length,
+                    "adapter_path": str(output_dir),
+                    "lora_parameters": {
+                        "rank": int(lora_cfg.r),
+                        "scale": float(lora_cfg.alpha)
+                        / max(1.0, float(lora_cfg.r)),
+                        "dropout": 0.0,
+                        "keys": list(
+                            lora_cfg.target_modules
+                            if isinstance(lora_cfg.target_modules, list)
+                            else [lora_cfg.target_modules]
+                        ),
+                    },
+                    "mask_prompt": False,
+                    "grad_checkpoint": False,
+                    "grad_accumulation_steps": 1,
+                },
+                indent=2,
+            )
+        )
+
+        losses = captured.get("losses") or [0.0]
+        result = {
+            "initial_loss": losses[0],
+            "final_loss": losses[-1],
+            "total_steps": iters,
+            "duration_secs": duration,
+            "duration": f"{duration:.0f}s",
+            "output_dir": str(output_dir),
+        }
         console.print(f"[green]MLX training complete:[/] {output_dir}")
+        return result

--- a/src/soup_cli/trainer/mlx_sft.py
+++ b/src/soup_cli/trainer/mlx_sft.py
@@ -33,6 +33,9 @@ class MLXSFTTrainerWrapper:
 
     def __init__(self, config: SoupConfig, **kwargs) -> None:
         self.config = config
+        # Accepted for CLI-contract parity (trainer_kwargs forward). Stored
+        # intentionally unused: trust_remote_code has no MLX meaning and
+        # load_mlx_model does not take it.
         self.extra_kwargs = kwargs
         self.model = None
         self.tokenizer = None
@@ -136,7 +139,9 @@ class MLXSFTTrainerWrapper:
         output_dir.mkdir(parents=True, exist_ok=True)
 
         if self.model is None or self.tokenizer is None:
-            self.setup({})
+            raise RuntimeError(
+                "MLX backend: setup(dataset) must be called before train()"
+            )
 
         self._apply_lora(self.model)
 
@@ -156,7 +161,9 @@ class MLXSFTTrainerWrapper:
         steps_per_save = int(getattr(cfg.training, "save_steps", 0) or 0)
         if steps_per_save <= 0:
             steps_per_save = iters
-        steps_per_eval = max(1000, iters + 1)
+        # Real eval cadence when a val split exists; otherwise the value is
+        # irrelevant (val_dataset stays None and mlx-lm skips evaluation).
+        steps_per_eval = max(1, iters // 4) if val_rows else max(1000, iters + 1)
         args = TrainingArgs(
             batch_size=batch_size,
             iters=iters,

--- a/src/soup_cli/trainer/mlx_sft.py
+++ b/src/soup_cli/trainer/mlx_sft.py
@@ -1,12 +1,14 @@
 """MLX SFT trainer — Apple Silicon fine-tuning via mlx-lm.
 
-Rewritten for mlx-lm >= 0.31 (v0.73.0 local fix):
+Rewritten for mlx-lm >= 0.31 (v0.73.0 fix, PR #362):
 - ``mlx_lm.tuner.trainer.train`` no longer takes a ``tokenizer`` argument;
-  datasets are built with ``mlx_lm.tuner.datasets.create_dataset`` and loss is
-  reported through ``TrainingCallback.on_train_loss_report``.
+  datasets are built with ``mlx_lm.tuner.datasets.create_dataset``, wrapped in
+  ``CacheDataset`` (bare ``ChatDataset`` lacks ``__len__``/``__getitem__``),
+  and loss is reported through ``TrainingCallback.on_train_loss_report``.
 - LoRA layers are applied with ``mlx_lm.tuner.utils.linear_to_lora_layers``
-  (the previous wrapper never applied LoRA, which would have silently
-  full-fine-tuned the model).
+  after ``model.freeze()``: ``mlx_lm.load`` does NOT freeze, and without it
+  every parameter is trainable and the saved "adapter" is actually a full
+  fine-tune (172 tensors vs 24 LoRA tensors on a 1.2B model).
 - Implements the CLI trainer contract: ``train()`` accepts the common kwargs
   (display/tracker/run_id/resume_from_checkpoint) and returns the metrics
   dict that ``commands/train.py`` expects.
@@ -14,6 +16,8 @@ Rewritten for mlx-lm >= 0.31 (v0.73.0 local fix):
 
 from __future__ import annotations
 
+import json
+import math
 import time
 from pathlib import Path
 
@@ -27,8 +31,9 @@ console = Console()
 class MLXSFTTrainerWrapper:
     """High-level wrapper for MLX supervised fine-tuning."""
 
-    def __init__(self, config: SoupConfig) -> None:
+    def __init__(self, config: SoupConfig, **kwargs) -> None:
         self.config = config
+        self.extra_kwargs = kwargs
         self.model = None
         self.tokenizer = None
         self.trainer = None
@@ -90,8 +95,12 @@ class MLXSFTTrainerWrapper:
         cfg = self.config
         lora_cfg = cfg.training.lora
         target_keys = lora_cfg.target_modules
-        if not target_keys or target_keys == ["auto"] or target_keys == "auto":
+        if not target_keys or target_keys in (["auto"], "auto"):
             target_keys = ["self_attn.q_proj", "self_attn.v_proj"]
+            console.print(
+                "[yellow]MLX backend: target_modules: auto cannot be resolved for "
+                f"all architectures; defaulting to {target_keys}[/]"
+            )
         keys = set(target_keys)
         num_layers = len(getattr(model, "layers", []))
         linear_to_lora_layers(
@@ -100,14 +109,20 @@ class MLXSFTTrainerWrapper:
             {
                 "rank": int(lora_cfg.r),
                 "scale": float(lora_cfg.alpha) / max(1.0, float(lora_cfg.r)),
-                "dropout": 0.0,
+                "dropout": float(getattr(lora_cfg, "dropout", 0.0) or 0.0),
                 "keys": keys,
             },
         )
 
     def train(self, display=None, tracker=None, run_id=None, resume_from_checkpoint=None) -> dict:
         """Run MLX training loop via mlx-lm (mlx-lm >= 0.31 API)."""
-        del display, tracker, run_id, resume_from_checkpoint  # unused on MLX path
+        del display, tracker, run_id  # accepted for CLI-contract parity
+
+        if resume_from_checkpoint is not None:
+            console.print(
+                "[yellow]MLX backend does not support --resume yet; "
+                "starting training from scratch.[/]"
+            )
 
         self._require_mlx()
 
@@ -132,16 +147,23 @@ class MLXSFTTrainerWrapper:
         )
         train_rows = list(self._dataset.get("train", []))
         val_rows = list(self._dataset.get("val", []))
-        iters = int(cfg.training.epochs * max(1, len(train_rows)))
+        iters = int(
+            cfg.training.epochs * max(1, math.ceil(len(train_rows) / batch_size))
+        )
 
         max_seq_length = int(getattr(cfg.data, "max_length", 2048) or 2048)
+        steps_per_report = int(getattr(cfg.training, "logging_steps", 10) or 10)
+        steps_per_save = int(getattr(cfg.training, "save_steps", 0) or 0)
+        if steps_per_save <= 0:
+            steps_per_save = iters
+        steps_per_eval = max(1000, iters + 1)
         args = TrainingArgs(
             batch_size=batch_size,
             iters=iters,
             max_seq_length=max_seq_length,
-            steps_per_report=10,
-            steps_per_eval=max(1000, iters + 1),
-            steps_per_save=iters,
+            steps_per_report=steps_per_report,
+            steps_per_eval=steps_per_eval,
+            steps_per_save=steps_per_save,
             adapter_file=str(output_dir / "adapters.safetensors"),
         )
 
@@ -176,11 +198,9 @@ class MLXSFTTrainerWrapper:
         # mlx-lm's tuner only saves adapters.safetensors; write the
         # adapter_config.json so the output dir is directly loadable with
         # mlx_lm.load(..., adapter_path=output).
-        import json as _json
-
         lora_cfg = cfg.training.lora
         (output_dir / "adapter_config.json").write_text(
-            _json.dumps(
+            json.dumps(
                 {
                     "fine_tune_type": "lora",
                     "model": str(cfg.base),
@@ -188,16 +208,16 @@ class MLXSFTTrainerWrapper:
                     "batch_size": batch_size,
                     "iters": iters,
                     "learning_rate": float(cfg.training.lr),
-                    "steps_per_report": args.steps_per_report,
-                    "steps_per_eval": args.steps_per_eval,
-                    "steps_per_save": args.steps_per_save,
+                    "steps_per_report": steps_per_report,
+                    "steps_per_eval": steps_per_eval,
+                    "steps_per_save": steps_per_save,
                     "max_seq_length": max_seq_length,
                     "adapter_path": str(output_dir),
                     "lora_parameters": {
                         "rank": int(lora_cfg.r),
                         "scale": float(lora_cfg.alpha)
                         / max(1.0, float(lora_cfg.r)),
-                        "dropout": 0.0,
+                        "dropout": float(getattr(lora_cfg, "dropout", 0.0) or 0.0),
                         "keys": list(
                             lora_cfg.target_modules
                             if isinstance(lora_cfg.target_modules, list)

--- a/tests/test_mlx_dispatch.py
+++ b/tests/test_mlx_dispatch.py
@@ -1,0 +1,91 @@
+"""Dispatch tests for the MLX backend (PR #362).
+
+The original bug: `backend: mlx` silently fell through to the transformers
+trainer because commands/train.py branched on task only. These tests pin the
+backend-first resolution through `resolve_trainer` so the CLI can never
+silently ignore the backend again.
+
+Note: the config schema already rejects `backend: mlx` for non-SFT tasks
+("MLX backend only ships SFT..."), so the registry-level rejection in
+`get_mlx_trainer` is a second line of defence for callers that bypass the
+schema validator.
+"""
+
+import pytest
+
+
+def _cfg(backend, task):
+    from soup_cli.config.loader import load_config_from_string
+
+    return load_config_from_string(
+        "base: mlx-community/tiny\n"
+        f"task: {task}\n"
+        f"backend: {backend}\n"
+        "data: {train: d.jsonl, format: chatml}\n"
+        "training: {epochs: 1, lr: 2e-4, batch_size: 1}\n"
+        "output: ./out\n"
+    )
+
+
+def test_mlx_registry_resolves_known_trainers():
+    from soup_cli.trainer.mlx_dpo import MLXDPOTrainerWrapper
+    from soup_cli.trainer.mlx_grpo import MLXGRPOTrainerWrapper
+    from soup_cli.trainer.mlx_routing import get_mlx_trainer
+    from soup_cli.trainer.mlx_sft import MLXSFTTrainerWrapper
+
+    assert get_mlx_trainer("sft") is MLXSFTTrainerWrapper
+    assert get_mlx_trainer("dpo") is MLXDPOTrainerWrapper
+    assert get_mlx_trainer("grpo") is MLXGRPOTrainerWrapper
+
+
+def test_mlx_registry_rejects_unknown_task_loudly():
+    from soup_cli.trainer.mlx_routing import get_mlx_trainer
+
+    with pytest.raises(
+        ValueError, match="MLX backend does not support task 'pretrain'"
+    ):
+        get_mlx_trainer("pretrain")
+
+
+def test_mlx_backend_resolves_sft_trainer():
+    from soup_cli.trainer.mlx_routing import resolve_trainer
+    from soup_cli.trainer.mlx_sft import MLXSFTTrainerWrapper
+
+    cls, kwargs = resolve_trainer(_cfg("mlx", "sft"))
+    assert cls is MLXSFTTrainerWrapper
+    assert kwargs == {}
+
+
+def test_transformers_backend_falls_through_to_task_chain():
+    from soup_cli.trainer.mlx_routing import resolve_trainer
+
+    cls, kwargs = resolve_trainer(_cfg("transformers", "sft"))
+    assert cls is None
+    assert kwargs == {}
+
+
+def test_resolve_trainer_forwards_trainer_kwargs():
+    from soup_cli.trainer.mlx_routing import resolve_trainer
+
+    cls, kwargs = resolve_trainer(
+        _cfg("mlx", "sft"), {"trust_remote_code": True, "device": "cpu"}
+    )
+    assert cls is not None
+    assert kwargs == {"trust_remote_code": True, "device": "cpu"}
+
+
+def test_schema_rejects_mlx_for_non_sft_tasks():
+    """The schema gate (#270 prerequisite): mlx + dpo/grpo/ppo must not
+    reach the trainer dispatch with a silent fallthrough."""
+    from soup_cli.config.loader import load_config_from_string
+
+    for task in ("dpo", "grpo", "ppo"):
+        with pytest.raises(ValueError, match="MLX backend"):
+            load_config_from_string(
+                "base: mlx-community/tiny\n"
+                f"task: {task}\n"
+                "backend: mlx\n"
+                "data: {train: d.jsonl, format: chatml}\n"
+                "training: {epochs: 1, lr: 2e-4, batch_size: 1}\n"
+                "output: ./out\n"
+            )

--- a/tests/test_review_fixes_v07133.py
+++ b/tests/test_review_fixes_v07133.py
@@ -324,6 +324,9 @@ class TestMlxOptimizer:
         wrapper.tokenizer = object()
         wrapper._dataset = {"train": [{"messages": []}], "val": []}
         monkeypatch.setattr(wrapper, "_require_mlx", lambda: None)
+        # v0.73.0 rewrite: LoRA application is exercised elsewhere; stub it
+        # here so the optimizer contract is what this test asserts.
+        monkeypatch.setattr(wrapper, "_apply_lora", lambda model: None)
 
         seen: dict = {}
 
@@ -340,6 +343,18 @@ class TestMlxOptimizer:
         trainer_mod.TrainingArgs = _FakeArgs
         trainer_mod.train = _fake_train
         tuner_mod = types.ModuleType("mlx_lm.tuner")
+        tuner_mod.__path__ = []  # mark as package so submodules import
+
+        class _FakeCallback:
+            def on_train_loss_report(self, train_info):
+                pass
+
+        callbacks_mod = types.ModuleType("mlx_lm.tuner.callbacks")
+        callbacks_mod.TrainingCallback = _FakeCallback
+        datasets_mod = types.ModuleType("mlx_lm.tuner.datasets")
+        datasets_mod.CacheDataset = lambda ds: ds
+        datasets_mod.create_dataset = lambda data, tokenizer, args: data
+
         mlx_lm_mod = types.ModuleType("mlx_lm")
         opt_mod = types.ModuleType("mlx.optimizers")
         opt_mod.AdamW = lambda learning_rate=None: sentinel
@@ -350,6 +365,8 @@ class TestMlxOptimizer:
         monkeypatch.setitem(sys.modules, "mlx_lm", mlx_lm_mod)
         monkeypatch.setitem(sys.modules, "mlx_lm.tuner", tuner_mod)
         monkeypatch.setitem(sys.modules, "mlx_lm.tuner.trainer", trainer_mod)
+        monkeypatch.setitem(sys.modules, "mlx_lm.tuner.callbacks", callbacks_mod)
+        monkeypatch.setitem(sys.modules, "mlx_lm.tuner.datasets", datasets_mod)
 
         wrapper.train()
         assert "optimizer" in seen


### PR DESCRIPTION
## Summary

`backend: mlx` is broken for `task: sft` in v0.73.0: `commands/train.py` always dispatches `sft` to the transformers `SFTTrainerWrapper`, so training silently runs on MPS/CUDA instead of MLX. The `MLXSFTTrainerWrapper` exists but was never wired into the CLI dispatch (only referenced from `trainer/mlx_routing.py`, which the CLI doesn't use).

This PR wires the dispatch and rewrites `trainer/mlx_sft.py` for the current mlx-lm API (tested against mlx-lm 0.31.3).

## Changes

**`src/soup_cli/commands/train.py`**
- Dispatch `backend: mlx` + `task: sft` to `MLXSFTTrainerWrapper` before falling through to the transformers wrapper.

**`src/soup_cli/trainer/mlx_sft.py`** (rewritten for mlx-lm >= 0.31)
1. **Dataset API**: `mlx_lm.tuner.trainer.train` no longer accepts a `tokenizer` argument. Datasets are built with `mlx_lm.tuner.datasets.create_dataset` and must be wrapped in `CacheDataset` — a bare `ChatDataset` lacks `__len__`/`__getitem__` and crashes with `KeyError: 0` inside `iterate_batches`.
2. **Freeze before LoRA (critical)**: `mlx_lm.load` does NOT freeze the model. Without `model.freeze()` before `linear_to_lora_layers`, every parameter is trainable and the saved "adapter" is actually a full fine-tune (172 tensors / 9.4 GB peak on a 1.2B model). With the fix: 24 LoRA tensors / 3.0 GB peak.
3. **CLI contract**: `train()` now accepts the common kwargs (`display` / `tracker` / `run_id` / `resume_from_checkpoint`) and returns the metrics dict the CLI expects (`initial_loss`, `final_loss`, `total_steps`, `duration_secs`, `duration`, `output_dir`) — previously it crashed with `KeyError: 'duration'`.
4. **adapter_config.json**: mlx-lm's tuner only writes `adapters.safetensors`. The wrapper now writes `adapter_config.json` next to it so the output dir is directly loadable with `mlx_lm.load(..., adapter_path=dir)`.

## Verification

End-to-end on Apple Silicon (Mac mini M4, MLX backend, LFM2.5-1.2B-Instruct converted to MLX, 54 training rows, 1 epoch, LoRA r=16 on `self_attn.q_proj`/`self_attn.v_proj`):

- Training runs on MLX (Metal): 21s, ~648 tok/s, 3.0 GB peak memory
- Loss: 3.67 -> 0.51
- Saved adapter contains only LoRA weights (24 tensors)
- Model emits LFM tool calls (`<|tool_call_start|>{...}<|tool_call_end|>`) after one epoch on a tiny sample

## Notes

- Only `sft` is covered here. The `mlx_dpo` / `mlx_grpo` wrappers exist but were not wired or tested in this PR — they can follow the same pattern once verified.
- `target_modules: auto` does not resolve for LFM/LFM2 architectures; users should pass explicit keys (e.g. `[self_attn.q_proj, self_attn.v_proj]`).
