### PR TITLE
fix(draft): derive distill epochs from the effective step budget (#364)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ reproducing 70+ versions of notes.
 
 ### Fixed
 
+- **`soup draft distill --steps N` now delivers ~N optimiser steps instead of
+  N/4.44 (#364).** The epoch count that realised `--steps` divided the request
+  by `rows // batch_size`, ignoring that `val_split` (0.1) removes rows from
+  training and `gradient_accumulation_steps` (4) micro-batches make one
+  optimiser step — both divide the budget, so every distill run trained for
+  roughly a fifth of the requested steps, silently. Epochs are now derived from
+  the effective steps-per-epoch, the emitted config pins the run shape
+  (`val_split`, `gradient_accumulation_steps`) so the arithmetic and the trainer
+  cannot drift, and the pre-flight prints the resolved step count.
+
+### Fixed
+
 - **`MitigationLogWriter` silently dropped every record once its parent directory
   vanished mid-run (#343).** `record()` reopens the log per call and swallowed the
   `OSError` from `open("ab")` with a bare `return`, so when a shared temp root was

--- a/src/soup_cli/commands/draft.py
+++ b/src/soup_cli/commands/draft.py
@@ -64,6 +64,14 @@ _DISTILL_TIMEOUT_SECONDS = 24 * 60 * 60
 _DISTILL_BATCH_SIZE = 1
 _DISTILL_MAX_LENGTH = 1024
 _MAX_DISTILL_EPOCHS = 100
+# #364 — the epoch count that realises ``--steps N`` is derived from the
+# EFFECTIVE optimiser-step budget, which depends on the run shape: ``val_split``
+# removes rows from training and ``gradient_accumulation_steps`` micro-batches
+# make one optimiser step, so both divide the naive ``rows // batch``. Pin that
+# shape here (equal to the schema defaults) AND emit it into the config, so the
+# builder's arithmetic and the trainer's behaviour cannot drift apart.
+_DISTILL_VAL_SPLIT = 0.1   # DataConfig.val_split default
+_DISTILL_GRAD_ACCUM = 4    # TrainingConfig.gradient_accumulation_steps default
 # How much of a failed subprocess's output to surface (mirrors shrink.py).
 _SUBPROCESS_ERROR_TAIL_CHARS = 800
 # The distill trainer writes a LoRA adapter (never dense base weights), so it
@@ -180,6 +188,43 @@ def _load_pair_member(
 # ---------------------------------------------------------------------------
 # distill
 # ---------------------------------------------------------------------------
+def _distill_steps_per_epoch(
+    data_rows: int, *, val_split: float, batch_size: int, grad_accum: int
+) -> int:
+    """Optimiser steps one epoch actually delivers for the distill run shape.
+
+    ``val_split`` removes rows from training and ``grad_accum`` micro-batches
+    make one optimiser step, so both divide the naive ``rows // batch_size``
+    the epoch count used to assume (#364).
+    """
+    train_rows = math.floor(data_rows * (1.0 - val_split))
+    return max(1, train_rows // (batch_size * grad_accum))
+
+
+def _distill_epochs_for_steps(
+    steps: int,
+    data_rows: int,
+    *,
+    val_split: float,
+    batch_size: int,
+    grad_accum: int,
+) -> int:
+    """Epochs whose delivered optimiser steps land nearest to ``steps``.
+
+    There is no ``max_steps`` knob in the trainer (see
+    ``commands/shrink.py::_build_heal_config_yaml``), so ``--steps`` is realised
+    through the epoch count. Rounding up means the request is met or overshot by
+    less than one epoch, never the ~1/4.44 undershoot of the old arithmetic.
+    """
+    per_epoch = _distill_steps_per_epoch(
+        data_rows,
+        val_split=val_split,
+        batch_size=batch_size,
+        grad_accum=grad_accum,
+    )
+    return max(1, math.ceil(steps / per_epoch))
+
+
 def _build_distill_config_yaml(
     *,
     draft_base: str,
@@ -196,14 +241,18 @@ def _build_distill_config_yaml(
     newline cannot inject sibling YAML keys into the ``training:`` block.
     Mirrors ``commands/shrink.py::_build_heal_config_yaml``.
     """
-    per_epoch = max(1, data_rows // _DISTILL_BATCH_SIZE)
-    raw_epochs = math.ceil(steps / per_epoch)
-    if raw_epochs > _MAX_DISTILL_EPOCHS:
+    epochs = _distill_epochs_for_steps(
+        steps,
+        data_rows,
+        val_split=_DISTILL_VAL_SPLIT,
+        batch_size=_DISTILL_BATCH_SIZE,
+        grad_accum=_DISTILL_GRAD_ACCUM,
+    )
+    if epochs > _MAX_DISTILL_EPOCHS:
         raise ValueError(
-            f"--steps {steps} over {data_rows} rows expands to {raw_epochs} "
+            f"--steps {steps} over {data_rows} rows expands to {epochs} "
             f"epochs (> {_MAX_DISTILL_EPOCHS}); reduce --steps or grow --data."
         )
-    epochs = max(1, raw_epochs)
     return (
         "base: {draft_base}\n"
         "task: distill\n"
@@ -212,12 +261,14 @@ def _build_distill_config_yaml(
         "  train: {data}\n"
         "  format: auto\n"
         "  max_length: {max_length}\n"
+        "  val_split: {val_split}\n"
         "training:\n"
         "  teacher_model: {target}\n"
         "  distill_divergence: forward_kl\n"
         "  distill_temperature: 2.0\n"
         "  epochs: {epochs}\n"
         "  batch_size: {batch}\n"
+        "  gradient_accumulation_steps: {grad_accum}\n"
         "  gradient_checkpointing: true\n"
         "  quantization: none\n"
         "  lora:\n"
@@ -229,8 +280,10 @@ def _build_distill_config_yaml(
         data=json.dumps(data),
         target=json.dumps(target),
         max_length=_DISTILL_MAX_LENGTH,
+        val_split=_DISTILL_VAL_SPLIT,
         epochs=epochs,
         batch=_DISTILL_BATCH_SIZE,
+        grad_accum=_DISTILL_GRAD_ACCUM,
     )
 
 
@@ -275,6 +328,28 @@ def _run_distill(
         data_rows=data_rows,
     )
     load_config_from_string(yaml_text)  # validate before spending a subprocess
+
+    # #364 — surface the resolved optimiser-step budget before the run. Epoch
+    # granularity can only land NEAR ``--steps``; printing it makes any mismatch
+    # visible up front rather than after a full training run.
+    per_epoch = _distill_steps_per_epoch(
+        data_rows,
+        val_split=_DISTILL_VAL_SPLIT,
+        batch_size=_DISTILL_BATCH_SIZE,
+        grad_accum=_DISTILL_GRAD_ACCUM,
+    )
+    epochs = _distill_epochs_for_steps(
+        steps,
+        data_rows,
+        val_split=_DISTILL_VAL_SPLIT,
+        batch_size=_DISTILL_BATCH_SIZE,
+        grad_accum=_DISTILL_GRAD_ACCUM,
+    )
+    console.print(
+        f"[dim]--steps {steps} -> {epochs} epoch(s) ~= {epochs * per_epoch} "
+        f"optimiser steps ({data_rows} rows, val_split {_DISTILL_VAL_SPLIT}, "
+        f"accum {_DISTILL_GRAD_ACCUM}, batch {_DISTILL_BATCH_SIZE})[/]"
+    )
 
     # The config lives BESIDE out_dir, not inside it: the merge below replaces
     # out_dir wholesale, which would otherwise delete the config we just wrote.

--- a/tests/test_v07133.py
+++ b/tests/test_v07133.py
@@ -12,6 +12,7 @@ Covers:
 from __future__ import annotations
 
 import ast
+import math
 import os
 from pathlib import Path
 
@@ -1856,3 +1857,81 @@ class TestPromptTexts:
             {"messages": [{"role": "assistant", "content": "no user turn"}]},  # dropped
         ]
         assert _prompt_texts(rows) == ["hi", "direct"]
+
+
+class TestDistillStepBudget:
+    """#364 — ``soup draft distill --steps N`` must deliver ~N optimiser steps.
+
+    The epoch count that realises ``--steps`` used to divide the request by
+    ``rows // batch_size``, ignoring that ``val_split`` removes rows from
+    training and ``gradient_accumulation_steps`` micro-batches make one
+    optimiser step. Both divide the budget, so ``--steps N`` delivered ~N/4.44.
+    """
+
+    @staticmethod
+    def _epochs_from_yaml(yaml_text: str) -> int:
+        import yaml  # noqa: PLC0415
+
+        return int(yaml.safe_load(yaml_text)["training"]["epochs"])
+
+    @staticmethod
+    def _true_steps_per_epoch(rows: int, *, val_split: float, batch: int, accum: int) -> int:
+        # The optimiser-step count one epoch actually delivers.
+        train_rows = math.floor(rows * (1.0 - val_split))
+        return max(1, train_rows // (batch * accum))
+
+    def test_steps_are_delivered_not_quartered(self):
+        """Asking for 100 steps must reach ~100, not ~22 (100 / 4.44)."""
+        from soup_cli.commands import draft
+        from soup_cli.config.schema import DataConfig, TrainingConfig
+
+        rows, requested = 100, 100
+        val_split = float(DataConfig.model_fields["val_split"].default)
+        accum = int(TrainingConfig.model_fields["gradient_accumulation_steps"].default)
+        yaml_text = draft._build_distill_config_yaml(
+            draft_base="org/tiny", target="org/target", data="d.jsonl",
+            out_dir="draft/_adapter", steps=requested, data_rows=rows,
+        )
+        epochs = self._epochs_from_yaml(yaml_text)
+        per_epoch = self._true_steps_per_epoch(
+            rows, val_split=val_split, batch=draft._DISTILL_BATCH_SIZE, accum=accum
+        )
+        delivered = epochs * per_epoch
+        # Nearest reachable at this granularity: the request is met or overshot
+        # by less than one epoch — never the old ~1/4.44 undershoot.
+        assert delivered >= requested
+        assert delivered - requested < per_epoch
+
+    @pytest.mark.parametrize(
+        "val_split,accum",
+        [(0.0, 1), (0.1, 1), (0.0, 4), (0.1, 4), (0.2, 8)],
+    )
+    def test_delivered_steps_track_request_across_shapes(self, val_split, accum):
+        """val_split and gradient_accumulation_steps each divide the budget —
+        vary them independently (one arm at defaults is not discriminating)."""
+        from soup_cli.commands import draft
+
+        rows, requested = 500, 120
+        per_epoch = draft._distill_steps_per_epoch(
+            rows, val_split=val_split, batch_size=1, grad_accum=accum
+        )
+        epochs = draft._distill_epochs_for_steps(
+            requested, rows, val_split=val_split, batch_size=1, grad_accum=accum
+        )
+        delivered = epochs * per_epoch
+        assert delivered >= requested
+        assert delivered - requested < per_epoch
+
+    def test_emitted_config_pins_the_run_shape_and_loads(self):
+        """The config must pin the shape the epoch math assumed, so a
+        schema-default change cannot silently reintroduce the drift (#364)."""
+        from soup_cli.commands import draft
+        from soup_cli.config.loader import load_config_from_string
+
+        yaml_text = draft._build_distill_config_yaml(
+            draft_base="HuggingFaceTB/SmolLM2-135M", target="org/target",
+            data="d.jsonl", out_dir="draft/_adapter", steps=50, data_rows=200,
+        )
+        cfg = load_config_from_string(yaml_text)
+        assert cfg.data.val_split == draft._DISTILL_VAL_SPLIT
+        assert cfg.training.gradient_accumulation_steps == draft._DISTILL_GRAD_ACCUM


### PR DESCRIPTION
## Summary

Fix #364

`soup draft distill --steps N` delivered only `~N/4.44` optimiser steps. The epoch
count that realises `--steps` divided the request by `rows // batch_size`, ignoring
that `val_split` (0.1) removes rows from training and `gradient_accumulation_steps`
(4) micro-batches make one optimiser step. Both divide the budget, so every distill
run trained for roughly a fifth of the requested steps, silently.

- Epochs are now derived from the **effective** steps-per-epoch:
  `rows * (1 - val_split) / (batch_size * gradient_accumulation_steps)`, then
  `epochs = ceil(requested_steps / steps_per_epoch)`.
- The emitted distill config now **pins** the run shape it assumed (`val_split`,
  `gradient_accumulation_steps`) so the arithmetic and the trainer cannot drift.
- There is no `max_steps` knob in the trainer (per `shrink.py::_build_heal_config_yaml`),
  so `--steps` is realised through the epoch count; rounding up meets or overshoots
  the request by less than one epoch.
- The pre-flight prints the resolved step count, so a mismatch is visible before the run.

## Test verification (RED → GREEN)

New tests in `tests/test_v07133.py::TestDistillStepBudget` (the module that already
covers `soup draft distill`).

RED — on unmodified `main`, `_build_distill_config_yaml(steps=100, data_rows=100)`
emits `epochs: 1`, which delivers `floor(100*0.9)//(1*4) = 22` optimiser steps:

```
    assert delivered >= requested
E   assert 22 >= 100
tests/test_v07133.py:1902: AssertionError
1 failed
```

GREEN — with the fix, the same request emits `epochs: 5` (≈110 delivered), and the
suite passes:

```
tests/test_v07133.py::TestDistillStepBudget .......                       [100%]
tests/test_v07133.py::TestDraftDistillCli .....................
36 passed
```

The parametrised arm varies `val_split` and `gradient_accumulation_steps`
independently (one arm at defaults is not discriminating). `ruff check src/soup_cli/ tests/`
passes clean on both base and the fix.

## Files changed

| File | Change |
|------|--------|
| `src/soup_cli/commands/draft.py` | effective-step epoch derivation + pinned run shape + pre-flight print |
| `tests/test_v07133.py` | `TestDistillStepBudget` — delivered-steps RED→GREEN + independent shape variation |
| `CHANGELOG.md` | `### Fixed` entry (#364) |

## Full local suite

The change is torch-free (pure epoch arithmetic in `commands/draft.py`), so the two
CI jobs that can catch it were replayed locally on both the `main` baseline and the
fix commit — iso-or-better, no new failures:

- `ruff check src/soup_cli/ tests/` — passes clean (blocking CI job).
- `pytest tests/test_v07133.py` distill/config classes (`TestDistillStepBudget`,
  `TestDraftDistillCli`, `TestDraftCliPlumbing`, `TestDraftNoTopLevelTorch`) — 36 passed.

The full `torch` pytest matrix (3.10/3.11/3.12) and the 77% coverage gate run in CI;
this change adds tests and touches no torch code path, so it cannot lower either.
