### PR TITLE
fix(draft): gate measure on config.vocab_size and write its report incrementally (#344)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,8 +83,10 @@ reproducing 70+ versions of notes.
   so a multimodal target like Llava is no longer refused), keeps `same_tokenizer()`
   as an additional check, and writes the report incrementally so a failing assisted
   arm leaves the acceptance rate and plain throughput on disk. The report records
-  an `assisted_status` (`complete` / `untimed` / `crash` / `interrupted`) so a
-  failed arm is distinguishable on disk from a completed or un-run one.
+  an `assisted_status` (`pending` / `complete` / `untimed` / `crash` /
+  `interrupted`) so a failed arm is distinguishable on disk from a completed or
+  un-run one — `pending` is what a report keeps when the process dies mid-arm
+  and no handler runs, which is the case the incremental write exists for.
 
 ## [0.73.3] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,8 @@ reproducing 70+ versions of notes.
   the "no matching architecture" advisory now share one message.
 
 - **`soup draft measure` now refuses a mismatched pair up front and no longer
-  discards a completed measurement when the assisted arm fails (#344).** `measure`
+  discards a completed measurement when the assisted arm fails
+  (#344 by @ousamabenyounes in #409).** `measure`
   gated on `same_tokenizer()` (tokenizer vocab + probe ids), which accepts a pair
   whose tokenizers are identical but whose `config.vocab_size` differs by padded
   embedding rows (e.g. Qwen2.5 large←small) — exactly the pair `distill` refuses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,20 @@ reproducing 70+ versions of notes.
   the wrong kernel or crashing. The two call sites that separately hand-wrote
   the "no matching architecture" advisory now share one message.
 
+- **`soup draft measure` now refuses a mismatched pair up front and no longer
+  discards a completed measurement when the assisted arm fails (#344).** `measure`
+  gated on `same_tokenizer()` (tokenizer vocab + probe ids), which accepts a pair
+  whose tokenizers are identical but whose `config.vocab_size` differs by padded
+  embedding rows (e.g. Qwen2.5 large←small) — exactly the pair `distill` refuses.
+  Transformers' assisted generation gates on `config.vocab_size`, so the run died
+  with "different tokenizers" deep inside `generate()`, after the expensive load,
+  and because the report was written only after that arm every completed
+  acceptance/plain-throughput number was thrown away. `measure` now uses the same
+  `config.vocab_size` precondition as `distill` (refusing before any model loads),
+  keeps `same_tokenizer()` as an additional check, and writes the report
+  incrementally so a failing assisted arm leaves the acceptance rate and plain
+  throughput on disk.
+
 ## [0.73.3] - 2026-08-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,10 +78,13 @@ reproducing 70+ versions of notes.
   with "different tokenizers" deep inside `generate()`, after the expensive load,
   and because the report was written only after that arm every completed
   acceptance/plain-throughput number was thrown away. `measure` now uses the same
-  `config.vocab_size` precondition as `distill` (refusing before any model loads),
-  keeps `same_tokenizer()` as an additional check, and writes the report
-  incrementally so a failing assisted arm leaves the acceptance rate and plain
-  throughput on disk.
+  `config.vocab_size` precondition as `distill` (refusing before any model loads;
+  the shared `_vocab_size_of` also reads a composite model's `get_text_config()`,
+  so a multimodal target like Llava is no longer refused), keeps `same_tokenizer()`
+  as an additional check, and writes the report incrementally so a failing assisted
+  arm leaves the acceptance rate and plain throughput on disk. The report records
+  an `assisted_status` (`complete` / `untimed` / `crash` / `interrupted`) so a
+  failed arm is distinguishable on disk from a completed or un-run one.
 
 ## [0.73.3] - 2026-08-18
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -190,7 +190,7 @@ soup shrink --model <id|path> --drop-ratio 0.25 --calib c.jsonl -o shrunk  Depth
 soup shrink ... --drop-layers N --heal h.jsonl --heal-steps 200 --device cpu  Drop N layers + distill-heal (fuse LoRA back to one dense model)
 soup shrink ... --tolerance 0.10 --plan-only [--attach-to-registry <id>]  Ppl-regression tolerance / print importance table only / registry attach
 soup draft measure --target <m> --draft <d> --prompts p.jsonl  Draft acceptance rate + real plain-vs-assisted tok/s (exit 0 measured — a best-effort assisted-arm failure stays 0 and is recorded as `assisted_status`; 2 below `--min-acceptance`; 1 error before results) (v0.71.33)
-soup draft measure ... --min-acceptance 0.6 -o report.json  Exit 2 below the floor (CI gate) / write the JSON report (fields incl. `assisted_status`: complete/untimed/crash/interrupted)
+soup draft measure ... --min-acceptance 0.6 -o report.json  Exit 2 below the floor (CI gate) / write the JSON report (fields incl. `assisted_status`: pending/complete/untimed/crash/interrupted)
 soup draft distill --target <tuned> --draft-base <tiny> --data d.jsonl -o draft/  Distil a DENSE speculative-decoding draft + register it (v0.71.33)
 soup draft distill ... --steps N --device cpu --force --plan-only  Training budget / device / overwrite -o / render the config only
 soup draft list                               List local drafts that `soup serve --auto-spec` will pick up (v0.71.33)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -189,8 +189,8 @@ soup mcp serve --allow-execute                Implies --allow-mutating; enables 
 soup shrink --model <id|path> --drop-ratio 0.25 --calib c.jsonl -o shrunk  Depth-prune least-important layer block + SHIP/DON'T-SHIP ppl verdict (exit 0/2/1) (v0.71.29)
 soup shrink ... --drop-layers N --heal h.jsonl --heal-steps 200 --device cpu  Drop N layers + distill-heal (fuse LoRA back to one dense model)
 soup shrink ... --tolerance 0.10 --plan-only [--attach-to-registry <id>]  Ppl-regression tolerance / print importance table only / registry attach
-soup draft measure --target <m> --draft <d> --prompts p.jsonl  Draft acceptance rate + real plain-vs-assisted tok/s (exit 0/2/1) (v0.71.33)
-soup draft measure ... --min-acceptance 0.6 -o report.json  Exit 2 below the floor (CI gate) / write the JSON report
+soup draft measure --target <m> --draft <d> --prompts p.jsonl  Draft acceptance rate + real plain-vs-assisted tok/s (exit 0 measured — a best-effort assisted-arm failure stays 0 and is recorded as `assisted_status`; 2 below `--min-acceptance`; 1 error before results) (v0.71.33)
+soup draft measure ... --min-acceptance 0.6 -o report.json  Exit 2 below the floor (CI gate) / write the JSON report (fields incl. `assisted_status`: complete/untimed/crash/interrupted)
 soup draft distill --target <tuned> --draft-base <tiny> --data d.jsonl -o draft/  Distil a DENSE speculative-decoding draft + register it (v0.71.33)
 soup draft distill ... --steps N --device cpu --force --plan-only  Training budget / device / overwrite -o / render the config only
 soup draft list                               List local drafts that `soup serve --auto-spec` will pick up (v0.71.33)

--- a/src/soup_cli/commands/draft.py
+++ b/src/soup_cli/commands/draft.py
@@ -174,6 +174,34 @@ def _write_draft_report(report: AcceptanceReport, output: str) -> None:
     )
 
 
+def _record_assisted_status(
+    report: AcceptanceReport, output: Optional[str], status: str
+) -> AcceptanceReport:
+    """Stamp ``status`` on ``report`` and persist it best-effort.
+
+    Only for the assisted-arm handlers: a write that raises there would replace
+    the exception being handled — swapping the "assisted arm crashed" warning,
+    or Ctrl-C's exit code, for an unrelated ``OSError`` — and so lose exactly the
+    outcome the handler exists to record (#344 review). The pre-arm write has
+    already put acceptance + plain throughput on disk, so a failed status update
+    is a warning, not a failure. The success path deliberately does NOT use this:
+    there is no exception to mask, and failing to write the completed report is a
+    real error.
+    """
+    report = replace(report, assisted_status=status)
+    if output is None:
+        return report
+    try:
+        _write_draft_report(report, output)
+    except OSError as exc:
+        console.print(
+            f"[yellow]Warning:[/] could not record the assisted-arm outcome in "
+            f"{escape(output)} ({escape(str(exc))}); the acceptance rate and "
+            f"plain throughput written before the arm are still on disk."
+        )
+    return report
+
+
 def _resolve_trust(model_id: str, requested: bool = False) -> bool:
     from soup_cli.utils.trust_remote import (
         model_requires_trust_remote_code,
@@ -748,14 +776,10 @@ def measure(
         # an untimed run — otherwise all three write byte-identical reports
         # (#344 review). Record the outcome, then re-raise so the exit code and
         # the "arm is best-effort" contract are unchanged.
-        report = replace(report, assisted_status="interrupted")
-        if output is not None:
-            _write_draft_report(report, output)
+        _record_assisted_status(report, output, "interrupted")
         raise
     except Exception as exc:  # noqa: BLE001 — assisted arm is best-effort
-        report = replace(report, assisted_status="crash")
-        if output is not None:
-            _write_draft_report(report, output)
+        report = _record_assisted_status(report, output, "crash")
         console.print(
             f"[yellow]Warning:[/] assisted-generation throughput could not be "
             f"measured ({escape(str(exc))}); the acceptance rate and plain "

--- a/src/soup_cli/commands/draft.py
+++ b/src/soup_cli/commands/draft.py
@@ -135,6 +135,11 @@ def _vocab_size_of(model_id: str, trc: bool = False) -> int:
 
     config = AutoConfig.from_pretrained(model_id, trust_remote_code=trc)
     vocab = getattr(config, "vocab_size", None)
+    if vocab is None and hasattr(config, "get_text_config"):
+        # Composite / multimodal configs (e.g. LlavaConfig) keep vocab_size on
+        # the text sub-config, not the top level; get_text_config() returns it
+        # (#344 review). Shared by measure and distill, so this fixes both.
+        vocab = getattr(config.get_text_config(), "vocab_size", None)
     if vocab is None:
         raise ValueError(f"{model_id} config has no vocab_size")
     return int(vocab)
@@ -738,7 +743,19 @@ def measure(
             num_assistant_tokens=num_assistant_tokens,
             max_new_tokens=max_new_tokens,
         )
+    except KeyboardInterrupt:
+        # A Ctrl-C during the arm must be distinguishable on disk from a crash or
+        # an untimed run — otherwise all three write byte-identical reports
+        # (#344 review). Record the outcome, then re-raise so the exit code and
+        # the "arm is best-effort" contract are unchanged.
+        report = replace(report, assisted_status="interrupted")
+        if output is not None:
+            _write_draft_report(report, output)
+        raise
     except Exception as exc:  # noqa: BLE001 — assisted arm is best-effort
+        report = replace(report, assisted_status="crash")
+        if output is not None:
+            _write_draft_report(report, output)
         console.print(
             f"[yellow]Warning:[/] assisted-generation throughput could not be "
             f"measured ({escape(str(exc))}); the acceptance rate and plain "
@@ -752,9 +769,12 @@ def measure(
                 report,
                 tok_s_assisted=assisted,
                 speedup=assisted / plain if plain else None,
+                assisted_status="complete",
             )
-            if output is not None:
-                _write_draft_report(report, output)
+        else:
+            report = replace(report, assisted_status="untimed")
+        if output is not None:
+            _write_draft_report(report, output)
 
     console.print(render_draft_panel(report))
     if output is not None:

--- a/src/soup_cli/commands/draft.py
+++ b/src/soup_cli/commands/draft.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import json
 import math
 import os
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn, Optional
 
@@ -137,6 +138,35 @@ def _vocab_size_of(model_id: str, trc: bool = False) -> int:
     if vocab is None:
         raise ValueError(f"{model_id} config has no vocab_size")
     return int(vocab)
+
+
+def _pair_vocab_sizes_or_fail(
+    target: str, draft_id: str, target_trc: bool, draft_trc: bool
+) -> "tuple[int, int]":
+    """(target, draft) ``config.vocab_size`` — the signal transformers' assisted
+    generation actually gates on, read from config only (no weight download).
+
+    Shared by ``distill`` and ``measure`` so the two never disagree on the
+    same-tokenizer precondition and both refuse a mismatched pair before any
+    model loads (issue #344).
+    """
+    try:
+        return (
+            _vocab_size_of(target, target_trc),
+            _vocab_size_of(draft_id, draft_trc),
+        )
+    except Exception as exc:  # noqa: BLE001 — surface as a friendly CLI error
+        _fail(f"could not read model config: {exc}")
+
+
+def _write_draft_report(report: AcceptanceReport, output: str) -> None:
+    """Serialise a ``measure`` report to ``output`` (shared by the incremental
+    writes so a later failure cannot discard an earlier result — issue #344)."""
+    atomic_write_text(
+        json.dumps(draft_report_to_dict(report), indent=2),
+        output,
+        field="report path",
+    )
 
 
 def _resolve_trust(model_id: str, requested: bool = False) -> bool:
@@ -468,12 +498,9 @@ def distill(
     # Same-tokenizer gate. Speculative decoding proposes DRAFT token ids into
     # the TARGET's vocabulary — a mismatch silently produces garbage rather
     # than failing, so refuse up front.
-    try:
-        target_vocab = _vocab_size_of(target, target_trc)
-        draft_vocab = _vocab_size_of(draft_base, draft_trc)
-    except Exception as exc:  # noqa: BLE001 — surface as a friendly CLI error
-        _fail(f"could not read model config: {exc}")
-
+    target_vocab, draft_vocab = _pair_vocab_sizes_or_fail(
+        target, draft_base, target_trc, draft_trc
+    )
     if target_vocab != draft_vocab:
         _fail(
             f"Draft and target must share a tokenizer, but vocab sizes differ "
@@ -618,6 +645,25 @@ def measure(
     target_trc = _resolve_trust(target, trust_remote_code)
     draft_trc = _resolve_trust(draft, trust_remote_code)
 
+    # Refuse a pair transformers cannot run BEFORE loading either model. Assisted
+    # generation gates on config.vocab_size (not the tokenizer's vocab) and raises
+    # "different tokenizers" deep inside generate() — after the expensive load —
+    # for a pair whose tokenizers ARE identical but whose padded embedding rows
+    # differ (e.g. Qwen2.5 large<-small). `soup draft distill` already refuses
+    # such a pair up front; measure uses the SAME definition here so the two agree
+    # (issue #344). same_tokenizer() below stays as an additional check.
+    target_vocab, draft_vocab = _pair_vocab_sizes_or_fail(
+        target, draft, target_trc, draft_trc
+    )
+    if target_vocab != draft_vocab:
+        _fail(
+            f"Draft and target must share a tokenizer, but their vocab sizes "
+            f"differ (target={target_vocab}, draft={draft_vocab}). Speculative "
+            f"decoding proposes draft token ids into the target's vocabulary, so "
+            f"transformers refuses a mismatched pair. Distil a draft from this "
+            f"target with `soup draft distill`."
+        )
+
     console.print(f"[dim]Loading target: {escape(target)}[/]")
     try:
         target_model, target_tok, resolved_device = _load_pair_member(
@@ -658,20 +704,15 @@ def measure(
     tok_s_plain = measure_throughput(
         target_model, target_tok, prompt_texts, max_new_tokens=max_new_tokens
     )
-    tok_s_assisted = measure_throughput(
-        target_model,
-        target_tok,
-        prompt_texts,
-        assistant_model=draft_model,
-        num_assistant_tokens=num_assistant_tokens,
-        max_new_tokens=max_new_tokens,
-    )
     # A measured 0.0 tok/s means "we could not time it", not "zero throughput";
     # normalise explicitly rather than leaning on 0.0 being falsy.
     plain = None if tok_s_plain <= 0 else tok_s_plain
-    assisted = None if tok_s_assisted <= 0 else tok_s_assisted
-    speedup = assisted / plain if (plain and assisted) else None
 
+    # Persist acceptance + plain throughput BEFORE the assisted arm. That arm runs
+    # after the two expensive measurements and can still fail inside transformers
+    # (issue #344); the report used to be written only after it, so a failure
+    # there discarded results that had already succeeded. Write incrementally,
+    # then upgrade the report in place if the assisted arm returns a number.
     report = AcceptanceReport(
         target=target,
         draft=draft,
@@ -680,19 +721,43 @@ def measure(
         acceptance_rate=rate,
         verdict=verdict,
         tok_s_plain=plain,
-        tok_s_assisted=assisted,
-        speedup=speedup,
+        tok_s_assisted=None,
+        speedup=None,
         num_assistant_tokens=num_assistant_tokens,
         soup_version=__version__,
     )
-    console.print(render_draft_panel(report))
-
     if output is not None:
-        atomic_write_text(
-            json.dumps(draft_report_to_dict(report), indent=2),
-            output,
-            field="report path",
+        _write_draft_report(report, output)
+
+    try:
+        tok_s_assisted = measure_throughput(
+            target_model,
+            target_tok,
+            prompt_texts,
+            assistant_model=draft_model,
+            num_assistant_tokens=num_assistant_tokens,
+            max_new_tokens=max_new_tokens,
         )
+    except Exception as exc:  # noqa: BLE001 — assisted arm is best-effort
+        console.print(
+            f"[yellow]Warning:[/] assisted-generation throughput could not be "
+            f"measured ({escape(str(exc))}); the acceptance rate and plain "
+            f"throughput are still valid"
+            + (" and are on disk." if output is not None else ".")
+        )
+    else:
+        assisted = None if tok_s_assisted <= 0 else tok_s_assisted
+        if assisted is not None:
+            report = replace(
+                report,
+                tok_s_assisted=assisted,
+                speedup=assisted / plain if plain else None,
+            )
+            if output is not None:
+                _write_draft_report(report, output)
+
+    console.print(render_draft_panel(report))
+    if output is not None:
         console.print(f"[dim]Report written to {escape(output)}[/]")
 
     if min_acceptance is not None and rate < min_acceptance:

--- a/src/soup_cli/utils/draft.py
+++ b/src/soup_cli/utils/draft.py
@@ -187,6 +187,13 @@ class AcceptanceReport:
     speedup: Optional[float]
     num_assistant_tokens: int
     soup_version: str
+    #: Outcome of the best-effort assisted-throughput arm (#344 review): one of
+    #: "pending" (arm not reached), "complete" (a positive tok/s was measured),
+    #: "untimed" (arm returned no usable number), "crash" (arm raised), or
+    #: "interrupted" (Ctrl-C). Without it the crash / untimed / interrupt reports
+    #: are byte-identical on disk, so a failed arm is indistinguishable from an
+    #: un-run one.
+    assisted_status: str = "pending"
 
 
 def draft_report_to_dict(report: AcceptanceReport) -> dict:

--- a/tests/test_v07133.py
+++ b/tests/test_v07133.py
@@ -1856,6 +1856,87 @@ class TestDraftMeasureVocabGate:
         assert data["tok_s_plain"] == 20.0
         assert data["tok_s_assisted"] is None
         assert data["speedup"] is None
+        # #344 review: a crashed arm is recorded on disk (else it is byte-identical
+        # to an untimed or interrupted one), and the loud warning is actually shown
+        # (deleting the message fails this).
+        assert data["assisted_status"] == "crash"
+        assert "could not be measured" in result.output
+
+    def _run_measure(self, runner, in_tmp_cwd, monkeypatch, throughput):
+        """Drive `measure` to the assisted arm with everything before it mocked;
+        `throughput` decides the assisted arm's outcome."""
+        from soup_cli.commands import draft as draft_cmd
+        from soup_cli.commands.draft import app
+
+        monkeypatch.setattr(draft_cmd, "_vocab_size_of", lambda mid, trc=False: 49152)
+        monkeypatch.setattr(
+            draft_cmd,
+            "_load_pair_member",
+            lambda model_id, **kw: (object(), _FakeTok(49152), "cpu"),
+        )
+        monkeypatch.setattr(draft_cmd, "measure_acceptance", lambda *a, **k: (75, 100))
+        monkeypatch.setattr(draft_cmd, "measure_throughput", throughput)
+        prompts = self._prompts(in_tmp_cwd)
+        return runner.invoke(
+            app,
+            ["measure", "--target", "org/target", "--draft", "org/tiny",
+             "--prompts", prompts, "-o", "report.json"],
+        )
+
+    def test_assisted_arm_outcomes_are_distinguishable_on_disk(
+        self, runner, in_tmp_cwd, monkeypatch
+    ):
+        """#344 review: crash / untimed / interrupt / complete wrote byte-identical
+        JSON. Each now records a distinct ``assisted_status``."""
+        import json as _json
+
+        def _complete(model, tok, prompts, *, assistant_model=None, **kw):
+            return 30.0 if assistant_model is not None else 20.0
+
+        result = self._run_measure(runner, in_tmp_cwd, monkeypatch, _complete)
+        assert result.exit_code == 0, (result.output, repr(result.exception))
+        data = _json.loads((in_tmp_cwd / "report.json").read_text(encoding="utf-8"))
+        assert data["assisted_status"] == "complete"
+        assert data["tok_s_assisted"] == 30.0
+        assert data["speedup"] == 1.5
+
+    def test_assisted_arm_untimed_is_recorded_and_silent(
+        self, runner, in_tmp_cwd, monkeypatch
+    ):
+        """A non-positive assisted number is 'untimed', not 'crash', and prints no
+        warning — the two must not collapse to the same on-disk state."""
+        import json as _json
+
+        def _untimed(model, tok, prompts, *, assistant_model=None, **kw):
+            return 0.0 if assistant_model is not None else 20.0
+
+        result = self._run_measure(runner, in_tmp_cwd, monkeypatch, _untimed)
+        assert result.exit_code == 0, (result.output, repr(result.exception))
+        data = _json.loads((in_tmp_cwd / "report.json").read_text(encoding="utf-8"))
+        assert data["assisted_status"] == "untimed"
+        assert data["tok_s_assisted"] is None
+        assert "could not be measured" not in result.output
+
+    def test_assisted_arm_interrupt_is_recorded_and_reraised(
+        self, runner, in_tmp_cwd, monkeypatch
+    ):
+        """Ctrl-C during the arm is recorded as 'interrupted' and re-raised (so the
+        exit is not 0). Widening the ``except`` to swallow BaseException — or
+        dropping the KeyboardInterrupt handler — fails this."""
+        import json as _json
+
+        def _interrupt(model, tok, prompts, *, assistant_model=None, **kw):
+            if assistant_model is not None:
+                raise KeyboardInterrupt
+            return 20.0
+
+        result = self._run_measure(runner, in_tmp_cwd, monkeypatch, _interrupt)
+        # click converts the re-raised KeyboardInterrupt to exit 130 — the point
+        # is that it is NOT swallowed into a 0 like crash/untimed are.
+        assert result.exit_code == 130, (result.output, repr(result.exception))
+        data = _json.loads((in_tmp_cwd / "report.json").read_text(encoding="utf-8"))
+        assert data["assisted_status"] == "interrupted"
+        assert data["tok_s_assisted"] is None
 
 
 class TestDraftListCli:

--- a/tests/test_v07133.py
+++ b/tests/test_v07133.py
@@ -1572,6 +1572,12 @@ class TestDraftMeasureCli:
         tok_a = _FakeTok(49152)
         tok_b = _FakeTok(49152) if compatible else _FakeTok(151936)
 
+        # measure now gates on config.vocab_size before loading (issue #344). Make
+        # that gate pass (equal config vocab) so these tests keep exercising the
+        # load / same_tokenizer / measurement paths; the tokenizer-vocab mismatch
+        # `compatible=False` sets still trips same_tokenizer as before.
+        monkeypatch.setattr(draft_cmd, "_vocab_size_of", lambda mid, trc=False: 49152)
+
         def _fake_load(model_id, **kwargs):
             tok = tok_a if "target" in model_id else tok_b
             return object(), tok, "cpu"
@@ -1683,6 +1689,9 @@ class TestDraftMeasureCli:
         def _boom(model_id, **kw):
             raise OSError("model not found")
 
+        # Config gate passes (issue #344) so the flow reaches the load, which is
+        # what this test exercises.
+        monkeypatch.setattr(draft_cmd, "_vocab_size_of", lambda mid, trc=False: 49152)
         monkeypatch.setattr(draft_cmd, "_load_pair_member", _boom)
         prompts = self._prompts(in_tmp_cwd)
         result = runner.invoke(
@@ -1752,6 +1761,101 @@ class TestDraftMeasureCli:
         )
         assert result.exit_code == 1
         assert "no tokens" in result.output.lower()
+
+
+class TestDraftMeasureVocabGate:
+    """issue #344 — measure must refuse the SAME pairs distill refuses (on
+    config.vocab_size, before loading), and must not discard a completed
+    measurement when the assisted arm fails inside transformers."""
+
+    def _prompts(self, tmp_path):
+        return _write_jsonl(
+            tmp_path / "p.jsonl", [{"prompt": "What is 2+2?"}, {"prompt": "Hi"}]
+        )
+
+    def test_config_vocab_mismatch_refused_before_any_model_loads(
+        self, runner, in_tmp_cwd, monkeypatch
+    ):
+        # Qwen2.5 large<-small: identical tokenizers, but config.vocab_size differs
+        # by padded embedding rows (152064 vs 151936). same_tokenizer() accepts it;
+        # transformers' assisted generation does not. measure must gate on the
+        # config vocab up front, exactly like distill.
+        from soup_cli.commands import draft as draft_cmd
+        from soup_cli.commands.draft import app
+
+        monkeypatch.setattr(
+            draft_cmd,
+            "_vocab_size_of",
+            lambda mid, trc=False: 152064 if "target" in mid else 151936,
+        )
+        loaded: list[str] = []
+
+        def _fake_load(model_id, **kwargs):
+            loaded.append(model_id)
+            return object(), _FakeTok(151643), "cpu"
+
+        # Everything past the gate is patched out, so the only thing that can make
+        # this test pass is the gate itself refusing before the load.
+        monkeypatch.setattr(draft_cmd, "_load_pair_member", _fake_load)
+        monkeypatch.setattr(draft_cmd, "measure_acceptance", lambda *a, **k: (75, 100))
+        monkeypatch.setattr(draft_cmd, "measure_throughput", lambda *a, **k: 20.0)
+
+        prompts = self._prompts(in_tmp_cwd)
+        result = runner.invoke(
+            app,
+            ["measure", "--target", "org/target-qwen-32b", "--draft", "org/qwen-0_5b",
+             "--prompts", prompts, "-o", "report.json"],
+        )
+        assert result.exit_code == 1, (result.output, repr(result.exception))
+        assert "vocab" in result.output.lower()
+        # Refused BEFORE the expensive load, and no report written.
+        assert loaded == []
+        assert not (in_tmp_cwd / "report.json").exists()
+
+    def test_assisted_arm_failure_keeps_acceptance_and_plain_on_disk(
+        self, runner, in_tmp_cwd, monkeypatch
+    ):
+        import json as _json
+
+        from soup_cli.commands import draft as draft_cmd
+        from soup_cli.commands.draft import app
+
+        monkeypatch.setattr(draft_cmd, "_vocab_size_of", lambda mid, trc=False: 49152)
+        monkeypatch.setattr(
+            draft_cmd,
+            "_load_pair_member",
+            lambda model_id, **kw: (object(), _FakeTok(49152), "cpu"),
+        )
+        monkeypatch.setattr(draft_cmd, "measure_acceptance", lambda *a, **k: (75, 100))
+
+        def _throughput(model, tok, prompts, *, assistant_model=None,
+                        num_assistant_tokens=5, max_new_tokens=64):
+            # The assisted arm is the one transformers refuses (issue #344); the
+            # plain arm has already succeeded by the time it runs.
+            if assistant_model is not None:
+                raise ValueError(
+                    "The main and assistant models have different tokenizers"
+                )
+            return 20.0
+
+        monkeypatch.setattr(draft_cmd, "measure_throughput", _throughput)
+
+        prompts = self._prompts(in_tmp_cwd)
+        result = runner.invoke(
+            app,
+            ["measure", "--target", "org/target", "--draft", "org/tiny",
+             "--prompts", prompts, "-o", "report.json"],
+        )
+        # A failed assisted arm is a loud warning, not a crash: the acceptance rate
+        # and plain throughput already succeeded and must survive on disk.
+        assert result.exit_code == 0, (result.output, repr(result.exception))
+        report = in_tmp_cwd / "report.json"
+        assert report.exists()
+        data = _json.loads(report.read_text(encoding="utf-8"))
+        assert data["acceptance_rate"] == 0.75
+        assert data["tok_s_plain"] == 20.0
+        assert data["tok_s_assisted"] is None
+        assert data["speedup"] is None
 
 
 class TestDraftListCli:

--- a/tests/test_v07133.py
+++ b/tests/test_v07133.py
@@ -14,9 +14,20 @@ from __future__ import annotations
 import ast
 import math
 import os
+import re
 from pathlib import Path
 
 import pytest
+
+# Rich styles console output, so a phrase assertion must never read raw
+# `result.output`: an escape sequence can land inside the phrase and a wrap can
+# split it across a line. Strip ANSI, then collapse whitespace — the repo-wide
+# rule enforced by `test_cli_help_assertions_are_ansi_safe.py`.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(text: str) -> str:
+    return re.sub(r"\s+", " ", _ANSI_RE.sub("", text or ""))
 
 
 # ---------------------------------------------------------------------------
@@ -1763,6 +1774,15 @@ class TestDraftMeasureCli:
         assert "no tokens" in result.output.lower()
 
 
+#: Qwen2.5's config.vocab_size with the padded embedding rows, and without them.
+#: The tokenizers are identical; only these two numbers differ (issue #344).
+_QWEN_PADDED_VOCAB = 152064
+_QWEN_BASE_VOCAB = 151936
+#: `LlavaConfig().get_text_config().vocab_size` on transformers 4.57.6 — the
+#: composite shape whose top-level `vocab_size` is absent (#344 review).
+_LLAVA_TEXT_VOCAB = 32000
+
+
 class TestDraftMeasureVocabGate:
     """issue #344 — measure must refuse the SAME pairs distill refuses (on
     config.vocab_size, before loading), and must not discard a completed
@@ -1773,8 +1793,18 @@ class TestDraftMeasureVocabGate:
             tmp_path / "p.jsonl", [{"prompt": "What is 2+2?"}, {"prompt": "Hi"}]
         )
 
+    @pytest.mark.parametrize(
+        ("target_vocab", "draft_vocab"),
+        [
+            (_QWEN_PADDED_VOCAB, _QWEN_BASE_VOCAB),
+            # The mirror image. The gate is `!=`, not `>`: a draft with the LARGER
+            # config vocab is refused too. Without this direction, mutating the
+            # comparison to `>` survives (#344 review, finding 3).
+            (_QWEN_BASE_VOCAB, _QWEN_PADDED_VOCAB),
+        ],
+    )
     def test_config_vocab_mismatch_refused_before_any_model_loads(
-        self, runner, in_tmp_cwd, monkeypatch
+        self, runner, in_tmp_cwd, monkeypatch, target_vocab, draft_vocab
     ):
         # Qwen2.5 large<-small: identical tokenizers, but config.vocab_size differs
         # by padded embedding rows (152064 vs 151936). same_tokenizer() accepts it;
@@ -1786,7 +1816,7 @@ class TestDraftMeasureVocabGate:
         monkeypatch.setattr(
             draft_cmd,
             "_vocab_size_of",
-            lambda mid, trc=False: 152064 if "target" in mid else 151936,
+            lambda mid, trc=False: target_vocab if "target" in mid else draft_vocab,
         )
         loaded: list[str] = []
 
@@ -1860,7 +1890,7 @@ class TestDraftMeasureVocabGate:
         # to an untimed or interrupted one), and the loud warning is actually shown
         # (deleting the message fails this).
         assert data["assisted_status"] == "crash"
-        assert "could not be measured" in result.output
+        assert "could not be measured" in _plain(result.output)
 
     def _run_measure(self, runner, in_tmp_cwd, monkeypatch, throughput):
         """Drive `measure` to the assisted arm with everything before it mocked;
@@ -1915,7 +1945,7 @@ class TestDraftMeasureVocabGate:
         data = _json.loads((in_tmp_cwd / "report.json").read_text(encoding="utf-8"))
         assert data["assisted_status"] == "untimed"
         assert data["tok_s_assisted"] is None
-        assert "could not be measured" not in result.output
+        assert "could not be measured" not in _plain(result.output)
 
     def test_assisted_arm_interrupt_is_recorded_and_reraised(
         self, runner, in_tmp_cwd, monkeypatch
@@ -1937,6 +1967,175 @@ class TestDraftMeasureVocabGate:
         data = _json.loads((in_tmp_cwd / "report.json").read_text(encoding="utf-8"))
         assert data["assisted_status"] == "interrupted"
         assert data["tok_s_assisted"] is None
+
+    def test_hard_death_in_the_assisted_arm_keeps_the_incremental_report(
+        self, runner, in_tmp_cwd, monkeypatch
+    ):
+        """The incremental write earns its keep on a death NO handler catches.
+
+        `SystemExit` derives from `BaseException`, so neither `except Exception`
+        nor `except KeyboardInterrupt` catches it and nothing in `measure` runs
+        after the arm dies here — the only reason acceptance + plain throughput
+        are on disk is the write that already happened BEFORE the arm. A hard
+        kill is the same shape with no Python frame at all. Delete just that
+        write and every other test in this class stays green; this one goes red
+        (#344 review, blocker 1). It is also the only assertion on `pending`,
+        which is reachable on disk exactly in this case.
+        """
+        import json as _json
+
+        def _hard_death(model, tok, prompts, *, assistant_model=None, **kw):
+            if assistant_model is not None:
+                raise SystemExit(137)
+            return 20.0
+
+        result = self._run_measure(runner, in_tmp_cwd, monkeypatch, _hard_death)
+        assert result.exit_code == 137, (result.output, repr(result.exception))
+        report = in_tmp_cwd / "report.json"
+        assert report.exists(), "acceptance + plain throughput were discarded"
+        data = _json.loads(report.read_text(encoding="utf-8"))
+        assert data["acceptance_rate"] == 0.75
+        assert data["tok_s_plain"] == 20.0
+        assert data["assisted_status"] == "pending"
+
+    @pytest.mark.parametrize(
+        ("outcome", "expected_exit"),
+        [("crash", 0), ("interrupt", 130)],
+    )
+    def test_a_failed_status_write_does_not_mask_the_arm_outcome(
+        self, runner, in_tmp_cwd, monkeypatch, outcome, expected_exit
+    ):
+        """#344 review nit: the status write inside the two handlers was unguarded,
+        so an `OSError` there replaced the exception being handled — the crashed
+        arm's warning became an unrelated traceback, and Ctrl-C lost its exit 130.
+        Drop the guard in `_record_assisted_status` and both cases fail.
+        """
+        import json as _json
+
+        from soup_cli.commands import draft as draft_cmd
+
+        real_write = draft_cmd._write_draft_report
+        writes = {"n": 0}
+
+        def _fail_after_the_pre_arm_write(report, output):
+            writes["n"] += 1
+            if writes["n"] == 1:
+                real_write(report, output)
+                return
+            raise OSError("no space left on device")
+
+        monkeypatch.setattr(
+            draft_cmd, "_write_draft_report", _fail_after_the_pre_arm_write
+        )
+
+        def _throughput(model, tok, prompts, *, assistant_model=None, **kw):
+            if assistant_model is None:
+                return 20.0
+            if outcome == "interrupt":
+                raise KeyboardInterrupt
+            raise ValueError("boom")
+
+        result = self._run_measure(runner, in_tmp_cwd, monkeypatch, _throughput)
+        assert result.exit_code == expected_exit, (
+            result.output,
+            repr(result.exception),
+        )
+        # The failed update is reported, not swallowed silently...
+        assert "could not record the assisted-arm outcome" in _plain(result.output)
+        # ...and the results the pre-arm write persisted are untouched on disk.
+        data = _json.loads((in_tmp_cwd / "report.json").read_text(encoding="utf-8"))
+        assert data["acceptance_rate"] == 0.75
+        assert data["tok_s_plain"] == 20.0
+
+    def test_a_crashed_arm_without_an_output_path_still_warns(
+        self, runner, in_tmp_cwd, monkeypatch
+    ):
+        """`measure` without `-o` has no report to update, so recording the outcome
+        must be a no-op rather than a write against `None` — the arm still warns
+        and the run still exits 0."""
+        from soup_cli.commands import draft as draft_cmd
+        from soup_cli.commands.draft import app
+
+        monkeypatch.setattr(draft_cmd, "_vocab_size_of", lambda mid, trc=False: 49152)
+        monkeypatch.setattr(
+            draft_cmd,
+            "_load_pair_member",
+            lambda model_id, **kw: (object(), _FakeTok(49152), "cpu"),
+        )
+        monkeypatch.setattr(draft_cmd, "measure_acceptance", lambda *a, **k: (75, 100))
+
+        def _crash(model, tok, prompts, *, assistant_model=None, **kw):
+            if assistant_model is not None:
+                raise ValueError("boom")
+            return 20.0
+
+        monkeypatch.setattr(draft_cmd, "measure_throughput", _crash)
+        result = runner.invoke(
+            app,
+            ["measure", "--target", "org/target", "--draft", "org/tiny",
+             "--prompts", self._prompts(in_tmp_cwd)],
+        )
+        assert result.exit_code == 0, (result.output, repr(result.exception))
+        assert "could not be measured" in _plain(result.output)
+        assert not list(in_tmp_cwd.glob("*.json"))
+
+
+class TestVocabSizeOfCompositeConfig:
+    """#344 review, blocker 2 — `_vocab_size_of` reads a composite/multimodal
+    config's `get_text_config()` when the top-level `vocab_size` is absent, so a
+    VLM target is no longer refused with "could not read model config". It is the
+    shared helper, so this covers `measure` and `distill` at once.
+
+    Stubbed configs rather than a real `LlavaConfig`: the repo allows
+    `transformers>=4.36,<5`, and the top-level `vocab_size` this fallback exists
+    for was only dropped from `LlavaConfig` partway through that range — on the
+    older cells a real config would satisfy the assertion without ever reaching
+    the fallback. The shapes below are the ones measured on 4.57.6
+    (`LlavaConfig().vocab_size` missing, `get_text_config().vocab_size == 32000`).
+    """
+
+    def _vocab_size_for(self, config):
+        from unittest.mock import patch
+
+        from soup_cli.commands.draft import _vocab_size_of
+
+        with patch("transformers.AutoConfig.from_pretrained", return_value=config):
+            return _vocab_size_of("org/model")
+
+    @pytest.mark.parametrize(
+        "text_vocab", [_LLAVA_TEXT_VOCAB, _QWEN_PADDED_VOCAB]
+    )
+    def test_composite_config_resolves_through_get_text_config(self, text_vocab):
+        """Two sizes, because one would be satisfied by a fallback that returns a
+        hardcoded 32000 rather than reading the sub-config."""
+        import types
+
+        config = types.SimpleNamespace(
+            get_text_config=lambda: types.SimpleNamespace(vocab_size=text_vocab)
+        )
+        assert self._vocab_size_for(config) == text_vocab
+
+    def test_top_level_vocab_size_still_wins(self):
+        """The control. Without it a fallback that took PRIORITY would also pass
+        the test above — here `get_text_config()` raises, so calling it at all is
+        a failure, and the plain (Qwen-shaped) path must be untouched."""
+        import types
+
+        def _must_not_be_called():
+            raise AssertionError("get_text_config() shadowed the top-level vocab_size")
+
+        config = types.SimpleNamespace(
+            vocab_size=_QWEN_BASE_VOCAB, get_text_config=_must_not_be_called
+        )
+        assert self._vocab_size_for(config) == _QWEN_BASE_VOCAB
+
+    def test_neither_source_still_raises(self):
+        """A config with no vocab size anywhere keeps the pre-existing error —
+        the fallback must not turn an unreadable config into a silent default."""
+        import types
+
+        with pytest.raises(ValueError, match="vocab_size"):
+            self._vocab_size_for(types.SimpleNamespace())
 
 
 class TestDraftListCli:


### PR DESCRIPTION
## What does this PR do?

Fix #344 — `soup draft measure` and `soup draft distill` disagreed on the same-tokenizer precondition, and `measure` discarded a completed measurement when the assisted arm failed.

`measure` gated on `same_tokenizer()` (tokenizer vocab + probe ids), which **accepts** a pair whose tokenizers are identical but whose `config.vocab_size` differs by padded embedding rows (e.g. Qwen2.5 large←small: 152064 vs 151936). Transformers' assisted generation gates on `config.vocab_size`, so the run died with `ValueError: The main and assistant models have different tokenizers` deep inside `generate()` — **after** the expensive load. `soup draft distill` already refuses that pair up front on `config.vocab_size`. Worse, `measure` wrote its report only after the assisted arm, so when that arm raised, the acceptance rate and plain throughput it had already computed were thrown away (no JSON).

### Fix

- `measure` now applies the **same `config.vocab_size` precondition as `distill`**, refusing a mismatched pair **before any model loads**. `same_tokenizer()` stays as an additional check.
- The shared reader is factored into `_pair_vocab_sizes_or_fail`, so the two commands cannot drift. It also reads a composite model's `get_text_config()`, so a multimodal target (e.g. Llava, whose top-level `vocab_size` is absent) is no longer refused with "could not read model config".
- `measure` writes the report **incrementally**: acceptance + plain throughput are persisted before the assisted arm runs, then upgraded in place if it returns.
- The report records an `assisted_status` (`pending` / `complete` / `untimed` / `crash` / `interrupted`), so a failed arm is distinguishable on disk from a completed or un-run one — previously crash / untimed / interrupt wrote byte-identical JSON. A failed arm stays exit 0 (the arm is a best-effort *throughput* measurement; the `--min-acceptance` gate is unaffected and still exits 2), Ctrl-C is re-raised and keeps exit 130.
- Recording that status is best-effort: an `OSError` while updating the report cannot replace the exception being handled, so a crashed arm still prints its warning and Ctrl-C still exits 130.

Maps to the four acceptance criteria in the issue: (1) measure/distill accept and refuse the same pairs; (2) a transformers-incompatible pair is refused before any model is loaded; (3) a failure in the assisted arm still leaves acceptance + plain-throughput on disk; (4) a test on a vocab-size-mismatched pair with matching tokenizers (the Qwen2.5 shape).

## Type of change

- [x] Bug fix

## Test verification (RED → GREEN)

Tests live in the matching module `tests/test_v07133.py` (`TestDraftMeasureVocabGate` + `TestVocabSizeOfCompositeConfig`). Every torch boundary is monkeypatched, so they run without the training stack.

**RED — the original symptom, on unmodified `main` with only the new tests applied:**

```
>       assert result.exit_code == 1, (result.output, repr(result.exception))
E       assert 0 == 1                       # measure ACCEPTED the mismatched pair, loaded, wrote a report

>       assert result.exit_code == 0, (result.output, repr(result.exception))
E         ', "ValueError('The main and assistant models have different tokenizers')")
E       assert 1 == 0                       # assisted arm raised; report was NOT written
FAILED tests/test_v07133.py::TestDraftMeasureVocabGate::test_config_vocab_mismatch_refused_before_any_model_loads
FAILED tests/test_v07133.py::TestDraftMeasureVocabGate::test_assisted_arm_failure_keeps_acceptance_and_plain_on_disk
```

**RED — by mutation.** Each load-bearing line broken in turn; the control that dies is named:

```
drop the pre-arm incremental write   -> 3 failed  (test_hard_death_in_the_assisted_arm_keeps_the_incremental_report + both write-guard cases)
drop the get_text_config() fallback  -> 2 failed  (test_composite_config_resolves_through_get_text_config[32000] and [152064])
hardcode the fallback to 32000       -> 1 failed  (…[152064] — the second size exists so a constant cannot satisfy it)
let the fallback shadow the top level-> 1 failed  (test_top_level_vocab_size_still_wins)
change the gate's `!=` to `>`        -> 1 failed  (test_config_vocab_mismatch_refused_before_any_model_loads[151936-152064])
drop the OSError guard on the status write -> 2 failed (test_a_failed_status_write_does_not_mask_the_arm_outcome[crash-0] and [interrupt-130])
```

**GREEN — unmutated:**

```
tests/test_v07133.py::TestDraftMeasureVocabGate
tests/test_v07133.py::TestVocabSizeOfCompositeConfig
14 passed
```

**Full local replay** (`ruff` + the touched module + the two repo-wide ratchets it is exposed to), run on `upstream/main` first and then on this branch:

```
== ruff check src/soup_cli/ tests/ (blocking CI job) ==
All checks passed!            (baseline and final)

== pytest tests/test_v07133.py tests/test_cli_help_assertions_are_ansi_safe.py tests/test_cli_startup_is_light.py ==
baseline (upstream/main): 8 failed, 140 passed, 1 skipped
final    (this branch):   8 failed, 154 passed, 1 skipped
```

The 8 failures are identical on both sides (`TestMeasureAcceptance` / `TestMeasureThroughput` — they `import torch`, which this torch-free environment does not have); the full matrix with the training stack and the 77% coverage gate runs in CI. Diff coverage on the changed production lines: 41/41.

## Checklist

- [x] `ruff check src/soup_cli/ tests/` passes
- [x] `pytest tests/ -v` passes (torch-free classes locally; full matrix runs in CI)
- [x] Updated relevant docs — `docs/commands.md` documents the exit contract and the `assisted_status` values, `CHANGELOG.md` `[Unreleased] → Fixed`
- [x] New tests added (`TestDraftMeasureVocabGate`, `TestVocabSizeOfCompositeConfig`)
