### PR TITLE
fix(mitigation): recreate log dir and warn instead of dropping records (#343)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ reproducing 70+ versions of notes.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`MitigationLogWriter` silently dropped every record once its parent directory
+  vanished mid-run (#343).** `record()` reopens the log per call and swallowed the
+  `OSError` from `open("ab")` with a bare `return`, so when a shared temp root was
+  cleaned by another process the controller kept acting while its log quietly stopped
+  growing — the run completes while its evidence goes missing, the failure shape this
+  project treats as the worst kind. The writer now recreates the directory and retries
+  the write, and surfaces the loss once via a warning naming the path. `record()` still
+  never raises, so a vanished log never takes down the training run.
+
 ## [0.73.2] - 2026-08-15
 
 `soup ship`'s leg 2 is the project's differentiator, and it was lying in both

--- a/src/soup_cli/utils/reward_hack_control.py
+++ b/src/soup_cli/utils/reward_hack_control.py
@@ -677,6 +677,10 @@ class MitigationLogWriter:
         self._cap_bytes = cap_mb * 1024 * 1024
         # Single-process lock: protects rotate + write within ONE run process.
         self._lock = threading.Lock()
+        # Warn only once about a failed write (e.g. the parent directory
+        # vanished mid-run) — the controller records every step, so warning on
+        # each dropped write would flood the log.
+        self._warned_write_failed = False
 
     @property
     def path(self) -> Path:
@@ -702,11 +706,47 @@ class MitigationLogWriter:
         line_bytes = (line + "\n").encode("utf-8")
         with self._lock:
             self._maybe_rotate(extra=len(line_bytes))
-            try:
-                with self._path.open("ab") as handle:
-                    handle.write(line_bytes)
-            except OSError:
+            if self._append(line_bytes):
                 return
+            # The first write failed. The dominant cause in the wild is the
+            # parent directory disappearing mid-run (a shared temp root cleaned
+            # by another process, #343). Silently dropping every subsequent
+            # record is the one outcome this log must never have: the run
+            # completes while its evidence quietly goes missing. Recreate the
+            # directory and retry once, then surface the loss via a one-time
+            # warning naming the path. record() stays non-raising so a
+            # vanished log never takes down the training run.
+            recovered = False
+            try:
+                self._path.parent.mkdir(parents=True, exist_ok=True)
+                recovered = self._append(line_bytes)
+            except OSError:
+                recovered = False
+            if not self._warned_write_failed:
+                self._warned_write_failed = True
+                if recovered:
+                    logger.warning(
+                        "mitigation log directory for %s vanished mid-run and "
+                        "was recreated; earlier records may have been lost.",
+                        self._path,
+                    )
+                else:
+                    logger.warning(
+                        "mitigation log write to %s failed and could not be "
+                        "recovered; subsequent records may be lost.",
+                        self._path,
+                    )
+
+    def _append(self, line_bytes: bytes) -> bool:
+        """Append raw bytes to the active log. Returns ``False`` on ``OSError``
+        (disk full, permissions, vanished parent directory) instead of raising —
+        the caller decides how to recover."""
+        try:
+            with self._path.open("ab") as handle:
+                handle.write(line_bytes)
+        except OSError:
+            return False
+        return True
 
     def _maybe_rotate(self, *, extra: int) -> None:
         try:

--- a/tests/test_v07126.py
+++ b/tests/test_v07126.py
@@ -15,9 +15,11 @@ task on one RTX 3050. PPO ships BETA (unit-tested; GPU proof is GRPO-only).
 from __future__ import annotations
 
 import json
+import logging
 import math
 import os
 import random
+import shutil
 import types
 
 import pytest
@@ -244,6 +246,40 @@ class TestMitigationLogWriter:
         for i in range(6):
             w.record(step=i, snapshot={"x": i})
         assert target.read_text() == "keep me"  # symlink target untouched
+
+    def test_vanished_directory_is_not_silently_dropped(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """A parent dir deleted mid-stream must not silently swallow the next
+        record (#343): the writer recreates the directory, the entry lands, and
+        the loss is surfaced once via a warning naming the path."""
+        monkeypatch.chdir(tmp_path)
+        from soup_cli.utils.reward_hack_control import MitigationLogWriter
+
+        w = MitigationLogWriter("logs/mit.jsonl")
+        w.record(step=1, snapshot={"x": 1})
+
+        # Another process wipes the shared temp root mid-run.
+        shutil.rmtree(tmp_path / "logs")
+        with caplog.at_level(logging.WARNING):
+            w.record(step=2, snapshot={"x": 2})
+
+        # 1. The loss is surfaced once, naming the path — not swallowed silently.
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert "mit.jsonl" in warnings[0].getMessage()
+
+        # 2. The record itself is not lost — the directory is recreated and the
+        #    entry lands.
+        lines = (tmp_path / "logs" / "mit.jsonl").read_text().strip().splitlines()
+        assert [json.loads(line)["step"] for line in lines] == [2]
+
+        # 3. Warns at most once even if the directory vanishes again.
+        shutil.rmtree(tmp_path / "logs")
+        with caplog.at_level(logging.WARNING):
+            w.record(step=3, snapshot={"x": 3})
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
 
 
 # =====================================================================


### PR DESCRIPTION
## What does this PR do?

Fixes #343. `MitigationLogWriter.record()` reopens the log per call and swallowed the
`OSError` from `open("ab")` with a bare `return`. When the parent directory vanished
mid-run — a shared temp root cleaned by another process — every subsequent record was
dropped with **no warning**: the controller kept acting while its log quietly stopped
growing. That is the failure shape the project treats as the worst kind — a run that
completes successfully while its evidence goes missing (it silently truncated controller
logs for several arms in #286).

The writer now takes the maintainer-offered recovery path: on a failed write it recreates
the directory and retries once, then surfaces the loss **once** via a warning naming the
path. `record()` still never raises, so a vanished log never takes down the training run.

The related `output: off` YAML coercion note in the issue is intentionally left out of
scope (separate concern).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests

## Checklist

- [x] `ruff check src/soup_cli/ tests/` passes
- [x] `pytest tests/ -v` passes (writer suite; full torch/typer matrix is CI-only)
- [x] Updated relevant docs — CHANGELOG `## [Unreleased] > ### Fixed`

## Acceptance criteria (from the issue)

- [x] a write to a vanished directory raises or warns, once, naming the path
- [x] a test that deletes the directory mid-stream and asserts the writer does not silently swallow the next record

## Test verification (RED → GREEN)

New test: `tests/test_v07126.py::TestMitigationLogWriter::test_vanished_directory_is_not_silently_dropped`.

RED — on unmodified `main` (bug present), the vanished-dir write is silently swallowed:

```
>       assert len(warnings) == 1
E       assert 0 == 1
E        +  where 0 = len([])
tests/test_v07126.py:269: AssertionError
1 failed in 0.26s
```

GREEN — with the fix, the whole `MitigationLogWriter` suite passes:

```
........                                                                 [100%]
8 passed in 0.23s
```

## Full local suite

Ran the full local validation suite (`ruff check src/soup_cli/ tests/` + the whole
`tests/test_v07126.py` module) on both the unmodified base and the final commit:

- ruff: `All checks passed!`
- base `tests/test_v07126.py`: **176 passed, 9 failed, 1 skipped**
- final `tests/test_v07126.py`: **177 passed, 9 failed, 1 skipped**

The 9 failures are the same pre-existing ones on both base and final — CLI/checkpoint
tests that need the torch/typer training stack (`ModuleNotFoundError` on a CPU box, not
runnable here) — so the branch is iso-or-better: no new failures, the new test is the +1.
