### PR TITLE
fix(sft): #351 - checkpoint-* adapters kept torch.compile's key prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,9 +63,17 @@ reproducing 70+ versions of notes.
   does not warn (it hands the missing keys back in the load result instead, which
   nothing reads), while `load_state_dict(strict=False)` discards the `_orig_mod.` keys
   without a word. A resumed run therefore continues from a re-zeroed `lora_B` in total
-  silence: #335's failure shape with its one warning removed. Normalising now happens
-  on HF's `on_save`, as each checkpoint is written, guarded to the main process because
-  `save_model` writes on one rank while `on_save` fires on all of them.
+  silence: #335's failure shape with its one warning removed. `load_best_model_at_end`
+  was reloading a dead adapter for the same reason, since the Trainer restores
+  `state.best_model_checkpoint` through that same `load_adapter`, and this repairs that
+  path too. Normalising now happens on HF's `on_save`, as each checkpoint is written.
+  Both that callback and the final save are gated on `args.should_save`, the condition
+  `save_model` writes under, so exactly the rank holding the file repairs it rather
+  than all eight opening it at once. The callback is attached in `setup()`, ahead of
+  anything a caller adds later: `HFPushCallback.on_save` uploads `checkpoint-{step}` on
+  this same event and `CallbackHandler` dispatches in insertion order, so a
+  normalisation attached after it would leave `--push-as` publishing the prefixed
+  adapter and keeping the repaired one on local disk.
 
 ## [0.73.0] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,22 @@ reproducing 70+ versions of notes.
   `training.seed` / `training.data_seed` so it is greppable as written. A warning, not a
   rejection: a config valid on transformers should not become unloadable by switching
   backend. Seeding MLX for real is separate work with a separate RNG.
+- **Under `use_fsdp2_compile`, every `checkpoint-*` still loads as a dead adapter
+  (#351).** #335's repair runs once, on the output root, after the final `save_model`.
+  HF's Trainer writes its periodic checkpoints through that same `save_model` with
+  `output_dir=<run>/checkpoint-N`, so they come out carrying `_orig_mod.` on every key
+  and nothing ever normalised them. Measured at 70B on 8×H100
+  (`benchmarks/gate-h100-validation.md`, STEP 28): 320 canonical keys in the output
+  root, **320 prefixed ones in `checkpoint-100`**. Resuming is the case that decides
+  how bad this is, and it is worse than #335 was.
+  `PeftModel.from_pretrained` at least warns; `Trainer._load_from_checkpoint` calls
+  `model.load_adapter(...)` and drops its return value, and `load_adapter` deliberately
+  does not warn (it hands the missing keys back in the load result instead, which
+  nothing reads), while `load_state_dict(strict=False)` discards the `_orig_mod.` keys
+  without a word. A resumed run therefore continues from a re-zeroed `lora_B` in total
+  silence: #335's failure shape with its one warning removed. Normalising now happens
+  on HF's `on_save`, as each checkpoint is written, guarded to the main process because
+  `save_model` writes on one rank while `on_save` fires on all of them.
 
 ## [0.73.0] - 2026-08-09
 

--- a/src/soup_cli/trainer/sft.py
+++ b/src/soup_cli/trainer/sft.py
@@ -659,6 +659,23 @@ class SFTTrainerWrapper(StreamingSetupMixin):
         self._output_dir = str(output_dir)
         self._batch_size = batch_size
 
+        # #351: normalise every `checkpoint-*` adapter as the Trainer writes it.
+        # The final save is repaired at the end of `train()`; HF dispatches
+        # `on_save` only for the periodic checkpoints, so the two call sites
+        # cover different files and neither is redundant.
+        #
+        # Attached in `setup()` rather than alongside the other callbacks in
+        # `train()` because `CallbackHandler.call_event` dispatches in insertion
+        # order and `HFPushCallback.on_save` UPLOADS `checkpoint-{step}` on this
+        # same event. `--push-as` adds that callback straight to this trainer
+        # once `setup()` has returned (`commands/train.py`), so a normalisation
+        # attached any later than it would publish the prefixed adapter and keep
+        # the repaired one to itself. Being ahead of anything the caller adds is
+        # the whole point of the position.
+        from soup_cli.utils.peft_wiring import attach_compile_prefix_callback
+
+        attach_compile_prefix_callback(self.trainer, tcfg, self._output_dir, console)
+
     def _prepare_raft_dataset(self, dataset: dict, cfg, tcfg):
         """v0.71.10 #199 — build pre-tokenised RAFT rows (answer-only mask).
 
@@ -1429,7 +1446,6 @@ class SFTTrainerWrapper(StreamingSetupMixin):
 
         # ReLoRA callback (v0.39.0 Part B / v0.40.6 #67) via shared helper.
         from soup_cli.utils.peft_wiring import (
-            attach_compile_prefix_callback,
             attach_curriculum_callback,
             attach_lisa_callback,
             attach_plugin_callback,
@@ -1444,13 +1460,6 @@ class SFTTrainerWrapper(StreamingSetupMixin):
         )
         # v0.53.6 #101 — Soup plugin TrainerCallback.
         attach_plugin_callback(self.trainer, console)
-        # #351: normalise every checkpoint-* adapter as it is written. The
-        # final save is repaired separately at the end of this method; HF
-        # dispatches on_save only for the periodic checkpoints, so the two call
-        # sites cover different files and neither is redundant.
-        attach_compile_prefix_callback(
-            self.trainer, self.config.training, self._output_dir, console
-        )
 
         # v0.53.2 #135 — EBFT compute_loss hook (no-op if ebft_variant unset).
         from soup_cli.utils.ebft_gdpo import attach_ebft_compute_loss
@@ -1510,10 +1519,18 @@ class SFTTrainerWrapper(StreamingSetupMixin):
         # non-zero against 96/96 for the paired non-compile run.
         # #351: this call covers the FINAL save only. The periodic
         # `checkpoint-*` directories are written by the same `save_model` and are
-        # normalised by attach_compile_prefix_callback above, which runs on HF's
+        # normalised by the callback `setup()` attaches, which runs on HF's
         # `on_save` event. `on_save` is not dispatched for the save below, so
         # both are needed.
-        if getattr(self.config.training, "use_fsdp2_compile", False):
+        #
+        # Gated on `args.should_save` for the reason the callback is: that is the
+        # condition `save_model` gates the write on, so it names the rank that
+        # actually has a file here to repair. Eight ranks opening and rewriting
+        # one adapter is safe only by accident, and `os.replace` on a shared
+        # filesystem is not the guarantee it is on local disk.
+        if getattr(self.config.training, "use_fsdp2_compile", False) and getattr(
+            self.trainer.args, "should_save", True
+        ):
             from soup_cli.utils.peft_wiring import strip_compile_prefix
 
             renamed = strip_compile_prefix(self._output_dir)

--- a/src/soup_cli/trainer/sft.py
+++ b/src/soup_cli/trainer/sft.py
@@ -1429,6 +1429,7 @@ class SFTTrainerWrapper(StreamingSetupMixin):
 
         # ReLoRA callback (v0.39.0 Part B / v0.40.6 #67) via shared helper.
         from soup_cli.utils.peft_wiring import (
+            attach_compile_prefix_callback,
             attach_curriculum_callback,
             attach_lisa_callback,
             attach_plugin_callback,
@@ -1443,6 +1444,13 @@ class SFTTrainerWrapper(StreamingSetupMixin):
         )
         # v0.53.6 #101 — Soup plugin TrainerCallback.
         attach_plugin_callback(self.trainer, console)
+        # #351: normalise every checkpoint-* adapter as it is written. The
+        # final save is repaired separately at the end of this method; HF
+        # dispatches on_save only for the periodic checkpoints, so the two call
+        # sites cover different files and neither is redundant.
+        attach_compile_prefix_callback(
+            self.trainer, self.config.training, self._output_dir, console
+        )
 
         # v0.53.2 #135 — EBFT compute_loss hook (no-op if ebft_variant unset).
         from soup_cli.utils.ebft_gdpo import attach_ebft_compute_loss
@@ -1500,6 +1508,11 @@ class SFTTrainerWrapper(StreamingSetupMixin):
         # none of them: it warns and leaves lora_B at zero init, i.e. the run
         # exits 0 having written an adapter that does nothing. Measured 0/96
         # non-zero against 96/96 for the paired non-compile run.
+        # #351: this call covers the FINAL save only. The periodic
+        # `checkpoint-*` directories are written by the same `save_model` and are
+        # normalised by attach_compile_prefix_callback above, which runs on HF's
+        # `on_save` event. `on_save` is not dispatched for the save below, so
+        # both are needed.
         if getattr(self.config.training, "use_fsdp2_compile", False):
             from soup_cli.utils.peft_wiring import strip_compile_prefix
 

--- a/src/soup_cli/utils/peft_wiring.py
+++ b/src/soup_cli/utils/peft_wiring.py
@@ -13,6 +13,7 @@ training never crashes because a Gemma4 swap or 3-D dropout strip failed.
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -556,3 +557,138 @@ def strip_compile_prefix(output_dir: str) -> int:
             os.unlink(tmp_path)
         raise
     return changed
+
+
+def _build_compile_prefix_callback_class() -> type:
+    """Construct ``CompilePrefixCallback`` with transformers as its parent.
+
+    Built inside a function rather than at module scope so importing this module
+    stays free of transformers: every transformer-backend trainer imports it for
+    the ``attach_*`` helpers above, and today that import pulls in neither
+    transformers nor torch. Mirrors
+    ``monitoring/plugin_callback._build_callback_class``.
+    """
+    from rich.markup import escape
+    from transformers import TrainerCallback
+
+    class CompilePrefixCallback(TrainerCallback):
+        """Normalise each ``checkpoint-*`` adapter as the Trainer writes it.
+
+        #351: :func:`strip_compile_prefix` ran once, on ``self._output_dir``
+        after the final ``save_model``. The HF Trainer writes its periodic
+        checkpoints through that SAME ``save_model``, with
+        ``output_dir=<run>/checkpoint-N``, so they come out carrying the prefix
+        exactly as the final save did and nothing ever repaired them. Measured
+        at 70B on 8xH100: 320 canonical keys in the output root, 320 prefixed
+        ones in ``checkpoint-100``.
+
+        Resuming is the case that decides how bad that is.
+        ``PeftModel.from_pretrained`` at least warns.
+        ``Trainer._load_from_checkpoint`` calls ``model.load_adapter(...)`` and
+        drops the return value, and ``load_adapter`` deliberately does not warn
+        (it returns the missing keys in the load result instead), while the
+        unexpected ``_orig_mod.`` keys are dropped by
+        ``load_state_dict(strict=False)``. So a resumed run silently continues
+        from a re-zeroed ``lora_B``, which is #335's failure with its one
+        warning removed.
+
+        Subclasses ``TrainerCallback`` so it inherits the no-op default for
+        every other event: HF's ``CallbackHandler.call_event`` dispatches via
+        ``getattr(cb, event)`` with no ``hasattr`` guard, so a duck-typed
+        callback survives wiring and then dies on ``on_epoch_begin`` (#308).
+        """
+
+        def __init__(self, output_dir: str = "", console: Any = None) -> None:
+            super().__init__()
+            # Fallback only: under real training the run directory comes from
+            # ``args.output_dir``. Mirrors HFPushCallback.
+            self.output_dir = output_dir
+            self.console = console
+
+        def on_save(self, args, state, control, **kwargs) -> None:
+            """Normalise the checkpoint ``_save_checkpoint`` has just written."""
+            # ``save_model`` writes the adapter only where ``args.should_save``
+            # is true, but this event is dispatched on every rank. Without the
+            # guard all 8 ranks of the run this was measured on would rewrite
+            # one file at once. Default True so a single-process run (and a
+            # test driving the callback directly) still does the work.
+            if not getattr(state, "is_world_process_zero", True):
+                return
+            step = int(getattr(state, "global_step", 0) or 0)
+            if step <= 0:
+                return
+            output_dir = getattr(args, "output_dir", None) or self.output_dir
+            if not output_dir:
+                return
+
+            checkpoint = os.path.join(output_dir, f"checkpoint-{step}")
+            try:
+                renamed = strip_compile_prefix(checkpoint)
+            except Exception as exc:  # noqa: BLE001
+                # Never take a multi-hour run down over one checkpoint: the
+                # rewrite is atomic, so the prefixed file is still there and
+                # still holds the trained numbers. But say so loudly: the
+                # checkpoint that was left alone is a dead adapter, and a dead
+                # adapter nobody hears about is the entire defect.
+                message = (
+                    f"could not normalise {checkpoint}: {exc}. It keeps "
+                    "torch.compile's key prefix, so it will load as an adapter "
+                    "of zeros; the run directory's final save is unaffected."
+                )
+                logger.warning("CompilePrefixCallback: %s", message)
+                # escape: the path and the exception text are both interpolated,
+                # and an unescaped `[` in either would be eaten as Rich markup.
+                self._print(f"[yellow]{escape(message)}[/]")
+                return
+            if renamed:
+                self._print(
+                    f"[dim]Normalised {renamed} adapter keys in "
+                    f"checkpoint-{step} saved through torch.compile's wrapper[/]"
+                )
+
+        def _print(self, message: str) -> None:
+            if self.console is None:
+                return
+            try:
+                self.console.print(message)
+            except Exception:  # noqa: BLE001 (never crash on console issues)
+                pass
+
+    return CompilePrefixCallback
+
+
+def build_compile_prefix_callback(output_dir: str = "", console: Any = None) -> Any:
+    """Return a ``CompilePrefixCallback`` for ``output_dir``."""
+    callback_cls = _build_compile_prefix_callback_class()
+    return callback_cls(output_dir=output_dir, console=console)
+
+
+def attach_compile_prefix_callback(
+    trainer: Any,
+    tcfg: Any,
+    output_dir: str,
+    console: Any = None,
+) -> bool:
+    """Attach :class:`CompilePrefixCallback` when ``use_fsdp2_compile`` is set.
+
+    Returns ``True`` when attached, ``False`` otherwise. Gated on
+    ``use_fsdp2_compile`` alone, matching the final-save call site in
+    ``sft.py``: ``torch_compile`` is only really switched on when an FSDP config
+    is present too (see :func:`utils.fsdp.apply_fsdp_training_kwargs`), but
+    :func:`strip_compile_prefix` is a no-op on an adapter that has no prefix, so
+    the narrower condition would buy nothing and let the two gates drift.
+
+    Args:
+        trainer: HF Trainer (or duck-typed equivalent with ``add_callback``).
+        tcfg: ``SoupConfig.training`` model.
+        output_dir: The run directory HF writes ``checkpoint-N`` under. Used
+            only if ``TrainingArguments.output_dir`` is missing at save time.
+        console: Optional Rich Console, for the same per-save note the final
+            save prints.
+    """
+    if not getattr(tcfg, "use_fsdp2_compile", False):
+        return False
+    trainer.add_callback(
+        build_compile_prefix_callback(output_dir=output_dir, console=console)
+    )
+    return True

--- a/src/soup_cli/utils/peft_wiring.py
+++ b/src/soup_cli/utils/peft_wiring.py
@@ -612,7 +612,15 @@ def _build_compile_prefix_callback_class() -> type:
             # guard all 8 ranks of the run this was measured on would rewrite
             # one file at once. Default True so a single-process run (and a
             # test driving the callback directly) still does the work.
-            if not getattr(state, "is_world_process_zero", True):
+            #
+            # ``args.should_save`` rather than ``state.is_world_process_zero``
+            # because it is the same condition that decided whether this rank
+            # wrote the file at all: ``TrainingArguments.should_save`` is
+            # ``local_process_index == 0`` under ``save_on_each_node`` and
+            # ``process_index == 0`` otherwise. Under ``save_on_each_node`` the
+            # two disagree, and every node but the first would then keep a
+            # checkpoint it had written and never repaired.
+            if not getattr(args, "should_save", True):
                 return
             step = int(getattr(state, "global_step", 0) or 0)
             if step <= 0:

--- a/tests/test_v07300.py
+++ b/tests/test_v07300.py
@@ -49,6 +49,7 @@ one bf16 ulp: worst 3.95e-3 relative to scale against 2^-8 = 3.9e-3.
 
 import os
 import sys
+import types
 
 import pytest
 
@@ -505,6 +506,27 @@ class TestMultiGpuLaunchArgvIsRunnable:
 # ==========================================================================
 # #335 — use_fsdp2_compile wrote an adapter that reloads as all zeros
 # ==========================================================================
+def _write_adapter(directory, prefix=""):
+    """Write a two-tensor LoRA adapter, optionally through torch.compile's prefix.
+
+    Module-level so #351's checkpoint tests below build the file the same way
+    #335's do. Both are assertions about one exact key spelling, and two copies
+    of the fixture that produces it would drift.
+    """
+    from safetensors.torch import save_file
+
+    directory.mkdir(parents=True, exist_ok=True)
+    tensors = {
+        f"{prefix}base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight":
+            torch.ones(4, 8),
+        f"{prefix}base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight":
+            torch.full((8, 4), 0.007),
+    }
+    path = directory / "adapter_model.safetensors"
+    save_file(tensors, str(path))
+    return path
+
+
 class TestCompiledAdapterKeysAreCanonical:
     """A run that completes, exits 0, and writes a file that silently does nothing.
 
@@ -524,26 +546,12 @@ class TestCompiledAdapterKeysAreCanonical:
     ``.inner.`` segment, and it is the worst one this project has: nothing raises.
     """
 
-    def _write_adapter(self, directory, prefix=""):
-        from safetensors.torch import save_file
-
-        directory.mkdir(parents=True, exist_ok=True)
-        tensors = {
-            f"{prefix}base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight":
-                torch.ones(4, 8),
-            f"{prefix}base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight":
-                torch.full((8, 4), 0.007),
-        }
-        path = directory / "adapter_model.safetensors"
-        save_file(tensors, str(path))
-        return path
-
     def test_the_compile_prefix_is_stripped(self, tmp_path):
         from safetensors.torch import load_file
 
         from soup_cli.utils.peft_wiring import strip_compile_prefix
 
-        path = self._write_adapter(tmp_path / "a", prefix="_orig_mod.")
+        path = _write_adapter(tmp_path / "a", prefix="_orig_mod.")
         changed = strip_compile_prefix(str(tmp_path / "a"))
         assert changed == 2, f"expected both keys rewritten, got {changed}"
         keys = set(load_file(str(path)))
@@ -558,7 +566,7 @@ class TestCompiledAdapterKeysAreCanonical:
 
         from soup_cli.utils.peft_wiring import strip_compile_prefix
 
-        path = self._write_adapter(tmp_path / "a", prefix="_orig_mod.")
+        path = _write_adapter(tmp_path / "a", prefix="_orig_mod.")
         strip_compile_prefix(str(tmp_path / "a"))
         loaded = load_file(str(path))
         b = loaded["base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight"]
@@ -572,7 +580,7 @@ class TestCompiledAdapterKeysAreCanonical:
 
         from soup_cli.utils.peft_wiring import strip_compile_prefix
 
-        path = self._write_adapter(tmp_path / "a")
+        path = _write_adapter(tmp_path / "a")
         before = set(load_file(str(path)))
         assert strip_compile_prefix(str(tmp_path / "a")) == 0
         assert set(load_file(str(path))) == before
@@ -584,6 +592,173 @@ class TestCompiledAdapterKeysAreCanonical:
 
         (tmp_path / "empty").mkdir()
         assert strip_compile_prefix(str(tmp_path / "empty")) == 0
+
+
+# ==========================================================================
+# #351: the repair above ran on the final save only
+# ==========================================================================
+def _fire_on_save(callback, output_dir, step, *, main_process=True):
+    """Drive one ``on_save`` the way HF's CallbackHandler does.
+
+    ``args`` / ``state`` are the two attributes the callback reads, so a
+    SimpleNamespace is the whole Trainer this needs, the same shape
+    ``tests/test_hf_integration.py`` uses to drive ``HFPushCallback.on_save``.
+    """
+    args = types.SimpleNamespace(output_dir=str(output_dir))
+    state = types.SimpleNamespace(global_step=step, is_world_process_zero=main_process)
+    control = types.SimpleNamespace()
+    callback.on_save(args, state, control)
+
+
+class TestCheckpointAdaptersAreCanonicalToo:
+    """#335's repair fires once, after the final ``save_model``. The
+    ``checkpoint-*`` directories written on the way there keep the prefix.
+
+    Both are written by the SAME ``Trainer.save_model`` (``_save_checkpoint``
+    calls it with ``output_dir=<run>/checkpoint-N``), so they come out identical
+    and only the last one was ever normalised. Measured at 70B on 8xH100
+    (``benchmarks/gate-h100-validation.md``, STEP 28): 320 canonical keys in the
+    output root, 320 prefixed ones in ``checkpoint-100``.
+
+    Resuming is the case that decides how bad this is. ``from_pretrained`` at
+    least warns. ``Trainer._load_from_checkpoint`` calls
+    ``model.load_adapter(...)`` and drops the return value, and ``load_adapter``
+    deliberately does not warn: it hands the missing keys back in the load
+    result instead, which nothing reads. The unexpected ``_orig_mod.`` keys go
+    to ``load_state_dict(strict=False)``, which discards them without a word. So
+    a resumed run continues from a re-zeroed ``lora_B`` in total silence: the
+    #335 failure shape with the last warning removed.
+    """
+
+    def test_a_checkpoint_written_under_compile_is_normalised(self, tmp_path):
+        from safetensors.torch import load_file
+
+        from soup_cli.utils.peft_wiring import build_compile_prefix_callback
+
+        path = _write_adapter(tmp_path / "checkpoint-100", prefix="_orig_mod.")
+        _fire_on_save(build_compile_prefix_callback(), tmp_path, 100)
+
+        keys = set(load_file(str(path)))
+        assert not any(k.startswith("_orig_mod.") for k in keys), keys
+        assert all(k.startswith("base_model.model.") for k in keys), keys
+
+    def test_the_trained_values_survive_in_a_checkpoint(self, tmp_path):
+        """The standard #335's repair was held to. A rename that loses the
+        numbers is the same defect wearing a different mechanism."""
+        from safetensors.torch import load_file
+
+        from soup_cli.utils.peft_wiring import build_compile_prefix_callback
+
+        path = _write_adapter(tmp_path / "checkpoint-100", prefix="_orig_mod.")
+        _fire_on_save(build_compile_prefix_callback(), tmp_path, 100)
+
+        loaded = load_file(str(path))
+        b = loaded["base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight"]
+        assert float(b.abs().max()) == pytest.approx(0.007), "trained values lost"
+
+    def test_a_repaired_checkpoint_is_byte_identical_to_an_uncompiled_one(
+        self, tmp_path
+    ):
+        """What ``resume_from_checkpoint`` actually needs.
+
+        A real resume needs FSDP2 and several GPUs, but the thing being resumed
+        is a file, and peft matches it by name. So the assertion that carries
+        the same weight off-GPU is that the repaired checkpoint is
+        indistinguishable from what the paired non-compile run writes: same
+        keys, same values. Anything peft finds in one it finds in the other.
+        """
+        from safetensors.torch import load_file
+
+        from soup_cli.utils.peft_wiring import build_compile_prefix_callback
+
+        repaired = _write_adapter(tmp_path / "checkpoint-100", prefix="_orig_mod.")
+        _fire_on_save(build_compile_prefix_callback(), tmp_path, 100)
+        reference = _write_adapter(tmp_path / "no-compile")
+
+        got, want = load_file(str(repaired)), load_file(str(reference))
+        assert set(got) == set(want)
+        for key, tensor in want.items():
+            assert torch.equal(got[key], tensor), key
+        assert all(float(v.abs().max()) > 0 for k, v in got.items() if "lora_B" in k)
+
+    def test_only_the_main_process_rewrites(self, tmp_path):
+        """``save_model`` writes the adapter only where ``args.should_save`` is
+        true, but ``on_save`` is dispatched on EVERY rank. Unguarded, the 8 ranks
+        of the run this was measured on would all rewrite one file at once."""
+        from safetensors.torch import load_file
+
+        from soup_cli.utils.peft_wiring import build_compile_prefix_callback
+
+        path = _write_adapter(tmp_path / "checkpoint-100", prefix="_orig_mod.")
+        before = set(load_file(str(path)))
+        _fire_on_save(build_compile_prefix_callback(), tmp_path, 100, main_process=False)
+        assert set(load_file(str(path))) == before
+
+    def test_a_checkpoint_without_an_adapter_is_not_an_error(self, tmp_path):
+        """Full fine-tuning checkpoints carry no adapter file. Mid-run is a worse
+        place to raise than the end of a run, so this must stay a no-op."""
+        from soup_cli.utils.peft_wiring import build_compile_prefix_callback
+
+        (tmp_path / "checkpoint-100").mkdir()
+        _fire_on_save(build_compile_prefix_callback(), tmp_path, 100)
+
+    def test_a_rewrite_that_fails_warns_and_keeps_training(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """A broken rewrite must not kill a multi-hour run, but it must not pass
+        in silence either, because a checkpoint left with the prefix is a dead
+        adapter and that is the whole bug."""
+        from soup_cli.utils import peft_wiring
+
+        _write_adapter(tmp_path / "checkpoint-100", prefix="_orig_mod.")
+
+        def boom(_output_dir):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(peft_wiring, "strip_compile_prefix", boom)
+        with caplog.at_level("WARNING"):
+            _fire_on_save(peft_wiring.build_compile_prefix_callback(), tmp_path, 100)
+
+        assert "checkpoint-100" in caplog.text, caplog.text
+
+    def test_the_callback_answers_every_trainer_event(self):
+        """#308. HF's ``CallbackHandler.call_event`` dispatches through
+        ``getattr(cb, event)`` with no ``hasattr`` guard, so a duck-typed
+        callback dies on the first ``on_epoch_begin`` rather than at wiring
+        time. Inheriting ``TrainerCallback`` is what supplies the no-op stubs."""
+        from transformers import TrainerCallback
+
+        from soup_cli.utils.peft_wiring import build_compile_prefix_callback
+
+        callback = build_compile_prefix_callback()
+        assert isinstance(callback, TrainerCallback)
+        callback.on_epoch_begin(
+            types.SimpleNamespace(), types.SimpleNamespace(), types.SimpleNamespace()
+        )
+
+    def test_it_is_wired_only_when_compile_is_on(self):
+        """CONTROL. Every ordinary run would otherwise carry a callback that
+        reopens each checkpoint for nothing."""
+        from soup_cli.utils.peft_wiring import attach_compile_prefix_callback
+
+        class FakeTrainer:
+            def __init__(self):
+                self.callbacks = []
+
+            def add_callback(self, callback):
+                self.callbacks.append(callback)
+
+        off = FakeTrainer()
+        assert attach_compile_prefix_callback(
+            off, types.SimpleNamespace(use_fsdp2_compile=False), "out"
+        ) is False
+        assert off.callbacks == []
+
+        on = FakeTrainer()
+        assert attach_compile_prefix_callback(
+            on, types.SimpleNamespace(use_fsdp2_compile=True), "out"
+        ) is True
+        assert len(on.callbacks) == 1
 
 
 # ==========================================================================

--- a/tests/test_v07300.py
+++ b/tests/test_v07300.py
@@ -597,15 +597,22 @@ class TestCompiledAdapterKeysAreCanonical:
 # ==========================================================================
 # #351: the repair above ran on the final save only
 # ==========================================================================
-def _fire_on_save(callback, output_dir, step, *, main_process=True):
+def _fire_on_save(callback, output_dir, step, *, should_save=True, world_zero=None):
     """Drive one ``on_save`` the way HF's CallbackHandler does.
 
     ``args`` / ``state`` are the two attributes the callback reads, so a
     SimpleNamespace is the whole Trainer this needs, the same shape
     ``tests/test_hf_integration.py`` uses to drive ``HFPushCallback.on_save``.
+
+    ``world_zero`` defaults to following ``should_save``, which is what every
+    run Soup can produce today does. Pass it explicitly to drive them apart, the
+    way ``save_on_each_node`` does.
     """
-    args = types.SimpleNamespace(output_dir=str(output_dir))
-    state = types.SimpleNamespace(global_step=step, is_world_process_zero=main_process)
+    args = types.SimpleNamespace(output_dir=str(output_dir), should_save=should_save)
+    state = types.SimpleNamespace(
+        global_step=step,
+        is_world_process_zero=should_save if world_zero is None else world_zero,
+    )
     control = types.SimpleNamespace()
     callback.on_save(args, state, control)
 
@@ -681,7 +688,7 @@ class TestCheckpointAdaptersAreCanonicalToo:
             assert torch.equal(got[key], tensor), key
         assert all(float(v.abs().max()) > 0 for k, v in got.items() if "lora_B" in k)
 
-    def test_only_the_main_process_rewrites(self, tmp_path):
+    def test_only_the_rank_that_wrote_the_file_rewrites(self, tmp_path):
         """``save_model`` writes the adapter only where ``args.should_save`` is
         true, but ``on_save`` is dispatched on EVERY rank. Unguarded, the 8 ranks
         of the run this was measured on would all rewrite one file at once."""
@@ -691,8 +698,37 @@ class TestCheckpointAdaptersAreCanonicalToo:
 
         path = _write_adapter(tmp_path / "checkpoint-100", prefix="_orig_mod.")
         before = set(load_file(str(path)))
-        _fire_on_save(build_compile_prefix_callback(), tmp_path, 100, main_process=False)
+        _fire_on_save(build_compile_prefix_callback(), tmp_path, 100, should_save=False)
         assert set(load_file(str(path))) == before
+
+    def test_a_writing_rank_that_is_not_world_zero_still_repairs(self, tmp_path):
+        """The reason the guard reads ``args.should_save`` and not
+        ``state.is_world_process_zero``.
+
+        ``TrainingArguments.should_save`` is ``local_process_index == 0`` when
+        ``save_on_each_node`` is set and ``process_index == 0`` otherwise, and
+        ``save_model`` gates the write on it. So under ``save_on_each_node`` the
+        local rank 0 of every node after the first writes a checkpoint while
+        reporting ``is_world_process_zero=False``, and a guard on world-zero
+        would leave exactly those nodes holding an unrepaired adapter. Soup sets
+        no such flag today, which is what makes this the kind of thing that goes
+        unnoticed until someone does.
+        """
+        from safetensors.torch import load_file
+
+        from soup_cli.utils.peft_wiring import build_compile_prefix_callback
+
+        path = _write_adapter(tmp_path / "checkpoint-100", prefix="_orig_mod.")
+        _fire_on_save(
+            build_compile_prefix_callback(),
+            tmp_path,
+            100,
+            should_save=True,
+            world_zero=False,
+        )
+
+        keys = set(load_file(str(path)))
+        assert not any(k.startswith("_orig_mod.") for k in keys), keys
 
     def test_a_checkpoint_without_an_adapter_is_not_an_error(self, tmp_path):
         """Full fine-tuning checkpoints carry no adapter file. Mid-run is a worse
@@ -910,3 +946,75 @@ class TestLigerDetectsArchitectureFromTheConfig:
         monkeypatch.setattr(liger_mod, "check_liger_available", lambda: True)
 
         assert liger_mod.apply_liger_kernel(str(directory)) is False
+
+
+# ==========================================================================
+# #351 review: the normalisation has to reach the file before anything
+# that PUBLISHES it does
+# ==========================================================================
+class TestTheNormalisationRunsBeforeAnythingThatPublishes:
+    """``HFPushCallback.on_save`` uploads ``checkpoint-{step}`` on the same event
+    this normalisation runs on, so the order the two are dispatched in decides
+    what ``--push-as`` puts on the Hub.
+
+    ``CallbackHandler.add_callback`` appends and ``call_event`` iterates in
+    insertion order, and ``--push-as`` adds its callback to the trainer after
+    ``setup()`` has returned (``commands/train.py``). Attaching the
+    normalisation in ``setup()`` is therefore what keeps it in front: attached in
+    ``train()`` instead, it landed second, the Hub received the prefixed adapter
+    and only local disk got the repaired one. That is the same dead-adapter
+    defect on the path where it is least recoverable, since what is published is
+    the dead file.
+
+    Asserted through the real ``callback_handler`` rather than by comparing list
+    indices, because the property that matters is what a later callback SEES.
+    """
+
+    def test_a_later_added_on_save_sees_the_repaired_keys(self, tmp_path, monkeypatch):
+        from pathlib import Path
+
+        from safetensors.torch import load_file
+        from transformers import TrainerCallback
+
+        wrapper = _sft_wrapper(tmp_path, monkeypatch, use_fsdp2_compile=True)
+        trainer = wrapper.trainer
+        seen = {}
+
+        class Spy(TrainerCallback):
+            """Stands in for ``HFPushCallback``: reads the checkpoint it is told
+            was just written, which is what an upload does."""
+
+            def on_save(self, args, state, control, **kwargs):
+                adapter = (
+                    Path(args.output_dir)
+                    / f"checkpoint-{state.global_step}"
+                    / "adapter_model.safetensors"
+                )
+                seen["keys"] = set(load_file(str(adapter)))
+
+        # Exactly what `--push-as` does, and it can only ever happen after
+        # `setup()` has run.
+        trainer.add_callback(Spy())
+
+        _write_adapter(
+            Path(trainer.args.output_dir) / "checkpoint-100", prefix="_orig_mod."
+        )
+        trainer.state.global_step = 100
+        trainer.control = trainer.callback_handler.on_save(
+            trainer.args, trainer.state, trainer.control
+        )
+
+        assert seen, "the spy's on_save never fired; the wiring changed shape"
+        assert not any(k.startswith("_orig_mod.") for k in seen["keys"]), (
+            f"a callback added after setup() saw the PREFIXED adapter, so "
+            f"--push-as would publish a dead one: {sorted(seen['keys'])}"
+        )
+
+    def test_the_callback_is_attached_by_setup_not_by_train(self, tmp_path, monkeypatch):
+        """The position itself, so a move back into ``train()`` fails here rather
+        than only in the subtler assertion above."""
+        wrapper = _sft_wrapper(tmp_path, monkeypatch, use_fsdp2_compile=True)
+        names = [
+            type(cb).__name__ for cb in wrapper.trainer.callback_handler.callbacks
+        ]
+        assert "CompilePrefixCallback" in names, names


### PR DESCRIPTION
## What does this PR do?

Fixes #351. `strip_compile_prefix` was called once, on the output root, after the final `save_model`, so every `checkpoint-*` directory written on the way there kept torch.compile's `_orig_mod.` prefix on all of its keys.

### Resuming is silent, not merely warned about

The issue describes the failure as loading "with only a `UserWarning`". That is true through one door and not the other, and I think the difference decides how this should be weighted:

- **`--adapter <checkpoint-N>`, i.e. `PeftModel.from_pretrained`, does warn.** peft filters the missing keys down to the adapter's own and calls `warnings.warn("Found missing adapter keys while loading the checkpoint: ...")`.
- **`resume_from_checkpoint` warns nothing at all.** `Trainer._load_from_checkpoint` calls `model.load_adapter(resume_from_checkpoint, active_adapter, is_trainable=True)` and discards the return value. `load_adapter` deliberately does not warn: it collects the missing keys into the `load_result` it hands back, and peft's own comment in `from_pretrained` says why it warns there and not in `load_adapter` ("Let's warn here since (in contrast to load_adapter) we don't return the load result"). Nothing reads that result. Meanwhile the 320 unexpected `_orig_mod.` keys go to `set_peft_model_state_dict`'s `load_state_dict(..., strict=False)`, which drops them without a word.

So resuming a 70B run from `checkpoint-100` throws away every step trained before it, continues from a re-zeroed `lora_B`, and prints nothing. That is #335's failure shape with its one warning removed, which makes the third acceptance criterion the one carrying the weight here.

### The fix

`CompilePrefixCallback.on_save` normalises `<output_dir>/checkpoint-<global_step>` as the Trainer writes it. Two notes on the shape:

- **Both call sites are needed.** HF dispatches `on_save` right after `_save_checkpoint` and never for the final `save_model`, so the callback covers the periodic checkpoints and the existing call at the end of `train()` covers the run directory. The comment at each site now says so, since the natural next edit is for somebody to delete one as redundant.
- **The callback is guarded to the main process.** `save_model` writes the adapter only where `args.should_save` is true, but `on_save` is dispatched on every rank, so without `state.is_world_process_zero` the 8 ranks of the run this was measured on would all rewrite one file at once.

A failed rewrite warns and lets training continue instead of taking down a multi-hour run: the rewrite is atomic, so the prefixed file is still there and still holds the trained numbers. It does say so loudly, though, naming the checkpoint. A dead adapter nobody hears about is the whole defect.

**One observation I did not act on:** the existing final-save call at `sft.py` has no rank guard either, so on that same 8-rank run all eight processes call `strip_compile_prefix` on the output root. It evidently survives (the STEP 28 log shows the expected single "Normalised 320 adapter keys" line), and `os.replace` is atomic, so I left it alone rather than widen a bugfix. Happy to add the guard here if you would rather it went in with this.

### Testing

`tests/test_v07300.py`, alongside #335's, no GPU required:

- a `checkpoint-*` written under compile ends with 0 `_orig_mod.` keys (criterion 1)
- the trained **values** survive in a checkpoint, not just the key names (criterion 2, the standard #335's repair was held to)
- a repaired checkpoint is indistinguishable from what the paired non-compile run writes, same keys and same tensors, with `lora_B` non-zero. A real resume needs FSDP2 and several GPUs, but what resuming consumes is a file matched by name, so this is criterion 3 at the level it can be settled off-GPU
- the rank guard: a non-main rank leaves the file alone
- a checkpoint with no adapter file (full fine-tuning) is a no-op, not a crash
- a failing rewrite warns and keeps training
- the callback inherits `TrainerCallback`, so `on_epoch_begin` exists (#308: `CallbackHandler.call_event` dispatches through `getattr` with no `hasattr` guard, so a duck-typed callback wires fine and dies at the first epoch)
- CONTROL: nothing is attached when `use_fsdp2_compile` is off

I also checked the new tests fail without the fix rather than merely passing with it: making `on_save` a no-op fails the three repair assertions plus the warning test, and removing the rank guard fails exactly the rank-guard test and nothing else.

`_write_adapter` moved to module scope so both issues' tests build the file the same way. Duplicating it was the alternative, and this file's own header explains why that is the wrong one.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests

## Checklist

- [x] `ruff check src/soup_cli/ tests/` passes
- [x] `pytest tests/ -v` passes
- [x] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed

On the suite: my machine cannot run it in-range (Python 3.13 against `requires-python <3.13`, and transformers 5.12 against the `<5.0.0` pin), so I ran the full 17,485 tests on this branch and again on a pristine checkout of the base commit and compared. Both report 83 failures, and the two failure sets are identical, so nothing here regresses; this branch is those same 83 plus 8 new passing tests. The pre-existing failures sit in `test_v07204`, `test_trl_preference_config_contract` and `test_trl_version_compat`, which is consistent with the out-of-range transformers/trl. The compile-prefix tests themselves pass, and `mypy` is clean on the changed module. CI is the real check for the in-range matrix.

No docs change: `docs/performance-and-quantization.md` documents `use_fsdp2_compile` as a config knob and says nothing about saved key names, so it stays accurate.
