### PR TITLE
feat(stream): let training.stream_vram_override replace the measured free VRAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,19 @@ reproducing 70+ versions of notes.
   `named_buffers()` carry the same segment and are deliberately not covered — the
   comparison that produced the false green was over parameter names.
 
+### Added
+
+- **`training.stream_vram_override` gives the layer-streaming VRAM pre-flight an
+  explicit escape hatch (#347).** `decide_stream_fit` refused any run it predicted
+  would not fit, with no way through except lowering `batch_size` or `max_length`.
+  Setting this field now replaces the measured free-VRAM figure the pre-flight
+  checks against, in either direction: raised past a documented over-prediction to
+  let a known-safe config through, or lowered to enforce a cap `mem_get_info()`
+  cannot see, such as `set_per_process_memory_fraction` on a shared or capped card
+  (a Colab/Kaggle T4, a MIG slice). Rejected at config load when set while
+  `stream_layers` is false, mirroring the existing `stream_source`/`stream_buffers`
+  footgun gate.
+
 ### Fixed
 
 - **bf16 was assumed on every CUDA card, so the entire free GPU tier failed (#385, #387).**

--- a/docs/performance-and-quantization.md
+++ b/docs/performance-and-quantization.md
@@ -347,7 +347,7 @@ prints this advice when it sees you accumulating.
 - `task: kto` with `batch_size: 1` → TRL's KL term is degenerate at batch 1; refused when the config is read rather than minutes later after sharding
 - `lora.use_dora` / `lora.use_vera` / `lora.init_strategy` other than `random` → these initialise from the real base weight, which is on the meta device under streaming
 - `unfrozen_parameters`, `lisa_enabled`, `packing`, `multipack`, `use_fsdp2_compile`, `train_router_only`, `expand_layers` → each independently rewrites or re-freezes the same layers
-- `stream_source` / `stream_buffers` set while `stream_layers: false` → a footgun, refused
+- `stream_source` / `stream_buffers` / `stream_vram_override` set while `stream_layers: false` → a footgun, refused
 - an architecture outside the supported list (llama / qwen2 / qwen3 / mistral / gemma / gemma2 / gemma3_text / phi / phi3) → named explicitly
 
 **Config example:**

--- a/src/soup_cli/config/schema.py
+++ b/src/soup_cli/config/schema.py
@@ -3019,6 +3019,31 @@ class TrainingConfig(BaseModel):
             raise ValueError("training.stream_buffers must be an int, not bool")
         return v
 
+    stream_vram_override: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Bytes to assume free instead of measuring "
+            "torch.cuda.mem_get_info(). mem_get_info() is a device-level "
+            "driver query, so it cannot see a per-process cap "
+            "(set_per_process_memory_fraction, a MIG slice, a card another "
+            "process is also using), so on that hardware the pre-flight sees the "
+            "whole device's free VRAM regardless of what this process can "
+            "actually use. Set this to replace the measured figure in either "
+            "direction: raise it to let a known-safe over-prediction through, "
+            "or lower it to make the pre-flight enforce a cap the driver "
+            "itself cannot report."
+        ),
+    )
+
+    @field_validator("stream_vram_override", mode="before")
+    @classmethod
+    def _validate_stream_vram_override_int(cls, v: Any) -> Any:
+        """Reject bool-as-int (bool subclasses int), mirrors stream_buffers."""
+        if isinstance(v, bool):
+            raise ValueError("training.stream_vram_override must be an int (bytes), not bool")
+        return v
+
     # Sample packing — pack multiple short samples into one sequence
     packing: bool = Field(
         default=False,
@@ -4807,11 +4832,16 @@ class SoupConfig(BaseModel):
         if not tcfg.stream_layers:
             # Footgun: a non-default stream_* while streaming is off almost
             # certainly means the user forgot stream_layers=true.
-            if tcfg.stream_source != "auto" or tcfg.stream_buffers != 2:
+            if (
+                tcfg.stream_source != "auto"
+                or tcfg.stream_buffers != 2
+                or tcfg.stream_vram_override is not None
+            ):
                 raise ValueError(
-                    "training.stream_source / training.stream_buffers set but "
-                    "stream_layers is false — set stream_layers=true to stream "
-                    "the base layer-by-layer."
+                    "training.stream_source / training.stream_buffers / "
+                    "training.stream_vram_override set but stream_layers is "
+                    "false; set stream_layers=true to stream the base "
+                    "layer-by-layer."
                 )
             return self
         # v0.72.4 — the four preference losses join SFT. DPO and KTO take their

--- a/src/soup_cli/trainer/stream_setup.py
+++ b/src/soup_cli/trainer/stream_setup.py
@@ -431,6 +431,7 @@ class StreamingSetupMixin:
             estimate_logits_bytes,
             estimate_stream_peak_vram,
             forecast_stream_throughput,
+            resolve_available_vram_bytes,
         )
         from soup_cli.utils.layer_stream_runtime import measure_gemm_tflops
 
@@ -483,11 +484,20 @@ class StreamingSetupMixin:
 
         import torch
 
-        available = int(torch.cuda.mem_get_info()[0])
+        measured_available = int(torch.cuda.mem_get_info()[0])
+        available = resolve_available_vram_bytes(
+            measured_bytes=measured_available, override_bytes=tcfg.stream_vram_override
+        )
         fit = decide_stream_fit(predicted_bytes=predicted, available_bytes=available)
         if not fit.fits:
             raise ValueError(fit.reason)
-        lines.append(f"  free VRAM    {available / 1e9:.2f} GB")
+        if tcfg.stream_vram_override is None:
+            lines.append(f"  free VRAM    {available / 1e9:.2f} GB")
+        else:
+            lines.append(
+                f"  free VRAM    {available / 1e9:.2f} GB (training.stream_vram_override; "
+                f"driver reports {measured_available / 1e9:.2f} GB)"
+            )
 
         # A per-card TFLOPS constant baked into the source would be a
         # fabrication; measuring the user's own card in this session is the only

--- a/src/soup_cli/utils/layer_stream.py
+++ b/src/soup_cli/utils/layer_stream.py
@@ -811,6 +811,21 @@ def decide_stream_fit(*, predicted_bytes: int, available_bytes: int) -> VramFit:
     )
 
 
+def resolve_available_vram_bytes(
+    *, measured_bytes: int, override_bytes: Optional[int]
+) -> int:
+    """The free-VRAM figure the pre-flight fit check measures against.
+
+    ``mem_get_info()`` is a device-level driver query, so it cannot see a
+    per-process cap (``set_per_process_memory_fraction``, a MIG slice, a card
+    another process is also using). ``training.stream_vram_override``, when
+    set, REPLACES the driver reading rather than padding it, in either
+    direction: raised to let a documented over-prediction through, or lowered
+    to enforce a cap the driver itself cannot report.
+    """
+    return measured_bytes if override_bytes is None else override_bytes
+
+
 #: Measured (GATE 3) speed-up from reaching an effective batch by raising
 #: ``batch_size`` rather than ``gradient_accumulation_steps``: Qwen2.5-0.5B bf16,
 #: S=256, pinned store — 1393.4 tok/s at batch 4 / accum 1 against 553.2 at

--- a/tests/test_v07200.py
+++ b/tests/test_v07200.py
@@ -760,12 +760,43 @@ class TestStreamSchemaDefaults:
         assert cfg.training.stream_layers is False
         assert cfg.training.stream_source == "auto"
         assert cfg.training.stream_buffers == 2
+        assert cfg.training.stream_vram_override is None
 
     def test_happy_path_parses(self):
         cfg = _load(_stream_yaml(training={"stream_source": "ram", "stream_buffers": 3}))
         assert cfg.training.stream_layers is True
         assert cfg.training.stream_source == "ram"
         assert cfg.training.stream_buffers == 3
+
+
+class TestStreamVramOverride:
+    def test_defaults_to_none(self):
+        assert _load(_stream_yaml()).training.stream_vram_override is None
+
+    def test_accepts_an_explicit_byte_count(self):
+        cfg = _load(_stream_yaml(training={"stream_vram_override": 4_000_000_000}))
+        assert cfg.training.stream_vram_override == 4_000_000_000
+
+    def test_zero_is_accepted(self):
+        """A degenerate but legal value: 'assume nothing is free'."""
+        cfg = _load(_stream_yaml(training={"stream_vram_override": 0}))
+        assert cfg.training.stream_vram_override == 0
+
+    def test_negative_rejected(self):
+        with pytest.raises(ValueError, match="stream_vram_override"):
+            _load(_stream_yaml(training={"stream_vram_override": -1}))
+
+    def test_bool_rejected(self):
+        with pytest.raises(ValueError, match="bool"):
+            _load(_stream_yaml(training={"stream_vram_override": True}))
+
+    def test_without_stream_layers_rejected(self):
+        with pytest.raises(ValueError, match="stream_layers"):
+            _load(
+                _stream_yaml(
+                    training={"stream_layers": False, "stream_vram_override": 4_000_000_000}
+                )
+            )
 
 
 class TestStreamTaskAndBackendGates:

--- a/tests/test_v07203.py
+++ b/tests/test_v07203.py
@@ -284,6 +284,54 @@ class TestStreamFitDecision:
         assert "batch_size" in reason and "max_length" in reason
 
 
+class TestResolveAvailableVramBytes:
+    """training.stream_vram_override (#347): the driver's mem_get_info() is a
+    device-level query and cannot see a per-process cap, so the override must
+    fully REPLACE the measured figure, not adjust it."""
+
+    def test_no_override_uses_the_measured_figure(self):
+        from soup_cli.utils.layer_stream import resolve_available_vram_bytes
+
+        got = resolve_available_vram_bytes(measured_bytes=3_445_000_000, override_bytes=None)
+        assert got == 3_445_000_000
+
+    def test_override_replaces_a_larger_measured_figure(self):
+        """Raising the budget: let a documented over-prediction through even
+        though the driver reports plenty of headroom."""
+        from soup_cli.utils.layer_stream import resolve_available_vram_bytes
+
+        got = resolve_available_vram_bytes(
+            measured_bytes=16_000_000_000, override_bytes=3_541_000_000
+        )
+        assert got == 3_541_000_000
+
+    def test_override_replaces_a_smaller_measured_figure(self):
+        """Lowering the budget below what the driver reports: the Colab/Kaggle
+        case from #347's follow-up comment, where set_per_process_memory_fraction
+        caps the process but mem_get_info() still reports the whole card."""
+        from soup_cli.utils.layer_stream import resolve_available_vram_bytes
+
+        got = resolve_available_vram_bytes(
+            measured_bytes=16_000_000_000, override_bytes=4_000_000_000
+        )
+        assert got == 4_000_000_000
+
+    def test_override_below_real_free_vram_makes_a_fitting_config_refused(self):
+        """The acceptance test #347's follow-up comment asks for verbatim: an
+        override set below the real free VRAM must turn an otherwise-fitting
+        config into a refusal, because that is the assertion nothing can fake."""
+        from soup_cli.utils.layer_stream import decide_stream_fit, resolve_available_vram_bytes
+
+        predicted = 5_000_000_000
+        measured_free = 16_000_000_000  # plenty, would normally fit
+        assert decide_stream_fit(predicted_bytes=predicted, available_bytes=measured_free).fits
+
+        capped = resolve_available_vram_bytes(
+            measured_bytes=measured_free, override_bytes=4_000_000_000
+        )
+        assert not decide_stream_fit(predicted_bytes=predicted, available_bytes=capped).fits
+
+
 class TestThroughputForecast:
     def test_ceiling_uses_c_equals_six(self):
         from soup_cli.utils.layer_stream import forecast_stream_throughput
@@ -796,7 +844,7 @@ class TestAutoTierFallback:
 
     def _run(
         self, tmp_path, monkeypatch, *, free_ram, stream_source,
-        disk_kind="nvme", device="cpu",
+        disk_kind="nvme", device="cpu", extra_training_yaml="",
     ):
         from soup_cli.config.loader import load_config_from_string
         from soup_cli.trainer.sft import SFTTrainerWrapper
@@ -823,7 +871,7 @@ class TestAutoTierFallback:
             "data:\n  train: data.jsonl\n  format: alpaca\n"
             "training:\n  batch_size: 1\n  gradient_accumulation_steps: 1\n"
             f"  quantization: none\n  stream_layers: true\n"
-            f"  stream_source: {stream_source}\n"
+            f"  stream_source: {stream_source}\n{extra_training_yaml}"
             "  lora:\n    r: 4\n    target_modules: [q_proj, v_proj]\n"
         )
         wrapper = SFTTrainerWrapper(cfg)
@@ -892,6 +940,45 @@ class TestAutoTierFallback:
                 tmp_path, monkeypatch, free_ram=10_000_000_000,
                 stream_source="auto", device="cuda",
             )
+
+    @requires_cuda
+    def test_stream_vram_override_below_measured_free_refuses_a_fitting_config(
+        self, tmp_path, monkeypatch
+    ):
+        """#347: mem_get_info() is device-level and cannot see a per-process cap
+        (a Colab/Kaggle set_per_process_memory_fraction, a MIG slice, a shared
+        card), so it reports plenty of free VRAM here on purpose. The override
+        must still make the pre-flight refuse, because on the real hardware this
+        models that is the whole point."""
+        import torch
+
+        monkeypatch.setattr(
+            torch.cuda, "mem_get_info", lambda *_a, **_k: (16_000_000_000, 16_000_000_000)
+        )
+        with pytest.raises(ValueError, match="predicted to need"):
+            self._run(
+                tmp_path, monkeypatch, free_ram=10_000_000_000,
+                stream_source="auto", device="cuda",
+                extra_training_yaml="  stream_vram_override: 1000000\n",
+            )
+
+    @requires_cuda
+    def test_stream_vram_override_above_measured_free_lets_a_refused_config_through(
+        self, tmp_path, monkeypatch
+    ):
+        """The other direction: a documented over-prediction that would
+        otherwise refuse a known-safe config now proceeds."""
+        import torch
+
+        monkeypatch.setattr(
+            torch.cuda, "mem_get_info", lambda *_a, **_k: (1_000_000, 4_000_000_000)
+        )
+        wrapper = self._run(
+            tmp_path, monkeypatch, free_ram=10_000_000_000,
+            stream_source="auto", device="cuda",
+            extra_training_yaml="  stream_vram_override: 16000000000\n",
+        )
+        assert wrapper._stream_runtime is not None
 
     def test_the_fallback_says_the_cost_is_unmeasured(self, tmp_path, monkeypatch):
         """A silent fallback to a slower path is the failure mode this project

--- a/tests/test_v07203.py
+++ b/tests/test_v07203.py
@@ -316,6 +316,20 @@ class TestResolveAvailableVramBytes:
         )
         assert got == 4_000_000_000
 
+    def test_override_zero_is_honoured_not_treated_as_absent(self):
+        """0 is a legitimate override ("assume nothing is free, refuse
+        everything") and the value someone sets first to confirm the flag is
+        wired at all, expecting a refusal. The `is None` check in
+        resolve_available_vram_bytes is correct, but nothing previously
+        exercised it at the resolver: a `override_bytes or measured_bytes`
+        mutation (falsy-0 falls back to the driver figure) still passed the
+        full suite (review on #386, blocking item). This pins the resolver
+        itself, not just that 0 survives config load."""
+        from soup_cli.utils.layer_stream import resolve_available_vram_bytes
+
+        got = resolve_available_vram_bytes(measured_bytes=15_360_000_000, override_bytes=0)
+        assert got == 0
+
     def test_override_below_real_free_vram_makes_a_fitting_config_refused(self):
         """The acceptance test #347's follow-up comment asks for verbatim: an
         override set below the real free VRAM must turn an otherwise-fitting


### PR DESCRIPTION
## Root cause

`decide_stream_fit` refuses any layer-streaming step it predicts will not fit, with no way through except lowering `training.batch_size` or `data.max_length` (`trainer/stream_setup.py:_stream_budget_lines`). That refusal is deliberate for the common case: on Windows an under-prediction does not raise, it silently spills to host memory. But the free-VRAM figure it checks against comes from `torch.cuda.mem_get_info()`, a device-level driver query, and that query cannot see a per-process cap: `torch.cuda.set_per_process_memory_fraction`, a MIG slice, or a card another process is also using. On that hardware the pre-flight sees the whole device's free VRAM regardless of what the process can actually use, so there was no way to make the pre-flight simulate the real constraint either.

## Fix

`training.stream_vram_override` (bytes) replaces the measured free-VRAM figure the pre-flight checks against, in either direction:

- raised past a documented over-prediction, to let a known-safe config through;
- lowered below the real free VRAM, to enforce a cap the driver itself cannot report (a capped Colab/Kaggle T4, a MIG slice).

Rejected at config load when set while `stream_layers` is false, mirroring the existing `stream_source`/`stream_buffers` footgun gate.

**One note on shape, since the issue changed under me while it was open.** The original acceptance criteria describe a `bool`/`force` flag that lets an over-budget run proceed. The follow-up comment on this issue narrows and extends that: a boolean cannot express "assume only 4 GB is free" for the capped-notebook case, so it asks for a numeric value that *replaces* the measured figure instead. I built the follow-up comment's shape, since it is the one the notebook use case actually needs and it still satisfies the original ask (an over-prediction can be raised past). One consequence: the override does not unconditionally let a run "proceed" the way the original bool would have. It changes the yardstick `decide_stream_fit` measures against, and that comparison still refuses if the predicted peak exceeds it, which is what makes "override set below real free VRAM refuses a fitting config" a real test rather than a tautology.

## Verification

- New tests fail on `main` (`ImportError`, `resolve_available_vram_bytes` does not exist there) and pass on this branch: `resolve_available_vram_bytes` unit tests (no override uses the measured figure; override replaces a larger or smaller measured figure either way), the acceptance test the follow-up comment describes verbatim (override set below real free VRAM turns an otherwise-fitting config into a refusal), and schema tests (default `None`, accepts an explicit byte count, rejects `bool`/negative, rejects being set while `stream_layers` is false).
- `pytest tests/test_v07200.py tests/test_v07201.py tests/test_v07202.py tests/test_v07203.py tests/test_v07204.py tests/test_v07300.py` (the layer-streaming and preference-loss suites, 476 tests): all pass, 21 skipped (CUDA-gated, expected offline). `ruff check src/soup_cli/ tests/` clean.
- Not verified: the trainer-level wiring in `_stream_budget_lines` (the `on_cuda` branch that actually calls `resolve_available_vram_bytes`) has no GPU available in this sandbox, so its two CUDA-gated integration tests are skipped, the same as every other test in this file that drives that branch. Only Python 3.12 of this repo's 3.10/3.11/3.12 CI matrix was run.

Fixes #347
