### PR TITLE
fix(stream): wire calibrated_logits_bytes_per_element into the VRAM pre-flight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ reproducing 70+ versions of notes.
 
 ### Fixed
 
+- **Layer streaming's VRAM pre-flight now actually calls its own calibration hook (#348).**
+  `calibrated_logits_bytes_per_element()` exists to raise the budget when a stack's loss
+  path measures a heavier retention than the shipped constant assumes, guarding against a
+  future stack silently under-budgeting by 12.5% with nothing to catch it. `_stream_budget_lines`
+  called `estimate_stream_peak_vram()` without `logits_bytes_per_element=`, so the parameter
+  was always `None` and the calibration never ran outside its own test. It is now forwarded to
+  both the budget and the panel's `logits` figure; the value can only raise the prediction
+  (floored at the shipped constant), and the panel prints an extra line naming both numbers
+  when the calibration measures above it.
 - **MLX backend now actually dispatches to the MLX trainer for `task: sft`.** Previously `backend: mlx` silently fell through to the transformers `SFTTrainerWrapper`, training on MPS/CUDA instead of MLX. The trainer was also rewritten for mlx-lm >= 0.31 (`create_dataset` + `CacheDataset`, `TrainingCallback`), with `model.freeze()` before LoRA — without it the saved "adapter" was a full fine-tune (172 tensors vs 24 LoRA tensors on a 1.2B model) — and an `adapter_config.json` is written so the output dir loads directly with `mlx_lm.load(..., adapter_path=dir)`. (#362)
 - **`mlx-lm` floor raised to >= 0.31.3** (the version the MLX SFT path is built against).
 - **`training.seed` reached the SFT wrapper and nothing else (#353).** #341 added the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,13 @@ reproducing 70+ versions of notes.
   was always `None` and the calibration never ran outside its own test. It is now forwarded to
   both the budget and the panel's `logits` figure; the value can only raise the prediction
   (floored at the shipped constant), and the panel prints an extra line naming both numbers
-  when the calibration measures above it.
+  when the calibration measures above it. This makes the probe unconditional rather than
+  opt-in (see #327 below, whose wording is updated to match): every streamed run now pays
+  one transient `14 * vocab_size * max(tokens)` allocation (96 MiB at the defaults) plus two
+  `torch.cuda.synchronize()` calls before the fit decision is taken. On today's measured
+  stacks this is a no-op in effect (`measured` is 12.0 with zero spread, `max(14, 14)` is
+  14, no extra line prints), so the cost buys nothing yet, which is the point of a guard
+  against a stack that hasn't shipped.
 - **MLX backend now actually dispatches to the MLX trainer for `task: sft`.** Previously `backend: mlx` silently fell through to the transformers `SFTTrainerWrapper`, training on MPS/CUDA instead of MLX. The trainer was also rewritten for mlx-lm >= 0.31 (`create_dataset` + `CacheDataset`, `TrainingCallback`), with `model.freeze()` before LoRA — without it the saved "adapter" was a full fine-tune (172 tensors vs 24 LoRA tensors on a 1.2B model) — and an `adapter_config.json` is written so the output dir loads directly with `mlx_lm.load(..., adapter_path=dir)`. (#362)
 - **`mlx-lm` floor raised to >= 0.31.3** (the version the MLX SFT path is built against).
 - **`training.seed` reached the SFT wrapper and nothing else (#353).** #341 added the
@@ -335,10 +341,12 @@ exist, and repairs four backends.
 - **`LOGITS_BYTES_PER_ELEMENT` is split into two independently measured terms** (#327).
   The 14 is 12 + 2, measured stage by stage on an H100 with zero spread across three
   repeats, and only the 2 differs between stacks. It is deliberately **not lowered** —
-  see Known Limitations. What is new is an opt-in, upward-only calibration
+  see Known Limitations. What is new is an upward-only calibration
   (`max(14, measured + 2)`), which closes a real unguarded hole: a future stack that
   grew a fourth fp32 buffer would be under-budgeted by 12.5% today with nothing to catch
   it. Default behaviour is byte-identical and the pre-flight path takes no new CUDA.
+  (Originally landed as an opt-in probe with no caller; #348 above wires it into the
+  pre-flight itself, so it now runs on every streamed run rather than sitting inert.)
 
 ### Fixed — eval, ship and export
 

--- a/src/soup_cli/trainer/stream_setup.py
+++ b/src/soup_cli/trainer/stream_setup.py
@@ -427,7 +427,9 @@ class StreamingSetupMixin:
         is merely slow.
         """
         from soup_cli.utils.layer_stream import (
+            LOGITS_BYTES_PER_ELEMENT,
             accumulation_advice,
+            calibrated_logits_bytes_per_element,
             decide_stream_fit,
             estimate_logits_bytes,
             estimate_stream_peak_vram,
@@ -459,6 +461,9 @@ class StreamingSetupMixin:
             )
             return ()
 
+        # calibrated_logits_bytes_per_element() is floored at LOGITS_BYTES_PER_ELEMENT,
+        # so forwarding it here can only raise the budget, never lower it (issue #348).
+        calibrated = calibrated_logits_bytes_per_element()
         predicted = estimate_stream_peak_vram(
             layer_bytes=layer_bytes,
             buffers=tcfg.stream_buffers,
@@ -470,8 +475,11 @@ class StreamingSetupMixin:
             n_layers=index.n_layers,
             seq_len=seq_len,
             batch_size=rows,
+            logits_bytes_per_element=calibrated,
         )
-        logits = estimate_logits_bytes(vocab_size=vocab, seq_len=seq_len, batch_size=rows)
+        logits = estimate_logits_bytes(
+            vocab_size=vocab, seq_len=seq_len, batch_size=rows, bytes_per_element=calibrated
+        )
         paired = (
             "" if rows == batch else f" ({rows} rows — chosen+rejected are one concatenated tensor)"
         )
@@ -479,6 +487,11 @@ class StreamingSetupMixin:
             f"  peak VRAM    ~{predicted / 1e9:.2f} GB at batch {batch} x seq "
             f"{seq_len}{paired} (logits {logits / 1e9:.2f} GB)"
         ]
+        if calibrated > LOGITS_BYTES_PER_ELEMENT:
+            lines.append(
+                f"  logits       calibrated {calibrated:.3f} B/element on this stack, "
+                f"above the shipped {LOGITS_BYTES_PER_ELEMENT:.0f}: budget raised to match"
+            )
 
         if not on_cuda:
             return tuple(lines)

--- a/tests/test_issue348_calibrated_logits_wiring.py
+++ b/tests/test_issue348_calibrated_logits_wiring.py
@@ -1,0 +1,130 @@
+"""#348 — ``calibrated_logits_bytes_per_element()`` has no caller.
+
+#327 added the calibration hook (and the probe underneath it) as the guard against
+a stack whose loss path grows a fourth fp32 buffer, which would otherwise
+under-budget the VRAM pre-flight by 12.5% with nothing to catch it. But
+``_stream_budget_lines`` called ``estimate_stream_peak_vram`` without
+``logits_bytes_per_element=``, so the parameter was always ``None`` and the
+calibration was exercised only by ``tests/test_issue327_logits_estimate.py``, never
+by a real run. These tests assert the wiring, not the arithmetic (already pinned in
+the #327 suite): the parameter must actually be reachable from the pre-flight.
+"""
+
+from soup_cli.trainer.stream_setup import StreamingSetupMixin
+
+
+class _Index:
+    n_layers = 4
+
+
+class _ModelConfig:
+    # A large vocab so a 14 -> 40 bytes-per-element swing moves the displayed
+    # GB figure at 2-decimal precision, not just the underlying byte count.
+    vocab_size = 2_000_000
+    hidden_size = 8
+    intermediate_size = 16
+    num_hidden_layers = 4
+
+
+class _Lora:
+    r = 8
+    target_modules = ["q_proj", "v_proj"]
+
+
+class _TrainConfig:
+    batch_size = 1
+    stream_buffers = 2
+    lora = _Lora()
+
+
+class _Data:
+    max_length = 4
+
+
+class _Config:
+    data = _Data()
+
+
+def _budget_lines():
+    """``on_cuda=False`` exercises the panel without needing a GPU: the fit
+    decision is skipped, but the calibrated budget and its display line are
+    built either way (a CPU dry run reports the same peak VRAM figure a CUDA
+    run would refuse or accept against)."""
+    return StreamingSetupMixin()._stream_budget_lines(
+        _Config(),
+        _TrainConfig(),
+        model_config=_ModelConfig(),
+        layer_bytes=1000,
+        embed_bytes=0,
+        index=_Index(),
+        on_cuda=False,
+    )
+
+
+class TestCalibrationIsForwardedToTheBudget:
+    def test_a_high_calibration_raises_the_predicted_peak(self, monkeypatch):
+        from soup_cli.utils import layer_stream
+
+        monkeypatch.setattr(layer_stream, "calibrated_logits_bytes_per_element", lambda: 14.0)
+        baseline = _budget_lines()[0]
+
+        monkeypatch.setattr(layer_stream, "calibrated_logits_bytes_per_element", lambda: 40.0)
+        raised = _budget_lines()[0]
+
+        assert baseline != raised
+
+    def test_a_below_constant_calibration_does_not_lower_the_peak(self, monkeypatch):
+        """calibrated_logits_bytes_per_element() itself floors at the shipped
+        constant, so this also guards a future caller that bypasses the floor."""
+        from soup_cli.utils import layer_stream
+
+        monkeypatch.setattr(layer_stream, "calibrated_logits_bytes_per_element", lambda: 14.0)
+        at_constant = _budget_lines()
+
+        monkeypatch.setattr(layer_stream, "calibrated_logits_bytes_per_element", lambda: 4.0)
+        below = _budget_lines()
+
+        assert at_constant == below
+
+    def test_a_none_probe_leaves_the_peak_byte_identical_to_today(self, monkeypatch):
+        """No CUDA: measure_logits_loss_bytes_per_element() returns None and
+        calibrated_logits_bytes_per_element() falls back to LOGITS_BYTES_PER_ELEMENT,
+        so a machine without a GPU sees exactly today's number."""
+        from soup_cli.utils import layer_stream
+        from soup_cli.utils.layer_stream import estimate_stream_peak_vram
+
+        monkeypatch.setattr(
+            layer_stream, "measure_logits_loss_bytes_per_element", lambda **kw: None
+        )
+        (line,) = _budget_lines()
+
+        direct = estimate_stream_peak_vram(
+            layer_bytes=1000,
+            buffers=2,
+            extras_bytes=0,
+            adapter_params=4 * 2 * 2 * 8 * 8,
+            vocab_size=2_000_000,
+            hidden_size=8,
+            intermediate_size=16,
+            n_layers=4,
+            seq_len=4,
+            batch_size=1,
+        )
+        assert f"peak VRAM    ~{direct / 1e9:.2f} GB" in line
+
+
+class TestThePanelReportsWhenCalibrationDiverges:
+    def test_no_extra_line_at_the_shipped_constant(self, monkeypatch):
+        from soup_cli.utils import layer_stream
+
+        monkeypatch.setattr(layer_stream, "calibrated_logits_bytes_per_element", lambda: 14.0)
+        assert len(_budget_lines()) == 1
+
+    def test_an_extra_line_names_both_numbers_above_the_constant(self, monkeypatch):
+        from soup_cli.utils import layer_stream
+
+        monkeypatch.setattr(layer_stream, "calibrated_logits_bytes_per_element", lambda: 18.0)
+        lines = _budget_lines()
+        assert len(lines) == 2
+        assert "18.000" in lines[1]
+        assert "14" in lines[1]

--- a/tests/test_issue348_calibrated_logits_wiring.py
+++ b/tests/test_issue348_calibrated_logits_wiring.py
@@ -61,6 +61,13 @@ def _budget_lines():
     )
 
 
+def _peak_gb(line: str) -> str:
+    """Isolate the peak-VRAM figure from the trailing ``(logits ... GB)`` aside,
+    so a change confined to the logits display cannot satisfy an assertion about
+    the peak (the budget that actually refuses a run)."""
+    return line.split("~", 1)[1].split(" GB", 1)[0]
+
+
 class TestCalibrationIsForwardedToTheBudget:
     def test_a_high_calibration_raises_the_predicted_peak(self, monkeypatch):
         from soup_cli.utils import layer_stream
@@ -71,7 +78,20 @@ class TestCalibrationIsForwardedToTheBudget:
         monkeypatch.setattr(layer_stream, "calibrated_logits_bytes_per_element", lambda: 40.0)
         raised = _budget_lines()[0]
 
-        assert baseline != raised
+        assert _peak_gb(baseline) != _peak_gb(raised)
+
+    def test_a_high_calibration_also_raises_the_displayed_logits_figure(self, monkeypatch):
+        """The panel's logits figure is a separate claim from the peak above,
+        and moving together is not itself proof either one is wired correctly."""
+        from soup_cli.utils import layer_stream
+
+        monkeypatch.setattr(layer_stream, "calibrated_logits_bytes_per_element", lambda: 14.0)
+        baseline = _budget_lines()[0]
+
+        monkeypatch.setattr(layer_stream, "calibrated_logits_bytes_per_element", lambda: 40.0)
+        raised = _budget_lines()[0]
+
+        assert baseline.split("(logits ", 1)[1] != raised.split("(logits ", 1)[1]
 
     def test_a_below_constant_calibration_does_not_lower_the_peak(self, monkeypatch):
         """calibrated_logits_bytes_per_element() itself floors at the shipped


### PR DESCRIPTION
## Root cause

`calibrated_logits_bytes_per_element()` exists to raise the VRAM pre-flight's budget when this stack's loss path measures a heavier retention than the shipped constant assumes: the guard against a future stack silently under-budgeting by 12.5% with nothing to catch it. It had no caller. `_stream_budget_lines` calls `estimate_stream_peak_vram()` without `logits_bytes_per_element=`, so the parameter was always `None` and the calibration ran only inside `tests/test_issue327_logits_estimate.py`.

## Fix

`_stream_budget_lines` now calls `calibrated_logits_bytes_per_element()` once and forwards the result to both `estimate_stream_peak_vram()` (the actual budget) and `estimate_logits_bytes()` (the panel's `logits` figure), so the two stay consistent. The value is floored at the shipped constant inside `estimate_logits_bytes`, so this can only raise the prediction, never lower it. When the calibration measures above the constant, the panel prints an extra line naming both numbers.

## Verification

- `tests/test_issue348_calibrated_logits_wiring.py` (new): a stubbed high calibration raises the predicted peak, a stubbed calibration below the constant does not lower it, a `None` probe (no CUDA) leaves the prediction byte-identical to today, and the panel adds a line only when the calibration diverges from the constant. Confirmed each assertion fails on `main` and passes on this branch.
- `tests/test_issue327_logits_estimate.py` (the existing calibration-arithmetic suite) passes unchanged.
- Full suite (`pytest tests/`, Docker, `pip install -e .[dev]`) on Python 3.10 and 3.12: 186 passed, 18 skipped (CUDA-only rows this sandbox has no GPU for). `ruff check` and `mypy` clean on the changed file.
- Not verified: the actual GPU probe path (`measure_logits_loss_bytes_per_element` with a real CUDA device) and the Windows/macOS legs of the CI matrix, since this sandbox is Linux CPU-only. The wiring is covered by stubbing the calibration function; the probe's own arithmetic was already pinned by #327's tests.

Fixes #348
