### PR TITLE
feat(ship): commit the noise floor to soup.yaml via eval.ship.noise_floor (#406)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ reproducing 70+ versions of notes.
 
 ## [Unreleased]
 
+### Added
+
+- **`eval.ship.noise_floor` is now committable to `soup.yaml` (#406).** Every
+  `soup ship` gate-policy flag was settable in a committed config and read back by
+  `--config` — except `--noise-floor` (added in v0.73.2), which had no field and
+  could only be passed on the command line, so a team enforcing a floor in CI had
+  to hand-edit the workflow. `ShipConfig` gains a bounded `noise_floor`
+  (`[2, 10]`, imported from `ship_verdict` so the schema and the CLI validator
+  cannot disagree; bool-as-int rejected), wired with the same CLI > config >
+  default precedence as the other five flags. As a live-measurement input it is
+  measured only when producing evidence and refused under `--evidence` exactly as
+  the flag is; it follows `forgetting_threshold` in being excluded from the
+  recipe `config_sha`, so setting a floor never invalidates evidence.
+
 ### Fixed
 
 - **`soup draft distill --steps N` now delivers ~N optimiser steps instead of

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -463,7 +463,10 @@ every PR instead of relying on a hand-edited JSON file.
   reproduces an identical verdict.
 - **`--config soup.yaml`** reads a committed `eval.ship` block for the gate defaults
   (`task_eval` / `task_mode` / `general_suite` / `forgetting_threshold` / `judge_model` /
-  `baseline`); an explicit CLI flag always wins. This makes the gate reviewable in a PR diff.
+  `baseline` / `noise_floor`); an explicit CLI flag always wins. This makes the gate reviewable
+  in a PR diff. `noise_floor` is a live-measurement input like the `--noise-floor` flag: it is
+  measured when a live run produces evidence and, like the flag, is refused under `--evidence`
+  (there is nothing to re-run offline — a floor already recorded in the evidence is applied).
 - **Provenance + staleness.** With `--emit-evidence`, `--config` STAMPS a `provenance` block
   (`config_sha` — a semantic, order-insensitive recipe hash that EXCLUDES the `eval.ship` gate
   policy, so tuning the threshold never invalidates evidence — plus `base_model` and a

--- a/src/soup_cli/commands/ship.py
+++ b/src/soup_cli/commands/ship.py
@@ -1095,6 +1095,13 @@ def ship(
                 baseline = ship_cfg.baseline
             if _flag_is_default(ctx, "forgetting_threshold"):
                 forgetting_threshold = ship_cfg.forgetting_threshold
+            if _flag_is_default(ctx, "noise_floor") and ship_cfg.noise_floor is not None:
+                # A config floor is a live-measurement request just like the CLI
+                # flag: _validate_noise_floor_flag re-checks bounds below, and the
+                # --evidence guard refuses it there exactly as it refuses the flag
+                # (a floor is measured against a live base, nothing to run
+                # offline; a floor already in the evidence is applied on read).
+                noise_floor = ship_cfg.noise_floor
 
     _validate_task_mode_flag(task_mode)
     threshold = _validate_threshold_flag(forgetting_threshold)

--- a/src/soup_cli/config/schema.py
+++ b/src/soup_cli/config/schema.py
@@ -19,6 +19,14 @@ from soup_cli.utils.layer_stream import (
     SUPPORTED_STREAM_TASKS as _STREAM_SUPPORTED_TASKS,
 )
 
+# Noise-floor bounds live with the ship verdict so the schema bound and the
+# `--noise-floor` CLI validator can never disagree (ship_verdict has no torch,
+# same reasoning as stream_buffers importing its bounds from layer_stream).
+from soup_cli.utils.ship_verdict import (
+    MAX_NOISE_FLOOR_RUNS,
+    MIN_NOISE_FLOOR_RUNS,
+)
+
 # v0.39.0 Part C — per-pattern LoRA rank/alpha bounds
 _MAX_LORA_RANK_PATTERN_KEYS = 256
 _MAX_LORA_RANK_PATTERN_VALUE = 1024
@@ -3752,6 +3760,30 @@ class ShipConfig(BaseModel):
         default=None,
         description="registry://<id> | file JSON of base leg-2 scores",
     )
+    # v0.73.2 shipped `--noise-floor` (#376) without its config surface, so it
+    # was the one gate-policy flag that could not be committed to soup.yaml
+    # (#406). Bounds import from ship_verdict so the schema and the CLI
+    # validator (_validate_noise_floor_flag) share one source of truth.
+    noise_floor: Optional[int] = Field(
+        default=None,
+        ge=MIN_NOISE_FLOOR_RUNS,
+        le=MAX_NOISE_FLOOR_RUNS,
+        description=(
+            "Repeats of the BASE run used to measure a leg-2 noise floor; a "
+            "leg-2 drop within the floor is treated as noise, not regression. "
+            f"Bounded [{MIN_NOISE_FLOOR_RUNS}, {MAX_NOISE_FLOOR_RUNS}]. A live "
+            "input: measured when producing evidence, refused under --evidence."
+        ),
+    )
+
+    @field_validator("noise_floor", mode="before")
+    @classmethod
+    def _validate_noise_floor_int(cls, v: Any) -> Any:
+        """Reject bool-as-int (bool subclasses int), mirrors stream_buffers and
+        the ``--noise-floor`` CLI validator."""
+        if isinstance(v, bool):
+            raise ValueError("eval.ship.noise_floor must be an int, not bool")
+        return v
 
 
 class EvalConfig(BaseModel):
@@ -3776,7 +3808,8 @@ class EvalConfig(BaseModel):
     ship: Optional[ShipConfig] = Field(
         default=None,
         description="soup ship verdict defaults (task_eval / task_mode / "
-        "general_suite / forgetting_threshold / judge_model / baseline)",
+        "general_suite / forgetting_threshold / judge_model / baseline / "
+        "noise_floor)",
     )
 
 

--- a/tests/test_v07139.py
+++ b/tests/test_v07139.py
@@ -239,6 +239,40 @@ class TestShipConfigSchema:
         with pytest.raises(pydantic.ValidationError):
             ShipConfig(forgetting_threshold=bad)
 
+    def test_noise_floor_default_is_none(self):
+        # #406 — the field exists and defaults to None (unset = no floor).
+        from soup_cli.config.schema import ShipConfig
+
+        assert ShipConfig().noise_floor is None
+
+    def test_parses_noise_floor_under_eval(self):
+        # #406 — a committed eval.ship.noise_floor is honoured, not dropped.
+        from soup_cli.config.loader import load_config_from_string
+
+        cfg = load_config_from_string(_CONFIG_LENIENT + "    noise_floor: 3\n")
+        assert cfg.eval.ship.noise_floor == 3
+
+    @pytest.mark.parametrize("bad", [1, 11])
+    def test_rejects_out_of_bounds_noise_floor(self, bad):
+        # #406 — same [MIN_NOISE_FLOOR_RUNS, MAX_NOISE_FLOOR_RUNS] bounds the CLI
+        # validator enforces, imported from ship_verdict so they cannot drift.
+        import pydantic
+
+        from soup_cli.config.schema import ShipConfig
+
+        with pytest.raises(pydantic.ValidationError):
+            ShipConfig(noise_floor=bad)
+
+    @pytest.mark.parametrize("bad", [True, False])
+    def test_rejects_bool_noise_floor(self, bad):
+        # #406 — bool subclasses int; reject it like stream_buffers does.
+        import pydantic
+
+        from soup_cli.config.schema import ShipConfig
+
+        with pytest.raises(pydantic.ValidationError):
+            ShipConfig(noise_floor=bad)
+
 
 class TestShipConfigReader:
     def _ev_010_bound(self) -> dict:
@@ -321,6 +355,62 @@ class TestShipConfigReader:
             assert captured["general_suite"] == "mini_mmlu"
             assert captured["judge_model"] == "https://judge.example"
             assert captured["baseline_spec"] == "registry://abc"
+
+    def _capture_live(self, monkeypatch):
+        """Patch _verdict_live to a SHIP verdict and record its kwargs."""
+        from soup_cli.commands import ship as ship_cmd
+
+        captured: dict = {}
+
+        def _fake_live(**kwargs):
+            captured.update(kwargs)
+            win = build_task_win("metric", 0.5, 0.7)
+            deltas = compute_benchmark_deltas({"b": 0.6}, {"b": 0.6})
+            return decide_ship(win, deltas)
+
+        monkeypatch.setattr(ship_cmd, "_verdict_live", _fake_live)
+        return ship_cmd, captured
+
+    def test_config_noise_floor_threads_to_live(self, monkeypatch):
+        """#406 — a committed noise_floor reaches the live run (CLI > config)."""
+        ship_cmd, captured = self._capture_live(monkeypatch)
+        cfg = _CONFIG_MIN + "eval:\n  ship:\n    noise_floor: 3\n"
+        with runner.isolated_filesystem():
+            Path("soup.yaml").write_text(cfg, encoding="utf-8")
+            res = runner.invoke(
+                ship_cmd.app, ["--base", "m", "--adapter", "a", "--config", "soup.yaml"]
+            )
+            assert res.exit_code == 0, (res.output, repr(res.exception))
+            assert captured["noise_floor_runs"] == 3
+
+    def test_explicit_noise_floor_overrides_config(self, monkeypatch):
+        """#406 — an explicit --noise-floor wins over the config value."""
+        ship_cmd, captured = self._capture_live(monkeypatch)
+        cfg = _CONFIG_MIN + "eval:\n  ship:\n    noise_floor: 3\n"
+        with runner.isolated_filesystem():
+            Path("soup.yaml").write_text(cfg, encoding="utf-8")
+            res = runner.invoke(
+                ship_cmd.app,
+                ["--base", "m", "--adapter", "a", "--config", "soup.yaml",
+                 "--noise-floor", "5"],
+            )
+            assert res.exit_code == 0, (res.output, repr(res.exception))
+            assert captured["noise_floor_runs"] == 5
+
+    def test_config_noise_floor_refused_under_evidence(self):
+        """#406 — a config floor under --evidence is refused, exactly as the CLI
+        flag is (nothing to re-run offline), not silently ignored."""
+        from soup_cli.commands import ship as ship_cmd
+
+        cfg = _CONFIG_MIN + "eval:\n  ship:\n    noise_floor: 3\n"
+        with runner.isolated_filesystem():
+            _write_evidence(Path("ev.json"), _ship_evidence())
+            Path("soup.yaml").write_text(cfg, encoding="utf-8")
+            res = runner.invoke(
+                ship_cmd.app, ["--evidence", "ev.json", "--config", "soup.yaml"]
+            )
+            assert res.exit_code == 3, (res.output, repr(res.exception))
+            assert "noise-floor" in res.output
 
 
 def _dont_ship_evidence_010() -> dict:
@@ -532,6 +622,17 @@ class TestComputeProvenance:
         assert _config_sha(with_ship) == _config_sha(different_ship)
         # ...and a ship block hashes the same as no ship block at all.
         assert _config_sha(with_ship) == _config_sha(no_ship)
+
+    def test_config_sha_excludes_noise_floor(self):
+        """#406 — noise_floor is gate policy, so it follows the same exclusion:
+        adding it must NOT change the recipe hash (a floor tunes the verdict,
+        not the trained model)."""
+        no_floor = (
+            _CONFIG_MIN + "eval:\n  auto_eval: false\n  ship:\n"
+            "    forgetting_threshold: 0.20\n"
+        )
+        with_floor = no_floor + "    noise_floor: 3\n"
+        assert _config_sha(with_floor) == _config_sha(no_floor)
 
     def test_config_sha_changes_on_real_recipe_edit(self):
         """A genuine base/data change DOES change the sha (the gate still bites)."""


### PR DESCRIPTION
## Summary

`eval.ship` in `soup.yaml` could carry every `soup ship` gate-policy flag — `task_eval`, `task_mode`, `general_suite`, `forgetting_threshold`, `judge_model`, `baseline` — and `soup ship --config` read each back with CLI > config > default precedence. The one exception was `--noise-floor`, added in v0.73.2 (#376) without a config surface, so it could only be passed on the command line and the key was silently ignored if placed under `eval.ship`.

This adds that surface (proposed-fix-path steps 1–3), following the pattern already established six times over.

Fix #406

## What changed (acceptance criteria)

- [x] `eval.ship.noise_floor: 3` is honoured by `soup ship --config soup.yaml` — a bounded `Optional[int]` field on `ShipConfig`, wired in `commands/ship.py` beside the other five `_flag_is_default(ctx, ...)` reads.
- [x] An explicit `--noise-floor` on the command line **overrides** the config value (CLI > config > default) — test added.
- [x] Out-of-range and bool-as-int values are rejected at config-parse time — bounds `[MIN_NOISE_FLOOR_RUNS, MAX_NOISE_FLOOR_RUNS]` **imported from `utils.ship_verdict`** (not re-typed), so the schema bound and the CLI validator cannot disagree — same reasoning as `stream_buffers` importing its bounds from `utils.layer_stream`.
- [x] `eval.ship` stays excluded from `_config_sha_of` — a test pins that adding this field did not change the recipe hash (`_config_sha_of` already excludes the whole `eval.ship` block, so a floor tunes the verdict, never the model fingerprint).
- [x] A config-supplied floor combined with `--evidence` **behaves exactly as the CLI flag does there** — refused (nothing to re-run offline; a floor already recorded in the evidence is applied), not silently ignored — test added.
- [ ] **`soup ci init` emitting the flag (step 4) — left for your direction, see the open question below.**

## Open question — step 4 / `soup ci init` (why this is a draft)

I could not resolve step 4 without guessing at intended behaviour, and would rather ask than ship a design you'd have to unwind.

The generated gate step is `soup ship --evidence <ev> --config <cfg>` (offline). With the acceptance-criteria rule that a **config-supplied floor under `--evidence` is refused** (implemented above), binding a config that *sets* `noise_floor` to that gate step would make the generated gate exit 3. So the two goals pull against each other:

- **"config floor + `--evidence` ⇒ refused"** (criterion 5), and
- **"`soup ci init` emits the flag when the bound config sets it"** (criterion 6)

can't both hold for the *same* config used as the gate's `--config` binding.

`noise_floor` is a live-measurement input, so it is only meaningful on the **producer** run (`soup ship ... --config <cfg> --emit-evidence <ev>`), which the header note already documents and which is `--config`-bound (so it already carries the floor into the measured evidence). If your intent for step 4 is one of:

1. `soup ci init` reads the bound config and, when it sets `noise_floor`, surfaces it in the header producer-command note (gate step unchanged), or
2. `soup ci init` warns that a floor-carrying config is measured at evidence-production time and not re-run at the gate, or
3. something else,

I'll add it in this PR. I kept steps 1–3 self-contained so the config surface lands cleanly regardless of how step 4 is shaped.

## Test verification (RED → GREEN)

Tests live in the `ShipConfig` area module `tests/test_v07139.py` (extending `TestShipConfigSchema`, `TestShipConfigReader`, `TestComputeProvenance`).

**RED** — new tests run against unmodified `main` (only the test file applied, production files untouched):

```
8 failed, 2 passed, 57 deselected
FAILED ...TestShipConfigSchema::test_noise_floor_default_is_none
FAILED ...TestShipConfigSchema::test_parses_noise_floor_under_eval
FAILED ...TestShipConfigSchema::test_rejects_out_of_bounds_noise_floor[1]
FAILED ...TestShipConfigSchema::test_rejects_out_of_bounds_noise_floor[11]
FAILED ...TestShipConfigSchema::test_rejects_bool_noise_floor[True]
FAILED ...TestShipConfigSchema::test_rejects_bool_noise_floor[False]
FAILED ...TestShipConfigReader::test_config_noise_floor_threads_to_live
FAILED ...TestShipConfigReader::test_config_noise_floor_refused_under_evidence
```

The 2 that pass on `main` are the intended controls: `test_config_sha_excludes_noise_floor` (the hash-exclusion regression pin — a floor is dropped either way, so the sha is unchanged before and after) and `test_explicit_noise_floor_overrides_config` (on `main` the config is ignored, so the explicit flag trivially wins — it corroborates precedence, mirroring the existing `test_explicit_flag_overrides_config`).

**GREEN** — same tests on this branch:

```
10 passed, 57 deselected
```

## Full local suite (no regression)

`ruff check src/soup_cli/ tests/` clean on both. `tests/test_v07139.py`: **57 → 67** (57 existing + 10 new, no failures). `tests/test_cli_startup_is_light.py`: **22 passed, 1 skipped** unchanged — confirming the new schema-scope import of `ship_verdict` pulls no `torch`/`transformers` (`import soup_cli.config.schema` leaves both out of `sys.modules`).

## Files changed

| File | Change |
|------|--------|
| `src/soup_cli/config/schema.py` | `ShipConfig.noise_floor` field + bool-reject validator; bounds imported from `ship_verdict`; `EvalConfig.ship` description updated |
| `src/soup_cli/commands/ship.py` | config read for `noise_floor` beside the other `_flag_is_default` reads |
| `tests/test_v07139.py` | schema + reader + hash-exclusion tests |
| `docs/evaluation.md` | `eval.ship` key list + live-input note |
| `CHANGELOG.md` | `[Unreleased] → Added` entry |
