### PR TITLE
fix(mitigation): skip the coefficient write on a kl_control hold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ reproducing 70+ versions of notes.
 
 ### Fixed
 
+- **`kl_control` rewrote the trainer's β/kl_coef on every step, including a `hold`, so a
+  non-acting run was numerically identical to `log_only` (#371).** `_run_bang_bang` called
+  `_apply_coefficient` unconditionally; on a `hold` the controller writes back the value
+  already there, which is a no-op value but not a no-op write. The write is now skipped when
+  the bang-bang step holds, and the mitigation log records `mitigation_status` (`held` /
+  `acted` / `released`) so a non-acting step is distinguishable from an acting one without
+  parsing the free-text `action` reason.
+
+### Fixed
+
 - **`soup draft distill --steps N` now delivers ~N optimiser steps instead of
   N/4.44 (#364).** The epoch count that realised `--steps` divided the request
   by `rows // batch_size`, ignoring that `val_split` (0.1) removes rows from

--- a/src/soup_cli/utils/reward_hack_control.py
+++ b/src/soup_cli/utils/reward_hack_control.py
@@ -1037,12 +1037,23 @@ class RewardHackMitigationCallback(_TrainerCallbackBase):  # type: ignore[misc, 
         vote = self._compute_vote(signals)
         new_state, action = bang_bang_step(policy, self._state, vote=vote)
         self._state = new_state
-        self._apply_coefficient(action.new_beta)
+        held = action.reason == "hold"
+        # bang_bang_step leaves reason == "hold" only when new_beta == beta,
+        # so skipping the write here changes no committed β.
+        if not held:
+            self._apply_coefficient(action.new_beta)
         self._record_action(action.reason)
         telemetry["vote"] = vote
         telemetry["new_beta"] = action.new_beta
         telemetry["tripped"] = action.tripped
         telemetry["action"] = action.reason
+        telemetry["mitigation_status"] = (
+            "held"
+            if held
+            else "released"
+            if action.reason.startswith("relax")
+            else "acted"
+        )
 
     def _request_stop(self, control: Any) -> None:
         if control is not None:

--- a/tests/test_v07126.py
+++ b/tests/test_v07126.py
@@ -1000,6 +1000,72 @@ class TestKlControlCallback:
         for key in ("vote", "new_beta", "tripped", "action"):
             assert key in last
 
+    def test_hold_step_performs_no_coefficient_write(self, tmp_path, monkeypatch):
+        """A dead-band (hold) step must not touch the trainer at all, so a
+        non-acting kl_control run is observably identical to log_only."""
+        monkeypatch.chdir(tmp_path)
+
+        class _WriteCountingTrainer:
+            def __init__(self, beta):
+                self._beta = beta
+                self.writes = 0
+                self.args = types.SimpleNamespace(beta=beta)
+
+            @property
+            def beta(self):
+                return self._beta
+
+            @beta.setter
+            def beta(self, value):
+                self.writes += 1
+                self._beta = value
+
+        cb = _kl_callback(tmp_path, _SeqBuffer([_HEALTHY, _HEALTHY]))
+        trainer = _WriteCountingTrainer(0.02)
+        cb.attach(trainer)
+        cb.on_step_end(None, types.SimpleNamespace(global_step=1), None)
+        cb.on_step_end(None, types.SimpleNamespace(global_step=2), None)
+        assert trainer.writes == 0
+        assert trainer.beta == 0.02
+
+    def test_hold_then_raise_writes_exactly_once(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        class _WriteCountingTrainer:
+            def __init__(self, beta):
+                self._beta = beta
+                self.writes = 0
+                self.args = types.SimpleNamespace(beta=beta)
+
+            @property
+            def beta(self):
+                return self._beta
+
+            @beta.setter
+            def beta(self, value):
+                self.writes += 1
+                self._beta = value
+
+        cb = _kl_callback(tmp_path, _SeqBuffer([_HEALTHY, _HACK]))
+        trainer = _WriteCountingTrainer(0.02)
+        cb.attach(trainer)
+        cb.on_step_end(None, types.SimpleNamespace(global_step=1), None)  # hold
+        cb.on_step_end(None, types.SimpleNamespace(global_step=2), None)  # raise
+        assert trainer.writes == 1
+        assert trainer.beta == pytest.approx(0.04)
+
+    def test_mitigation_status_distinguishes_held_acted_released(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        cb = _kl_callback(tmp_path, _SeqBuffer([_HEALTHY, _HACK, _HEALTHY]))
+        cb.attach(_fake_grpo_trainer(beta=0.02))
+        for step in (1, 2, 3):  # hold, raise (acted), relax (released)
+            cb.on_step_end(None, types.SimpleNamespace(global_step=step), None)
+        lines = (tmp_path / "m.jsonl").read_text().strip().splitlines()
+        statuses = [json.loads(line)["mitigation_status"] for line in lines]
+        assert statuses == ["held", "acted", "released"]
+
 
 class TestAttachKlControl:
     """attach_rl_callbacks builds the bang-bang policy from tcfg for kl_control."""

--- a/tests/test_v07126.py
+++ b/tests/test_v07126.py
@@ -1066,6 +1066,32 @@ class TestKlControlCallback:
         statuses = [json.loads(line)["mitigation_status"] for line in lines]
         assert statuses == ["held", "acted", "released"]
 
+    def test_sentinel_is_resolved_before_the_first_hold_step(
+        self, tmp_path, monkeypatch
+    ):
+        """``bang_bang_step`` falls back to ``policy.beta_floor`` whenever
+        ``state.beta <= 0.0`` (the unseeded sentinel). ``_run_bang_bang`` seeds
+        ``state.beta`` from the live trainer coefficient *before* calling
+        ``bang_bang_step``, which is what keeps the hold-implies-no-write skip
+        safe: on a hold, ``new_beta == beta``, so nothing is lost by not
+        writing. If seeding ever moved to run after the hold check (or were
+        dropped), a hold on step 1 would silently commit ``beta_floor`` into
+        the controller's state instead of the trainer's actual live
+        coefficient, with no write and no error to reveal it.
+
+        Assert on the *state* the step observes rather than on call order, so
+        this survives a refactor that keeps the seed-before-step behaviour.
+        """
+        monkeypatch.chdir(tmp_path)
+        cb = _kl_callback(tmp_path, _SeqBuffer([_HEALTHY]))
+        trainer = _fake_grpo_trainer(beta=0.05)  # != beta_floor (0.02)
+        cb.attach(trainer)
+        assert cb._state.beta == 0.0  # unseeded sentinel, before the first step
+        cb.on_step_end(None, types.SimpleNamespace(global_step=1), None)  # hold
+        assert cb._state.beta == pytest.approx(0.05)  # seeded from the trainer,
+        # not left at 0.0 and not silently dropped to beta_floor (0.02)
+        assert trainer.beta == 0.05  # hold performed no write, as expected
+
 
 class TestAttachKlControl:
     """attach_rl_callbacks builds the bang-bang policy from tcfg for kl_control."""


### PR DESCRIPTION
## Root cause

`_run_bang_bang` (the `kl_control` mode of the reward-hack mitigation controller) calls
`_apply_coefficient(action.new_beta)` on every training step, including a `hold`. On a
`hold`, `bang_bang_step` leaves `reason == "hold"` exactly when `new_beta == beta` (the
dead-band case, and the two clamped-at-ceiling/floor cases), so the write puts back the
value that was already there. With the default `grpo_beta` and `reward_hack_beta_floor`
both at `0.02`, most `kl_control` runs spend most of their steps in `hold`, so a run that
never trips the controller is, step for step, a same-value write repeated rather than the
no-op `log_only` claims to be.

## Fix

Skip `_apply_coefficient` when `action.reason == "hold"`. Since `hold` only occurs when
`new_beta == beta`, this changes no committed β; it only removes the redundant write. The
mitigation log now also carries `mitigation_status` (`held` / `acted` / `released`), so a
step where the controller did nothing is recoverable directly from the log instead of
inferred by parsing the free-text `action` field.

## Scope

This addresses fix-path item 3 of #371 only ("skip the coefficient write on a hold ... log
the distinction"), which is the `kl_control` sub-issue and is fully CPU-testable. Items 1
(`pid_lagrangian` needs a completed run on GPU hardware) and 2 (reconciling the rollback and
beta ladder thresholds, which needs the same GPU runs to observe) are unaddressed here; this
runner has no GPU access to produce or verify either. `Refs #371` rather than `Fixes #371`
for that reason.

## Verification

- `pytest tests/test_v07126.py -k TestKlControlCallback -v`: the three new tests fail against
  unpatched `main` (write-count assertions, missing `mitigation_status` key) and pass on this
  branch, checked in a clean Docker container on both ends of the CI matrix (Python 3.10 and
  3.12).
- Full `pytest tests/test_v07126.py` (190 tests, the whole reward-hack-mitigation suite):
  green on this branch, both Python versions.
- `ruff check src/soup_cli/ tests/`: clean. `mypy`: one pre-existing error in this file at
  line 922, unrelated to this change and present on `main` too (this repo's `type-check` CI
  job is non-blocking).
- Not run: anything requiring GPU (items 1/2 above), and the repository's full test suite
  (17k+ tests across 360 files) beyond the one file this change touches.
