### PR TITLE
fix(eval): raise instead of scoring 0.0 for a bad gen in score_bundled_suite (#355)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ reproducing 70+ versions of notes.
 
 ### Fixed
 
+- **`score_bundled_suite` returned `0.0` for a non-callable `gen` instead of
+  raising, so a caller error was indistinguishable from a model failing every
+  item (#355).** The function feeds `soup ship`'s leg 2, where `0.0` is a
+  DON'T-SHIP verdict. A non-callable `gen` (a list, `None`, a string) reached the
+  per-item exception isolation in `_fraction_passing`, which turned a programming
+  error into a plausible unanimous zero — the docstring already promised the
+  opposite ("Raises `ValueError` for an unknown suite, never silently 0.0"), but
+  the guarantee was only half enforced. `score_bundled_suite` now raises
+  `TypeError` for a non-callable `gen` (covering both the MCQ and behavioural
+  routes), and a generator that *raises* on every item raises `RuntimeError`
+  rather than reporting `0.0`. A generator that *returns* a non-str still scores
+  as a failed item, so the existing "non-str generation scores 0, never raises"
+  contract is unchanged.
 
 - **The MLX `adapter_config.json` shipped `target_modules` unresolved, so a default
   MLX adapter loaded as a silent no-op (#392).** `_apply_lora` resolved

--- a/src/soup_cli/eval/gate_suites.py
+++ b/src/soup_cli/eval/gate_suites.py
@@ -163,14 +163,21 @@ def load_suite_items(name: str) -> Tuple[dict, ...]:
     return _load_gate_fixture(filename)
 
 
-def _call(gen: GeneratorFn, prompt: str) -> str:
-    """Invoke ``gen`` for one prompt; a generation error / non-str result scores
-    as a failure (empty string) and an oversized result is truncated to
-    ``_MAX_OUTPUT_LEN`` — so one bad generation never aborts a run."""
+def _call(gen: GeneratorFn, prompt: str) -> str | None:
+    """Invoke ``gen`` for one prompt, returning the (length-capped) string output.
+
+    Returns ``None`` only when the generator *raised* — an errored item, distinct
+    from one that produced output. A non-str return still scores as a failed item
+    (empty string), preserving the documented "non-str generation scores 0, never
+    raises" contract. One errored item never aborts a run
+    (:func:`_fraction_passing` isolates it), but an *entire suite* of items that
+    all raised is a broken generator rather than a model scoring zero, and the
+    caller surfaces that instead of reporting a misleading unanimous ``0.0``
+    (#355)."""
     try:
         out = gen(prompt)
     except Exception:  # noqa: BLE001 — a generation error is a failed item, not a crash
-        return ""
+        return None
     if not isinstance(out, str):
         return ""
     return out[:_MAX_OUTPUT_LEN]
@@ -184,17 +191,34 @@ def _fraction_passing(
     Each item is scored independently: a predicate that raises (e.g. a
     ``RecursionError`` from ``json.loads`` on a pathologically-nested output)
     scores that one item as a failure rather than aborting the whole leg-2 run.
+
+    Raises :class:`RuntimeError` when the generator *raised* on every item — a
+    broken generator, not a model that genuinely scores zero. Isolating a single
+    bad item is a feature; converting a total generator failure into a plausible
+    unanimous ``0.0`` (a DON'T-SHIP verdict) is the #355 defect this guards. A
+    generator that *returns* a non-str is a scored failure, not an error, so the
+    documented "non-str generation scores 0, never raises" contract is unchanged.
     """
     if not items:
         return 0.0
     passed = 0
+    errored = 0
     for item in items:
         output = _call(gen, item.get("prompt", ""))
+        if output is None:
+            errored += 1
+            continue
         try:
             if predicate(item, output):
                 passed += 1
         except Exception:  # noqa: BLE001 — a scoring error is a failed item, not a crash
             continue
+    if errored == len(items):
+        raise RuntimeError(
+            f"generator raised on every one of {len(items)} items — this is a "
+            f"broken generator, not a model scoring zero; check the generator is "
+            f"callable and returns str"
+        )
     return passed / len(items)
 
 
@@ -334,8 +358,17 @@ def score_bundled_suite(name: str, gen: GeneratorFn) -> float:
 
     MCQ / arithmetic suites route through the (fixed) ``ForgettingDetector``
     scorer; behavioural suites through their bundled pure scorer. Raises
-    ``ValueError`` for an unknown suite (never silently 0.0).
+    ``TypeError`` for a non-callable ``gen`` and ``ValueError`` for an unknown
+    suite — never a silent ``0.0``, which reads as "the model failed every item"
+    (a DON'T-SHIP verdict) and makes a caller error indistinguishable from a real
+    regression (#355).
     """
+    if not callable(gen):
+        raise TypeError(
+            f"score_bundled_suite() gen must be callable, got "
+            f"{type(gen).__name__!r}; a non-callable generator would otherwise "
+            f"score a misleading 0.0 rather than surfacing the caller error"
+        )
     if name in MINI_BENCHMARKS:
         return ForgettingDetector(generate_fn=gen, benchmark=name).run_baseline()
     if name in _EXTENDED_SUITES:

--- a/tests/test_issue355_gate_gen_validation.py
+++ b/tests/test_issue355_gate_gen_validation.py
@@ -1,0 +1,120 @@
+"""#355 — ``score_bundled_suite`` returned 0.0 for a non-callable ``gen``.
+
+``score_bundled_suite(name, gen)`` feeds ``soup ship``'s leg 2. Its output is a
+per-model absolute score in ``[0, 1]`` where ``0.0`` reads as "the model failed
+every item" — a DON'T-SHIP verdict. Before this fix, handing it anything that is
+not a callable generator (a list, ``None``, a string) returned ``0.0`` instead of
+raising, so a *caller error* was indistinguishable from a real model regression,
+and it failed in the direction that looks like a genuine finding.
+
+The docstring already committed to the opposite behaviour for a neighbouring
+case ("Raises ``ValueError`` for an unknown suite — never silently 0.0"); the
+intent was only half enforced. This locks in:
+
+- a non-callable ``gen`` raises ``TypeError`` (both behavioural and MCQ suites);
+- a callable generator that errors on *every* item raises ``RuntimeError`` rather
+  than reporting a plausible unanimous ``0.0``;
+- a working generator still scores normally, and a generator that legitimately
+  returns ``""`` on every item is a real ``0.0`` — NOT an error — so it must not
+  raise. That control is what keeps the fix from turning every genuine zero into
+  a crash.
+"""
+
+import pytest
+
+from soup_cli.eval.gate_suites import (
+    MINI_TOOL_CALL,
+    load_suite_items,
+    score_bundled_suite,
+)
+
+_BEHAVIOURAL_SUITE = MINI_TOOL_CALL  # JSONL-backed, routes through _fraction_passing
+_MCQ_SUITE = "mini_arithmetic"  # routes through ForgettingDetector
+_JSON_SUITE = "mini_format_json"  # scorer = "is this a JSON container?"
+
+_NON_CALLABLES = [["a", "b"], None, "text", 42, {"function": "get_weather"}]
+
+
+class TestNonCallableGenRaises:
+    """Acceptance 1 — a non-callable ``gen`` raises ``TypeError``, never 0.0."""
+
+    @pytest.mark.parametrize("bad_gen", _NON_CALLABLES)
+    def test_behavioural_suite_rejects_non_callable(self, bad_gen):
+        with pytest.raises(TypeError):
+            score_bundled_suite(_BEHAVIOURAL_SUITE, bad_gen)
+
+    @pytest.mark.parametrize("bad_gen", _NON_CALLABLES)
+    def test_mcq_suite_rejects_non_callable(self, bad_gen):
+        # Acceptance 4 — the guard covers the OTHER entry route too, not just the
+        # behavioural scorers where the bug was first observed.
+        with pytest.raises(TypeError):
+            score_bundled_suite(_MCQ_SUITE, bad_gen)
+
+    def test_exact_issue_examples_no_longer_return_zero(self):
+        """The three snippets from the issue body, each of which returned 0.0."""
+        for bad in (["a", "b"], None, "text"):
+            with pytest.raises(TypeError):
+                score_bundled_suite(_BEHAVIOURAL_SUITE, bad)
+
+
+class TestAllItemsErroredIsDistinguishable:
+    """Acceptance 2 — a generator that raises on every item is a broken
+    generator, not a model scoring zero, so it raises rather than returning 0.0."""
+
+    def test_generator_raising_on_every_item_raises(self):
+        def broken(_prompt):
+            raise RuntimeError("generator is broken")
+
+        with pytest.raises(RuntimeError):
+            score_bundled_suite(_BEHAVIOURAL_SUITE, broken)
+
+    def test_a_single_raising_item_is_still_isolated_not_fatal(self):
+        # The per-item isolation stays a feature: only a TOTAL failure raises.
+        # One raising prompt among many still scores, it does not abort the run.
+        items = load_suite_items(_JSON_SUITE)
+        first_prompt = items[0].get("prompt", "")
+
+        def flaky(prompt):
+            if prompt == first_prompt:
+                raise RuntimeError("one bad row")
+            return '{"answer": 1}'
+
+        score = score_bundled_suite(_JSON_SUITE, flaky)
+        assert 0.0 < score < 1.0
+
+    def test_generator_returning_non_str_scores_zero_not_raises(self):
+        # A callable that RETURNS a non-str produced output, it did not error, so
+        # the documented "non-str generation scores 0, never raises" contract is
+        # preserved (a raise is reserved for a generator that never runs at all).
+        assert score_bundled_suite(_BEHAVIOURAL_SUITE, lambda _p: None) == 0.0
+
+
+class TestGenuineZeroStillReturns:
+    """Control (acceptance 3) — the fix must not turn a real 0.0 into a crash.
+
+    A generator that legitimately returns ``""`` runs fine on every item; the
+    model just never produces a JSON container. That is a true ``0.0`` and must
+    stay a returned value, distinguishable from the errored cases above.
+    """
+
+    def test_empty_string_generator_scores_zero_without_raising(self):
+        assert score_bundled_suite(_JSON_SUITE, lambda _p: "") == 0.0
+
+    def test_working_generator_scores_above_zero(self):
+        # Every answer is a valid JSON container -> the format suite passes it.
+        score = score_bundled_suite(_JSON_SUITE, lambda _p: '{"answer": 1}')
+        assert score > 0.0
+
+
+class TestUnknownSuiteContractUnchanged:
+    """The pre-existing contract (unknown suite -> ValueError) still holds, and a
+    callable ``gen`` is validated before the suite name so neither guard hides
+    the other."""
+
+    def test_unknown_suite_still_raises_value_error(self):
+        with pytest.raises(ValueError):
+            score_bundled_suite("no_such_suite", lambda _p: "x")
+
+    def test_non_callable_gen_is_rejected_even_for_unknown_suite(self):
+        with pytest.raises(TypeError):
+            score_bundled_suite("no_such_suite", ["not", "callable"])


### PR DESCRIPTION
## What does this PR do?

Fix #355 — `score_bundled_suite(name, gen)` returned `0.0` for a non-callable
`gen` instead of raising, so a *caller error* was indistinguishable from a model
failing every item. Since this score feeds `soup ship`'s leg 2, `0.0` reads as a
DON'T-SHIP verdict, and the bug failed in the direction that looks like a real
regression.

**Root cause.** A non-callable `gen` (a list, `None`, a string) reached the
per-item exception isolation in `_fraction_passing` — a documented, good property
that stops one bad row from losing a whole suite — but a non-callable `gen`
throws on *every* item, so the isolation converted a programming error into a
plausible unanimous `0.0`. The docstring already promised the opposite for a
neighbouring case ("Raises `ValueError` for an unknown suite — never silently
0.0"); the guarantee was only half enforced.

**Fix.**
- `score_bundled_suite` raises `TypeError` for a non-callable `gen`. The guard
  sits before the suite dispatch, so it covers both the MCQ/arithmetic route
  (`ForgettingDetector`) and the behavioural route — acceptance point 4.
- `_fraction_passing` raises `RuntimeError` when the generator *raised* on every
  item — a broken generator, not a model scoring zero (acceptance point 2). A
  single raising item is still isolated; only a total failure raises.
- A generator that *returns* a non-str still scores as a failed item, so the
  existing "non-str generation scores 0, never raises" contract
  (`test_v07138.py::TestBundledScorers::test_non_str_generation_scores_as_failure`)
  is unchanged.

The `soup ship` leg-2 dispatch calls `score_bundled_suite` with no surrounding
catch, so the raise surfaces as a runtime error (exit 1) rather than being
mistaken for a caught regression (exit 2).

## Reproduces with (unmodified `main`)

```python
from soup_cli.eval.gate_suites import score_bundled_suite
score_bundled_suite("mini_tool_call", ["a", "b"])  # -> 0.0  (should raise)
score_bundled_suite("mini_tool_call", None)        # -> 0.0
score_bundled_suite("mini_tool_call", "text")      # -> 0.0
```

## Test verification (RED → GREEN)

New tests in `tests/test_issue355_gate_gen_validation.py`, run against the exact
upstream base and the fix:

RED — new tests on unmodified `main` (`git checkout upstream/main -- src/soup_cli/eval/gate_suites.py`):
```
8 failed, 10 passed
FAILED ...TestNonCallableGenRaises::test_exact_issue_examples_no_longer_return_zero
FAILED ...TestAllItemsErroredIsDistinguishable::test_generator_raising_on_every_item_raises
FAILED ...TestUnknownSuiteContractUnchanged::test_non_callable_gen_is_rejected_even_for_unknown_suite
```
The 10 that pass on base are the controls (a working generator still scores, a
generator returning `""` is a genuine `0.0`, an unknown suite still raises
`ValueError`) — they must be green on both sides.

GREEN — with the fix:
```
18 passed
```

## Full local suite

Ran the full local validation suite for the affected surface on both the upstream
base and this branch:

- `ruff check src/soup_cli/ tests/` → clean.
- Gate-suite pytest (`test_issue355_gate_gen_validation.py`,
  `test_issue316_suites.py`, `test_v07138.py`): iso-baseline — `62 passed` on
  `main` and `80 passed` on this branch (the +18 are the new tests), no failure
  turned green→red. 6 CLI-integration tests need the full pydantic/torch stack
  and are unrunnable in a CPU-only env identically on both sides.

The full torch/typer training matrix and the 77% coverage gate run in CI; they
are unaffected by a change confined to `eval/gate_suites.py`.

## Type of change

- [x] Bug fix

## Checklist

- [x] `ruff check src/soup_cli/ tests/` passes
- [x] `pytest tests/ -v` passes (CPU-testable gate-suite slice; RED→GREEN above)
- [x] Updated relevant docs if needed — behaviour is internal to `gate_suites`;
      no user-facing doc enumerates the old `0.0` return. `CHANGELOG.md`
      `## [Unreleased] → Fixed` updated.
