### PR TITLE
test(forgetting): cover \boxed{X} MCQ letter extraction (#357)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ reproducing 70+ versions of notes.
 
 ### Fixed
 
+- **`extract_mcq_letter` scored zero for `\boxed {A}` — whitespace between the
+  command and the brace (#357).** The shipped `\boxed\{` regex tolerates spaces
+  *inside* the braces but not between `\boxed` and `{`; LaTeX permits it there and
+  models emit it, so `\boxed { C }` still read as no answer and was not rescued by
+  the cue tier either. The boxed-letter regex now allows `\s*` after the command.
+
 - **`soup draft distill --steps N` now delivers ~N optimiser steps instead of
   N/4.44 (#364).** The epoch count that realised `--steps` divided the request
   by `rows // batch_size`, ignoring that `val_split` (0.1) removes rows from

--- a/src/soup_cli/eval/forgetting.py
+++ b/src/soup_cli/eval/forgetting.py
@@ -47,7 +47,10 @@ _PAREN_RE = re.compile(r"(?<![A-Za-z0-9])\(?([A-Ja-j])\)(?![A-Za-z0-9])")
 # a single A–J letter. ``\boxed{4}`` is the model answering with a VALUE, and
 # reading that as "option 4" would be a wrong credit rather than a repair — the
 # prompt is what has to change there (see ``_MCQ_ANSWER_CUE``). #357.
-_BOXED_LETTER_RE = re.compile(r"\\boxed\{\s*([A-Ja-j])\s*\}")
+# The ``\s*`` after ``\boxed`` matters: LaTeX permits whitespace between the
+# command and its brace and models emit it (``\boxed {A}``), so without it the
+# spaced spelling scores zero — the same #357 defect, one space to the left.
+_BOXED_LETTER_RE = re.compile(r"\\boxed\s*\{\s*([A-Ja-j])\s*\}")
 # Bare standalone UPPERCASE letter that TERMINATES a clause — i.e. followed by
 # end-of-string or sentence punctuation, not by more words. Requiring upper-case
 # skips the lower-case article "a"/"an", and the terminating look-ahead skips a

--- a/tests/test_v07138.py
+++ b/tests/test_v07138.py
@@ -144,8 +144,14 @@ class TestExtractMcqLetterBoxed:
     def test_boxed_tolerates_whitespace_and_lowercase(self):
         from soup_cli.eval.forgetting import extract_mcq_letter
 
+        # Whitespace inside the braces, and a lowercase letter.
         assert extract_mcq_letter("\\boxed{ C }") == "C"
         assert extract_mcq_letter("\\boxed{b}") == "B"
+        # Whitespace BETWEEN the command and the brace: LaTeX permits it and
+        # models emit it, so the spaced spelling must resolve too (#357).
+        assert extract_mcq_letter("\\boxed { C }") == "C"
+        assert extract_mcq_letter("\\boxed  {B}") == "B"
+        assert extract_mcq_letter("The answer is \\boxed {A}.") == "A"
 
     def test_last_box_wins(self):
         from soup_cli.eval.forgetting import extract_mcq_letter

--- a/tests/test_v07138.py
+++ b/tests/test_v07138.py
@@ -119,6 +119,55 @@ class TestExtractMcqLetter:
         assert extract_mcq_letter(None) is None  # type: ignore[arg-type]
 
 
+class TestExtractMcqLetterBoxed:
+    """`\\boxed{X}` is how math/reasoning models mark a final answer (#357).
+
+    The v0.71.38 scorer had no boxed tier, so a Llama-3.1-8B that answered
+    ``\\boxed{C}`` scored zero on every such item and was ranked below a 0.5B
+    model. A boxed letter is the model's definitive choice, so it outranks the
+    cue/paren/bare tiers, and the LAST box wins when a trace draws more than one.
+    """
+
+    def test_boxed_letter_is_extracted(self):
+        from soup_cli.eval.forgetting import extract_mcq_letter
+
+        assert extract_mcq_letter("\\boxed{C}") == "C"
+        assert extract_mcq_letter("The answer is \\boxed{B}.") == "B"
+        assert extract_mcq_letter("...long reasoning trace... \\boxed{A}") == "A"
+
+    def test_boxed_letter_scores(self):
+        from soup_cli.eval.forgetting import score_answer
+
+        # The item Llama-3.1-8B lost before the fix: right letter, boxed.
+        assert score_answer("Paris is the capital, so \\boxed{C}.", "C") is True
+
+    def test_boxed_tolerates_whitespace_and_lowercase(self):
+        from soup_cli.eval.forgetting import extract_mcq_letter
+
+        assert extract_mcq_letter("\\boxed{ C }") == "C"
+        assert extract_mcq_letter("\\boxed{b}") == "B"
+
+    def test_last_box_wins(self):
+        from soup_cli.eval.forgetting import extract_mcq_letter
+
+        # A reasoning model boxes a candidate, reconsiders, boxes its decision.
+        assert extract_mcq_letter("first \\boxed{A} then \\boxed{C}") == "C"
+
+    def test_boxed_letter_outranks_earlier_prose_cue(self):
+        from soup_cli.eval.forgetting import extract_mcq_letter
+
+        # The final boxed choice must beat an option letter named mid-reasoning.
+        assert extract_mcq_letter("Option A looks plausible, but \\boxed{B}") == "B"
+
+    def test_boxed_value_is_not_a_letter(self):
+        from soup_cli.eval.forgetting import extract_mcq_letter
+
+        # A boxed free-text VALUE (not an A-J option letter) is not an MCQ
+        # choice — fix 1's scope is boxed letters only (#357).
+        assert extract_mcq_letter("\\boxed{Paris}") is None
+        assert extract_mcq_letter("\\boxed{42}") is None
+
+
 class TestForgettingDetectorUsesNewScorer:
     def test_detector_evaluate_uses_boundary_scorer(self):
         from soup_cli.eval.forgetting import ForgettingDetector


### PR DESCRIPTION
Shortened to a **test-only** contribution now that the fix itself shipped in
v0.73.2 (`extract_mcq_letter` learning `\boxed{C}`, issue #357). The scorer
change is already on `main`; this adds the regression coverage it went in
without.

`TestExtractMcqLetterBoxed` pins the boxed-letter answer form the leg-2
forgetting scorer credits:
- `\boxed{C}` is extracted and scores the item;
- whitespace and lowercase inside the box (`\boxed{ C }`, `\boxed{b}`) resolve to the letter;
- the **last** box wins when a model self-corrects;
- a boxed letter outranks an earlier prose cue;
- a boxed **value** (`\boxed{4}`) correctly returns no letter, so a value is never mis-credited as an option.

No production code, no CHANGELOG churn (the fix's entry already exists under
`[0.73.2]`). All six assertions pass against the shipped implementation;
`ruff` clean.
