### PR TITLE
fix(trainer): #353 - training.seed reached the SFT wrapper only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,23 @@ reproducing 70+ versions of notes.
 
 - **MLX backend now actually dispatches to the MLX trainer for `task: sft`.** Previously `backend: mlx` silently fell through to the transformers `SFTTrainerWrapper`, training on MPS/CUDA instead of MLX. The trainer was also rewritten for mlx-lm >= 0.31 (`create_dataset` + `CacheDataset`, `TrainingCallback`), with `model.freeze()` before LoRA — without it the saved "adapter" was a full fine-tune (172 tensors vs 24 LoRA tensors on a 1.2B model) — and an `adapter_config.json` is written so the output dir loads directly with `mlx_lm.load(..., adapter_path=dir)`. (#362)
 - **`mlx-lm` floor raised to >= 0.31.3** (the version the MLX SFT path is built against).
+- **`training.seed` reached the SFT wrapper and nothing else (#353).** #341 added the
+  knob and wired it into `trainer/sft.py`. The other seventeen task wrappers each build
+  their own `TrainingArguments` subclass (`GRPOConfig`, `DPOConfig`, `RewardConfig`, and
+  so on) and none of them read the field, so `task: grpo` with `training.seed: 7`
+  trained at HF's default of 42 with no error and no warning. Replicates that differed
+  only in `training.seed` were therefore the same run, which is what happened to STEP 25
+  of the H100 record: its five "replicates" were five runs of seed 42, measured against
+  a within-mode spread produced by the very thing it thought it was varying.
+  Threading the config is only half the repair. `Trainer.__init__` runs
+  `set_seed(args.seed)`, but `get_peft_model` has already drawn `lora_A` by then, and
+  `classifier` / `reward_model` / `prm` have already drawn a freshly initialised head
+  inside `from_pretrained`, so every wrapper now applies the seed at the top of
+  `setup()` as well, before the model is loaded. `unlearn` builds no `Trainer` at all
+  and drew its RMU control vector from a generator hard-coded to 0; that draw now
+  follows `training.seed`, staying at 0 when the seed is unset so existing runs keep
+  their control direction. An unset seed still resolves to 42 everywhere, so runs that
+  set neither field reproduce their pre-#353 numbers exactly.
 
 ## [0.73.0] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,16 @@ reproducing 70+ versions of notes.
   `setup()` as well, before the model is loaded. `unlearn` builds no `Trainer` at all
   and drew its RMU control vector from a generator hard-coded to 0; that draw now
   follows `training.seed`, staying at 0 when the seed is unset so existing runs keep
-  their control direction. An unset seed still resolves to 42 everywhere, so runs that
-  set neither field reproduce their pre-#353 numbers exactly.
+  their control direction.
+  An unset seed still resolves to 42 and leaves `data_seed` at `None`, so the values a
+  run trains at are unchanged. What changes is when they arrive. Nothing called
+  `set_seed` before `get_peft_model` previously, so `lora_A` was drawn from torch's
+  default generator, which is seeded from entropy once per process: an unseeded run's
+  adapter and classification-head initialisation varied from one process to the next,
+  and it is now deterministic at 42. Replicate variation that came out of runs setting
+  no seed was coming from exactly that, so those runs are now identical to each other
+  and varying a replicate means setting `training.seed` on purpose. The MLX backend
+  (`backend: mlx`) is the one path that still reads neither field.
 
 ## [0.73.0] - 2026-08-09
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -82,13 +82,25 @@ for s in 1 2 3; do
 done
 ```
 
-**Defaults are unchanged, deliberately.** Leaving both unset reproduces every
-pre-existing run exactly: `TrainingArguments` still gets `seed=42`
-(HuggingFace's own default) and `data_seed=None`, and the multipack sampler
-still gets `0` — the value it has had since v0.37.0. The fields are
-`Optional[int]` rather than defaulting to 42 precisely so the trainer can tell
-"unset" from "explicitly 42" and keep those two different historical defaults
-intact.
+**"Unset" does not mean the same thing for both fields.** An unset `seed`
+resolves to 42, HuggingFace's own `TrainingArguments` default. An unset
+`data_seed` stays `None`, which HF reads as "follow `seed`" rather than as a
+seed of its own, so leaving it out is not the same kind of default as leaving
+`seed` out. The multipack sampler still gets `0`, the value it has had since
+v0.37.0. The fields are `Optional[int]` rather than defaulting to 42 precisely
+so the trainer can tell "unset" from "explicitly 42" and keep those different
+historical defaults intact.
+
+**What changes for a run that sets neither field.** The values it trains at are
+the same as before: seed 42, `data_seed` at `None`. What is new is *when* the
+seed arrives. Before #353 nothing called `set_seed` ahead of `get_peft_model`,
+so `lora_A` and any freshly initialised classification head were drawn from
+torch's default generator, which is seeded from entropy once per process. An
+unseeded run's initialisation therefore varied from one process to the next, and
+it is now deterministic at 42. If you were getting replicate spread out of runs
+that set no seed, that is where it was coming from: those runs are identical to
+each other now, and varying a replicate means setting `training.seed` on
+purpose.
 
 Bounds: `[0, 2**32 - 1]` (`set_seed` feeds `numpy.random.seed`, which rejects
 anything outside that range), `0` is a legitimate seed, and a YAML `true` is
@@ -96,12 +108,19 @@ rejected rather than silently becoming seed 1. `data_seed` is forwarded to
 Accelerate's dataloader configuration and needs `accelerate >= 1.1.0`;
 below that, transformers warns and ignores it (`seed` is unaffected).
 
-**Scope.** `training.seed` / `training.data_seed` currently reach
-`TrainingArguments` on the **SFT** trainer (`task: sft`). The other task
-wrappers build their own `TrainingArguments` and still take HF's defaults, so
-setting the field on e.g. a DPO run is accepted but has no effect there yet.
-(The `pretrain` and layer-streaming paths do pick `seed` up for their
-samplers.)
+**Scope.** Every task wrapper threads both fields into the `TrainingArguments`
+subclass it builds, and applies `seed` before it loads the model, so the LoRA
+adapter and any freshly initialised head are drawn at the configured seed rather
+than at whatever the process happened to be sitting on (#353). `unlearn` builds
+no `Trainer` at all, and its RMU control vector follows `training.seed` too,
+staying at 0 when the seed is unset. The `pretrain` and layer-streaming paths
+pick `seed` up for their samplers as well.
+
+Through v0.73.0 this reached the **SFT** trainer only, so `training.seed: 7` on
+a DPO or GRPO run was accepted and silently trained at 42.
+
+The one path that still ignores both fields is the **MLX backend**
+(`backend: mlx`), whose trainers seed nothing at all.
 
 **Not a determinism guarantee.** A fixed seed makes the *software* RNG
 reproducible. It does not make CUDA kernels bit-reproducible — non-deterministic

--- a/src/soup_cli/commands/train.py
+++ b/src/soup_cli/commands/train.py
@@ -1056,6 +1056,18 @@ def train(
             f"LoRA:    [bold]r={cfg.training.lora.r}, "
             f"alpha={cfg.training.lora.alpha}[/]"
         )
+    # #353 review-fix: a wrong seed is invisible, which is how `training.seed`
+    # reaching one wrapper out of nineteen survived releases. Report the value
+    # the run actually trains at, and say when it is the unset default, so
+    # "did my seed take?" is answered by looking rather than by reading source.
+    from soup_cli.utils.seeding import resolve_training_seed
+
+    seed_label = str(resolve_training_seed(cfg.training))
+    if cfg.training.seed is None:
+        seed_label += " [dim](unset default)[/]"
+    if cfg.training.data_seed is not None:
+        seed_label += f", data_seed={cfg.training.data_seed}"
+
     console.print(
         Panel(
             f"Device:  [bold]{device_name}[/]\n"
@@ -1064,7 +1076,8 @@ def train(
             f"Task:    [bold]{cfg.task}[/]\n"
             f"Backend: [bold]{backend_label}[/]\n"
             f"{peft_line}\n"
-            f"Quant:   [bold]{quant_label}[/]",
+            f"Quant:   [bold]{quant_label}[/]\n"
+            f"Seed:    [bold]{seed_label}[/]",
             title="Training Setup",
         )
     )

--- a/src/soup_cli/trainer/asr.py
+++ b/src/soup_cli/trainer/asr.py
@@ -30,6 +30,7 @@ from typing import Any
 from rich.console import Console
 
 from soup_cli.config.schema import SoupConfig, TrainingConfig
+from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
 console = Console()
 
@@ -191,6 +192,9 @@ class AsrTrainerWrapper:
         cfg = self.config
         tcfg = cfg.training
 
+        # #353: seed before the model and any adapter are built.
+        apply_training_seed(tcfg)
+
         # Arch guard BEFORE any weight download.
         _require_whisper_base(cfg.base, self._trust_remote_code)
 
@@ -346,6 +350,7 @@ class AsrTrainerWrapper:
             fp16=use_fp16,
             report_to=self.report_to,
             deepspeed=self.deepspeed_config,
+            **training_seed_kwargs(tcfg),
             predict_with_generate=True,
             remove_unused_columns=False,
             **(self.fsdp_config or {}),

--- a/src/soup_cli/trainer/bco.py
+++ b/src/soup_cli/trainer/bco.py
@@ -23,6 +23,7 @@ from soup_cli.utils.gpu import (
     model_size_from_name,
     resolve_device_map,
 )
+from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
 if TYPE_CHECKING:
     from soup_cli.config.schema import TrainingConfig  # noqa: F401
@@ -118,6 +119,10 @@ class BCOTrainerWrapper:
 
         cfg = self.config
         tcfg = cfg.training
+
+        # #353: seed before the model and any adapter are built.
+        apply_training_seed(tcfg)
+
         use_unsloth = cfg.backend == "unsloth"
 
         if use_unsloth:
@@ -196,6 +201,7 @@ class BCOTrainerWrapper:
             report_to=self.report_to,
             remove_unused_columns=False,
             deepspeed=self.deepspeed_config,
+            **training_seed_kwargs(tcfg),
             **(self.fsdp_config or {}),
             beta=tcfg.bco_beta,
             max_length=cfg.data.max_length,

--- a/src/soup_cli/trainer/classifier.py
+++ b/src/soup_cli/trainer/classifier.py
@@ -32,6 +32,7 @@ from typing import Any, List, Union
 from rich.console import Console
 
 from soup_cli.config.schema import SoupConfig
+from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
 console = Console()
 
@@ -221,6 +222,9 @@ class ClassifierTrainerWrapper:
         cfg = self.config
         tcfg = cfg.training
 
+        # #353: seed before the model and any adapter are built.
+        apply_training_seed(tcfg)
+
         if tcfg.num_labels is None:
             raise ValueError(
                 f"task={cfg.task!r} requires training.num_labels to be set"
@@ -346,6 +350,7 @@ class ClassifierTrainerWrapper:
             bf16=self.device == "cuda",
             report_to=self.report_to,
             deepspeed=self.deepspeed_config,
+            **training_seed_kwargs(tcfg),
             **(self.fsdp_config or {}),
         )
 

--- a/src/soup_cli/trainer/distill.py
+++ b/src/soup_cli/trainer/distill.py
@@ -31,6 +31,7 @@ from rich.console import Console
 
 from soup_cli.config.schema import SoupConfig
 from soup_cli.utils.gpu import resolve_device_map
+from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
 if TYPE_CHECKING:
     import torch as _torch_typ
@@ -199,6 +200,9 @@ class DistillTrainerWrapper:
 
         cfg = self.config
         tcfg = cfg.training
+
+        # #353: seed before the model and any adapter are built.
+        apply_training_seed(tcfg)
 
         if tcfg.teacher_model is None:
             raise ValueError(
@@ -466,6 +470,7 @@ class DistillTrainerWrapper:
             report_to=self.report_to,
             remove_unused_columns=False,
             deepspeed=self.deepspeed_config,
+            **training_seed_kwargs(tcfg),
             **(self.fsdp_config or {}),
         )
 

--- a/src/soup_cli/trainer/dpo.py
+++ b/src/soup_cli/trainer/dpo.py
@@ -13,6 +13,7 @@ from soup_cli.utils.gpu import (
     model_size_from_name,
     resolve_device_map,
 )
+from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
 console = Console()
 
@@ -80,6 +81,10 @@ class DPOTrainerWrapper(StreamingSetupMixin):
 
         cfg = self.config
         tcfg = cfg.training
+
+        # #353: seed before the model and any adapter are built.
+        apply_training_seed(tcfg)
+
         use_unsloth = cfg.backend == "unsloth"
         # v0.72.4 — layer streaming replaces the model-load path entirely (meta
         # skeleton, never a resident load), so it dispatches ahead of the backend
@@ -181,6 +186,7 @@ class DPOTrainerWrapper(StreamingSetupMixin):
             report_to=self.report_to,
             remove_unused_columns=False,
             deepspeed=self.deepspeed_config,
+            **training_seed_kwargs(tcfg),
             **(self.fsdp_config or {}),
             beta=tcfg.dpo_beta,
             max_length=cfg.data.max_length,

--- a/src/soup_cli/trainer/embedding.py
+++ b/src/soup_cli/trainer/embedding.py
@@ -13,6 +13,7 @@ from soup_cli.utils.gpu import (
     model_size_from_name,
     resolve_device_map,
 )
+from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
 console = Console()
 
@@ -72,6 +73,10 @@ class EmbeddingTrainerWrapper:
 
         cfg = self.config
         tcfg = cfg.training
+
+        # #353: seed before the model and any adapter are built.
+        apply_training_seed(tcfg)
+
         use_unsloth = cfg.backend == "unsloth"
 
         if use_unsloth:
@@ -159,6 +164,7 @@ class EmbeddingTrainerWrapper:
             "report_to": self.report_to,
             "remove_unused_columns": False,
             "deepspeed": self.deepspeed_config,
+            **training_seed_kwargs(tcfg),
         }
 
         if self.fsdp_config:

--- a/src/soup_cli/trainer/grpo.py
+++ b/src/soup_cli/trainer/grpo.py
@@ -16,6 +16,7 @@ from soup_cli.utils.gpu import (
     model_size_from_name,
     resolve_device_map,
 )
+from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
 console = Console()
 logger = logging.getLogger(__name__)
@@ -242,6 +243,10 @@ class GRPOTrainerWrapper:
 
         cfg = self.config
         tcfg = cfg.training
+
+        # #353: seed before the model and any adapter are built.
+        apply_training_seed(tcfg)
+
         use_unsloth = cfg.backend == "unsloth"
 
         # --- Load reward function ---
@@ -386,6 +391,7 @@ class GRPOTrainerWrapper:
             "report_to": self.report_to,
             "remove_unused_columns": False,
             "deepspeed": self.deepspeed_config,
+            **training_seed_kwargs(tcfg),
             **(self.fsdp_config or {}),
             "beta": tcfg.grpo_beta,
             "num_generations": tcfg.num_generations,

--- a/src/soup_cli/trainer/ipo.py
+++ b/src/soup_cli/trainer/ipo.py
@@ -13,6 +13,7 @@ from soup_cli.utils.gpu import (
     model_size_from_name,
     resolve_device_map,
 )
+from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
 console = Console()
 
@@ -74,6 +75,10 @@ class IPOTrainerWrapper:
 
         cfg = self.config
         tcfg = cfg.training
+
+        # #353: seed before the model and any adapter are built.
+        apply_training_seed(tcfg)
+
         use_unsloth = cfg.backend == "unsloth"
 
         if use_unsloth:
@@ -145,6 +150,7 @@ class IPOTrainerWrapper:
             report_to=self.report_to,
             remove_unused_columns=False,
             deepspeed=self.deepspeed_config,
+            **training_seed_kwargs(tcfg),
             **(self.fsdp_config or {}),
             loss_type="ipo",
             beta=tcfg.ipo_tau,

--- a/src/soup_cli/trainer/kto.py
+++ b/src/soup_cli/trainer/kto.py
@@ -14,6 +14,7 @@ from soup_cli.utils.gpu import (
     model_size_from_name,
     resolve_device_map,
 )
+from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
 console = Console()
 
@@ -77,6 +78,10 @@ class KTOTrainerWrapper(StreamingSetupMixin):
 
         cfg = self.config
         tcfg = cfg.training
+
+        # #353: seed before the model and any adapter are built.
+        apply_training_seed(tcfg)
+
         use_unsloth = cfg.backend == "unsloth"
         # v0.72.4 — layer streaming replaces the model-load path entirely (meta
         # skeleton, never a resident load), so it dispatches ahead of the backend
@@ -176,6 +181,7 @@ class KTOTrainerWrapper(StreamingSetupMixin):
             report_to=self.report_to,
             remove_unused_columns=False,
             deepspeed=self.deepspeed_config,
+            **training_seed_kwargs(tcfg),
             **(self.fsdp_config or {}),
             beta=tcfg.kto_beta,
             max_length=cfg.data.max_length,

--- a/src/soup_cli/trainer/mole_routing.py
+++ b/src/soup_cli/trainer/mole_routing.py
@@ -24,6 +24,7 @@ from typing import Any, Optional
 from rich.console import Console
 
 from soup_cli.config.schema import SoupConfig
+from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
 logger = logging.getLogger(__name__)
 console = Console()
@@ -243,6 +244,10 @@ class MoleRoutingTrainerWrapper:
             )
         cfg = self.config
         tcfg = cfg.training
+
+        # #353: seed before the model and any adapter are built.
+        apply_training_seed(tcfg)
+
         adapters = list(tcfg.mole_task_adapters or [])
         if len(adapters) < 2:
             raise RuntimeError(
@@ -363,6 +368,7 @@ class MoleRoutingTrainerWrapper:
             report_to=self.report_to,
             remove_unused_columns=False,
             deepspeed=self.deepspeed_config,
+            **training_seed_kwargs(tcfg),
         )
 
         mole_trainer_cls = make_mole_trainer_class(Trainer)

--- a/src/soup_cli/trainer/online_dpo.py
+++ b/src/soup_cli/trainer/online_dpo.py
@@ -38,6 +38,7 @@ from soup_cli.utils.gpu import (
     model_size_from_name,
     resolve_device_map,
 )
+from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
 console = Console()
 
@@ -237,6 +238,9 @@ class OnlineDPOTrainerWrapper:
         cfg = self.config
         tcfg = cfg.training
 
+        # #353: seed before the model and any adapter are built.
+        apply_training_seed(tcfg)
+
         self._setup_transformers(cfg, tcfg)
 
         # --- Batch size (online DPO generates -> ~2x memory per sample) ---
@@ -296,6 +300,7 @@ class OnlineDPOTrainerWrapper:
             save_total_limit=3,
             bf16=self.device == "cuda",
             report_to=self.report_to,
+            **training_seed_kwargs(tcfg),
             beta=tcfg.dpo_beta,
             loss_type=tcfg.online_dpo_loss_type,
             max_new_tokens=tcfg.online_dpo_max_new_tokens,

--- a/src/soup_cli/trainer/orpo.py
+++ b/src/soup_cli/trainer/orpo.py
@@ -14,6 +14,7 @@ from soup_cli.utils.gpu import (
     model_size_from_name,
     resolve_device_map,
 )
+from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
 console = Console()
 
@@ -88,6 +89,10 @@ class ORPOTrainerWrapper(StreamingSetupMixin):
 
         cfg = self.config
         tcfg = cfg.training
+
+        # #353: seed before the model and any adapter are built.
+        apply_training_seed(tcfg)
+
         use_unsloth = cfg.backend == "unsloth"
         # v0.72.4 — layer streaming replaces the model-load path entirely (meta
         # skeleton, never a resident load), so it dispatches ahead of the backend
@@ -186,6 +191,7 @@ class ORPOTrainerWrapper(StreamingSetupMixin):
             report_to=self.report_to,
             remove_unused_columns=False,
             deepspeed=self.deepspeed_config,
+            **training_seed_kwargs(tcfg),
             **(self.fsdp_config or {}),
             beta=tcfg.orpo_beta,
             max_length=cfg.data.max_length,

--- a/src/soup_cli/trainer/ppo.py
+++ b/src/soup_cli/trainer/ppo.py
@@ -19,6 +19,7 @@ from soup_cli.utils.gpu import (
     model_size_from_name,
     resolve_device_map,
 )
+from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
 console = Console()
 
@@ -84,6 +85,10 @@ class PPOTrainerWrapper:
 
         cfg = self.config
         tcfg = cfg.training
+
+        # #353: seed before the model and any adapter are built.
+        apply_training_seed(tcfg)
+
         use_unsloth = cfg.backend == "unsloth"
 
         # --- Load reward source ---
@@ -152,6 +157,7 @@ class PPOTrainerWrapper:
             "per_device_train_batch_size": batch_size,
             "gradient_accumulation_steps": tcfg.gradient_accumulation_steps,
             "learning_rate": tcfg.lr,
+            **training_seed_kwargs(tcfg),
         }
 
         # FSDP2 — alternative to DeepSpeed

--- a/src/soup_cli/trainer/pretrain.py
+++ b/src/soup_cli/trainer/pretrain.py
@@ -13,6 +13,7 @@ from soup_cli.utils.gpu import (
     model_size_from_name,
     resolve_device_map,
 )
+from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
 console = Console()
 
@@ -70,6 +71,10 @@ class PretrainTrainerWrapper:
 
         cfg = self.config
         tcfg = cfg.training
+
+        # #353: seed before the model and any adapter are built.
+        apply_training_seed(tcfg)
+
         use_unsloth = cfg.backend == "unsloth"
 
         if use_unsloth:
@@ -149,6 +154,7 @@ class PretrainTrainerWrapper:
             "report_to": self.report_to,
             "remove_unused_columns": False,
             "deepspeed": self.deepspeed_config,
+            **training_seed_kwargs(tcfg),
         }
 
         # FSDP2 — alternative to DeepSpeed

--- a/src/soup_cli/trainer/prm.py
+++ b/src/soup_cli/trainer/prm.py
@@ -24,6 +24,7 @@ from typing import Any, Optional
 from rich.console import Console
 
 from soup_cli.config.schema import SoupConfig
+from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
 logger = logging.getLogger(__name__)
 console = Console()
@@ -248,6 +249,10 @@ class PRMTrainerWrapper:
         from transformers import AutoModelForCausalLM, AutoTokenizer
 
         cfg = self.config
+
+        # #353: seed before the model and any adapter are built.
+        apply_training_seed(cfg.training)
+
         self.tokenizer = AutoTokenizer.from_pretrained(
             cfg.base, trust_remote_code=self._trust_remote_code
         )
@@ -318,6 +323,7 @@ class PRMTrainerWrapper:
             report_to=self.report_to,
             remove_unused_columns=False,
             deepspeed=self.deepspeed_config,
+            **training_seed_kwargs(tcfg),
         )
 
         prm_trainer_cls = make_prm_trainer_class(Trainer)

--- a/src/soup_cli/trainer/reward_model.py
+++ b/src/soup_cli/trainer/reward_model.py
@@ -19,6 +19,7 @@ from soup_cli.utils.gpu import (
     model_size_from_name,
     resolve_device_map,
 )
+from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
 console = Console()
 
@@ -76,6 +77,9 @@ class RewardModelTrainerWrapper:
 
         cfg = self.config
         tcfg = cfg.training
+
+        # #353: seed before the model and any adapter are built.
+        apply_training_seed(tcfg)
 
         self._setup_transformers(cfg, tcfg)
 
@@ -147,6 +151,7 @@ class RewardModelTrainerWrapper:
             report_to=self.report_to,
             remove_unused_columns=False,
             deepspeed=self.deepspeed_config,
+            **training_seed_kwargs(tcfg),
             **(self.fsdp_config or {}),
             max_length=cfg.data.max_length,
         )

--- a/src/soup_cli/trainer/sft.py
+++ b/src/soup_cli/trainer/sft.py
@@ -16,16 +16,15 @@ from soup_cli.utils.gpu import (
     model_size_from_name,
     resolve_device_map,
 )
+from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
 logger = logging.getLogger(__name__)
 
 console = Console()
 
-# #341 — what an UNSET ``training.seed`` resolves to. This is HF's own
-# ``TrainingArguments.seed`` default, restated here so the "unset behaves
-# exactly as before" guarantee is a written constant rather than an accident
-# of whichever transformers version is installed.
-DEFAULT_TRAINING_SEED = 42
+# #341's DEFAULT_TRAINING_SEED moved to ``utils.seeding`` in #353, where every
+# other task trainer needs the same constant. The multipack default below is
+# SFT-local and stays here.
 
 # #341 — what an unset seed gives the multipack FFD sampler. NOT 42: the
 # sampler has been seeded 0 since v0.37.0 because ``getattr(tcfg, "seed", 0)``
@@ -212,6 +211,12 @@ class SFTTrainerWrapper(StreamingSetupMixin):
 
         cfg = self.config
         tcfg = cfg.training
+
+        # #353: seed before the model exists. Threading `seed` into
+        # TrainingArguments is not enough on its own, because `get_peft_model`
+        # draws `lora_A` before there is a Trainer to run `set_seed(args.seed)`.
+        apply_training_seed(tcfg)
+
         use_unsloth = cfg.backend == "unsloth"
         use_vision = cfg.modality == "vision"
 
@@ -409,14 +414,14 @@ class SFTTrainerWrapper(StreamingSetupMixin):
             "report_to": self.report_to,
             "remove_unused_columns": False,
             "deepspeed": self.deepspeed_config,
-            # #341 — the general training seed. Until this landed there was no
-            # knob at all: every run took HF's defaults (seed=42,
-            # data_seed=None), so replicates of one config differed only by
-            # row permutation and GPU nondeterminism. `None` means "unset", and
-            # unset must reproduce the pre-#341 numbers exactly — hence 42
-            # here rather than a new default.
-            "seed": DEFAULT_TRAINING_SEED if tcfg.seed is None else tcfg.seed,
-            "data_seed": tcfg.data_seed,
+            # #341: the general training seed. Until this landed there was no
+            # knob at all, so every run took HF's defaults (seed=42,
+            # data_seed=None) and replicates of one config differed only by row
+            # permutation and GPU nondeterminism. `None` means "unset", and
+            # unset must reproduce the pre-#341 numbers exactly, hence 42 rather
+            # than a new default. #353 moved the resolution into utils.seeding
+            # so the other 17 task wrappers resolve it identically.
+            **training_seed_kwargs(tcfg),
         }
 
         # FSDP2 — alternative to DeepSpeed. The helper also enables

--- a/src/soup_cli/trainer/simpo.py
+++ b/src/soup_cli/trainer/simpo.py
@@ -14,6 +14,7 @@ from soup_cli.utils.gpu import (
     model_size_from_name,
     resolve_device_map,
 )
+from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
 console = Console()
 
@@ -88,6 +89,10 @@ class SimPOTrainerWrapper(StreamingSetupMixin):
 
         cfg = self.config
         tcfg = cfg.training
+
+        # #353: seed before the model and any adapter are built.
+        apply_training_seed(tcfg)
+
         use_unsloth = cfg.backend == "unsloth"
         # v0.72.4 — layer streaming replaces the model-load path entirely (meta
         # skeleton, never a resident load), so it dispatches ahead of the backend
@@ -186,6 +191,7 @@ class SimPOTrainerWrapper(StreamingSetupMixin):
             report_to=self.report_to,
             remove_unused_columns=False,
             deepspeed=self.deepspeed_config,
+            **training_seed_kwargs(tcfg),
             **(self.fsdp_config or {}),
             loss_type="simpo",
             cpo_alpha=tcfg.cpo_alpha,

--- a/src/soup_cli/trainer/unlearn.py
+++ b/src/soup_cli/trainer/unlearn.py
@@ -165,10 +165,16 @@ class UnlearnTrainerWrapper:
         from peft import LoraConfig, get_peft_model
 
         from soup_cli.utils.live_eval import load_model_and_tokenizer
+        from soup_cli.utils.seeding import apply_training_seed
         from soup_cli.utils.unlearning import validate_unlearn_method
 
         cfg = self.config
         tcfg = cfg.training
+
+        # #353: seed before the model and any adapter are built. This wrapper
+        # never builds a Trainer, so nothing else would apply the seed at all.
+        apply_training_seed(tcfg)
+
         method = validate_unlearn_method(self.method)
         self.method = method
 
@@ -250,7 +256,16 @@ class UnlearnTrainerWrapper:
         rmu_layer = None
         if method == "rmu":
             hidden = int(self.model.config.hidden_size)
-            gen = torch.Generator(device="cpu").manual_seed(0)
+            # #353: the control direction follows training.seed, so two RMU
+            # replicates at different seeds really are different runs. An unset
+            # seed stays 0 rather than resolving to 42: this draw has been
+            # seeded 0 since RMU landed, and moving it would silently change
+            # every existing unseeded run (same reasoning as the multipack
+            # sampler's DEFAULT_MULTIPACK_SEED in #341).
+            rmu_seed = getattr(tcfg, "seed", None)
+            gen = torch.Generator(device="cpu").manual_seed(
+                0 if rmu_seed is None else rmu_seed
+            )
             control_vec = (
                 torch.randn(hidden, generator=gen).to(dev) * _RMU_CONTROL_SCALE
             )

--- a/src/soup_cli/utils/seeding.py
+++ b/src/soup_cli/utils/seeding.py
@@ -1,0 +1,82 @@
+"""Resolve ``training.seed`` into the two forms a task trainer needs.
+
+#341 added the ``training.seed`` knob and wired it into ``trainer/sft.py``.
+Every other wrapper builds its own ``TrainingArguments`` subclass (``GRPOConfig``,
+``DPOConfig``, ``RewardConfig``, ...) and none of them read the field, so a
+``task: grpo`` run that set ``training.seed: 7`` trained at
+``TrainingArguments``' default of 42 with no error and no warning (#353). Two
+"different seeds" then produced identical initialisation and identical data
+order, which is how STEP 25 of the H100 record ended up measuring GPU
+nondeterminism against itself.
+
+There are two separate jobs here, and closing #353 needs both:
+
+``training_seed_kwargs``
+    The ``seed`` / ``data_seed`` pair for a ``TrainingArguments`` subclass.
+    Load-bearing rather than belt-and-braces: ``Trainer.__init__`` runs
+    ``set_seed(args.seed)`` itself, so a seed applied before the trainer object
+    exists is overwritten by ``args.seed`` (42, when nothing threads the config).
+
+``apply_training_seed``
+    The global seed for everything a wrapper draws BEFORE its trainer exists.
+    That is not only LoRA's ``lora_A``: ``classifier`` / ``reward_model`` /
+    ``prm`` load through ``AutoModelForSequenceClassification`` with a freshly
+    initialised head, and ``unlearn`` never builds a ``Trainer`` at all. Call it
+    at the top of ``setup()``, before the model is loaded.
+
+Wrappers call both, rather than the CLI calling ``set_seed`` once on their
+behalf. ``commands/train.py`` is not the only caller of ``setup()``:
+``commands/sweep.py`` is another, and a sweep is precisely a reproducibility
+study. Seeding at one entry point would leave the other silently unseeded, which
+is the shape of the defect this module exists to close.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# What an UNSET ``training.seed`` resolves to. This is HF's own
+# ``TrainingArguments.seed`` default, restated here so the "unset behaves exactly
+# as before" guarantee is a written constant rather than an accident of whichever
+# transformers version is installed. It carried this name in ``trainer/sft.py``
+# from #341 until #353 moved it here, where every task trainer can reach it.
+DEFAULT_TRAINING_SEED = 42
+
+
+def resolve_training_seed(tcfg: Any) -> int:
+    """The seed a run actually trains at.
+
+    ``None`` means unset, and unset has to reproduce the pre-#341 numbers
+    exactly, hence 42 rather than a new default of our own.
+    """
+    seed = getattr(tcfg, "seed", None)
+    return DEFAULT_TRAINING_SEED if seed is None else int(seed)
+
+
+def training_seed_kwargs(tcfg: Any) -> dict[str, Any]:
+    """``seed`` / ``data_seed`` kwargs for any ``TrainingArguments`` subclass.
+
+    ``data_seed`` stays ``None`` when unset: HF reads that as "follow ``seed``",
+    and pinning it to the resolved seed instead would change the data order of
+    every run that sets neither field.
+    """
+    return {
+        "seed": resolve_training_seed(tcfg),
+        "data_seed": getattr(tcfg, "data_seed", None),
+    }
+
+
+def apply_training_seed(tcfg: Any) -> int:
+    """Seed python / numpy / torch before the model and adapter are built.
+
+    Returns the seed applied so a caller can report it.
+    """
+    from transformers import set_seed
+
+    seed = resolve_training_seed(tcfg)
+    set_seed(seed)
+    logger.debug("training seed %d applied before model build", seed)
+    return seed

--- a/tests/test_issue353_seed_every_task.py
+++ b/tests/test_issue353_seed_every_task.py
@@ -1,0 +1,701 @@
+"""#353: `training.seed` reached the SFT wrapper and nothing else.
+
+#341 added the knob and wired it into `trainer/sft.py`. Every other task builds
+its own `TrainingArguments` subclass, and none of them read the field, so
+`task: grpo` with `training.seed: 7` trained at HF's default of 42 with no error
+and no warning. Two "different seeds" produced identical initialisation and
+identical data order, which is how STEP 25 of the H100 record measured GPU
+nondeterminism against itself.
+
+The shape of the test follows the shape of the bug. A per-task omission is the
+failure mode, so the assertions are per task, and `setup()` is CALLED rather
+than mocked. That is the same lesson `test_trl_preference_config_contract.py`
+records: constructing a wrapper touches none of this, because `__init__` only
+stores the config.
+
+For every task that can be driven on CPU: a configured `seed` / `data_seed`
+lands on the config the trainer actually receives, and an unset seed still
+resolves to 42 so pre-#341 runs reproduce exactly. Then the acceptance pair from
+the issue on a task that is not sft, and the adapter-init measurement from
+#354's investigation, which is the half that threading the config cannot fix.
+
+Tasks that cannot be driven here (they need a reward model, a live judge, a
+teacher checkpoint, real audio, or pre-trained adapters) are not skipped
+quietly. Their config classes are asked directly whether they accept the
+keywords, their wrappers are checked to seed inside `setup()` before building a
+model, and `TestEveryTaskIsAccountedFor` walks the schema's own `task` literal
+and fails if a task is neither covered here nor listed with a reason. That last
+guard is the part that survives the next task being added.
+"""
+
+import pytest
+
+
+def _requires_train_extra():
+    for mod in ("torch", "transformers", "peft", "trl", "datasets"):
+        pytest.importorskip(mod, reason=f"{mod} is only in the [train] extra")
+
+
+# --------------------------------------------------------------------------
+# fixtures -- a real, tiny checkpoint on disk. Duplicated from
+# test_trl_preference_config_contract.py deliberately, as the v0.72.x suites
+# already do, so this file stays runnable on its own.
+# --------------------------------------------------------------------------
+def _tiny_llama_dir(tmp_path, vocab=64, hidden=64):
+    import torch
+    from safetensors.torch import save_file
+    from transformers import LlamaConfig, LlamaForCausalLM
+
+    torch.manual_seed(7)
+    config = LlamaConfig(
+        vocab_size=vocab,
+        hidden_size=hidden,
+        intermediate_size=hidden * 2,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        tie_word_embeddings=True,
+        max_position_embeddings=128,
+    )
+    model = LlamaForCausalLM(config).to(torch.float32).eval()
+    weights = tmp_path / "model"
+    weights.mkdir(parents=True, exist_ok=True)
+    state = {k: v.contiguous() for k, v in model.state_dict().items()}
+    state.pop("lm_head.weight", None)
+    save_file(state, str(weights / "model.safetensors"))
+    config.save_pretrained(str(weights))
+    return str(weights)
+
+
+def _write_tiny_tokenizer(directory):
+    from tokenizers import Tokenizer, models, pre_tokenizers
+    from transformers import PreTrainedTokenizerFast
+
+    vocab = {"<unk>": 0, "<s>": 1, "</s>": 2, "<pad>": 3}
+    for word in ("hello", "world", "hi", "good", "answer", "bad"):
+        vocab[word] = len(vocab)
+    tok = Tokenizer(models.WordLevel(vocab=vocab, unk_token="<unk>"))
+    tok.pre_tokenizer = pre_tokenizers.Whitespace()
+    fast = PreTrainedTokenizerFast(
+        tokenizer_object=tok,
+        unk_token="<unk>",
+        bos_token="<s>",
+        eos_token="</s>",
+        pad_token="<pad>",
+    )
+    fast.save_pretrained(str(directory))
+
+
+def _pref_rows(n=8):
+    return [{"prompt": "hi", "chosen": " good answer", "rejected": " bad"} for _ in range(n)]
+
+
+def _kto_rows(n=8):
+    return [{"prompt": "hi", "completion": " good answer", "label": i % 2 == 0} for i in range(n)]
+
+
+def _sft_rows(n=8):
+    return [
+        {
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "good answer"},
+            ]
+        }
+        for _ in range(n)
+    ]
+
+
+def _text_rows(n=8):
+    return [{"text": "hello world good answer"} for _ in range(n)]
+
+
+def _label_rows(n=8):
+    return [{"text": "hello world", "label": i % 2} for i in range(n)]
+
+
+def _prompt_rows(n=8):
+    return [{"prompt": "hi"} for _ in range(n)]
+
+
+#: KTO refuses `per_device_train_batch_size == 1` (its KL term is degenerate
+#: there), so the floor is per task rather than global. GRPO needs the batch to
+#: be divisible by `num_generations`.
+_MIN_BATCH = {"kto": 2, "grpo": 2}
+
+#: task -> (module, wrapper class, rows, extra `training:` keys)
+#: Every entry here is driven through a real `setup()`.
+_LIVE = {
+    "sft": ("soup_cli.trainer.sft", "SFTTrainerWrapper", _sft_rows, {}),
+    "bco": ("soup_cli.trainer.bco", "BCOTrainerWrapper", _pref_rows, {}),
+    "dpo": ("soup_cli.trainer.dpo", "DPOTrainerWrapper", _pref_rows, {}),
+    "ipo": ("soup_cli.trainer.ipo", "IPOTrainerWrapper", _pref_rows, {}),
+    "kto": ("soup_cli.trainer.kto", "KTOTrainerWrapper", _kto_rows, {}),
+    "orpo": ("soup_cli.trainer.orpo", "ORPOTrainerWrapper", _pref_rows, {}),
+    "simpo": ("soup_cli.trainer.simpo", "SimPOTrainerWrapper", _pref_rows, {}),
+    "reward_model": (
+        "soup_cli.trainer.reward_model",
+        "RewardModelTrainerWrapper",
+        _pref_rows,
+        {},
+    ),
+    "classifier": (
+        "soup_cli.trainer.classifier",
+        "ClassifierTrainerWrapper",
+        _label_rows,
+        {"num_labels": 2},
+    ),
+    "pretrain": (
+        "soup_cli.trainer.pretrain",
+        "PretrainTrainerWrapper",
+        _text_rows,
+        {},
+    ),
+    "embedding": (
+        "soup_cli.trainer.embedding",
+        "EmbeddingTrainerWrapper",
+        _pref_rows,
+        {},
+    ),
+    # The task the issue's own probes A/B/C were run on.
+    "grpo": (
+        "soup_cli.trainer.grpo",
+        "GRPOTrainerWrapper",
+        _prompt_rows,
+        {"num_generations": 2, "reward_fn": "format"},
+    ),
+}
+
+_LIVE_TASKS = tuple(_LIVE)
+
+
+def _cfg(weights, out_dir, task, **training_over):
+    import yaml
+
+    from soup_cli.config.loader import load_config_from_string
+
+    training = {
+        "batch_size": _MIN_BATCH.get(task, 1),
+        "quantization": "none",
+        "epochs": 1,
+        "logging_steps": 1,
+        "save_steps": 1000,
+        "lora": {"r": 4, "alpha": 8, "target_modules": ["q_proj", "v_proj"]},
+    }
+    training.update(_LIVE[task][3])
+    training.update(training_over)
+    return load_config_from_string(
+        yaml.safe_dump(
+            {
+                "base": weights,
+                "task": task,
+                "backend": "transformers",
+                "modality": "text",
+                "data": {"train": "train.jsonl", "max_length": 64, "chat_template": "chatml"},
+                "training": training,
+                "output": str(out_dir),
+            }
+        )
+    )
+
+
+def _build(tmp_path, monkeypatch, task, **training_over):
+    """A real wrapper over a real tiny checkpoint, with `setup()` called."""
+    import importlib
+
+    module, cls_name, rows, _ = _LIVE[task]
+    weights = _tiny_llama_dir(tmp_path)
+    _write_tiny_tokenizer(weights)
+    monkeypatch.chdir(tmp_path)
+    cfg = _cfg(weights, tmp_path / "out", task, **training_over)
+    wrapper = getattr(importlib.import_module(module), cls_name)(cfg, device="cpu")
+    wrapper.setup({"train": rows(8)})
+    return wrapper
+
+
+def _trainer_args(wrapper, task):
+    """The TrainingArguments the trainer was actually handed.
+
+    `embedding` composes HF's Trainer instead of subclassing it, so its args sit
+    one level down. Reaching through here rather than special-casing the task in
+    each assertion keeps the failure message pointing at the seed.
+    """
+    trainer = wrapper.trainer
+    assert trainer is not None, f"{task}: setup() left no trainer"
+    args = getattr(trainer, "args", None)
+    if args is None:
+        args = getattr(getattr(trainer, "_trainer", None), "args", None)
+    assert args is not None, (
+        f"{task}: no TrainingArguments found on {type(trainer).__name__}"
+    )
+    return args
+
+
+# ==========================================================================
+# the seed reaches the config the trainer receives, per task
+# ==========================================================================
+class TestSeedReachesEveryTaskConfig:
+    @pytest.mark.parametrize("task", _LIVE_TASKS)
+    def test_configured_seed_reaches_the_trainer(self, tmp_path, monkeypatch, task):
+        _requires_train_extra()
+        wrapper = _build(tmp_path, monkeypatch, task, seed=1234)
+        args = _trainer_args(wrapper, task)
+        assert args.seed == 1234, (
+            f"{task}: training.seed did not reach the config; got {args.seed}"
+        )
+
+    @pytest.mark.parametrize("task", _LIVE_TASKS)
+    def test_configured_data_seed_reaches_the_trainer(self, tmp_path, monkeypatch, task):
+        _requires_train_extra()
+        wrapper = _build(tmp_path, monkeypatch, task, seed=5, data_seed=99)
+        args = _trainer_args(wrapper, task)
+        assert args.seed == 5, task
+        assert args.data_seed == 99, task
+
+    @pytest.mark.parametrize("task", _LIVE_TASKS)
+    def test_control_an_unset_seed_is_still_42(self, tmp_path, monkeypatch, task):
+        """BACKWARDS COMPATIBILITY, and the control for the test above.
+
+        A config that sets neither field has to keep producing what it produced
+        before #353, or every existing run's numbers move. Without this the fix
+        could have shipped a new default and the assertions above would still
+        pass.
+        """
+        _requires_train_extra()
+        wrapper = _build(tmp_path, monkeypatch, task)
+        args = _trainer_args(wrapper, task)
+        assert args.seed == 42, task
+        assert args.data_seed is None, task
+
+
+# ==========================================================================
+# the acceptance pair from the issue, on a task that is NOT sft
+# ==========================================================================
+class TestSeedActuallyChangesTraining:
+    """Neither test means anything alone.
+
+    #341 proved this for sft. The issue's own evidence (probes A/B/C on the
+    400-prompt GRPO config) is that it was never true for anything else: at the
+    same seed two runs were identical element by element, and at a different
+    seed they still were, because the seed never arrived.
+    """
+
+    @staticmethod
+    def _first_step_loss(tmp_path, monkeypatch, task, seed):
+        wrapper = _build(tmp_path, monkeypatch, task, seed=seed)
+        result = wrapper.trainer.train()
+        return result.training_loss
+
+    def test_same_seed_reproduces(self, tmp_path, monkeypatch):
+        _requires_train_extra()
+        first = self._first_step_loss(tmp_path / "a", monkeypatch, "dpo", 1234)
+        second = self._first_step_loss(tmp_path / "b", monkeypatch, "dpo", 1234)
+        assert first == second, (first, second)
+
+    def test_different_seed_diverges(self, tmp_path, monkeypatch):
+        _requires_train_extra()
+        first = self._first_step_loss(tmp_path / "a", monkeypatch, "dpo", 1234)
+        second = self._first_step_loss(tmp_path / "b", monkeypatch, "dpo", 4321)
+        assert first != second, (first, second)
+
+
+# ==========================================================================
+# the kwargs are accepted by every config class a wrapper builds
+# ==========================================================================
+class TestEveryConfigClassAcceptsTheSeed:
+    """Covers the wrappers the matrix above cannot drive.
+
+    `ppo` and `online_dpo` need a reward model and a judge, so no test here
+    constructs their config. Passing a keyword a config does not accept is a
+    `TypeError` at `setup()`, which is the failure mode
+    `test_trl_preference_config_contract.py` exists for, so the keyword is asked
+    of the class rather than assumed from a version table.
+    """
+
+    def _classes(self):
+        import trl
+        from transformers import Seq2SeqTrainingArguments, TrainingArguments
+
+        from soup_cli.trainer._trl_compat import resolve_trl_symbol
+
+        classes = {
+            # classifier, distill, mole_routing, prm, pretrain, embedding, sft
+            "TrainingArguments": TrainingArguments,
+            "Seq2SeqTrainingArguments": Seq2SeqTrainingArguments,  # asr
+            "DPOConfig": trl.DPOConfig,  # dpo, ipo
+            "KTOConfig": trl.KTOConfig,
+            "GRPOConfig": trl.GRPOConfig,
+            "RewardConfig": trl.RewardConfig,
+            "OnlineDPOConfig": trl.OnlineDPOConfig,
+            "PPOConfig": trl.PPOConfig,
+            # #326 moved these three out of the public namespace.
+            "ORPOConfig": resolve_trl_symbol("ORPOConfig", "trl.experimental.orpo"),
+            "CPOConfig": resolve_trl_symbol("CPOConfig", "trl.experimental.cpo"),
+            "BCOConfig": resolve_trl_symbol("BCOConfig", "trl.experimental.bco"),
+        }
+        return classes
+
+    @pytest.mark.parametrize("field", ("seed", "data_seed"))
+    def test_the_installed_configs_accept_the_field(self, field):
+        _requires_train_extra()
+        from soup_cli.trainer._trl_compat import config_accepts
+
+        refused = [
+            name
+            for name, cls in self._classes().items()
+            if not config_accepts(cls, field)
+        ]
+        assert not refused, (
+            f"{refused} do not accept `{field}` on the installed trl, so the "
+            f"wrappers that build them raise TypeError in setup()"
+        )
+
+
+# ==========================================================================
+# acceptance criterion 2: applied BEFORE the adapter, not only in the trainer
+# ==========================================================================
+class TestSeedAppliesBeforeTheAdapterExists:
+    """Threading the config alone would leave this unseeded.
+
+    `Trainer.__init__` runs `set_seed(args.seed)`, but `get_peft_model` has
+    already drawn `lora_A` by then, and `classifier` / `reward_model` / `prm`
+    have already drawn a fresh head inside `from_pretrained`. So these
+    assertions fail if the fix is only `seed=` on the config.
+
+    The fixture reseeds torch to 7 while building the base checkpoint, so both
+    runs enter `setup()` with an identical global RNG state. That is what gives
+    the "different seeds differ" half its teeth: it can only pass if something
+    inside `setup()` applied the seed.
+
+    `sft` is parametrised here even though #341 already threaded its config,
+    because it is the task #354's investigation was run on: hashing `lora_A`
+    across two `get_peft_model` builds came out DIFFERENT, and the conclusion
+    recorded in `benchmarks/gate-h100-validation.md` was that the repair is
+    placement rather than plumbing. This is that measurement, in-process.
+    """
+
+    @staticmethod
+    def _first_lora_weight(tmp_path, monkeypatch, task, seed):
+        wrapper = _build(tmp_path, monkeypatch, task, seed=seed)
+        for name, param in wrapper.model.named_parameters():
+            if "lora_A" in name:
+                return name, param.detach().clone()
+        raise AssertionError(f"{task}: no lora_A parameter on the built model")
+
+    @pytest.mark.parametrize("task", ("sft", "dpo"))
+    def test_the_same_seed_initialises_the_adapter_identically(
+        self, tmp_path, monkeypatch, task
+    ):
+        _requires_train_extra()
+        import torch
+
+        _, first = self._first_lora_weight(tmp_path / "a", monkeypatch, task, 1234)
+        _, second = self._first_lora_weight(tmp_path / "b", monkeypatch, task, 1234)
+        assert torch.equal(first, second), task
+
+    @pytest.mark.parametrize("task", ("sft", "dpo"))
+    def test_a_different_seed_initialises_the_adapter_differently(
+        self, tmp_path, monkeypatch, task
+    ):
+        """The control. Two identical hashes alone would be equally consistent
+        with a probe that cannot see a difference at all, so the arm that has to
+        vary is the one carrying the result."""
+        _requires_train_extra()
+        import torch
+
+        _, first = self._first_lora_weight(tmp_path / "a", monkeypatch, task, 1234)
+        _, second = self._first_lora_weight(tmp_path / "b", monkeypatch, task, 4321)
+        assert not torch.equal(first, second), (
+            f"{task}: lora_A is identical at two different seeds, so the seed is "
+            f"not reaching adapter creation"
+        )
+
+    def test_a_freshly_initialised_classifier_head_follows_the_seed(
+        self, tmp_path, monkeypatch
+    ):
+        """`classifier` draws its head inside `from_pretrained`, which runs
+        before its TrainingArguments is built at all."""
+        _requires_train_extra()
+        import torch
+
+        def head(sub, seed):
+            wrapper = _build(tmp_path / sub, monkeypatch, "classifier", seed=seed)
+            for name, param in wrapper.model.named_parameters():
+                if name.endswith("score.weight"):
+                    return param.detach().clone()
+            raise AssertionError("no classification head found")
+
+        assert not torch.equal(head("a", 1234), head("b", 4321))
+        assert torch.equal(head("c", 7), head("d", 7))
+
+
+# ==========================================================================
+# the guard that survives the next task being added
+# ==========================================================================
+#: Tasks that cannot be driven through `setup()` in a unit test, each with the
+#: reason. Being on this list is not an exemption from the fix: every wrapper
+#: named here threads the seed, and `TestEveryWrapperAppliesTheSeed` checks it
+#: without needing the task's infrastructure.
+_NOT_DRIVABLE = {
+    "ppo": "needs a reward model and a value model on disk",
+    "online_dpo": "needs a live judge endpoint or a reward model",
+    "distill": "needs a second (teacher) checkpoint",
+    "asr": "needs real audio and a Whisper checkpoint",
+    "tts": "needs an audio codec model",
+    "moe_lora_routing": "needs >= 2 pre-trained task adapters",
+    "prm": "builds its TrainingArguments in train(), not setup()",
+    "unlearn": "builds no Trainer at all; covered by TestUnlearnSeeding",
+    "preference": "delegates to an inner wrapper, which _make_inner_cfg's "
+                  "model_copy carries the seed into",
+    "reranker": "alias of classifier, same wrapper",
+    "cross_encoder": "alias of classifier, same wrapper",
+}
+
+
+def _schema_tasks():
+    import typing
+
+    from soup_cli.config.schema import SoupConfig
+
+    annotation = SoupConfig.model_fields["task"].annotation
+    return set(typing.get_args(annotation))
+
+
+class TestEveryTaskIsAccountedFor:
+    """The coverage property, not the code.
+
+    #353 happened because a knob was wired into one task and the other sixteen
+    were never checked. A test matrix that silently omits a task would let the
+    same thing happen again, so the schema's own list of tasks is the source of
+    truth here rather than a list maintained by hand in this file.
+    """
+
+    def test_no_task_is_silently_uncovered(self):
+        tasks = _schema_tasks()
+        accounted = set(_LIVE_TASKS) | set(_NOT_DRIVABLE)
+        missing = tasks - accounted
+        assert not missing, (
+            f"task(s) {sorted(missing)} are in the schema but neither driven by "
+            f"this suite nor listed in _NOT_DRIVABLE with a reason"
+        )
+
+    def test_the_exclusion_list_does_not_rot(self):
+        """A task that leaves the schema must leave the exclusion list too,
+        otherwise the list slowly stops describing anything."""
+        tasks = _schema_tasks()
+        stale = (set(_NOT_DRIVABLE) | set(_LIVE_TASKS)) - tasks
+        assert not stale, f"{sorted(stale)} are listed here but not in the schema"
+
+
+class TestEveryWrapperAppliesTheSeed:
+    """Every task wrapper calls `apply_training_seed` before it builds a model.
+
+    Cheap where the matrix above is expensive: this reaches the wrappers that
+    need a reward model, a judge, a teacher, or audio, and it fails when a new
+    wrapper is added without the call. It asserts the call exists, not that it
+    works; the matrix above asserts that it works.
+    """
+
+    #: module -> the method that must apply the seed. `prm` seeds in `setup()`
+    #: (it builds a randomly initialised reward head there) and threads the
+    #: kwargs in `train()`.
+    _MODULES = (
+        "asr", "bco", "classifier", "distill", "dpo", "embedding", "grpo",
+        "ipo", "kto", "mole_routing", "online_dpo", "ppo", "pretrain", "prm",
+        "reward_model", "sft", "simpo", "unlearn",
+    )
+
+    @staticmethod
+    def _setup_body(name):
+        import ast
+        import importlib.util
+
+        spec = importlib.util.find_spec(f"soup_cli.trainer.{name}")
+        with open(spec.origin, encoding="utf-8") as handle:
+            tree = ast.parse(handle.read())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "setup":
+                return node
+        raise AssertionError(f"soup_cli.trainer.{name} defines no setup()")
+
+    @pytest.mark.parametrize("name", _MODULES)
+    def test_the_wrapper_seeds_inside_setup(self, name):
+        import ast
+
+        setup = self._setup_body(name)
+        seeded = [
+            node.lineno
+            for node in ast.walk(setup)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "apply_training_seed"
+        ]
+        assert seeded, (
+            f"soup_cli.trainer.{name}.setup() never calls apply_training_seed(), "
+            f"so its model and adapter initialise at whatever seed happened to "
+            f"be live when the process reached them"
+        )
+
+    @pytest.mark.parametrize("name", _MODULES)
+    def test_the_seed_is_applied_before_the_model_is_built(self, name):
+        """Position, not just presence.
+
+        A call placed after the model is built would satisfy the test above and
+        still leave the head and the adapter unseeded, which is the exact half
+        of #353 that threading the config does not fix.
+
+        "Builds the model" is any of `from_pretrained`, `get_peft_model`,
+        `load_model_and_tokenizer`, or one of the `self._setup_*` helpers the
+        wrappers delegate the load to. Most of them go through the last of
+        those, so matching only the direct calls would make this vacuous for
+        twelve of the eighteen.
+        """
+        import ast
+
+        loaders = {"get_peft_model", "load_model_and_tokenizer"}
+        setup = self._setup_body(name)
+        seeded, built = [], []
+        for node in ast.walk(setup):
+            if not isinstance(node, ast.Call):
+                continue
+            called = None
+            if isinstance(node.func, ast.Name):
+                called = node.func.id
+            elif isinstance(node.func, ast.Attribute):
+                called = node.func.attr
+            if called == "apply_training_seed":
+                seeded.append(node.lineno)
+            elif (
+                called in loaders
+                or called == "from_pretrained"
+                or (called or "").startswith("_setup_")
+            ):
+                built.append(node.lineno)
+        assert built, (
+            f"soup_cli.trainer.{name}.setup() has no recognisable model build; "
+            f"this check has gone stale and is no longer proving anything"
+        )
+        assert min(seeded) < min(built), (
+            f"soup_cli.trainer.{name}: apply_training_seed() is called at line "
+            f"{min(seeded)}, after the model is built at line {min(built)}"
+        )
+
+    @pytest.mark.parametrize("name", [m for m in _MODULES if m != "unlearn"])
+    def test_the_wrapper_threads_the_seed_into_its_config(self, name):
+        """`unlearn` is excluded because it builds no TrainingArguments."""
+        import importlib.util
+
+        spec = importlib.util.find_spec(f"soup_cli.trainer.{name}")
+        source = open(spec.origin, encoding="utf-8").read()
+        assert "training_seed_kwargs(" in source, (
+            f"soup_cli.trainer.{name} builds a TrainingArguments subclass "
+            f"without threading training.seed into it"
+        )
+
+
+class TestUnlearnSeeding:
+    """`unlearn` has no Trainer, so nothing else would ever seed it.
+
+    Its RMU control vector was drawn from a generator hard-coded to 0, which
+    made every RMU replicate share one control direction no matter what the
+    config said.
+    """
+
+    def test_the_rmu_control_vector_follows_the_seed(self):
+        import torch
+
+        hidden = 8
+        drawn = {}
+        for seed in (0, 1234, 1234):
+            gen = torch.Generator(device="cpu").manual_seed(seed)
+            drawn.setdefault(seed, []).append(torch.randn(hidden, generator=gen))
+        assert torch.equal(drawn[1234][0], drawn[1234][1])
+        assert not torch.equal(drawn[0][0], drawn[1234][0])
+
+    def test_an_unset_seed_still_draws_the_historical_vector(self):
+        """The control vector has been seeded 0 since RMU landed. An unset seed
+        must keep drawing that one rather than the resolved 42, or every
+        existing unseeded RMU run changes."""
+        from soup_cli.utils.seeding import resolve_training_seed
+
+        class _Tcfg:
+            seed = None
+
+        assert resolve_training_seed(_Tcfg()) == 42
+        rmu_seed = getattr(_Tcfg(), "seed", None)
+        assert (0 if rmu_seed is None else rmu_seed) == 0
+
+
+# ==========================================================================
+# the helper itself
+# ==========================================================================
+class TestSeedingHelper:
+    def test_unset_resolves_to_hf_default(self):
+        from soup_cli.utils.seeding import resolve_training_seed
+
+        class _Tcfg:
+            seed = None
+
+        assert resolve_training_seed(_Tcfg()) == 42
+
+    def test_zero_is_a_legitimate_seed(self):
+        from soup_cli.utils.seeding import resolve_training_seed
+
+        class _Tcfg:
+            seed = 0
+
+        assert resolve_training_seed(_Tcfg()) == 0
+
+    def test_kwargs_carry_both_fields(self):
+        from soup_cli.utils.seeding import training_seed_kwargs
+
+        class _Tcfg:
+            seed = 7
+            data_seed = 11
+
+        assert training_seed_kwargs(_Tcfg()) == {"seed": 7, "data_seed": 11}
+
+    def test_unset_data_seed_stays_none(self):
+        """`None` means "follow `seed`" to HF. Pinning it to the resolved seed
+        would change the data order of every run that sets neither field."""
+        from soup_cli.utils.seeding import training_seed_kwargs
+
+        class _Tcfg:
+            seed = 7
+            data_seed = None
+
+        assert training_seed_kwargs(_Tcfg()) == {"seed": 7, "data_seed": None}
+
+    def test_applying_the_seed_makes_torch_reproducible(self):
+        _requires_train_extra()
+        import torch
+
+        from soup_cli.utils.seeding import apply_training_seed
+
+        class _Tcfg:
+            seed = 1234
+            data_seed = None
+
+        apply_training_seed(_Tcfg())
+        first = torch.randn(4)
+        apply_training_seed(_Tcfg())
+        assert torch.equal(first, torch.randn(4))
+
+    def test_the_module_imports_without_torch(self):
+        """It is imported by every task wrapper, so it must stay light: the
+        `set_seed` import lives inside the function that needs it."""
+        import subprocess
+        import sys
+
+        code = (
+            "import sys;"
+            "sys.modules['torch'] = None;"
+            "sys.modules['transformers'] = None;"
+            "import soup_cli.utils.seeding as s;"
+            "print(s.resolve_training_seed(type('T', (), {'seed': None})()))"
+        )
+        out = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True
+        )
+        assert out.returncode == 0, out.stderr
+        assert out.stdout.strip() == "42"

--- a/tests/test_issue353_seed_every_task.py
+++ b/tests/test_issue353_seed_every_task.py
@@ -487,6 +487,52 @@ class TestEveryTaskIsAccountedFor:
         assert not stale, f"{sorted(stale)} are listed here but not in the schema"
 
 
+#: Trainer modules that define a `setup()` and legitimately do not seed in it,
+#: each with the reason. Everything else with a `setup()` must seed, and
+#: `_MODULES` is derived rather than written out: the first version of this
+#: guard WAS a hand-written tuple, and it shipped eighteen names long against
+#: nineteen seeding wrappers. `orpo` was the omission, so the one wrapper whose
+#: `apply_training_seed` call could be deleted with the whole suite still green
+#: was sitting inside the guard built to stop precisely that. The task list is
+#: derived from the schema thirty lines up for the same reason; this is the same
+#: move one level down, at the module.
+_NOT_SEEDED = {
+    "tts": "delegates to sft's setup() via super().setup(dataset)",
+    "preference": "delegates to an inner wrapper, which _make_inner_cfg's "
+                  "model_copy carries the seed into",
+    "bitnet": "raises before it builds anything; hardware-gated path",
+    "mlx_sft": "MLX backend, which seeds nothing on any path yet",
+    "mlx_dpo": "MLX backend, which seeds nothing on any path yet",
+    "mlx_grpo": "MLX backend, which seeds nothing on any path yet",
+}
+
+
+def _modules_defining_setup():
+    """`soup_cli.trainer` module name -> its `setup()` AST node.
+
+    Read off the package directory, so a wrapper added tomorrow is covered
+    without anyone remembering to add it here. A module with no `setup()` is not
+    a task wrapper and cannot seed in one, which keeps helpers, mixins and the
+    reward-function library out without a second hand-written list.
+    """
+    import ast
+    import importlib.util
+    from pathlib import Path
+
+    spec = importlib.util.find_spec("soup_cli.trainer")
+    found = {}
+    for path in sorted(Path(spec.origin).parent.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "setup":
+                found[path.stem] = node
+                break
+    return found
+
+
+_MODULES = tuple(sorted(set(_modules_defining_setup()) - set(_NOT_SEEDED)))
+
+
 class TestEveryWrapperAppliesTheSeed:
     """Every task wrapper calls `apply_training_seed` before it builds a model.
 
@@ -494,29 +540,68 @@ class TestEveryWrapperAppliesTheSeed:
     need a reward model, a judge, a teacher, or audio, and it fails when a new
     wrapper is added without the call. It asserts the call exists, not that it
     works; the matrix above asserts that it works.
-    """
 
-    #: module -> the method that must apply the seed. `prm` seeds in `setup()`
-    #: (it builds a randomly initialised reward head there) and threads the
-    #: kwargs in `train()`.
-    _MODULES = (
-        "asr", "bco", "classifier", "distill", "dpo", "embedding", "grpo",
-        "ipo", "kto", "mole_routing", "online_dpo", "ppo", "pretrain", "prm",
-        "reward_model", "sft", "simpo", "unlearn",
-    )
+    `prm` is here rather than in the matrix because it seeds in `setup()` (it
+    builds a randomly initialised reward head there) and threads the kwargs in
+    `train()`.
+    """
 
     @staticmethod
     def _setup_body(name):
-        import ast
-        import importlib.util
+        setups = _modules_defining_setup()
+        assert name in setups, f"soup_cli.trainer.{name} defines no setup()"
+        return setups[name]
 
-        spec = importlib.util.find_spec(f"soup_cli.trainer.{name}")
-        with open(spec.origin, encoding="utf-8") as handle:
-            tree = ast.parse(handle.read())
-        for node in ast.walk(tree):
-            if isinstance(node, ast.FunctionDef) and node.name == "setup":
-                return node
-        raise AssertionError(f"soup_cli.trainer.{name} defines no setup()")
+    @staticmethod
+    def _calls_apply_training_seed(setup):
+        import ast
+
+        return [
+            node.lineno
+            for node in ast.walk(setup)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "apply_training_seed"
+        ]
+
+    def test_the_derivation_found_the_wrappers(self):
+        """Non-vacuity. A glob that returns nothing passes every test below it.
+
+        `_MODULES` is read off the installed package directory, so a layout this
+        does not expect (a zip import, a namespace package, a build shipping no
+        sources) would empty it and quietly turn the whole class into a no-op.
+        These four are the wrappers #353 is about; if they are not in the derived
+        list then the derivation is broken, not the code clean.
+        """
+        assert {"sft", "grpo", "orpo", "unlearn"} <= set(_MODULES), (
+            f"derived only {sorted(_MODULES)} from soup_cli.trainer, which "
+            f"cannot be right; the module discovery has gone stale"
+        )
+
+    def test_the_not_seeded_list_does_not_rot(self):
+        """A module that leaves the package, or loses its `setup()`, must leave
+        `_NOT_SEEDED` too, or the list slowly stops describing anything."""
+        setups = _modules_defining_setup()
+        stale = sorted(set(_NOT_SEEDED) - set(setups))
+        assert not stale, (
+            f"{stale} are excused from seeding here but no longer define a "
+            f"setup() in soup_cli.trainer"
+        )
+
+    def test_nothing_on_the_not_seeded_list_secretly_seeds(self):
+        """The other direction. A wrapper that starts seeding has to come off
+        the exclusion list, otherwise nothing watches it from then on: the
+        parametrised tests below never see a name that is excluded."""
+        setups = _modules_defining_setup()
+        seeding = sorted(
+            name
+            for name in _NOT_SEEDED
+            if name in setups and self._calls_apply_training_seed(setups[name])
+        )
+        assert not seeding, (
+            f"{seeding} call apply_training_seed() but are listed in "
+            f"_NOT_SEEDED, so the guard skips them; remove them from the list"
+        )
 
     @pytest.mark.parametrize("name", _MODULES)
     def test_the_wrapper_seeds_inside_setup(self, name):
@@ -548,7 +633,7 @@ class TestEveryWrapperAppliesTheSeed:
         `load_model_and_tokenizer`, or one of the `self._setup_*` helpers the
         wrappers delegate the load to. Most of them go through the last of
         those, so matching only the direct calls would make this vacuous for
-        twelve of the eighteen.
+        thirteen of the nineteen.
         """
         import ast
 
@@ -574,6 +659,11 @@ class TestEveryWrapperAppliesTheSeed:
         assert built, (
             f"soup_cli.trainer.{name}.setup() has no recognisable model build; "
             f"this check has gone stale and is no longer proving anything"
+        )
+        assert seeded, (
+            f"soup_cli.trainer.{name}.setup() never calls apply_training_seed() "
+            f"at all, so there is no position to check; "
+            f"test_the_wrapper_seeds_inside_setup[{name}] is the failure to read"
         )
         assert min(seeded) < min(built), (
             f"soup_cli.trainer.{name}: apply_training_seed() is called at line "


### PR DESCRIPTION
Closes #353.

## What was wrong

#341 added `training.seed` and wired it into `trainer/sft.py`. The other seventeen task
wrappers each build their own `TrainingArguments` subclass and none of them read the field, so
`task: grpo` with `training.seed: 7` trained at HF's default of 42 with no error and no
warning, and two "different seeds" were the same run.

I checked the acceptance list against the code rather than taking it as given, and it is two
short. Beyond the sixteen tasks named there:

- **`moe_lora_routing`** builds a `TrainingArguments` like the rest.
- **`unlearn`** builds no `TrainingArguments` at all. It has a hand-rolled loop, and its RMU
  control vector came from a generator hard-coded to 0, so every RMU replicate shared one
  control direction whatever the config said.

`tts` and `bitnet` subclass `SFTTrainerWrapper` and come along free. `preference` delegates
through `_make_inner_cfg`, which `model_copy`s the training block and so carries the seed into
whichever inner wrapper runs. `reranker` and `cross_encoder` are the classifier wrapper under
other names.

## Why the repair is in two parts

Threading the config is necessary but not sufficient, for the reason #354's investigation
already established: `Trainer.__init__` runs `set_seed(args.seed)`, but `get_peft_model` has
drawn `lora_A` before a Trainer exists. That record's conclusion was "the fix is placement, not
plumbing: seed before the adapter is created", so that is what every wrapper now does, at the
top of `setup()`.

It is not only LoRA. `classifier`, `reward_model` and `prm` draw a freshly initialised head
inside `from_pretrained` (or `nn.Linear`) before their `TrainingArguments` exists at all: in
`classifier` the head is built at line 242 and the args at line 332.

Nor is one `set_seed` in the CLI sufficient. `commands/train.py` is not the only caller of
`setup()`; `commands/sweep.py` is another, and a sweep is precisely a reproducibility study. An
entry-point call would leave the next caller silently unseeded, which is the shape of this
defect rather than a fix for it.

## What changed

- New `src/soup_cli/utils/seeding.py`: `resolve_training_seed`, `training_seed_kwargs`,
  `apply_training_seed`. It imports nothing heavy at module scope, since every wrapper imports
  it; `set_seed` is imported inside the one function that needs it.
- Seventeen wrappers gained `apply_training_seed(tcfg)` at the top of `setup()` and
  `**training_seed_kwargs(tcfg)` where they build their config. `prm` is the odd one: it seeds
  in `setup()`, where it builds the reward head, and threads the kwargs in `train()`, where its
  `TrainingArguments` actually lives.
- `unlearn` seeds in `setup()`, and its RMU control vector now follows `training.seed`. An
  unset seed keeps drawing at 0 rather than the resolved 42, on the same reasoning as
  `DEFAULT_MULTIPACK_SEED`: moving it would silently change every existing unseeded RMU run.
- `sft.py` now uses the shared helper. `DEFAULT_TRAINING_SEED` moved to `utils.seeding` with a
  comment left at its old home. Nothing in the tree imported it from `sft`, but say the word
  and I will re-export it.

An unset seed still resolves to 42 everywhere and `data_seed` stays `None`, so the values a
config that sets neither field trains at are unchanged. What changes is that they now arrive
before the adapter and any fresh head are drawn, which previously came off an entropy-seeded
generator and so varied from process to process. That is asserted per task rather than assumed.

## Tests

`tests/test_issue353_seed_every_task.py`. `setup()` is called, not mocked, on the lesson
`test_trl_preference_config_contract.py` records.

- Twelve tasks driven through a real `setup()` on CPU (sft, dpo, ipo, kto, orpo, simpo, bco,
  grpo, reward_model, classifier, pretrain, embedding), asserting the configured `seed` and
  `data_seed` reach the config the trainer receives, each with the unset-is-still-42 control.
- The acceptance pair on a task that is not sft: same seed reproduces, different seeds diverge.
- Adapter initialisation, by the method #354's record used: `lora_A` across two builds,
  identical at one seed and different at two, for both `sft` and `dpo`, plus the classifier
  head. The differing arm is the one carrying the result.
- Every config class the wrappers build is asked whether it accepts `seed` / `data_seed`. That
  covers `ppo` and `online_dpo`, whose `setup()` needs a reward model and a judge and so cannot
  be driven here, and it asks the class rather than a version table.
- A coverage guard walks the schema's own `task` literal and fails if a task is neither driven
  here nor listed with a reason, so the next task added cannot silently repeat this. A second
  guard asserts every wrapper calls `apply_training_seed` inside `setup()` and before it builds
  the model.

Measured on transformers 4.57.6 / trl 0.28.0 / peft 0.20.0 / torch 2.12 CPU:

| run | result |
|---|---|
| new suite, this branch | 108 passed |
| new suite, copied onto a pristine 57c18e5 worktree | 86 failed, 22 passed |
| whole suite, this branch | 4 failed, 17402 passed, 179 skipped |
| whole suite, pristine 57c18e5 | 4 failed, 17296 passed, 179 skipped |

Both whole-suite runs fail the same four:
`test_cli_subprocess.py::TestInitCommand::test_init_default_output` and three subprocess-audit tests in
`test_v0713.py`. None is anywhere near this diff, and running those four on their own gives the same
answer on both worktrees: `test_init_default_output` fails, the other three pass. So the two runs differ
only by the tests this PR adds.

The 22 that pass on pristine are the controls, which is what makes the other 86 mean something:

- all three `sft` parametrisations, the one task #341 already wired, so the harness is proven to work
  before it is used to accuse anything;
- every `an_unset_seed_is_still_42` check, for all twelve tasks, since on pristine everything is 42
  anyway;
- `test_same_seed_reproduces`, which passes there precisely because nothing varies;
- both `the_same_seed_initialises_the_adapter_identically` arms, the halves that must not vary.

`test_different_seed_diverges` fails on pristine, and so does every
`a_different_seed_initialises_the_adapter_differently`: `lora_A` comes out element-for-element identical
at seed 1234 and 4321, as does the classifier head. That is the issue's probes A/B/C and #354's hash
comparison, reproduced in-process.

## Notes

This does not close #354. Its acceptance is a resident 4-bit `train_loss` match on real
hardware, which I cannot measure here. It does land the placement repair that investigation
confirmed and prescribed, and the `lora_A` assertion above is that investigation's own probe
run in-process on a tiny CPU model.

The CHANGELOG entry lands in the same `## [Unreleased]` hunk as #380, so one of them will need
a trivial rebase. Happy to take whichever side you prefer.

