### PR TITLE
Update contributor name for a tool in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ shipped v0.73.1 code before a line was changed.
   execution tools will use. `train_start` and `export` stay **plan-only** —
   nothing in this slice executes anything, and the help text says so in the
   present tense. `build_registry(allow_mutating=True)` still returns the same 16
-  tools. Contributed by [@darshvit20](https://github.com/darshvit20).
+  tools. Contributed by [@CODING-DARSH](https://github.com/CODING-DARSH).
 
 ### Fixed
 


### PR DESCRIPTION
Updated contributor name in CHANGELOG.md.

## What does this PR do?

Change changelog documentation username

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ x] Documentation
- [ ] Tests

## Checklist

- [ ] `ruff check src/soup_cli/ tests/` passes
- [ ] `pytest tests/ -v` passes
- [ ] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed
