### PR TITLE
fix(mcp): reconcile orphaned 'running' runs on read (#401)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ reproducing 70+ versions of notes.
 
 ### Fixed
 
+- **A run whose watcher died was reported `running` forever (#401).**
+  `ExecutionManager._watch` runs as a `daemon=True` thread, so when the MCP
+  server process exits it is killed without unwinding and `finish_execution`
+  never runs — `ExperimentTracker` kept the run at `running` with no watcher
+  left to correct it, training the operator to ignore the one status field that
+  guards against a second concurrent run. The tracker now reconciles on read:
+  when a `running` row carries a pid whose process is gone, `list_runs` /
+  `get_run` rewrite it to `terminated` with an unknown (`None`) exit code — an
+  unknown outcome is never recorded as success, and the richer
+  `completed`/`failed` terminal statuses are left untouched. `soup runs` no
+  longer hardcodes `running` for a non-running row.
+
+### Fixed
+
+### Fixed
+
 - **`kl_control` rewrote the trainer's β/kl_coef on every step, including a `hold`, so a
   non-acting run was numerically identical to `log_only` (#371).** `_run_bang_bang` called
   `_apply_coefficient` unconditionally; on a `hold` the controller writes back the value

--- a/src/soup_cli/commands/runs.py
+++ b/src/soup_cli/commands/runs.py
@@ -95,7 +95,10 @@ def list_runs(
         elif status == "failed":
             status_str = "[red]failed[/]"
         else:
-            status_str = "[yellow]running[/]"
+            # Show the real status (e.g. 'terminated' reconciled from a dead
+            # watcher, issue #401) — never hardcode 'running' for a row that is
+            # no longer running.
+            status_str = f"[yellow]{status}[/]"
 
         # Format loss
         loss_str = ""

--- a/src/soup_cli/experiment/tracker.py
+++ b/src/soup_cli/experiment/tracker.py
@@ -10,6 +10,7 @@ Usage:
 from __future__ import annotations
 
 import json
+import os
 import secrets
 import sqlite3
 from datetime import datetime
@@ -17,6 +18,42 @@ from pathlib import Path
 from typing import Optional
 
 from soup_cli.utils.constants import EXPERIMENTS_DB, SOUP_DIR
+
+# Run status values this module reconciles. A watcher that never unwound (its
+# daemon thread was killed when the MCP server exited) leaves the run at
+# _STATUS_RUNNING forever. Reconcile-on-read rewrites such a row to
+# _STATUS_TERMINATED with an unknown (None) exit code so a lost outcome is never
+# mistaken for success. See issue #401.
+_STATUS_RUNNING = "running"
+_STATUS_TERMINATED = "terminated"
+
+
+def _process_is_alive(pid: int) -> bool:
+    """Return True if a process with this PID currently exists.
+
+    Signal 0 runs the OS existence/permission check without delivering a
+    signal. A PID owned by another user raises PermissionError and still counts
+    as alive; only a missing process (ProcessLookupError / ESRCH) is dead.
+
+    The ``except OSError: return False`` branch is not an optional tidy-up: on
+    Windows a dead PID surfaces as ``OSError`` (winerror 87), never
+    ProcessLookupError, so on Windows that branch is the *primary* path every
+    reconciliation arrives through — do not narrow it away.
+
+    Known limitation — PID reuse: a dead run whose PID has since been recycled
+    by an unrelated process reads as alive forever, so reconciliation never
+    fires for it. That is inherent to PID-liveness (a start-time comparison
+    would be needed to close it) and is out of scope for issue #401.
+    """
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
 
 _SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS runs (
@@ -331,13 +368,35 @@ class ExperimentTracker:
         conn.execute("UPDATE runs SET status = 'failed' WHERE run_id = ?", (run_id,))
         conn.commit()
 
+    def _reconcile_orphaned_run(self, run: dict) -> dict:
+        """Rewrite a stale 'running' row whose process is gone (issue #401).
+
+        Only MCP-spawned runs carry a pid; a run recorded without one is left
+        untouched because its liveness cannot be checked here. A dead pid is
+        persisted as _STATUS_TERMINATED with exit_code None (unknown) through
+        finish_execution, whose guard keeps a richer 'completed'/'failed'
+        terminal status intact and makes the rewrite idempotent.
+        """
+        pid = run.get("pid")
+        if (
+            run.get("status") == _STATUS_RUNNING
+            and pid is not None
+            and not _process_is_alive(pid)
+        ):
+            self.finish_execution(
+                run["run_id"], status=_STATUS_TERMINATED, exit_code=None
+            )
+            run["status"] = _STATUS_TERMINATED
+            run["exit_code"] = None
+        return run
+
     def list_runs(self, limit: int = 50) -> list[dict]:
         """Return list of runs ordered by created_at desc."""
         conn = self._get_conn()
         rows = conn.execute(
             "SELECT * FROM runs ORDER BY created_at DESC, rowid DESC LIMIT ?", (limit,)
         ).fetchall()
-        return [dict(row) for row in rows]
+        return [self._reconcile_orphaned_run(dict(row)) for row in rows]
 
     def get_run(self, run_id: str) -> Optional[dict]:
         """Get full details of a single run. Supports prefix matching."""
@@ -365,7 +424,7 @@ class ExperimentTracker:
             elif len(rows) > 1:
                 return None  # ambiguous prefix
 
-        return dict(row) if row else None
+        return self._reconcile_orphaned_run(dict(row)) if row else None
 
     def get_metrics(self, run_id: str) -> list[dict]:
         """Get all metric rows for a run, ordered by step."""

--- a/src/soup_cli/experiment/tracker.py
+++ b/src/soup_cli/experiment/tracker.py
@@ -13,6 +13,7 @@ import json
 import os
 import secrets
 import sqlite3
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
@@ -27,24 +28,75 @@ from soup_cli.utils.constants import EXPERIMENTS_DB, SOUP_DIR
 _STATUS_RUNNING = "running"
 _STATUS_TERMINATED = "terminated"
 
+# Windows liveness constants (see _windows_process_is_alive). GetExitCodeProcess
+# returns STILL_ACTIVE for a running process; a failed OpenProcess distinguishes
+# a missing pid (ERROR_INVALID_PARAMETER) from one we merely cannot open
+# (ERROR_ACCESS_DENIED — it exists).
+_WIN_STILL_ACTIVE = 259
+_WIN_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+_WIN_ERROR_ACCESS_DENIED = 5
+
+
+def _windows_process_is_alive(pid: int) -> bool:
+    """Liveness check for Windows, where ``os.kill(pid, 0)`` cannot be used.
+
+    On Windows ``CTRL_C_EVENT`` is ``0``, so ``os.kill(pid, 0)`` routes signal 0
+    to ``GenerateConsoleCtrlEvent`` — it sends a console Ctrl+C to the process
+    group and never checks existence (it raises KeyboardInterrupt in-process
+    instead). Query the process directly: open a limited-information handle and
+    read its exit code — a live process reads ``STILL_ACTIVE`` (259). A failed
+    open means the pid is gone (ERROR_INVALID_PARAMETER) unless it is only
+    ERROR_ACCESS_DENIED, which means the process exists but we lack rights.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.GetExitCodeProcess.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(wintypes.DWORD),
+    ]
+    kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+
+    handle = kernel32.OpenProcess(
+        _WIN_PROCESS_QUERY_LIMITED_INFORMATION, False, pid
+    )
+    if not handle:
+        return ctypes.get_last_error() == _WIN_ERROR_ACCESS_DENIED
+    try:
+        exit_code = wintypes.DWORD()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+            return True  # opened but could not query — assume alive (conservative)
+        return exit_code.value == _WIN_STILL_ACTIVE
+    finally:
+        kernel32.CloseHandle(handle)
+
 
 def _process_is_alive(pid: int) -> bool:
     """Return True if a process with this PID currently exists.
 
-    Signal 0 runs the OS existence/permission check without delivering a
-    signal. A PID owned by another user raises PermissionError and still counts
-    as alive; only a missing process (ProcessLookupError / ESRCH) is dead.
+    POSIX uses signal 0 — a genuine existence/permission check that delivers no
+    signal: a PID owned by another user raises PermissionError and counts as
+    alive; only a missing process (ProcessLookupError / ESRCH) is dead. Any
+    other OSError is treated as not-alive so a corrupt record reconciles instead
+    of sticking on 'running' forever.
 
-    The ``except OSError: return False`` branch is not an optional tidy-up: on
-    Windows a dead PID surfaces as ``OSError`` (winerror 87), never
-    ProcessLookupError, so on Windows that branch is the *primary* path every
-    reconciliation arrives through — do not narrow it away.
+    Windows needs a different primitive entirely: ``os.kill(pid, 0)`` there
+    sends a console Ctrl+C (``CTRL_C_EVENT == 0``) rather than checking
+    existence, so liveness goes through OpenProcess + GetExitCodeProcess (see
+    ``_windows_process_is_alive``).
 
     Known limitation — PID reuse: a dead run whose PID has since been recycled
     by an unrelated process reads as alive forever, so reconciliation never
-    fires for it. That is inherent to PID-liveness (a start-time comparison
-    would be needed to close it) and is out of scope for issue #401.
+    fires for it. That is inherent to PID-liveness (a recorded process
+    start-time comparison would be needed to close it) and is out of scope for
+    issue #401.
     """
+    if sys.platform == "win32":
+        return _windows_process_is_alive(pid)
     try:
         os.kill(pid, 0)
     except ProcessLookupError:

--- a/tests/test_issue401_orphaned_run_reconcile.py
+++ b/tests/test_issue401_orphaned_run_reconcile.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+"""Reconcile-on-read for runs whose watcher never unwound (issue #401).
+
+`ExecutionManager._watch` runs as a daemon thread; when the MCP server exits it
+is killed without running `finish_execution`, leaving the run at 'running'
+forever. The tracker's read path reconciles such a row by checking whether the
+recorded PID is still alive.
+"""
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from soup_cli.experiment.tracker import ExperimentTracker
+
+_STATUS_RUNNING = "running"
+_STATUS_TERMINATED = "terminated"
+_STATUS_COMPLETED = "completed"
+_MCP_KIND = "mcp"
+_RUN_DEAD = "run-dead"
+_RUN_ALIVE = "run-alive"
+_RUN_NO_PID = "run-no-pid"
+_RUN_DONE = "run-done"
+
+
+def _tracker() -> ExperimentTracker:
+    return ExperimentTracker(db_path=Path(tempfile.mkdtemp()) / "experiments.db")
+
+
+def _launch(t: ExperimentTracker, run_id: str) -> None:
+    t.launch_run(
+        run_id=run_id,
+        kind=_MCP_KIND,
+        config_dict={"lr": 1},
+        command_digest="digest",
+        log_path="/tmp/soup.log",
+    )
+
+
+def _dead_pid() -> int:
+    """A PID that is guaranteed gone: spawn a real process and wait for it."""
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait()
+    return proc.pid
+
+
+def test_dead_watcher_run_is_reconciled_not_reported_running():
+    # The exact #401 shape: mark_running records a pid, the watcher never calls
+    # finish_execution (daemon thread killed), and the process is gone.
+    t = _tracker()
+    _launch(t, _RUN_DEAD)
+    t.mark_running(_RUN_DEAD, pid=_dead_pid())
+
+    run = t.get_run(_RUN_DEAD)
+    assert run["status"] == _STATUS_TERMINATED
+    # An unknown outcome must NOT be written as success.
+    assert run["status"] != _STATUS_COMPLETED
+    assert run["exit_code"] is None
+    # Reconciliation is persisted, so list_runs agrees.
+    assert t.list_runs()[0]["status"] == _STATUS_TERMINATED
+
+
+def test_control_a_live_process_is_still_reported_running():
+    # CONTROL: a genuinely-running process (this test's own PID) must stay running.
+    import os
+
+    t = _tracker()
+    _launch(t, _RUN_ALIVE)
+    t.mark_running(_RUN_ALIVE, pid=os.getpid())
+
+    assert t.get_run(_RUN_ALIVE)["status"] == _STATUS_RUNNING
+
+
+def test_running_run_without_a_pid_is_left_untouched():
+    # A run with no recorded pid (never MCP-spawned) cannot be liveness-checked,
+    # so it must not be reconciled away.
+    t = _tracker()
+    _launch(t, _RUN_NO_PID)
+    # A launched run carries no pid until mark_running; force 'running' with a
+    # NULL pid to model a run that was never MCP-spawned.
+    conn = t._get_conn()
+    conn.execute(
+        "UPDATE runs SET status = ?, pid = NULL WHERE run_id = ?",
+        (_STATUS_RUNNING, _RUN_NO_PID),
+    )
+    conn.commit()
+
+    assert t.get_run(_RUN_NO_PID)["status"] == _STATUS_RUNNING
+
+
+def test_terminal_status_is_never_overwritten_by_reconcile():
+    # A finished run keeps its terminal status even though its pid is long gone.
+    t = _tracker()
+    _launch(t, _RUN_DONE)
+    t.mark_running(_RUN_DONE, pid=_dead_pid())
+    t.finish_execution(_RUN_DONE, status=_STATUS_COMPLETED, exit_code=0)
+
+    run = t.get_run(_RUN_DONE)
+    assert run["status"] == _STATUS_COMPLETED
+    assert run["exit_code"] == 0


### PR DESCRIPTION
## Summary

Fix #401

`ExecutionManager._watch` runs as a `daemon=True` thread. When the MCP server
process exits, the watcher is killed without unwinding, so `finish_execution`
never runs and `ExperimentTracker` keeps the run at `running` forever — with no
watcher left to correct it. A permanently-`running` row in `soup runs` trains
the operator to ignore the status field, which is the only thing guarding
against a second concurrent training run.

Per the issue's suggested path, this **reconciles on read** rather than trying
to keep the watcher alive:

- `ExperimentTracker.list_runs` / `get_run` now check a `running` row's recorded
  pid. If the process is gone, the row is rewritten to `terminated` with an
  unknown (`None`) exit code via `finish_execution`, whose existing guard
  (`status NOT IN ('completed','failed')`) keeps a richer terminal status intact
  and makes the rewrite idempotent.
- An **unknown outcome is never written as success** — `terminated` + `exit_code
  = None` is distinct from `completed`.
- Only MCP-spawned runs carry a pid; a run without one is left untouched (its
  liveness cannot be checked), so direct training runs are unaffected.
- `soup runs` / `runs show` no longer hardcode `running` in the status
  fallback — they render the real status, so a reconciled row shows
  `terminated`, not `running`.

The same liveness check is what a restarted server needs for the sibling
capacity-slot issue.

## Acceptance criteria

- [x] a run whose process is gone is not reported as `running` by `soup runs` / `runs show`
- [x] `completed with exit code N` stays distinct from `the watcher never saw it finish` — an unknown outcome is written as `terminated` / `exit_code=None`, never success
- [x] a test kills the watcher (real process, exited, pid dead) without unwinding and asserts the reconciliation, with a CONTROL that a genuinely-running process (this test's own pid) is still reported `running`

## Test verification (RED → GREEN)

New test: `tests/test_issue401_orphaned_run_reconcile.py`.

RED — on unmodified `main`, a dead-process run is still reported `running`:

```
RED: dead-pid run status = running exit_code = None
AssertionError: BUG #401 present: dead-process run still 'running'
```

GREEN — with the fix:

```
tests/test_issue401_orphaned_run_reconcile.py ....                      [100%]
4 passed in 0.24s
```

## No regression

```
tests/test_tracker.py tests/test_runs.py tests/test_mcp_execute.py tests/test_issue401_orphaned_run_reconcile.py
63 passed in 4.06s
```
`ruff check` clean on the changed files.
