### PR TITLE
fix(stream): classify a fast virtio disk by a measured read, not the rotational flag (#365)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ docs/superpowers/
 
 # Local scratch / temp scripts at repo root (e.g. _smoke.py, _scratch.py) — never committed
 /_*.py
+
+# Layer-streaming disk-throughput probe scratch file (soup doctor --disk / training pre-flight)
+.soup-diskprobe-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,19 @@ reproducing 70+ versions of notes.
   unknown outcome is never recorded as success, and the richer
   `completed`/`failed` terminal statuses are left untouched. `soup runs` no
   longer hardcodes `running` for a non-running row.
+- **Layer streaming now accepts a fast virtio/cloud disk instead of refusing it
+  as an HDD (#365).** `detect_disk_kind` trusted `/sys/block/<dev>/queue/rotational`,
+  which a paravirtual (virtio) block device defaults to `1` with no media hint —
+  so a genuinely NVMe-backed cloud disk (measured 1.5 GB/s read) was classified
+  `hdd` and denied the disk-overflow tier, the very audience the tier targets.
+  `rotational=0` stays authoritative (solid state); when the flag is unreliable
+  (`rotational=1`), the media type is now decided by a bounded, O_DIRECT
+  sequential-read measurement rather than the flag — NVMe-class throughput
+  (>= 1 GB/s) earns the tier, a genuinely slow disk still classifies `hdd` and is
+  still refused (160 seeks/step, plan P11). A new `training.stream_disk_kind`
+  override (`nvme`/`ssd`/`hdd`) is the escape hatch for the case where even that
+  is wrong; it prints what it overrode beside what was detected. Disk detection
+  may write a small scratch file next to the streamed shards to run the probe.
 
 ### Fixed
 

--- a/docs/performance-and-quantization.md
+++ b/docs/performance-and-quantization.md
@@ -237,6 +237,7 @@ training:
   stream_buffers: 2            # Double-buffering; range [2, 8]
   # stream_vram_override: 4_000_000_000   # Bytes to assume free (v0.73.x); see below
   # stream_vram_probe: true    # Decide the fit by MEASURING one step (sft only); see below
+  # stream_disk_kind: nvme     # Override auto disk-kind detection: nvme/ssd/hdd; see below
 ```
 
 ```bash
@@ -277,7 +278,7 @@ The 3B NF4-vs-bf16 rows differ by 1.85×, but attribute that to **pinning, not a
 Untied `embed_tokens` + `lm_head` stay resident and unquantised (2.10 GB of the 8B row's 3.32 GB), which is why 8B sits close to this card's ceiling; treating them as streamed large layers is deferred beyond v0.72.3.
 
 **Honest scope:**
-- **RAM tier + disk overflow (v0.72.3).** `stream_source: auto` picks RAM when it fits, falls back to NVMe disk when not; SATA/HDD rejected. Correctness verified; disk performance unmeasured on the reference box.
+- **RAM tier + disk overflow (v0.72.3).** `stream_source: auto` picks RAM when it fits, falls back to NVMe disk when not; SATA/HDD rejected. Correctness verified; disk performance unmeasured on the reference box. A paravirtual (virtio) disk reports `rotational=1` with no media hint, so a genuinely NVMe-backed cloud disk was misread as an HDD and refused (#365); detection now measures a bounded O_DIRECT sequential read when the rotational flag is unreliable and admits NVMe-class throughput (>= 1 GB/s), while a genuinely slow disk stays rejected. Set `training.stream_disk_kind: nvme` (or `ssd`/`hdd`) to override when detection is still wrong — the resolved value is printed beside what was detected.
 - **Llama / Qwen / Mistral / Gemma / Gemma2 / Gemma3-Text / Phi / Phi3** (all verified bit-exact in bf16 and NF4), `task: sft`, `backend: transformers`, `modality: text`.
 - **Batch sizes, gradient accumulation, `--resume` / `--hf-resume`** all now work (v0.72.3).
 - **Pre-Ampere cards (T4, P100, V100, GTX 16xx, RTX 20xx) now stream in fp16 instead of bf16.** Until this fix the store dtype was hardcoded to bf16 on every CUDA device, so the entire free notebook tier was streaming a dtype its GPU has no units for, and nothing said so — it could not fail on the Ampere card every number above was measured on. fp16 is bit-exact against a resident reference of matching numerics, `0.000000e+00` in both quantisations, exactly as bf16 is.
@@ -352,7 +353,7 @@ prints this advice when it sees you accumulating.
 - `task: kto` with `batch_size: 1` → TRL's KL term is degenerate at batch 1; refused when the config is read rather than minutes later after sharding
 - `lora.use_dora` / `lora.use_vera` / `lora.init_strategy` other than `random` → these initialise from the real base weight, which is on the meta device under streaming
 - `unfrozen_parameters`, `lisa_enabled`, `packing`, `multipack`, `use_fsdp2_compile`, `train_router_only`, `expand_layers` → each independently rewrites or re-freezes the same layers
-- `stream_source` / `stream_buffers` / `stream_vram_override` / `stream_vram_probe` set while `stream_layers: false` → a footgun, refused
+- `stream_source` / `stream_buffers` / `stream_vram_override` / `stream_vram_probe` / `stream_disk_kind` set while `stream_layers: false` → a footgun, refused
 - `stream_vram_probe` on any task other than `sft` → the probe runs a plain causal-LM step, which *is* the SFT step but is not a preference loss. Measured at one matching shape it is conservative there too (6.02 GB against a real DPO step's 5.30 GB, +13.5%), but one shape is not a validation, so it is not offered for `dpo`/`orpo`/`simpo`/`kto` yet
 - an architecture outside the supported list (llama / qwen2 / qwen3 / mistral / gemma / gemma2 / gemma3_text / phi / phi3) → named explicitly
 
@@ -402,6 +403,7 @@ output: ./output
 
 **Troubleshooting:**
 - **"layer streaming needs the base to fit in RAM"** — the base is larger than free RAM. Set `stream_source: auto` to fall back to the NVMe disk tier, free RAM, or pick a smaller base.
+- **"layer streaming needs NVMe or more RAM … the detected disk is 'hdd'"** on a fast cloud disk — a virtio device reports `rotational=1` with no media hint. Detection now measures the disk when the flag is unreliable; if it still misreads yours, set `training.stream_disk_kind: nvme` to force the tier on (`ssd`/`hdd` force it off).
 - **"could not page-lock the base … falling back to a PAGEABLE RAM store"** — expected on a busy machine. Training continues, more slowly. Close other applications to keep the pinned store.
 - **"layer streaming does not support model_type=…"** — the supported list is llama / qwen2 / qwen3 / mistral / gemma / gemma2 / gemma3_text / phi / phi3. Multimodal `gemma3` is excluded on purpose; use `gemma3_text`.
 - **"predicted peak … exceeds free VRAM" and you believe it is wrong** — lower `batch_size` or `data.max_length` first. Otherwise there are two escape hatches and they are not interchangeable. `training.stream_vram_probe: true` (`sft` only) **measures** one real forward+backward at your configured shape and decides on that, printing the prediction beside it; it costs one step (1–5 s measured) and it can also refuse a run the formula accepted. `training.stream_vram_override: <bytes>` instead **replaces** the free-VRAM figure the check runs against — that is an assertion you are making, not a measurement, so raising it past a real limit is an OOM on Linux and a silent spill on Windows. Prefer the probe when you want to be told the truth; use the override when you know something the driver cannot report.

--- a/src/soup_cli/commands/doctor.py
+++ b/src/soup_cli/commands/doctor.py
@@ -62,7 +62,9 @@ def doctor(
         help=(
             "Detect the disk media type (NVMe / SSD / HDD). Layer streaming's "
             "disk overflow tier needs NVMe. Off by default: the probe costs ~9 s "
-            "on Windows."
+            "on Windows, and on Linux it WRITES a ~64 MiB scratch file "
+            "(.soup-diskprobe-*, git-ignored) into the current directory to "
+            "measure sequential read throughput."
         ),
     ),
 ):

--- a/src/soup_cli/config/schema.py
+++ b/src/soup_cli/config/schema.py
@@ -3083,6 +3083,19 @@ class TrainingConfig(BaseModel):
             "unsafe."
         ),
     )
+    stream_disk_kind: Optional[Literal["nvme", "ssd", "hdd"]] = Field(
+        default=None,
+        description=(
+            "Override the auto-detected disk media type for the streaming disk "
+            "overflow tier. Detection classifies a device by a measured "
+            "sequential read when the kernel's rotational flag is unreliable — "
+            "virtio and other paravirtual disks report spinning with no media "
+            "hint, so a fast cloud disk is otherwise refused (#365). Set this "
+            "for the case where even that is wrong: 'nvme' forces the disk tier "
+            "on, 'ssd'/'hdd' force it off. The resolved value is printed beside "
+            "what was detected."
+        ),
+    )
 
     # Sample packing — pack multiple short samples into one sequence
     packing: bool = Field(
@@ -4902,12 +4915,13 @@ class SoupConfig(BaseModel):
                 or tcfg.stream_buffers != 2
                 or tcfg.stream_vram_override is not None
                 or tcfg.stream_vram_probe
+                or tcfg.stream_disk_kind is not None
             ):
                 raise ValueError(
                     "training.stream_source / training.stream_buffers / "
                     "training.stream_vram_override / training.stream_vram_probe "
-                    "set but stream_layers is false; set stream_layers=true to "
-                    "stream the base layer-by-layer."
+                    "/ training.stream_disk_kind set but stream_layers is false; "
+                    "set stream_layers=true to stream the base layer-by-layer."
                 )
             return self
         # v0.72.4 — the four preference losses join SFT. DPO and KTO take their

--- a/src/soup_cli/trainer/stream_setup.py
+++ b/src/soup_cli/trainer/stream_setup.py
@@ -172,11 +172,11 @@ class StreamingSetupMixin:
             TIER_DISK,
             TIER_RAM,
             build_stream_plan,
-            detect_disk_kind,
             dtype_bytes,
             estimate_stream_store_bytes,
             free_ram_bytes,
             render_stream_panel,
+            resolve_disk_kind,
             resolve_stream_dtype,
             stream_arch_of,
         )
@@ -316,8 +316,12 @@ class StreamingSetupMixin:
             buffers=tcfg.stream_buffers,
             # v0.72.3: the REAL media type, not a constant. Passed as a callable
             # because probing costs ~9 s on Windows and the answer only matters
-            # when the base does not fit in RAM.
-            disk_kind=lambda: detect_disk_kind(shard_dir),
+            # when the base does not fit in RAM. #365: honour a
+            # stream_disk_kind override (with a loud detected-vs-override notice)
+            # for a disk the auto-probe still misreads.
+            disk_kind=lambda: resolve_disk_kind(
+                shard_dir, tcfg.stream_disk_kind, notify=console.print
+            ),
         )
         # v0.72.3 — the disk overflow tier is live, so a base that does not fit
         # in RAM is no longer fatal. `stream_source` decides: 'ram' insists,

--- a/src/soup_cli/utils/layer_stream.py
+++ b/src/soup_cli/utils/layer_stream.py
@@ -248,6 +248,12 @@ DISK_KINDS = (_NVME, "ssd", "hdd", "unknown")
 DiskKind = Union[str, Callable[[], str]]
 
 _DISK_KIND_CACHE: Dict[str, str] = {}
+#: Throughput (bytes/s) of the most recent O_DIRECT probe, or ``None`` when the
+#: last classification did not measure (NVMe by name, ``rotational=0``, or a
+#: non-Linux platform). ``choose_tier`` reads it so a refusal can cite the rate
+#: that earned it. Reset at the start of every probe, so it is never a stale
+#: figure from a different volume.
+_LAST_MEASURED_READ_BYTES_PER_S: Optional[float] = None
 
 # --- measured-throughput fallback (#365) ----------------------------------
 #: Bytes read by the O_DIRECT probe when the rotational flag is untrustworthy.
@@ -255,6 +261,12 @@ _DISK_KIND_CACHE: Dict[str, str] = {}
 #: second on anything at or above the tier floor (~0.06 s at 1 GB/s), keeping
 #: the fallback bounded (criterion 4).
 _MEASURE_READ_BYTES = 64 * 1024 * 1024
+#: How many times the O_DIRECT read is repeated; the best (fastest) sample wins.
+#: A single read can be slowed by a cold device queue or first-access latency and
+#: under-measure a genuinely fast disk, wrongly refusing it — the single-sample
+#: threshold weakness the #365 review called out. Three bounded reads of a 64 MiB
+#: file stay well under a second total on any tier-eligible device.
+_MEASURE_READ_SAMPLES = 3
 #: A device must sustain at least this sequential read rate to earn the NVMe
 #: disk-overflow tier. The tier is NVMe-class by policy — ``choose_tier``
 #: already refuses a SATA SSD (~550 MB/s) — so the floor sits above SATA at
@@ -366,12 +378,14 @@ def _measure_seq_read_bytes_per_s(path: str) -> Optional[float]:
     """Sequential ``O_DIRECT`` read throughput of the volume holding ``path``.
 
     Writes a small scratch file beside ``path``, reopens it with ``O_DIRECT`` to
-    bypass the page cache, and times one page-aligned sequential read. Best
-    effort: any failure (no ``O_DIRECT`` on this filesystem, no write
-    permission, no monotonic clock) returns ``None`` so the caller stays
-    conservative, and the scratch file is always removed. Bounded by
-    ``_MEASURE_READ_BYTES`` so it cannot become the ~9 s cost the Windows probe
-    already carries (criterion 4).
+    bypass the page cache, and times ``_MEASURE_READ_SAMPLES`` page-aligned
+    sequential reads, returning the **best** (fastest) one. Repeating the read
+    and keeping the best rejects a single cold/slow sample that would otherwise
+    under-measure a fast device and wrongly refuse it. Best effort: any failure
+    (no ``O_DIRECT`` on this filesystem, no write permission, no monotonic clock)
+    returns ``None`` so the caller stays conservative, and the scratch file is
+    always removed. Each read is bounded by ``_MEASURE_READ_BYTES`` so the probe
+    cannot become the ~9 s cost the Windows probe already carries (criterion 4).
     """
     import mmap
     import os
@@ -403,12 +417,18 @@ def _measure_seq_read_bytes_per_s(path: str) -> Optional[float]:
 
         buf = mmap.mmap(-1, _MEASURE_READ_BYTES)  # page-aligned for O_DIRECT
         fd_r = os.open(scratch, os.O_RDONLY | o_direct)
-        start = time.monotonic()
-        read_total = os.readv(fd_r, [buf])
-        elapsed = time.monotonic() - start
-        if elapsed <= 0 or read_total <= 0:
-            return None
-        return read_total / elapsed
+        best_bps: Optional[float] = None
+        for _ in range(_MEASURE_READ_SAMPLES):
+            os.lseek(fd_r, 0, os.SEEK_SET)  # offset 0 stays O_DIRECT-aligned
+            start = time.monotonic()
+            read_total = os.readv(fd_r, [buf])
+            elapsed = time.monotonic() - start
+            if elapsed <= 0 or read_total <= 0:
+                continue
+            bps = read_total / elapsed
+            if best_bps is None or bps > best_bps:
+                best_bps = bps
+        return best_bps
     except (OSError, ValueError):
         return None
     finally:
@@ -437,6 +457,8 @@ def _probe_disk_kind(path: str) -> str:
     import platform
     import subprocess
 
+    global _LAST_MEASURED_READ_BYTES_PER_S
+    _LAST_MEASURED_READ_BYTES_PER_S = None
     system = platform.system()
     try:
         if system == "Linux":
@@ -458,7 +480,8 @@ def _probe_disk_kind(path: str) -> str:
                         value = handle.read().strip()
                     if value == "0":
                         return "ssd"
-                    return _classify_measured_read(_measure_seq_read_bytes_per_s(path))
+                    _LAST_MEASURED_READ_BYTES_PER_S = _measure_seq_read_bytes_per_s(path)
+                    return _classify_measured_read(_LAST_MEASURED_READ_BYTES_PER_S)
             return "unknown"
         if system == "Windows":
             shell = _resolve_tool("powershell", _POWERSHELL_FALLBACK)
@@ -544,10 +567,20 @@ def choose_tier(
     kind = disk_kind() if callable(disk_kind) else disk_kind
     if kind == _NVME:
         return TIER_DISK
+    # When the classification came from a measured read (the virtio/#365 path),
+    # cite the rate that earned the refusal so "not NVMe" is not an opaque
+    # verdict — the operator can see how far under the floor the disk landed.
+    measured = _LAST_MEASURED_READ_BYTES_PER_S
+    measured_note = (
+        f" (measured {measured / 1e9:.2f} GB/s, under the "
+        f"{NVME_TIER_MIN_BYTES_PER_S / 1e9:.1f} GB/s NVMe floor)"
+        if measured is not None
+        else ""
+    )
     raise ValueError(
         f"layer streaming needs NVMe or more RAM: the base needs "
         f"{model_bytes / 1e9:.1f} GB, only {free_ram_bytes / 1e9:.1f} GB of RAM "
-        f"is free, and the detected disk is {kind!r} (not NVMe). "
+        f"is free, and the detected disk is {kind!r} (not NVMe){measured_note}. "
         f"Free RAM, pick a smaller base, or move the model to an NVMe drive."
     )
 

--- a/src/soup_cli/utils/layer_stream.py
+++ b/src/soup_cli/utils/layer_stream.py
@@ -247,13 +247,25 @@ DISK_KINDS = (_NVME, "ssd", "hdd", "unknown")
 #: actually depends on the answer.
 DiskKind = Union[str, Callable[[], str]]
 
-_DISK_KIND_CACHE: Dict[str, str] = {}
-#: Throughput (bytes/s) of the most recent O_DIRECT probe, or ``None`` when the
-#: last classification did not measure (NVMe by name, ``rotational=0``, or a
-#: non-Linux platform). ``choose_tier`` reads it so a refusal can cite the rate
-#: that earned it. Reset at the start of every probe, so it is never a stale
-#: figure from a different volume.
-_LAST_MEASURED_READ_BYTES_PER_S: Optional[float] = None
+@dataclass(frozen=True)
+class DiskClassification:
+    """A disk verdict and, when the verdict was DERIVED from an O_DIRECT read,
+    the rate that produced it.
+
+    ``measured_bps`` is set ONLY when ``kind`` came from the measured-throughput
+    fallback (the virtio/#365 path). It is ``None`` for NVMe-by-name,
+    ``rotational=0``, a non-Linux probe, and — crucially — an explicit
+    ``training.stream_disk_kind`` override, whose verdict is the user's, not the
+    probe's. Carrying the rate ALONGSIDE the kind (not in module state) means a
+    refusal can only ever cite the rate that produced its OWN verdict: the two
+    cannot desync across a cache hit or an override.
+    """
+
+    kind: str
+    measured_bps: Optional[float] = None
+
+
+_DISK_KIND_CACHE: Dict[str, DiskClassification] = {}
 
 # --- measured-throughput fallback (#365) ----------------------------------
 #: Bytes read by the O_DIRECT probe when the rotational flag is untrustworthy.
@@ -276,19 +288,11 @@ _MEASURE_READ_SAMPLES = 3
 NVME_TIER_MIN_BYTES_PER_S = 1_000_000_000
 
 
-def detect_disk_kind(path: str = ".") -> str:
-    """Media type of the volume holding ``path``: nvme / ssd / hdd / unknown.
-
-    **Costs about 9 s on Windows** (measured), because the only reliable source
-    is a PowerShell ``Get-PhysicalDisk`` CIM query. That is why ``choose_tier``
-    takes a *callable* and only invokes it when the base does not fit in RAM —
-    the answer is irrelevant on the RAM tier, which is the common case. The
-    result is cached per process.
-
-    ``unknown`` is returned rather than guessed whenever the platform cannot be
-    probed, and ``choose_tier`` refuses it. Refusing is the safe direction: the
-    cost of wrongly believing a spinning disk is NVMe is a run that thrashes for
-    hours (plan P11 — 80 shards x 2 reads = 160 seeks per step).
+def classify_disk_kind(path: str = ".") -> DiskClassification:
+    """Full disk verdict for ``path``: the ``kind`` plus, when the verdict was
+    measured, the rate that produced it. Cached per volume. The callable
+    ``choose_tier`` holds returns THIS, so a refusal cites the coupled rate and
+    never a stale/unrelated figure from module state.
     """
     import os
 
@@ -298,9 +302,27 @@ def detect_disk_kind(path: str = ".") -> str:
     key = os.path.splitdrive(resolved)[0] or resolved
     if key in _DISK_KIND_CACHE:
         return _DISK_KIND_CACHE[key]
-    kind = _probe_disk_kind(path)
-    _DISK_KIND_CACHE[key] = kind
-    return kind
+    result = _probe_disk_kind(path)
+    _DISK_KIND_CACHE[key] = result
+    return result
+
+
+def detect_disk_kind(path: str = ".") -> str:
+    """Media type of the volume holding ``path``: nvme / ssd / hdd / unknown.
+
+    **Costs about 9 s on Windows** (measured), because the only reliable source
+    is a PowerShell ``Get-PhysicalDisk`` CIM query. That is why ``choose_tier``
+    takes a *callable* and only invokes it when the base does not fit in RAM —
+    the answer is irrelevant on the RAM tier, which is the common case. The
+    result is cached per process. On Linux this WRITES a small scratch file to
+    probe throughput (see ``_measure_seq_read_bytes_per_s``).
+
+    ``unknown`` is returned rather than guessed whenever the platform cannot be
+    probed, and ``choose_tier`` refuses it. Refusing is the safe direction: the
+    cost of wrongly believing a spinning disk is NVMe is a run that thrashes for
+    hours (plan P11 — 80 shards x 2 reads = 160 seeks per step).
+    """
+    return classify_disk_kind(path).kind
 
 
 def resolve_disk_kind(
@@ -308,8 +330,8 @@ def resolve_disk_kind(
     override: Optional[str] = None,
     *,
     notify: Optional[Callable[[str], None]] = None,
-) -> str:
-    """Detected media type, or an explicit override with a loud notice (#365).
+) -> DiskClassification:
+    """Detected classification, or an explicit override with a loud notice (#365).
 
     ``training.stream_disk_kind`` is the escape hatch for the case where even
     the measured fallback is wrong. When set it wins, but detection still runs
@@ -319,7 +341,7 @@ def resolve_disk_kind(
     classify.
     """
     if override is None:
-        return detect_disk_kind(path)
+        return classify_disk_kind(path)
     try:
         detected = detect_disk_kind(path)
     except Exception:  # noqa: BLE001 — never let the probe break an overridden run
@@ -329,7 +351,9 @@ def resolve_disk_kind(
             f"[yellow]disk kind overridden:[/] using "
             f"training.stream_disk_kind={override!r} (detected {detected!r})"
         )
-    return override
+    # The verdict is the user's override, NOT the probe's — carry no measured
+    # rate, so a refusal can never cite a reading the user deliberately overrode.
+    return DiskClassification(override)
 
 
 def _resolve_tool(name: str, *fallbacks: str) -> Optional[str]:
@@ -452,13 +476,14 @@ def _measure_seq_read_bytes_per_s(path: str) -> Optional[float]:
                 pass
 
 
-def _probe_disk_kind(path: str) -> str:
+def _probe_disk_kind(path: str) -> DiskClassification:
+    """Classify the volume holding ``path``, carrying the measured rate only when
+    the verdict was DERIVED from a read (so a refusal can never cite a rate that
+    did not produce its own verdict — see ``DiskClassification``)."""
     import os
     import platform
     import subprocess
 
-    global _LAST_MEASURED_READ_BYTES_PER_S
-    _LAST_MEASURED_READ_BYTES_PER_S = None
     system = platform.system()
     try:
         if system == "Linux":
@@ -472,21 +497,21 @@ def _probe_disk_kind(path: str) -> str:
             for dev in names:
                 if not dev.startswith("nvme"):
                     continue
-                return _NVME
+                return DiskClassification(_NVME)
             for dev in names:
                 rot = os.path.join("/sys/block", dev, "queue", "rotational")
                 if os.path.exists(rot):
                     with open(rot, encoding="utf-8") as handle:
                         value = handle.read().strip()
                     if value == "0":
-                        return "ssd"
-                    _LAST_MEASURED_READ_BYTES_PER_S = _measure_seq_read_bytes_per_s(path)
-                    return _classify_measured_read(_LAST_MEASURED_READ_BYTES_PER_S)
-            return "unknown"
+                        return DiskClassification("ssd")
+                    measured = _measure_seq_read_bytes_per_s(path)
+                    return DiskClassification(_classify_measured_read(measured), measured)
+            return DiskClassification("unknown")
         if system == "Windows":
             shell = _resolve_tool("powershell", _POWERSHELL_FALLBACK)
             if shell is None:
-                return "unknown"
+                return DiskClassification("unknown")
             out = subprocess.run(
                 [
                     shell, "-NoProfile", "-NonInteractive", "-Command",
@@ -496,7 +521,7 @@ def _probe_disk_kind(path: str) -> str:
                 capture_output=True, text=True, timeout=60, check=False,
             )
             if out.returncode != 0 or not out.stdout.strip():
-                return "unknown"
+                return DiskClassification("unknown")
             import json
 
             payload = json.loads(out.stdout)
@@ -507,25 +532,25 @@ def _probe_disk_kind(path: str) -> str:
             # has NVMe.
             for candidate in ("hdd", "unknown", "ssd", _NVME):
                 if candidate in kinds:
-                    return candidate
-            return "unknown"
+                    return DiskClassification(candidate)
+            return DiskClassification("unknown")
         if system == "Darwin":
             tool = _resolve_tool("diskutil", "/usr/sbin/diskutil")
             if tool is None:
-                return "unknown"
+                return DiskClassification("unknown")
             out = subprocess.run(
                 [tool, "info", "-plist", "/"],
                 capture_output=True, text=True, timeout=60, check=False,
             )
             text = out.stdout.lower()
             if "nvme" in text:
-                return _NVME
+                return DiskClassification(_NVME)
             if "solid state" in text or ("<true/>" in text and "solidstate" in text):
-                return "ssd"
-            return "unknown"
+                return DiskClassification("ssd")
+            return DiskClassification("unknown")
     except (OSError, ValueError, subprocess.SubprocessError):
-        return "unknown"
-    return "unknown"
+        return DiskClassification("unknown")
+    return DiskClassification("unknown")
 
 
 def _windows_kind(disk: dict) -> str:
@@ -564,13 +589,20 @@ def choose_tier(
     """
     if model_bytes < free_ram_bytes * headroom:
         return TIER_RAM
-    kind = disk_kind() if callable(disk_kind) else disk_kind
+    result = disk_kind() if callable(disk_kind) else disk_kind
+    # The callable may return a DiskClassification (kind + the rate that produced
+    # it) or a bare kind string (tests, explicit callers). Either way the rate is
+    # taken FROM the same result, so it can only ever describe THIS verdict.
+    if isinstance(result, DiskClassification):
+        kind, measured = result.kind, result.measured_bps
+    else:
+        kind, measured = result, None
     if kind == _NVME:
         return TIER_DISK
-    # When the classification came from a measured read (the virtio/#365 path),
-    # cite the rate that earned the refusal so "not NVMe" is not an opaque
-    # verdict — the operator can see how far under the floor the disk landed.
-    measured = _LAST_MEASURED_READ_BYTES_PER_S
+    # When the verdict came from a measured read (the virtio/#365 path), cite the
+    # rate that earned the refusal so "not NVMe" is not an opaque verdict — the
+    # operator can see how far under the floor the disk landed. measured is None
+    # for a name/flag/override verdict, so the note only appears when it is true.
     measured_note = (
         f" (measured {measured / 1e9:.2f} GB/s, under the "
         f"{NVME_TIER_MIN_BYTES_PER_S / 1e9:.1f} GB/s NVMe floor)"

--- a/src/soup_cli/utils/layer_stream.py
+++ b/src/soup_cli/utils/layer_stream.py
@@ -249,6 +249,20 @@ DiskKind = Union[str, Callable[[], str]]
 
 _DISK_KIND_CACHE: Dict[str, str] = {}
 
+# --- measured-throughput fallback (#365) ----------------------------------
+#: Bytes read by the O_DIRECT probe when the rotational flag is untrustworthy.
+#: 64 MiB clears a device's small write-back window yet reads in well under a
+#: second on anything at or above the tier floor (~0.06 s at 1 GB/s), keeping
+#: the fallback bounded (criterion 4).
+_MEASURE_READ_BYTES = 64 * 1024 * 1024
+#: A device must sustain at least this sequential read rate to earn the NVMe
+#: disk-overflow tier. The tier is NVMe-class by policy — ``choose_tier``
+#: already refuses a SATA SSD (~550 MB/s) — so the floor sits above SATA at
+#: 1.0 GB/s: the reported virtio disk (1.5 GB/s read) clears it, a spinning
+#: disk (~0.1-0.25 GB/s) does not. Consulted ONLY when the rotational flag is
+#: unreliable; where a real media type is readable that route still wins.
+NVME_TIER_MIN_BYTES_PER_S = 1_000_000_000
+
 
 def detect_disk_kind(path: str = ".") -> str:
     """Media type of the volume holding ``path``: nvme / ssd / hdd / unknown.
@@ -277,6 +291,35 @@ def detect_disk_kind(path: str = ".") -> str:
     return kind
 
 
+def resolve_disk_kind(
+    path: str,
+    override: Optional[str] = None,
+    *,
+    notify: Optional[Callable[[str], None]] = None,
+) -> str:
+    """Detected media type, or an explicit override with a loud notice (#365).
+
+    ``training.stream_disk_kind`` is the escape hatch for the case where even
+    the measured fallback is wrong. When set it wins, but detection still runs
+    so the notice can report what was overridden and what was detected;
+    ``choose_tier`` then sees the override. Detection is wrapped because a
+    diagnostic read must not break a run the user has already told us how to
+    classify.
+    """
+    if override is None:
+        return detect_disk_kind(path)
+    try:
+        detected = detect_disk_kind(path)
+    except Exception:  # noqa: BLE001 — never let the probe break an overridden run
+        detected = "unknown"
+    if notify is not None:
+        notify(
+            f"[yellow]disk kind overridden:[/] using "
+            f"training.stream_disk_kind={override!r} (detected {detected!r})"
+        )
+    return override
+
+
 def _resolve_tool(name: str, *fallbacks: str) -> Optional[str]:
     """Absolute path to a system tool, or None.
 
@@ -302,6 +345,93 @@ def _resolve_tool(name: str, *fallbacks: str) -> Optional[str]:
 _POWERSHELL_FALLBACK = r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
 
 
+def _classify_measured_read(measured_bps: Optional[float]) -> str:
+    """Classify by a measured read a device the rotational flag calls spinning.
+
+    virtio and other paravirtual block devices expose no media hint, so the
+    guest kernel defaults ``rotational`` to 1 and a genuinely NVMe-backed cloud
+    disk is otherwise refused the overflow tier (#365). An actual HDD refusal is
+    correct (80 shards x 2 reads = 160 seeks per step, plan P11), so the
+    discriminator is throughput, not the flag: at or above
+    ``NVME_TIER_MIN_BYTES_PER_S`` the device is NVMe-class and usable; below it —
+    or unmeasurable (``None``) — it is treated as ``hdd`` and refused, the safe
+    direction.
+    """
+    if measured_bps is not None and measured_bps >= NVME_TIER_MIN_BYTES_PER_S:
+        return _NVME
+    return "hdd"
+
+
+def _measure_seq_read_bytes_per_s(path: str) -> Optional[float]:
+    """Sequential ``O_DIRECT`` read throughput of the volume holding ``path``.
+
+    Writes a small scratch file beside ``path``, reopens it with ``O_DIRECT`` to
+    bypass the page cache, and times one page-aligned sequential read. Best
+    effort: any failure (no ``O_DIRECT`` on this filesystem, no write
+    permission, no monotonic clock) returns ``None`` so the caller stays
+    conservative, and the scratch file is always removed. Bounded by
+    ``_MEASURE_READ_BYTES`` so it cannot become the ~9 s cost the Windows probe
+    already carries (criterion 4).
+    """
+    import mmap
+    import os
+    import tempfile
+    import time
+
+    o_direct = getattr(os, "O_DIRECT", None)
+    if o_direct is None:  # non-Linux — the caller only reaches here on Linux
+        return None
+    # Probe the volume that actually holds the shards. The caller passes a
+    # DIRECTORY (shard_dir), so write the scratch file inside it; only fall back
+    # to the parent for a file path. Taking dirname of a directory would measure
+    # the PARENT filesystem — wrong when the target is its own mount point.
+    resolved = os.path.realpath(os.path.expanduser(path))
+    directory = resolved if os.path.isdir(resolved) else (os.path.dirname(resolved) or ".")
+    fd_w = None
+    fd_r = None
+    scratch = None
+    buf = None
+    try:
+        fd_w, scratch = tempfile.mkstemp(dir=directory, prefix=".soup-diskprobe-")
+        block = b"\0" * (1024 * 1024)
+        written = 0
+        while written < _MEASURE_READ_BYTES:
+            written += os.write(fd_w, block[: _MEASURE_READ_BYTES - written])
+        os.fsync(fd_w)
+        os.close(fd_w)
+        fd_w = None
+
+        buf = mmap.mmap(-1, _MEASURE_READ_BYTES)  # page-aligned for O_DIRECT
+        fd_r = os.open(scratch, os.O_RDONLY | o_direct)
+        start = time.monotonic()
+        read_total = os.readv(fd_r, [buf])
+        elapsed = time.monotonic() - start
+        if elapsed <= 0 or read_total <= 0:
+            return None
+        return read_total / elapsed
+    except (OSError, ValueError):
+        return None
+    finally:
+        for fd in (fd_w, fd_r):
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+        if buf is not None:
+            try:
+                buf.close()
+            except (BufferError, ValueError):
+                # Isolated from the unlink below so a mmap-close failure can
+                # never leak the 64 MiB scratch file.
+                pass
+        if scratch is not None:
+            try:
+                os.unlink(scratch)
+            except OSError:
+                pass
+
+
 def _probe_disk_kind(path: str) -> str:
     import os
     import platform
@@ -311,7 +441,11 @@ def _probe_disk_kind(path: str) -> str:
     try:
         if system == "Linux":
             # /sys/block/<dev>/queue/rotational: 1 spinning, 0 solid state.
-            # Instant and authoritative; the device name distinguishes NVMe.
+            # The device name distinguishes NVMe, and rotational=0 is
+            # authoritative — a device that declares itself solid state is one.
+            # rotational=1 is NOT authoritative: virtio defaults it to 1 with no
+            # media hint, so a fast cloud disk lies as spinning (#365). Fall back
+            # to a measured read there rather than trust the flag.
             names = sorted(os.listdir("/sys/block"))
             for dev in names:
                 if not dev.startswith("nvme"):
@@ -321,7 +455,10 @@ def _probe_disk_kind(path: str) -> str:
                 rot = os.path.join("/sys/block", dev, "queue", "rotational")
                 if os.path.exists(rot):
                     with open(rot, encoding="utf-8") as handle:
-                        return "hdd" if handle.read().strip() == "1" else "ssd"
+                        value = handle.read().strip()
+                    if value == "0":
+                        return "ssd"
+                    return _classify_measured_read(_measure_seq_read_bytes_per_s(path))
             return "unknown"
         if system == "Windows":
             shell = _resolve_tool("powershell", _POWERSHELL_FALLBACK)

--- a/tests/test_v07203.py
+++ b/tests/test_v07203.py
@@ -581,7 +581,9 @@ class TestDiskKindDetection:
 
         calls = []
         monkeypatch.setattr(ls, "_DISK_KIND_CACHE", {})
-        monkeypatch.setattr(ls, "_probe_disk_kind", lambda p: calls.append(p) or "nvme")
+        monkeypatch.setattr(
+            ls, "_probe_disk_kind", lambda p: calls.append(p) or ls.DiskClassification("nvme")
+        )
 
         assert ls.detect_disk_kind(".") == "nvme"
         assert ls.detect_disk_kind(".") == "nvme"
@@ -736,17 +738,48 @@ class TestDiskKindMeasuredFallback:
         monkeypatch.delattr(os, "O_DIRECT", raising=False)
         assert ls._measure_seq_read_bytes_per_s(".") is None
 
-    def test_refusal_cites_the_measured_rate(self, monkeypatch):
+    def test_refusal_cites_the_measured_rate(self):
         """#411 review: a measurement-driven refusal names the rate that earned
-        it, not just the opaque ``'hdd'`` verdict."""
+        it, not just the opaque ``'hdd'`` verdict. CPU-only — the rate travels
+        with the verdict in a ``DiskClassification``, so no /sys simulation is
+        needed to exercise the note (it runs on all CI cells, not just Linux)."""
         import soup_cli.utils.layer_stream as ls
 
-        self._fake_linux(monkeypatch, devices=["vda"], rotational=1, measured_bps=150e6)
+        # A verdict DERIVED from a measurement carries the rate that produced it.
+        slow = ls.DiskClassification("hdd", measured_bps=150e6)
         with pytest.raises(ValueError) as excinfo:
-            ls.choose_tier(1000, 10, ls.detect_disk_kind("/data"))
+            ls.choose_tier(1000, 10, slow)
         message = str(excinfo.value)
         assert "measured 0.15 GB/s" in message
         assert "1.0 GB/s NVMe floor" in message
+
+    def test_override_verdict_does_not_cite_a_probe_rate(self):
+        """#411 re-review (blocker 2): the bug was a module global that let a
+        refusal cite a rate ABOVE the floor as the reason a disk fell UNDER it —
+        e.g. stream_disk_kind=hdd on a fast virtio disk. The rate now travels
+        with the verdict, and an override verdict carries none, so the refusal
+        structurally cannot cite a reading it did not produce. CPU-only."""
+        import soup_cli.utils.layer_stream as ls
+
+        # kind='hdd' from an override; measured_bps=None because the verdict is
+        # the user's, not the probe's (see resolve_disk_kind).
+        overridden = ls.DiskClassification("hdd", measured_bps=None)
+        with pytest.raises(ValueError) as excinfo:
+            ls.choose_tier(1000, 10, overridden)
+        assert "measured" not in str(excinfo.value)
+
+    def test_override_returns_a_measureless_classification(self, monkeypatch):
+        """resolve_disk_kind with an override must strip any probe rate, even
+        when detection measured a fast disk underneath (the #411 re-review repro:
+        detect 2.0 GB/s, override to hdd — the 2.0 must not survive)."""
+        import soup_cli.utils.layer_stream as ls
+
+        monkeypatch.setattr(
+            ls, "classify_disk_kind", lambda *_a, **_k: ls.DiskClassification("nvme", 2.0e9)
+        )
+        result = ls.resolve_disk_kind("/data", "hdd", notify=lambda _m: None)
+        assert result.kind == "hdd"
+        assert result.measured_bps is None
 
     def test_the_read_is_repeated_and_the_best_sample_wins(self, monkeypatch, tmp_path):
         """#411 review: the single-sample threshold is the weakness — repeat the
@@ -772,7 +805,12 @@ class TestDiskKindMeasuredFallback:
         monkeypatch.setattr(os, "lseek", lambda _fd, _off, _whence: 0)
         monkeypatch.setattr(os, "unlink", lambda _p: None)
         readv_calls = []
-        monkeypatch.setattr(os, "readv", lambda _fd, _bufs: readv_calls.append(1) or ls._MEASURE_READ_BYTES)
+
+        def fake_readv(_fd, _bufs):
+            readv_calls.append(1)
+            return ls._MEASURE_READ_BYTES
+
+        monkeypatch.setattr(os, "readv", fake_readv)
         # Three reads with elapsed 2s, 1s, 4s -> the 1s sample is the fastest.
         clock = iter([0.0, 2.0, 0.0, 1.0, 0.0, 4.0])
         monkeypatch.setattr(time, "monotonic", lambda: next(clock))
@@ -814,15 +852,17 @@ class TestDiskKindMeasuredFallback:
 
         monkeypatch.setattr(ls, "detect_disk_kind", lambda *_a, **_k: "hdd")
         notes = []
-        assert ls.resolve_disk_kind("/data", "nvme", notify=notes.append) == "nvme"
+        assert ls.resolve_disk_kind("/data", "nvme", notify=notes.append).kind == "nvme"
         assert notes and "nvme" in notes[0] and "hdd" in notes[0]
 
     def test_no_override_returns_the_detected_kind_silently(self, monkeypatch):
         import soup_cli.utils.layer_stream as ls
 
-        monkeypatch.setattr(ls, "detect_disk_kind", lambda *_a, **_k: "ssd")
+        monkeypatch.setattr(
+            ls, "classify_disk_kind", lambda *_a, **_k: ls.DiskClassification("ssd")
+        )
         notes = []
-        assert ls.resolve_disk_kind("/data", None, notify=notes.append) == "ssd"
+        assert ls.resolve_disk_kind("/data", None, notify=notes.append).kind == "ssd"
         assert notes == []
 
     def test_stream_disk_kind_is_a_footgun_without_stream_layers(self):
@@ -1129,8 +1169,12 @@ class TestAutoTierFallback:
         # Pinned rather than probed: the real media type differs between this
         # box (NVMe) and a CI runner (often "unknown"), and an
         # environment-dependent tier would make these flaky rather than wrong.
+        # Patch classify_disk_kind (what resolve_disk_kind and detect_disk_kind
+        # both route through) so the pin reaches the streaming setup's lambda.
+        import soup_cli.utils.layer_stream as _ls
+
         monkeypatch.setattr(
-            "soup_cli.utils.layer_stream.detect_disk_kind", lambda *_a, **_k: disk_kind
+            _ls, "classify_disk_kind", lambda *_a, **_k: _ls.DiskClassification(disk_kind)
         )
         cfg = load_config_from_string(
             f"base: {weights}\ntask: sft\nbackend: transformers\nmodality: text\n"

--- a/tests/test_v07203.py
+++ b/tests/test_v07203.py
@@ -626,6 +626,189 @@ class TestDiskKindDetection:
         assert _windows_kind({"MediaType": "5", "BusType": "SATA"}) == "unknown"
 
 
+class TestDiskKindMeasuredFallback:
+    """#365 — a virtio disk reports ``rotational=1`` with no media hint, so the
+    flag alone refused a genuinely NVMe-backed cloud disk the overflow tier. When
+    the flag is unreliable, classify on a measured sequential read instead; the
+    HDD refusal (160 seeks/step, plan P11) must survive as a control."""
+
+    def test_throughput_at_or_above_the_floor_is_nvme_class(self):
+        from soup_cli.utils.layer_stream import (
+            NVME_TIER_MIN_BYTES_PER_S,
+            _classify_measured_read,
+        )
+
+        assert _classify_measured_read(NVME_TIER_MIN_BYTES_PER_S) == "nvme"
+        assert _classify_measured_read(1.5e9) == "nvme"  # the reported virtio disk
+
+    def test_slow_or_unmeasurable_stays_hdd(self):
+        from soup_cli.utils.layer_stream import (
+            NVME_TIER_MIN_BYTES_PER_S,
+            _classify_measured_read,
+        )
+
+        assert _classify_measured_read(NVME_TIER_MIN_BYTES_PER_S - 1) == "hdd"
+        assert _classify_measured_read(150e6) == "hdd"  # a real spinning disk
+        assert _classify_measured_read(None) == "hdd"  # can't tell -> refuse
+
+    @staticmethod
+    def _fake_linux(monkeypatch, *, devices, rotational, measured_bps):
+        """Simulate a Linux ``/sys/block`` layout so the real probe branch runs."""
+        import builtins
+        import io
+        import os
+        import platform
+
+        import soup_cli.utils.layer_stream as ls
+
+        real_listdir = os.listdir
+        real_open = builtins.open
+        real_exists = os.path.exists
+
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        monkeypatch.setattr(
+            os,
+            "listdir",
+            lambda p: list(devices) if str(p) == "/sys/block" else real_listdir(p),
+        )
+        monkeypatch.setattr(
+            os.path,
+            "exists",
+            lambda p: True if "/queue/rotational" in str(p) else real_exists(p),
+        )
+
+        def fake_open(p, *a, **k):
+            if "/queue/rotational" in str(p):
+                return io.StringIO(f"{rotational}\n")
+            return real_open(p, *a, **k)
+
+        monkeypatch.setattr(builtins, "open", fake_open)
+        monkeypatch.setattr(ls, "_measure_seq_read_bytes_per_s", lambda _p: measured_bps)
+        monkeypatch.setattr(ls, "_DISK_KIND_CACHE", {})
+
+    def test_virtio_fast_disk_now_earns_the_disk_tier(self, monkeypatch):
+        """Criterion 1: no NVMe device, ``rotational=1``, fast measured read."""
+        import soup_cli.utils.layer_stream as ls
+
+        self._fake_linux(monkeypatch, devices=["vda"], rotational=1, measured_bps=1.5e9)
+        assert ls.detect_disk_kind("/data") == "nvme"
+        # ...and choose_tier accepts it where the pre-fix "hdd" would have raised.
+        assert ls.choose_tier(1000, 10, ls.detect_disk_kind("/data")) == ls.TIER_DISK
+
+    def test_a_genuinely_slow_device_is_still_refused(self, monkeypatch):
+        """Criterion 2 (the control): the fix cannot be satisfied by 'always allow'."""
+        import soup_cli.utils.layer_stream as ls
+
+        self._fake_linux(monkeypatch, devices=["vda"], rotational=1, measured_bps=150e6)
+        assert ls.detect_disk_kind("/data") == "hdd"
+        with pytest.raises(ValueError, match="NVMe"):
+            ls.choose_tier(1000, 10, ls.detect_disk_kind("/data"))
+
+    def test_rotational_zero_is_authoritative_and_never_measures(self, monkeypatch):
+        """A device that declares itself solid state is trusted — no probe cost."""
+        import soup_cli.utils.layer_stream as ls
+
+        self._fake_linux(monkeypatch, devices=["sda"], rotational=0, measured_bps=None)
+        calls = []
+        monkeypatch.setattr(
+            ls, "_measure_seq_read_bytes_per_s", lambda _p: calls.append(1) or 9e9
+        )
+        assert ls.detect_disk_kind("/data") == "ssd"
+        assert calls == [], "measured probe ran on an authoritative rotational=0"
+
+    def test_measurement_is_bounded_and_best_effort(self, monkeypatch):
+        """Criterion 4: no O_DIRECT (or any failure) degrades to None -> refused,
+        never an unbounded or crashing probe."""
+        import os
+
+        import soup_cli.utils.layer_stream as ls
+
+        monkeypatch.delattr(os, "O_DIRECT", raising=False)
+        assert ls._measure_seq_read_bytes_per_s(".") is None
+
+    def test_probe_writes_into_the_target_volume_not_its_parent(
+        self, monkeypatch, tmp_path
+    ):
+        """The caller passes shard_dir (a directory); the scratch probe must land
+        INSIDE it, not its parent — else a mount point's throughput is measured
+        on the wrong filesystem."""
+        import os
+        import tempfile
+
+        import soup_cli.utils.layer_stream as ls
+
+        if not hasattr(os, "O_DIRECT"):
+            pytest.skip("O_DIRECT is Linux-only")
+
+        target = tmp_path / "shards"
+        target.mkdir()
+        seen = {}
+        real_mkstemp = tempfile.mkstemp
+
+        def spy_mkstemp(*a, **k):
+            seen["dir"] = k.get("dir")
+            return real_mkstemp(*a, **k)
+
+        monkeypatch.setattr(tempfile, "mkstemp", spy_mkstemp)
+        ls._measure_seq_read_bytes_per_s(str(target))  # O_DIRECT may fail on tmpfs; fine
+        assert seen.get("dir") == str(target)
+
+    def test_override_wins_and_reports_what_it_overrode(self, monkeypatch):
+        """Criterion 3: the override is used AND the notice names both values."""
+        import soup_cli.utils.layer_stream as ls
+
+        monkeypatch.setattr(ls, "detect_disk_kind", lambda *_a, **_k: "hdd")
+        notes = []
+        assert ls.resolve_disk_kind("/data", "nvme", notify=notes.append) == "nvme"
+        assert notes and "nvme" in notes[0] and "hdd" in notes[0]
+
+    def test_no_override_returns_the_detected_kind_silently(self, monkeypatch):
+        import soup_cli.utils.layer_stream as ls
+
+        monkeypatch.setattr(ls, "detect_disk_kind", lambda *_a, **_k: "ssd")
+        notes = []
+        assert ls.resolve_disk_kind("/data", None, notify=notes.append) == "ssd"
+        assert notes == []
+
+    def test_stream_disk_kind_is_a_footgun_without_stream_layers(self):
+        import yaml
+
+        from soup_cli.config.loader import load_config_from_string
+
+        with pytest.raises(ValueError, match="stream_disk_kind"):
+            load_config_from_string(
+                yaml.safe_dump(_stream_disk_kind_config(stream_layers=False))
+            )
+
+    def test_stream_disk_kind_is_accepted_while_streaming(self):
+        import yaml
+
+        from soup_cli.config.loader import load_config_from_string
+
+        cfg = load_config_from_string(
+            yaml.safe_dump(_stream_disk_kind_config(stream_layers=True))
+        )
+        assert cfg.training.stream_disk_kind == "nvme"
+
+
+def _stream_disk_kind_config(*, stream_layers):
+    return {
+        "base": "hf-internal-testing/tiny-random-LlamaForCausalLM",
+        "task": "sft",
+        "backend": "transformers",
+        "modality": "text",
+        "data": {"train": "train.jsonl", "max_length": 64, "chat_template": "chatml"},
+        "training": {
+            "stream_layers": stream_layers,
+            "stream_disk_kind": "nvme",
+            "quantization": "none",
+            "batch_size": 1,
+            "epochs": 1,
+            "lora": {"r": 4, "alpha": 8, "target_modules": ["q_proj", "v_proj"]},
+        },
+    }
+
+
 class TestDoctorReportsTheDiskKind:
     """The rider's CLI half. Each branch of the verdict table is exercised —
     including the exception path, because a diagnostic that crashes the report

--- a/tests/test_v07203.py
+++ b/tests/test_v07203.py
@@ -736,6 +736,51 @@ class TestDiskKindMeasuredFallback:
         monkeypatch.delattr(os, "O_DIRECT", raising=False)
         assert ls._measure_seq_read_bytes_per_s(".") is None
 
+    def test_refusal_cites_the_measured_rate(self, monkeypatch):
+        """#411 review: a measurement-driven refusal names the rate that earned
+        it, not just the opaque ``'hdd'`` verdict."""
+        import soup_cli.utils.layer_stream as ls
+
+        self._fake_linux(monkeypatch, devices=["vda"], rotational=1, measured_bps=150e6)
+        with pytest.raises(ValueError) as excinfo:
+            ls.choose_tier(1000, 10, ls.detect_disk_kind("/data"))
+        message = str(excinfo.value)
+        assert "measured 0.15 GB/s" in message
+        assert "1.0 GB/s NVMe floor" in message
+
+    def test_the_read_is_repeated_and_the_best_sample_wins(self, monkeypatch, tmp_path):
+        """#411 review: the single-sample threshold is the weakness — repeat the
+        read and keep the fastest so a lone cold sample cannot refuse a fast disk.
+
+        The filesystem I/O is mocked so the timing is deterministic regardless of
+        whether the test host's temp dir actually supports O_DIRECT."""
+        import os
+        import tempfile
+        import time
+
+        import soup_cli.utils.layer_stream as ls
+
+        if getattr(os, "O_DIRECT", None) is None:
+            pytest.skip("O_DIRECT is Linux-only; the probe returns None elsewhere")
+
+        scratch = str(tmp_path / "scratch")
+        monkeypatch.setattr(tempfile, "mkstemp", lambda **_k: (123, scratch))
+        monkeypatch.setattr(os, "write", lambda _fd, b: len(b))
+        monkeypatch.setattr(os, "fsync", lambda _fd: None)
+        monkeypatch.setattr(os, "close", lambda _fd: None)
+        monkeypatch.setattr(os, "open", lambda _p, _flags: 456)
+        monkeypatch.setattr(os, "lseek", lambda _fd, _off, _whence: 0)
+        monkeypatch.setattr(os, "unlink", lambda _p: None)
+        readv_calls = []
+        monkeypatch.setattr(os, "readv", lambda _fd, _bufs: readv_calls.append(1) or ls._MEASURE_READ_BYTES)
+        # Three reads with elapsed 2s, 1s, 4s -> the 1s sample is the fastest.
+        clock = iter([0.0, 2.0, 0.0, 1.0, 0.0, 4.0])
+        monkeypatch.setattr(time, "monotonic", lambda: next(clock))
+
+        best = ls._measure_seq_read_bytes_per_s(str(tmp_path))
+        assert len(readv_calls) == ls._MEASURE_READ_SAMPLES
+        assert best == ls._MEASURE_READ_BYTES / 1.0  # bytes / fastest elapsed (1s)
+
     def test_probe_writes_into_the_target_volume_not_its_parent(
         self, monkeypatch, tmp_path
     ):

--- a/tests/test_v07203.py
+++ b/tests/test_v07203.py
@@ -658,6 +658,16 @@ class TestDiskKindMeasuredFallback:
         import io
         import os
         import platform
+        import sys
+
+        import pytest
+
+        # detect_disk_kind is a Linux /sys/block feature (it returns "unknown"
+        # elsewhere by design). This helper hardcodes forward-slash /sys paths,
+        # which os.path.join mangles on Windows, so the simulation is meaningful
+        # only on Linux — where the real CI cells and local runs exercise it.
+        if sys.platform != "linux":
+            pytest.skip("simulates a Linux /sys/block layout; disk-tier detection is Linux-only")
 
         import soup_cli.utils.layer_stream as ls
 


### PR DESCRIPTION
## Summary

Fix #365

`utils.layer_stream.detect_disk_kind()` classified a paravirtual (virtio) block
device as `hdd`, so the layer-streaming disk-overflow tier (`stream_source: disk`)
was refused on it — the very audience the tier targets, since disk overflow is
mostly used on cloud VMs whose disks are NVMe-backed but expose no media hint.

The Linux probe trusted `/sys/block/<dev>/queue/rotational`, which a guest kernel
defaults to `1` for virtio with no way to tell "spinning" from "cannot tell".

**Fix (the issue's three-way path):**
- `rotational=0` stays authoritative — a device that declares itself solid state is one.
- `rotational=1` is no longer trusted blindly: the media type is decided by a **bounded, best-effort O_DIRECT sequential-read measurement**. NVMe-class throughput (≥ 1 GB/s) earns the tier; a genuinely slow disk still classifies `hdd` and is **still refused** (80 shards × 2 reads = 160 seeks/step, plan P11) — a control, so the fix cannot be satisfied by "always allow".
- New `training.stream_disk_kind` override (`nvme`/`ssd`/`hdd`) for the case where even the measurement is wrong; it prints what it overrode beside what was detected.

`choose_tier`'s NVMe-only tier policy is intentionally **unchanged** — a measured-fast device is classified as NVMe-class, so no existing invariant is widened.

## Reproduces with (unmodified `main`)

A virtio-shaped probe — no NVMe device, `rotational=1`, a 1.5 GB/s measured read:

```
detect_disk_kind (virtio, 1.5 GB/s read) => 'hdd'
choose_tier RAISED => layer streaming needs NVMe or more RAM: ... the detected disk is 'hdd' (not NVMe).
```

## Test verification (RED → GREEN)

New tests live in the disk-kind area module `tests/test_v07203.py::TestDiskKindMeasuredFallback`
(the module already owning `TestDiskKindDetection`), covering all four acceptance
criteria plus the review-hardening cases.

RED — the new tests on unmodified `main` (prod reverted, only tests applied):

```
10 failed in 1.10s
```
(`AttributeError: 'TrainingConfig' object has no attribute 'stream_disk_kind'` /
missing `_classify_measured_read` / virtio still returns `'hdd'`.)

GREEN — with the fix:

```
27 passed in 1.82s
```

## Full local suite (ruff blocking + torch-free area, iso-or-better)

The change is torch-free (`layer_stream.py` is on the light-CLI import path, "no
top-level torch"). Baseline `main` vs this branch:

- `ruff check src/soup_cli/ tests/` — clean on both.
- disk-kind area classes: baseline 16 passed → branch 27 passed (+11 new), no regressions.
- light-CLI startup invariant: 22 passed, 1 skipped (touched imports stay torch-free).

The heavy torch pytest matrix + 77% coverage gate run in CI.

## Files changed

| File | Change |
|------|--------|
| `src/soup_cli/utils/layer_stream.py` | measured-throughput classifier + O_DIRECT probe + `resolve_disk_kind` override |
| `src/soup_cli/config/schema.py` | `training.stream_disk_kind` field + footgun validator |
| `src/soup_cli/trainer/stream_setup.py` | wire the override into the disk-kind callable |
| `docs/performance-and-quantization.md` | disk-tier scope, config example, footgun list, troubleshooting |
| `CHANGELOG.md` | `[Unreleased] → Fixed` entry |
| `tests/test_v07203.py` | `TestDiskKindMeasuredFallback` (11 tests) |
