### PR TITLE
feat(stream): make layer-streaming pinning configurable via training.stream_pin (#366)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,25 @@ reproducing 70+ versions of notes.
 
 ### Added
 
+- **`training.stream_pin` makes layer-streaming pinning configurable (#366 by @ousamabenyounes in #416).**
+  Page-locking the RAM store is chosen automatically by `decide_pinning`, and
+  until now nothing could override it — so while #331 was live, `pin=False` was
+  the only known mitigation for silently wrong NF4 gradients yet was unreachable
+  from `soup.yaml`. `stream_pin: false` now forces the pageable store (and the
+  pre-flight states the throughput it costs, up to 6.56x measured, rather than
+  absorbing it silently); `stream_pin: true` forces the pinned store and, **on
+  the RAM tier**, refuses the run — naming the store size, not the ceiling
+  (#366 AC3): `pinned_limit_bytes` is passed as `None`, so the page-lock ceiling
+  is deliberately left unprobed and the store size is the only figure the
+  refusal can honestly cite — if the box cannot page-lock it, instead of
+  degrading silently; unset keeps today's automatic behaviour. On the disk tier
+  (no RAM store to page-lock) and on CPU (no device to copy to) pinning is
+  *inapplicable* rather than unsatisfiable, so `true` is **announced and the run
+  proceeds** — refusing there would brick the large-model runs the disk tier
+  exists for, and would make the key uncommittable to a config shared between a
+  GPU box and a CPU box. Set while `stream_layers: false` it is rejected as a
+  footgun, like the other stream keys.
+
 - **A ready-made `qwen3.5-9b-grpo` recipe for GRPO reasoning training with `Qwen/Qwen3.5-9B` (#277 by @harshitthek in #448).**
   The recipe combines the established GRPO defaults (accuracy reward, beta=0.1, 4 generations)
   with LoRA r=16 and 4-bit quantization.
@@ -114,24 +133,6 @@ reproducing 70+ versions of notes.
   attestations also attach the detached `.sig` sidecar. The flag needs
   `--output` (omitting it exits 2), and a requested registry attachment failure
   exits 1 after preserving files already emitted.
-- **`training.stream_pin` makes layer-streaming pinning configurable (#366).**
-  Page-locking the RAM store is chosen automatically by `decide_pinning`, and
-  until now nothing could override it — so while #331 was live, `pin=False` was
-  the only known mitigation for silently wrong NF4 gradients yet was unreachable
-  from `soup.yaml`. `stream_pin: false` now forces the pageable store (and the
-  pre-flight states the throughput it costs, up to 6.56x measured, rather than
-  absorbing it silently); `stream_pin: true` forces the pinned store and, **on
-  the RAM tier**, refuses the run — naming the store size, not the ceiling
-  (#366 AC3): `pinned_limit_bytes` is passed as `None`, so the page-lock ceiling
-  is deliberately left unprobed and the store size is the only figure the
-  refusal can honestly cite — if the box cannot page-lock it, instead of
-  degrading silently; unset keeps today's automatic behaviour. On the disk tier
-  (no RAM store to page-lock) and on CPU (no device to copy to) pinning is
-  *inapplicable* rather than unsatisfiable, so `true` is **announced and the run
-  proceeds** — refusing there would brick the large-model runs the disk tier
-  exists for, and would make the key uncommittable to a config shared between a
-  GPU box and a CPU box. Set while `stream_layers: false` it is rejected as a
-  footgun, like the other stream keys.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,12 +120,17 @@ reproducing 70+ versions of notes.
   the only known mitigation for silently wrong NF4 gradients yet was unreachable
   from `soup.yaml`. `stream_pin: false` now forces the pageable store (and the
   pre-flight states the throughput it costs, up to 6.56x measured, rather than
-  absorbing it silently); `stream_pin: true` forces the pinned store and refuses
-  the run — naming the store size, not the ceiling (#366 AC3): `pinned_limit_bytes`
-  is passed as `None`, so the page-lock ceiling is deliberately left unprobed and
-  the store size is the only figure the refusal can honestly cite — if the box
-  cannot page-lock it, instead of degrading silently; unset keeps today's
-  automatic behaviour. Set while `stream_layers: false` it is rejected as a
+  absorbing it silently); `stream_pin: true` forces the pinned store and, **on
+  the RAM tier**, refuses the run — naming the store size, not the ceiling
+  (#366 AC3): `pinned_limit_bytes` is passed as `None`, so the page-lock ceiling
+  is deliberately left unprobed and the store size is the only figure the
+  refusal can honestly cite — if the box cannot page-lock it, instead of
+  degrading silently; unset keeps today's automatic behaviour. On the disk tier
+  (no RAM store to page-lock) and on CPU (no device to copy to) pinning is
+  *inapplicable* rather than unsatisfiable, so `true` is **announced and the run
+  proceeds** — refusing there would brick the large-model runs the disk tier
+  exists for, and would make the key uncommittable to a config shared between a
+  GPU box and a CPU box. Set while `stream_layers: false` it is rejected as a
   footgun, like the other stream keys.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,19 @@ reproducing 70+ versions of notes.
   attestations also attach the detached `.sig` sidecar. The flag needs
   `--output` (omitting it exits 2), and a requested registry attachment failure
   exits 1 after preserving files already emitted.
+- **`training.stream_pin` makes layer-streaming pinning configurable (#366).**
+  Page-locking the RAM store is chosen automatically by `decide_pinning`, and
+  until now nothing could override it — so while #331 was live, `pin=False` was
+  the only known mitigation for silently wrong NF4 gradients yet was unreachable
+  from `soup.yaml`. `stream_pin: false` now forces the pageable store (and the
+  pre-flight states the throughput it costs, up to 6.56x measured, rather than
+  absorbing it silently); `stream_pin: true` forces the pinned store and refuses
+  the run — naming the store size, not the ceiling (#366 AC3): `pinned_limit_bytes`
+  is passed as `None`, so the page-lock ceiling is deliberately left unprobed and
+  the store size is the only figure the refusal can honestly cite — if the box
+  cannot page-lock it, instead of degrading silently; unset keeps today's
+  automatic behaviour. Set while `stream_layers: false` it is rejected as a
+  footgun, like the other stream keys.
 
 ### Fixed
 

--- a/benchmarks/gate-h100-validation.md
+++ b/benchmarks/gate-h100-validation.md
@@ -1442,10 +1442,11 @@ LlamaConfig(vocab_size=4096, hidden_size=5120, intermediate_size=27648,
   exactly this, and `load_async` as issuing `stream.wait_stream(current)` before
   `copy_`. Both are evidently insufficient on this path.
 
-**No fix attempted and no Soup code changed**, per the brief. There is also no
-user-facing escape hatch: pinning is chosen automatically by `decide_pinning`,
-with no config key to disable it, so a user hitting this cannot work around it
-from `soup.yaml`.
+**No fix attempted and no Soup code changed**, per the brief. At the time this
+was measured there was also no user-facing escape hatch: pinning was chosen
+automatically by `decide_pinning` with no config key to disable it, so a user
+hitting this could not work around it from `soup.yaml`. That escape hatch now
+exists — `training.stream_pin: false` (#366) forces the pageable store.
 
 ### Everything measured, one table
 

--- a/docs/performance-and-quantization.md
+++ b/docs/performance-and-quantization.md
@@ -235,7 +235,7 @@ training:
   stream_layers: true          # Enable layer streaming
   stream_source: auto          # 'auto' (same-host RAM), 'ram', 'disk' (v0.72.3)
   stream_buffers: 2            # Double-buffering; range [2, 8]
-  # stream_pin: false          # Force the pinned RAM store off (escape hatch) or on; unset = automatic
+  # stream_pin: false          # Force the pinned RAM store off (escape hatch) or on; unset = automatic. See below
   # stream_vram_override: 4_000_000_000   # Bytes to assume free (v0.73.x); see below
   # stream_vram_probe: true    # Decide the fit by MEASURING one step (sft only); see below
   # stream_disk_kind: nvme     # Override auto disk-kind detection: nvme/ssd/hdd; see below
@@ -288,6 +288,39 @@ Untied `embed_tokens` + `lm_head` stay resident and unquantised (2.10 GB of the 
 - **A streamed 8B run now completes on a Turing card — free-tier Colab, Tesla T4 (sm_75) — and that is all it shows.** `NousResearch/Meta-Llama-3.1-8B-Instruct`, NF4, `stream_buffers: 2`, batch 1, `max_length: 256`, LoRA r=8, fp16: 7 steps, exit 0, adapter written with 128 of 128 tensors non-zero, **measured peak 2.91 GB** against a predicted ~3.02 GB (the pre-flight over-predicts by 3.8%, the safe direction it was fitted for). The T4 has 15.6 GB, so the process was capped to **4.00 GB** with `torch.cuda.set_per_process_memory_fraction`, and the cap was shown to bite — a 4.29 GiB allocation was refused. **No throughput is quoted from this run**: a card under an artificial cap is not a benchmark, and the [notebook](../notebooks/proof-4gb.ipynb) deliberately quotes none either. **What it does not establish**: backward/gradient exactness at 8B on Turing (a non-zero adapter shows gradients flowed, not that they were correct), and the notebook's streamed-vs-resident comparison produced no captured output, so it is recorded as unrun rather than as a pass. Note also that the pre-flight read **free VRAM 15.10 GB** — the device, not the per-process cap — so on capped hardware it is `training.stream_vram_override` and not the fit decision that enforces the real budget. Record: [`benchmarks/run-t4-colab-free-tier.md`](../benchmarks/run-t4-colab-free-tier.md).
 - **The bf16 3B throughput above is a LOWER BOUND.** The reference box could not page-lock the 5.55 GB base (its measured page-locked ceiling is 7.65 GB, and a CUDA context plus the model skeleton did not leave room), so that run fell back to a pageable store. Pageable memory makes the host-to-device copy synchronous, which costs overlap — visible as the GPU-utilisation drop from 96.8% (1.5B, pinned) to 79.3% (3B, pageable). Soup does this fallback automatically **and prints the cost** rather than absorbing it silently. NF4 lifts this at 3B: the store drops under the ceiling and pins.
 - Numbers are Windows/WDDM and therefore systematically pessimistic versus Linux. `expandable_segments:True` is silently ignored on Windows; Soup detects that and does not claim it is active.
+
+### Forcing the pin (`training.stream_pin`)
+
+Pinning is chosen automatically; `stream_pin` is how a config overrides that choice.
+
+- **`stream_pin: false`** forces the pageable RAM store. The pre-flight states the
+  throughput this costs — up to **6.56×** measured (Qwen2.5-32B NF4), **7.41×** on a
+  synthetic — rather than absorbing it silently. This is the escape hatch: it was the
+  only known mitigation while #331 was live.
+- **`stream_pin: true`** forces the page-locked store. **On the RAM tier it REFUSES the
+  run**, naming the store size, if the box cannot page-lock it — instead of degrading to
+  a pageable store and spending the whole margin pinning exists to provide.
+- **Unset (the default)** keeps today's behaviour: on the CUDA RAM tier, attempt a pinned store and fall back to
+  pageable and announce the cost when the host cannot page-lock it.
+
+**Where `true` announces instead of refusing.** Pinning page-locks the RAM store so that
+host→device copies can overlap compute — so it needs both a RAM store *and* a device to
+copy to. In the two cases below one of those is missing, the request is **inapplicable
+rather than unsatisfiable**, and the run *proceeds with an announcement* rather than
+refusing:
+
+| Tier / device | `stream_pin: true` does |
+|---|---|
+| RAM tier on CUDA | pins, or **refuses** naming the store size |
+| Disk tier (base does not fit in RAM, weights stream from NVMe) | announces that pinning does not apply, proceeds |
+| CPU (no CUDA device) | announces that page-locking is a host-to-device optimization, proceeds |
+
+Refusing on those two would brick the large-model runs the disk tier exists for, and
+would make `stream_pin: true` uncommittable to a `soup.yaml` shared between a GPU box and
+a CPU box. The RAM tier is where the flag has real semantics, and there it still refuses.
+
+Set while `stream_layers: false` the key is rejected as a footgun, like the other
+`stream_*` keys.
 
 ### Sizing a streaming run (v0.72.3)
 

--- a/docs/performance-and-quantization.md
+++ b/docs/performance-and-quantization.md
@@ -235,6 +235,7 @@ training:
   stream_layers: true          # Enable layer streaming
   stream_source: auto          # 'auto' (same-host RAM), 'ram', 'disk' (v0.72.3)
   stream_buffers: 2            # Double-buffering; range [2, 8]
+  # stream_pin: false          # Force the pinned RAM store off (escape hatch) or on; unset = automatic
   # stream_vram_override: 4_000_000_000   # Bytes to assume free (v0.73.x); see below
   # stream_vram_probe: true    # Decide the fit by MEASURING one step (sft only); see below
   # stream_disk_kind: nvme     # Override auto disk-kind detection: nvme/ssd/hdd; see below
@@ -353,7 +354,7 @@ prints this advice when it sees you accumulating.
 - `task: kto` with `batch_size: 1` → TRL's KL term is degenerate at batch 1; refused when the config is read rather than minutes later after sharding
 - `lora.use_dora` / `lora.use_vera` / `lora.init_strategy` other than `random` → these initialise from the real base weight, which is on the meta device under streaming
 - `unfrozen_parameters`, `lisa_enabled`, `packing`, `multipack`, `use_fsdp2_compile`, `train_router_only`, `expand_layers` → each independently rewrites or re-freezes the same layers
-- `stream_source` / `stream_buffers` / `stream_vram_override` / `stream_vram_probe` / `stream_disk_kind` set while `stream_layers: false` → a footgun, refused
+- `stream_source` / `stream_buffers` / `stream_vram_override` / `stream_vram_probe` / `stream_disk_kind` / `stream_pin` set while `stream_layers: false` → a footgun, refused
 - `stream_vram_probe` on any task other than `sft` → the probe runs a plain causal-LM step, which *is* the SFT step but is not a preference loss. Measured at one matching shape it is conservative there too (6.02 GB against a real DPO step's 5.30 GB, +13.5%), but one shape is not a validation, so it is not offered for `dpo`/`orpo`/`simpo`/`kto` yet
 - an architecture outside the supported list (llama / qwen2 / qwen3 / mistral / gemma / gemma2 / gemma3_text / phi / phi3) → named explicitly
 

--- a/src/soup_cli/config/schema.py
+++ b/src/soup_cli/config/schema.py
@@ -3059,6 +3059,22 @@ class TrainingConfig(BaseModel):
             raise ValueError("training.stream_buffers must be an int, not bool")
         return v
 
+    stream_pin: Optional[bool] = Field(
+        default=None,
+        description=(
+            "Force the page-locked (pinned) RAM store on or off. None (the "
+            "default) lets the box decide: it attempts a pinned store and falls "
+            "back to a pageable one — announcing the cost — when the host cannot "
+            "page-lock it. 'false' forces the pageable store, the only known "
+            "escape hatch when a pinning path is suspect (it was the sole "
+            "mitigation while #331 was live). 'true' forces the pinned store and "
+            "REFUSES the run, naming the store size, if the box cannot page-lock "
+            "it, rather than silently degrading — page-locking is worth up to "
+            "6.56x measured throughput, so a silent fallback spends the whole "
+            "margin the feature exists to provide."
+        ),
+    )
+
     stream_vram_override: Optional[int] = Field(
         default=None,
         ge=0,
@@ -4935,12 +4951,14 @@ class SoupConfig(BaseModel):
                 or tcfg.stream_vram_override is not None
                 or tcfg.stream_vram_probe
                 or tcfg.stream_disk_kind is not None
+                or tcfg.stream_pin is not None
             ):
                 raise ValueError(
                     "training.stream_source / training.stream_buffers / "
                     "training.stream_vram_override / training.stream_vram_probe "
-                    "/ training.stream_disk_kind set but stream_layers is false; "
-                    "set stream_layers=true to stream the base layer-by-layer."
+                    "/ training.stream_disk_kind / training.stream_pin set but "
+                    "stream_layers is false; set stream_layers=true to stream the "
+                    "base layer-by-layer."
                 )
             return self
         # v0.72.4 — the four preference losses join SFT. DPO and KTO take their

--- a/src/soup_cli/config/schema.py
+++ b/src/soup_cli/config/schema.py
@@ -3068,10 +3068,16 @@ class TrainingConfig(BaseModel):
             "page-lock it. 'false' forces the pageable store, the only known "
             "escape hatch when a pinning path is suspect (it was the sole "
             "mitigation while #331 was live). 'true' forces the pinned store and "
-            "REFUSES the run, naming the store size, if the box cannot page-lock "
-            "it, rather than silently degrading — page-locking is worth up to "
-            "6.56x measured throughput, so a silent fallback spends the whole "
-            "margin the feature exists to provide."
+            "REFUSES the run on the RAM tier, naming the store size, if the box "
+            "cannot page-lock it, rather than silently degrading — page-locking "
+            "is worth up to 6.56x measured throughput, so a silent fallback "
+            "spends the whole margin the feature exists to provide. On the disk "
+            "tier (the base does not fit in RAM, so there is no RAM store to "
+            "page-lock) and on CPU (page-locking is a host-to-device transfer "
+            "optimization and there is no device) pinning is INAPPLICABLE rather "
+            "than unsatisfiable: 'true' is announced and the run proceeds "
+            "without it, so the key stays committable to a config shared between "
+            "a GPU box and a CPU box."
         ),
     )
 

--- a/src/soup_cli/trainer/stream_setup.py
+++ b/src/soup_cli/trainer/stream_setup.py
@@ -400,6 +400,16 @@ class StreamingSetupMixin:
             use_rslora=tcfg.lora.use_rslora,
         )
 
+        # #366 review — on CPU there is no CUDA device, so page-locking (a
+        # host->device transfer optimization) is inapplicable. An explicit
+        # stream_pin=true is honoured by saying so, not by dropping it silently.
+        if tcfg.stream_pin is True and not on_cuda:
+            console.print(
+                "[yellow]training.stream_pin=true, but no CUDA device is present: "
+                "page-locking is a host-to-device transfer optimization and does "
+                "not apply on CPU. Proceeding without it.[/]"
+            )
+
         model, runtime = build_streamed_model(
             model_id=cfg.base,
             shard_dir=shard_dir,
@@ -409,8 +419,11 @@ class StreamingSetupMixin:
             dtype=dtype,
             buffers=tcfg.stream_buffers,
             pin=plan.pinned and on_cuda,
-            # #366: stream_pin=true must refuse rather than silently fall back to
-            # a pageable store when the box cannot page-lock it.
+            # #366: on the RAM tier stream_pin=true refuses rather than silently
+            # falling back to a pageable store; on the disk tier the runtime
+            # announces that pinning is inapplicable (no RAM store to lock); on
+            # CPU the notice above covers it. require_pin only carries the RAM
+            # refusal, so it is gated on a real CUDA device.
             require_pin=(tcfg.stream_pin is True) and on_cuda,
             seed=tcfg.seed if getattr(tcfg, "seed", None) is not None else 0,
             trust_remote_code=self._trust_remote_code,

--- a/src/soup_cli/trainer/stream_setup.py
+++ b/src/soup_cli/trainer/stream_setup.py
@@ -331,6 +331,9 @@ class StreamingSetupMixin:
             disk_kind=lambda: resolve_disk_kind(
                 shard_dir, tcfg.stream_disk_kind, notify=console.print
             ),
+            # #366: training.stream_pin (None/False/True) overrides the automatic
+            # pinning choice so the pageable escape hatch is reachable from config.
+            stream_pin=tcfg.stream_pin,
         )
         # v0.72.3 — the disk overflow tier is live, so a base that does not fit
         # in RAM is no longer fatal. `stream_source` decides: 'ram' insists,
@@ -406,6 +409,9 @@ class StreamingSetupMixin:
             dtype=dtype,
             buffers=tcfg.stream_buffers,
             pin=plan.pinned and on_cuda,
+            # #366: stream_pin=true must refuse rather than silently fall back to
+            # a pageable store when the box cannot page-lock it.
+            require_pin=(tcfg.stream_pin is True) and on_cuda,
             seed=tcfg.seed if getattr(tcfg, "seed", None) is not None else 0,
             trust_remote_code=self._trust_remote_code,
             console=console,

--- a/src/soup_cli/utils/layer_stream.py
+++ b/src/soup_cli/utils/layer_stream.py
@@ -672,9 +672,13 @@ def decide_pinning(
         return PinDecision(
             pinned=True,
             reason=(
-                "training.stream_pin=true forces a page-locked store; the run "
-                "refuses rather than falling back to a pageable store if the box "
-                "cannot page-lock it."
+                # Scoped to the RAM tier on purpose: this note is now surfaced
+                # for a forced-on pin, and the disk tier / CPU announce that
+                # pinning is inapplicable and PROCEED. An unconditional "the run
+                # refuses" here would print a promise those paths do not keep.
+                "training.stream_pin=true forces a page-locked store; on the RAM "
+                "tier the run refuses rather than falling back to a pageable "
+                "store if the box cannot page-lock it."
             ),
         )
     if pinned_limit_bytes is None:
@@ -1302,7 +1306,18 @@ def build_stream_plan(
             "refuse rather than fall back."
         )
     decision = decide_pinning(store_bytes, pinned_limit_bytes, stream_pin=stream_pin)
-    if not decision.pinned:
+    # #366 review round 3 — "record, never silence". An automatic pinned store is
+    # the unremarkable default and stays quiet, but an EXPLICIT stream_pin=true is
+    # a user decision, so the pre-flight states it too. Without this the forced-on
+    # branch was the one path that decided something and said nothing, which is
+    # also what decide_pinning's docstring already promised it did not do.
+    #
+    # Restricted to the RAM tier deliberately: the reason says the store IS
+    # page-locked, which is only true where a RAM store exists. On the disk tier
+    # there is none, and printing it there would state a promise that tier does
+    # not keep — the runtime announces the inapplicability instead
+    # (layer_stream_runtime._build_source), so the decision is still recorded.
+    if not decision.pinned or (stream_pin is True and tier == TIER_RAM):
         notes.append(decision.reason)
     return StreamPlan(
         arch=arch,

--- a/src/soup_cli/utils/layer_stream.py
+++ b/src/soup_cli/utils/layer_stream.py
@@ -661,6 +661,7 @@ def decide_pinning(
             reason=(
                 "training.stream_pin=false forces a pageable RAM store. "
                 "Host-to-device copies become synchronous, which costs overlap: "
+                "measured GPU utilisation drops from ~97% to ~79%, and "
                 f"page-locking is worth up to {PIN_THROUGHPUT_GAIN_REAL:.2f}x "
                 "measured throughput (Qwen2.5-32B NF4), "
                 f"{PIN_THROUGHPUT_GAIN_SYNTHETIC:.2f}x on a synthetic. Unset "

--- a/src/soup_cli/utils/layer_stream.py
+++ b/src/soup_cli/utils/layer_stream.py
@@ -36,6 +36,13 @@ STREAM_SOURCES = ("auto", "ram", "disk")
 #: model_bytes must be under this fraction of free RAM to claim the RAM tier.
 RAM_TIER_HEADROOM = 0.7
 
+# Measured throughput a page-locked RAM store buys over a pageable one
+# (benchmarks/gate-h100-validation.md): 6.56x on real Qwen2.5-32B NF4, 7.41x on
+# a 32-layer synthetic. Stated out loud whenever pinning is disabled so the cost
+# is not absorbed silently — a silent fallback spends the entire margin.
+PIN_THROUGHPUT_GAIN_REAL = 6.56
+PIN_THROUGHPUT_GAIN_SYNTHETIC = 7.41
+
 # --- buffers --------------------------------------------------------------
 MIN_STREAM_BUFFERS = 2
 MAX_STREAM_BUFFERS = 8
@@ -625,7 +632,12 @@ class PinDecision:
     reason: str
 
 
-def decide_pinning(store_bytes: int, pinned_limit_bytes: Optional[int]) -> PinDecision:
+def decide_pinning(
+    store_bytes: int,
+    pinned_limit_bytes: Optional[int],
+    *,
+    stream_pin: Optional[bool] = None,
+) -> PinDecision:
     """Pin the RAM store when the box can actually page-lock it.
 
     Measured on the dev box (RTX 3050 4 GB / 16.9 GB RAM): the maximum
@@ -635,7 +647,35 @@ def decide_pinning(store_bytes: int, pinned_limit_bytes: Optional[int]) -> PinDe
     ``copy_(non_blocking=True)`` synchronous and therefore costs overlap:
     measured GPU utilisation dropped from 96.8% (pinned) to 79.3% (pageable).
     That cost is stated out loud rather than absorbed silently.
+
+    ``stream_pin`` (``training.stream_pin``) overrides the automatic choice:
+    ``None`` keeps the behaviour above; ``False`` forces the pageable store and
+    states its throughput cost; ``True`` forces the pinned store — the run then
+    refuses (in the runtime) rather than falling back if the box cannot
+    page-lock it. The refusal itself lives where the pin is actually attempted;
+    here ``True`` only records the intent so the pre-flight reflects it.
     """
+    if stream_pin is False:
+        return PinDecision(
+            pinned=False,
+            reason=(
+                "training.stream_pin=false forces a pageable RAM store. "
+                "Host-to-device copies become synchronous, which costs overlap: "
+                f"page-locking is worth up to {PIN_THROUGHPUT_GAIN_REAL:.2f}x "
+                "measured throughput (Qwen2.5-32B NF4), "
+                f"{PIN_THROUGHPUT_GAIN_SYNTHETIC:.2f}x on a synthetic. Unset "
+                "stream_pin to let the box page-lock when it can."
+            ),
+        )
+    if stream_pin is True:
+        return PinDecision(
+            pinned=True,
+            reason=(
+                "training.stream_pin=true forces a page-locked store; the run "
+                "refuses rather than falling back to a pageable store if the box "
+                "cannot page-lock it."
+            ),
+        )
     if pinned_limit_bytes is None:
         return PinDecision(
             pinned=True,
@@ -1238,6 +1278,7 @@ def build_stream_plan(
     pinned_limit_bytes: Optional[int],
     buffers: int = DEFAULT_STREAM_BUFFERS,
     disk_kind: DiskKind = _NVME,
+    stream_pin: Optional[bool] = None,
 ) -> StreamPlan:
     """Decide tier + pinning and record every caveat as a visible note."""
     buffers = validate_stream_buffers(buffers)
@@ -1259,7 +1300,7 @@ def build_stream_plan(
             "tier is unmeasured on this hardware. Set stream_source='ram' to "
             "refuse rather than fall back."
         )
-    decision = decide_pinning(store_bytes, pinned_limit_bytes)
+    decision = decide_pinning(store_bytes, pinned_limit_bytes, stream_pin=stream_pin)
     if not decision.pinned:
         notes.append(decision.reason)
     return StreamPlan(

--- a/src/soup_cli/utils/layer_stream_runtime.py
+++ b/src/soup_cli/utils/layer_stream_runtime.py
@@ -1608,11 +1608,29 @@ def _build_source(shard_dir, n_layers, spec, pin, console, tier="ram", require_p
     not, so the fallback says so out loud.
 
     ``require_pin`` (from ``training.stream_pin=true``) turns that fallback into
-    a hard refusal: the user asked for the pinned store explicitly, so silently
-    degrading to a pageable one — spending the whole throughput margin pinning
-    exists to provide — is exactly the outcome the flag exists to prevent.
+    a hard refusal on the RAM tier: the user asked for the pinned store
+    explicitly, so silently degrading to a pageable one — spending the whole
+    throughput margin pinning exists to provide — is exactly the outcome the flag
+    exists to prevent.
+
+    On the DISK tier pinning is not *unsatisfiable*, it is *inapplicable*: the
+    base does not fit in RAM, so weights stream directly from NVMe and there is
+    no RAM store to page-lock. Refusing here would brick the very runs the disk
+    tier exists for, so ``require_pin`` proceeds — but it is announced, never
+    dropped in silence (#366 review).
     """
     if tier == "disk":
+        if require_pin:
+            message = (
+                "training.stream_pin=true, but this run is on the disk tier: the "
+                "base does not fit in RAM, so weights stream directly from NVMe "
+                "and there is no RAM store to page-lock. Pinning does not apply "
+                "here; proceeding without it."
+            )
+            if console is not None:
+                console.print(f"[yellow]{message}[/]")
+            else:
+                logger.warning(message)
         return DiskSource(shard_dir, n_layers, spec), False
     if not pin:
         return RamSource(shard_dir, n_layers, spec, pin=False), False

--- a/src/soup_cli/utils/layer_stream_runtime.py
+++ b/src/soup_cli/utils/layer_stream_runtime.py
@@ -1499,6 +1499,7 @@ def install_streaming(
     index: Any,
     buffers: int = 2,
     pin: bool = True,
+    require_pin: bool = False,
     device: str = "cuda",
     console: Any = None,
     codes: Optional[Mapping[str, Any]] = None,
@@ -1557,7 +1558,9 @@ def install_streaming(
             validate_quant_shape(ckpt, spec_q, shard_spec)
     spec = needed
 
-    source, pinned = _build_source(shard_dir, n_layers, spec, pin, console, tier)
+    source, pinned = _build_source(
+        shard_dir, n_layers, spec, pin, console, tier, require_pin=require_pin
+    )
     pool = LayerBufferPool(spec, n_buffers=buffers, device=device)
     stream = torch.cuda.Stream() if str(device).startswith("cuda") else None
     prefetcher = StreamPrefetcher(pool, source, n_layers, stream)
@@ -1596,13 +1599,18 @@ def install_streaming(
     )
 
 
-def _build_source(shard_dir, n_layers, spec, pin, console, tier="ram"):
+def _build_source(shard_dir, n_layers, spec, pin, console, tier="ram", require_pin=False):
     """Build the weight source for the chosen tier.
 
     On the RAM tier, page-locking is bounded by the box rather than by free RAM
     (the dev box topped out at 7.12 GB with 9.1 GB "available"). Falling back to
     a pageable store is correct; hiding the ~97% -> ~79% GPU-utilisation cost is
     not, so the fallback says so out loud.
+
+    ``require_pin`` (from ``training.stream_pin=true``) turns that fallback into
+    a hard refusal: the user asked for the pinned store explicitly, so silently
+    degrading to a pageable one — spending the whole throughput margin pinning
+    exists to provide — is exactly the outcome the flag exists to prevent.
     """
     if tier == "disk":
         return DiskSource(shard_dir, n_layers, spec), False
@@ -1611,6 +1619,17 @@ def _build_source(shard_dir, n_layers, spec, pin, console, tier="ram"):
     try:
         return RamSource(shard_dir, n_layers, spec, pin=True), True
     except (RuntimeError, MemoryError) as exc:
+        store_gb = n_layers * _spec_bytes(spec) / 1e9
+        if require_pin:
+            raise RuntimeError(
+                "training.stream_pin=true but this box could not page-lock the "
+                f"{store_gb:.2f} GB RAM store ({type(exc).__name__}). Refusing "
+                "rather than silently degrading to a pageable store, which makes "
+                "host-to-device copies synchronous and costs the ~97% -> ~79% "
+                "GPU-utilisation overlap pinning buys. Free RAM, use a smaller "
+                "base, or unset training.stream_pin to allow the pageable "
+                "fallback."
+            ) from exc
         message = (
             "layer streaming could not page-lock the base "
             f"({type(exc).__name__}); falling back to a PAGEABLE RAM store. "
@@ -1625,6 +1644,11 @@ def _build_source(shard_dir, n_layers, spec, pin, console, tier="ram"):
         return RamSource(shard_dir, n_layers, spec, pin=False), False
 
 
+def _spec_bytes(spec: Mapping[str, Tuple[Tuple[int, ...], str]]) -> int:
+    """Bytes held by ONE decoder layer, from the shard spec — for messages only."""
+    return sum(math.prod(shape) * _dtype_size(dtype) for shape, dtype in spec.values())
+
+
 def build_streamed_model(
     *,
     model_id: str,
@@ -1635,6 +1659,7 @@ def build_streamed_model(
     dtype: str = "bfloat16",
     buffers: int = 2,
     pin: bool = True,
+    require_pin: bool = False,
     seed: int = 0,
     trust_remote_code: bool = False,
     console: Any = None,
@@ -1664,6 +1689,7 @@ def build_streamed_model(
         index=index,
         buffers=buffers,
         pin=pin,
+        require_pin=require_pin,
         device=device,
         console=console,
         codes=extras.codes,

--- a/tests/test_v07200.py
+++ b/tests/test_v07200.py
@@ -143,6 +143,30 @@ class TestDecidePinning:
 
         assert decide_pinning(7 * 10**9, 7 * 10**9).pinned is True
 
+    def test_stream_pin_false_forces_pageable_and_states_the_cost(self):
+        """#366: pinning could not be turned off from config. stream_pin=false
+        forces the pageable store even where the box could page-lock it, and the
+        reason states the throughput it costs rather than absorbing it."""
+        from soup_cli.utils.layer_stream import decide_pinning
+
+        decision = decide_pinning(2 * 10**9, 7 * 10**9, stream_pin=False)
+        assert decision.pinned is False
+        assert "throughput" in decision.reason.lower()
+
+    def test_stream_pin_true_forces_pinned_even_above_ceiling(self):
+        """The override pins where the automatic path would have fallen back."""
+        from soup_cli.utils.layer_stream import decide_pinning
+
+        decision = decide_pinning(50 * 10**9, 7 * 10**9, stream_pin=True)
+        assert decision.pinned is True
+        assert "refuses" in decision.reason.lower()
+
+    def test_stream_pin_none_keeps_automatic_behaviour(self):
+        from soup_cli.utils.layer_stream import decide_pinning
+
+        assert decide_pinning(8 * 10**9, 7 * 10**9, stream_pin=None).pinned is False
+        assert decide_pinning(2 * 10**9, 7 * 10**9, stream_pin=None).pinned is True
+
 
 class TestBufferValidation:
     def test_default_is_two(self):
@@ -319,6 +343,26 @@ class TestStreamPlan:
         )
         assert plan.pinned is False
         assert any("pageable" in note.lower() for note in plan.notes)
+
+    def test_stream_pin_false_reaches_the_plan_as_pageable_with_cost(self):
+        """#366 criteria 1+2: stream_pin=false proceeds pageable AND the
+        pre-flight note states the throughput cost — the store here fits under
+        the pinned ceiling, so the automatic path would otherwise pin it."""
+        from soup_cli.utils.layer_stream import build_stream_plan
+
+        plan = build_stream_plan(
+            arch="qwen2",
+            n_layers=36,
+            layer_bytes=154 * 10**6,
+            embed_bytes=622 * 10**6,
+            available_ram_bytes=12 * 10**9,
+            pinned_limit_bytes=7 * 10**9,
+            buffers=2,
+            disk_kind="nvme",
+            stream_pin=False,
+        )
+        assert plan.pinned is False
+        assert any("throughput" in note.lower() for note in plan.notes)
 
     def test_plan_is_frozen(self):
         import dataclasses
@@ -873,6 +917,13 @@ class TestStreamScopeGates:
         with pytest.raises(ValueError, match="LoRA"):
             _load(_stream_yaml(training={"lora": {"r": 0}}))
 
+    def test_stream_pin_is_committable_to_config(self):
+        """#366: the pinning override joins the streaming config keys. Default
+        is None so today's automatic behaviour is unchanged."""
+        assert _load(_stream_yaml(training={"stream_pin": False})).training.stream_pin is False
+        assert _load(_stream_yaml(training={"stream_pin": True})).training.stream_pin is True
+        assert _load(_stream_yaml()).training.stream_pin is None
+
 
 class TestStreamMutualExclusions:
     def test_unfrozen_parameters_conflict(self):
@@ -920,6 +971,11 @@ class TestStreamFootgunRejection:
     def test_stream_source_without_stream_layers_rejected(self):
         with pytest.raises(ValueError, match="stream_layers"):
             _load(_stream_yaml(training={"stream_layers": False, "stream_source": "ram"}))
+
+    def test_stream_pin_without_stream_layers_rejected(self):
+        """#366 criterion 4: stream_pin set while streaming is off is a footgun."""
+        with pytest.raises(ValueError, match="stream_layers"):
+            _load(_stream_yaml(training={"stream_layers": False, "stream_pin": False}))
 
 
 class TestStreamBufferBounds:
@@ -2123,6 +2179,38 @@ class TestPinnedFallbackRuntime:
         assert source.nbytes > 0
         assert any("pageable" in msg.lower() for msg in printed)
         assert any("utilisation" in msg.lower() for msg in printed)
+
+
+class TestStreamPinRuntimeRefusal:
+    """#366 criterion 3: training.stream_pin=true (require_pin) must refuse
+    loudly when the box cannot page-lock the store, instead of silently
+    degrading to a pageable one and spending the whole throughput margin."""
+
+    _SPEC = {"weight": ((2, 2), "float32")}
+
+    def _patch_ramsource_to_fail_pinning(self, monkeypatch):
+        import soup_cli.utils.layer_stream_runtime as rt
+
+        class _FailsWhenPinned:
+            def __init__(self, shard_dir, n_layers, spec, *, pin=True):
+                if pin:
+                    raise RuntimeError("CUDA error: cannot allocate pinned memory")
+                self.nbytes = 1
+
+        monkeypatch.setattr(rt, "RamSource", _FailsWhenPinned)
+        return rt
+
+    def test_auto_falls_back_to_pageable(self, monkeypatch):
+        """Without the override, a page-lock failure still falls back (default)."""
+        rt = self._patch_ramsource_to_fail_pinning(monkeypatch)
+        source, pinned = rt._build_source("d", 1, self._SPEC, True, None)
+        assert pinned is False
+        assert source.nbytes > 0
+
+    def test_forced_pin_refuses_instead_of_falling_back(self, monkeypatch):
+        rt = self._patch_ramsource_to_fail_pinning(monkeypatch)
+        with pytest.raises(RuntimeError, match="stream_pin"):
+            rt._build_source("d", 1, self._SPEC, True, None, require_pin=True)
 
 
 class TestCachedIndexInvalidation:

--- a/tests/test_v07200.py
+++ b/tests/test_v07200.py
@@ -146,12 +146,29 @@ class TestDecidePinning:
     def test_stream_pin_false_forces_pageable_and_states_the_cost(self):
         """#366: pinning could not be turned off from config. stream_pin=false
         forces the pageable store even where the box could page-lock it, and the
-        reason states the throughput it costs rather than absorbing it."""
-        from soup_cli.utils.layer_stream import decide_pinning
+        reason states the throughput it costs rather than absorbing it.
+
+        #366 re-review: pin the ACTUAL figures, not just the word 'throughput' —
+        a bare-word assertion let the measured gain be changed to 1.01 with the
+        suite green. The forced-off reason must carry the same GPU-utilisation
+        sentence the automatic-fallback branch does, and both benchmark figures.
+        """
+        from soup_cli.utils.layer_stream import (
+            PIN_THROUGHPUT_GAIN_REAL,
+            PIN_THROUGHPUT_GAIN_SYNTHETIC,
+            decide_pinning,
+        )
 
         decision = decide_pinning(2 * 10**9, 7 * 10**9, stream_pin=False)
         assert decision.pinned is False
-        assert "throughput" in decision.reason.lower()
+        reason = decision.reason
+        # The exact measured figures (benchmarks/gate-h100-validation.md), so a
+        # silent change to either constant fails here.
+        assert f"{PIN_THROUGHPUT_GAIN_REAL:.2f}x" in reason
+        assert f"{PIN_THROUGHPUT_GAIN_SYNTHETIC:.2f}x" in reason
+        assert "6.56x" in reason and "7.41x" in reason
+        # The same GPU-utilisation sentence the automatic fallback carries.
+        assert "~97% to ~79%" in reason
 
     def test_stream_pin_true_forces_pinned_even_above_ceiling(self):
         """The override pins where the automatic path would have fallen back."""
@@ -972,10 +989,15 @@ class TestStreamFootgunRejection:
         with pytest.raises(ValueError, match="stream_layers"):
             _load(_stream_yaml(training={"stream_layers": False, "stream_source": "ram"}))
 
-    def test_stream_pin_without_stream_layers_rejected(self):
-        """#366 criterion 4: stream_pin set while streaming is off is a footgun."""
+    @pytest.mark.parametrize("stream_pin", [True, False])
+    def test_stream_pin_without_stream_layers_rejected(self, stream_pin):
+        """#366 criterion 4: stream_pin set while streaming is off is a footgun.
+
+        #366 re-review: cover BOTH values. The guard is ``stream_pin is not
+        None``; testing only ``False`` let it be narrowed to ``is False`` with the
+        suite green, leaving ``true`` + ``stream_layers: false`` unguarded."""
         with pytest.raises(ValueError, match="stream_layers"):
-            _load(_stream_yaml(training={"stream_layers": False, "stream_pin": False}))
+            _load(_stream_yaml(training={"stream_layers": False, "stream_pin": stream_pin}))
 
 
 class TestStreamBufferBounds:

--- a/tests/test_v07200.py
+++ b/tests/test_v07200.py
@@ -325,6 +325,13 @@ class TestLayerSpec:
             LayerSpec(name="w", shape=(2, 2), dtype="int4").nbytes
 
 
+#: Distinguishing fragment of the forced-ON pin note, so the assertions below
+#: select that note rather than any line that happens to mention the key.
+_FORCED_PIN_TEXT = "training.stream_pin=true"
+#: Free RAM too small for the fixture base, so the plan lands on the disk tier.
+_NO_RAM_BYTES = 1000
+
+
 class TestStreamPlan:
     def test_build_plan_reports_tier_and_pinning(self):
         from soup_cli.utils.layer_stream import build_stream_plan
@@ -380,6 +387,58 @@ class TestStreamPlan:
         )
         assert plan.pinned is False
         assert any("throughput" in note.lower() for note in plan.notes)
+
+    def _plan_with_stream_pin(self, stream_pin, *, available_ram_bytes=12 * 10**9):
+        from soup_cli.utils.layer_stream import build_stream_plan
+
+        return build_stream_plan(
+            arch="qwen2",
+            n_layers=36,
+            layer_bytes=154 * 10**6,
+            embed_bytes=622 * 10**6,
+            available_ram_bytes=available_ram_bytes,
+            pinned_limit_bytes=7 * 10**9,
+            buffers=2,
+            disk_kind="nvme",
+            stream_pin=stream_pin,
+        )
+
+    @staticmethod
+    def _forced_on_notes(plan):
+        return [note for note in plan.notes if _FORCED_PIN_TEXT in note]
+
+    def test_stream_pin_true_is_recorded_in_the_plan_notes(self):
+        """#366 round-3 nit: `decide_pinning`'s docstring says True "only records
+        the intent so the pre-flight reflects it", but the plan appended the
+        reason only when the decision came back UNpinned — so a forced-on pin was
+        the one branch that decided something and said nothing. This PR's whole
+        framing is record, never silence."""
+        plan = self._plan_with_stream_pin(True)
+        assert plan.pinned is True
+        notes = self._forced_on_notes(plan)
+        assert notes, plan.notes
+        # The SEMANTICS, not just the key name: a note that merely mentioned
+        # stream_pin would otherwise pass.
+        assert any("page-locked store" in note for note in notes), notes
+        assert any("RAM tier the run refuses" in note for note in notes), notes
+
+    def test_automatic_pinning_stays_quiet(self):
+        """Control: only an EXPLICIT request is worth a note. Without this a
+        mutant that always appended the reason would satisfy the case above, and
+        every automatic run would grow a line of noise."""
+        plan = self._plan_with_stream_pin(None)
+        assert plan.pinned is True
+        assert self._forced_on_notes(plan) == [], plan.notes
+
+    def test_the_disk_tier_does_not_claim_a_page_locked_store(self):
+        """The forced-on note says the store IS page-locked, which is only true
+        where a RAM store exists. On the disk tier there is none, so printing it
+        there would state a promise that tier does not keep — the same
+        text-contradicts-behaviour defect this review round is about. The runtime
+        announces the inapplicability instead."""
+        plan = self._plan_with_stream_pin(True, available_ram_bytes=_NO_RAM_BYTES)
+        assert plan.tier == "disk"
+        assert self._forced_on_notes(plan) == [], plan.notes
 
     def test_plan_is_frozen(self):
         import dataclasses
@@ -2203,6 +2262,22 @@ class TestPinnedFallbackRuntime:
         assert any("utilisation" in msg.lower() for msg in printed)
 
 
+#: One decoder layer's weight for the AC3 refusal message, sized realistically so
+#: the rendered figure is a real number and not `0.00 GB`.
+_REFUSAL_HIDDEN = 4096
+_REFUSAL_SPEC = {"weight": ((_REFUSAL_HIDDEN, _REFUSAL_HIDDEN), "bfloat16")}
+#: (n_layers, rendered GB) pairs. TWO of them on purpose: a single fixed
+#: expectation would be satisfied by a message that hardcoded that string, which
+#: is the presence-not-value defect this PR's review round is about. Each case
+#: also asserts the OTHER size is absent, so only a figure computed from the
+#: actual store can satisfy both. 4096^2 bf16 = 32 MiB per layer, so 32 layers is
+#: 1.073 GB and 64 layers is 2.147 GB.
+_REFUSAL_STORE_SIZES = ((32, "1.07 GB"), (64, "2.15 GB"))
+#: The distinguishing phrase of the disk-tier "pinning is inapplicable here"
+#: announcement, which must fire on an explicit request and stay silent without.
+_DISK_TIER_INAPPLICABLE_TEXT = "Pinning does not apply"
+
+
 class TestStreamPinRuntimeRefusal:
     """#366 criterion 3: training.stream_pin=true (require_pin) must refuse
     loudly when the box cannot page-lock the store, instead of silently
@@ -2233,6 +2308,89 @@ class TestStreamPinRuntimeRefusal:
         rt = self._patch_ramsource_to_fail_pinning(monkeypatch)
         with pytest.raises(RuntimeError, match="stream_pin"):
             rt._build_source("d", 1, self._SPEC, True, None, require_pin=True)
+
+    @pytest.mark.parametrize(("n_layers", "expected"), _REFUSAL_STORE_SIZES)
+    def test_the_refusal_names_the_store_size(self, monkeypatch, n_layers, expected):
+        """#366 AC3: the refusal must cite the STORE SIZE — not the page-locked
+        ceiling, which is deliberately left unprobed (`pinned_limit_bytes=None`)
+        and so cannot be quoted honestly. Dropping the figure from the message
+        left the suite green, which made AC3 unenforced.
+
+        Two sizes, each asserting the other is ABSENT: a message that hardcoded
+        one figure would satisfy a single-case test identically, which is exactly
+        the presence-not-value failure this review round is about."""
+        rt = self._patch_ramsource_to_fail_pinning(monkeypatch)
+        others = [gb for layers, gb in _REFUSAL_STORE_SIZES if layers != n_layers]
+        with pytest.raises(RuntimeError) as excinfo:
+            rt._build_source("d", n_layers, _REFUSAL_SPEC, True, None, require_pin=True)
+        message = str(excinfo.value)
+        assert expected in message, message
+        for other in others:
+            assert other not in message, message
+
+
+class TestDiskTierAnnouncesInapplicablePinning:
+    """#366 round-3: on the disk tier the base does not fit in RAM, so there is
+    no RAM store to page-lock — pinning is INAPPLICABLE rather than
+    unsatisfiable, and the run proceeds. That is a decision, not a silence, so
+    the announcement has to exist; deleting the whole block previously left the
+    suite green. `require_pin` is gated on a real CUDA device upstream, so this
+    drives `_build_source` directly to reach the branch without a GPU."""
+
+    _SPEC = {"weight": ((2, 2), "float32")}
+
+    class _RecordingConsole:
+        def __init__(self):
+            self.messages = []
+
+        def print(self, *args, **_kwargs):
+            self.messages.append(" ".join(str(a) for a in args))
+
+    def _build_on_disk(self, monkeypatch, *, require_pin):
+        import soup_cli.utils.layer_stream_runtime as rt
+
+        class _StubDisk:
+            def __init__(self, shard_dir, n_layers, spec):
+                self.nbytes = 0
+
+        monkeypatch.setattr(rt, "DiskSource", _StubDisk)
+        console = self._RecordingConsole()
+        _source, pinned = rt._build_source(
+            "d", 1, self._SPEC, True, console, "disk", require_pin=require_pin
+        )
+        assert pinned is False
+        return console.messages
+
+    def test_an_explicit_request_is_announced_not_dropped(self, monkeypatch):
+        messages = self._build_on_disk(monkeypatch, require_pin=True)
+        assert any(_DISK_TIER_INAPPLICABLE_TEXT in m for m in messages), messages
+
+    def test_nothing_is_announced_without_a_request(self, monkeypatch):
+        """Control: the announcement answers a request, so an ordinary disk-tier
+        run must not grow a line about a flag nobody set. Without this half, a
+        mutant that always printed it would pass."""
+        messages = self._build_on_disk(monkeypatch, require_pin=False)
+        assert messages == []
+
+    def test_it_still_reaches_the_log_without_a_console(self, monkeypatch, caplog):
+        """`_build_source` is also called with `console=None` (the runtime does
+        not always have one). The decision must still be recorded there, or the
+        carve-out is silent on exactly the path with no screen to print to."""
+        import logging
+
+        import soup_cli.utils.layer_stream_runtime as rt
+
+        class _StubDisk:
+            def __init__(self, shard_dir, n_layers, spec):
+                self.nbytes = 0
+
+        monkeypatch.setattr(rt, "DiskSource", _StubDisk)
+        with caplog.at_level(logging.WARNING):
+            _source, pinned = rt._build_source(
+                "d", 1, self._SPEC, True, None, "disk", require_pin=True
+            )
+        assert pinned is False
+        assert _DISK_TIER_INAPPLICABLE_TEXT in caplog.text, caplog.text
 
 
 class TestCachedIndexInvalidation:

--- a/tests/test_v07203.py
+++ b/tests/test_v07203.py
@@ -1141,6 +1141,25 @@ class TestDiskTier:
         runtime.close()
 
 
+#: Free RAM to report so the tiny base comfortably takes the RAM tier.
+_RAM_TIER_FREE_BYTES = 10_000_000_000
+#: Render width for the captured pre-flight. The plan notes arrive inside a
+#: `rich.panel.Panel`; too narrow a console wraps the measured figures across a
+#: line break and the assertions below miss text that IS on screen.
+_PANEL_CAPTURE_WIDTH = 200
+#: The measured page-locking gain (`PIN_THROUGHPUT_GAIN_REAL`, Qwen2.5-32B NF4)
+#: as it appears on screen. Written as the literal the user reads rather than
+#: imported, so that changing the production constant fails these tests too.
+_PIN_GAIN_REAL_TEXT = "6.56"
+#: The forced-pageable note must be identifiable as such, not merely contain the
+#: number: some unrelated line carrying "6.56" would otherwise satisfy the check.
+_FORCED_PAGEABLE_TEXT = "training.stream_pin=false"
+#: Free/total VRAM to report from a stubbed `torch.cuda.mem_get_info()` so the
+#: pre-flight fit check passes on a box with no GPU. Generous on purpose: the
+#: point of these cases is the require_pin wiring, not the VRAM budget.
+_SIMULATED_FREE_VRAM_BYTES = 16_000_000_000
+
+
 class TestAutoTierFallback:
     """`stream_source: auto` (the default) takes RAM when the base fits and
     falls back to the NVMe disk tier when it does not. Driven through the real
@@ -1245,6 +1264,108 @@ class TestAutoTierFallback:
         assert captured["require_pin"] is False
         # The explicit request was announced, not dropped (blocker 1).
         assert any("no CUDA device" in m for m in messages), messages
+
+    def _run_capture(self, tmp_path, monkeypatch, extra_training_yaml):
+        """Drive the real pre-flight and return what a user would SEE.
+
+        The plan notes reach the user inside a ``rich.panel.Panel``, so a
+        recording console that merely stringifies its arguments captures the
+        Panel's object repr and sees none of the note text — a false negative.
+        It has to render through a real ``Console`` writing to a buffer, wide
+        enough that the measured figures are not broken across a wrap."""
+        import io
+
+        from rich.console import Console
+
+        import soup_cli.trainer.stream_setup as ss
+
+        buffer = io.StringIO()
+        monkeypatch.setattr(
+            ss, "console", Console(file=buffer, width=_PANEL_CAPTURE_WIDTH)
+        )
+        self._stub_build_streamed_model(monkeypatch, {})
+        self._run(
+            tmp_path, monkeypatch, free_ram=_RAM_TIER_FREE_BYTES,
+            stream_source="auto", device="cpu",
+            extra_training_yaml=extra_training_yaml,
+        )
+        return buffer.getvalue()
+
+    def test_stream_pin_false_makes_the_preflight_state_the_cost(
+        self, tmp_path, monkeypatch
+    ):
+        """#366 round-3 C1: the VALUE of training.stream_pin must reach the plan,
+        not merely the keyword. Hardcoding `stream_pin=None` (or True/False) at
+        the build_stream_plan call left the whole suite green, because every
+        existing test called build_stream_plan directly and nothing crossed the
+        wiring. Driven end-to-end through the real pre-flight."""
+        out = self._run_capture(tmp_path, monkeypatch, "  stream_pin: false\n")
+        assert _FORCED_PAGEABLE_TEXT in out, out
+        assert _PIN_GAIN_REAL_TEXT in out, out
+
+    def test_unset_stream_pin_does_not_state_a_forced_pageable_cost(
+        self, tmp_path, monkeypatch
+    ):
+        """The control that makes the test above discriminating: without it a
+        mutant that ALWAYS emitted the forced-pageable note would pass."""
+        out = self._run_capture(tmp_path, monkeypatch, "")
+        assert _FORCED_PAGEABLE_TEXT not in out, out
+        assert _PIN_GAIN_REAL_TEXT not in out, out
+
+    def _run_on_simulated_cuda(self, tmp_path, monkeypatch, extra_training_yaml):
+        """Drive the pre-flight down its `on_cuda` branch WITHOUT a GPU.
+
+        `on_cuda` is `str(self.device).startswith("cuda")` — a plain string
+        check — so the branch itself needs no device. Only two things behind it
+        do: the free-VRAM measurement and the allocator hint, both stubbed here.
+        `build_streamed_model` is stubbed too, so nothing ever reaches a kernel.
+
+        Written this way on purpose: gated behind @requires_cuda these two cases
+        would skip on CI, which is exactly where the mutation they exist to kill
+        needs to die."""
+        import torch
+
+        import soup_cli.utils.layer_stream_runtime as rt
+
+        monkeypatch.setattr(
+            torch.cuda, "mem_get_info",
+            lambda *_a, **_k: (_SIMULATED_FREE_VRAM_BYTES, _SIMULATED_FREE_VRAM_BYTES),
+        )
+        # Patched on the SOURCE module, like build_streamed_model above:
+        # stream_setup imports it inside the function.
+        monkeypatch.setattr(
+            rt, "expandable_segments_status", lambda *_a, **_k: (True, "")
+        )
+        captured = {}
+        self._stub_build_streamed_model(monkeypatch, captured)
+        self._run(
+            tmp_path, monkeypatch, free_ram=_RAM_TIER_FREE_BYTES,
+            stream_source="auto", device="cuda",
+            extra_training_yaml=extra_training_yaml,
+        )
+        return captured
+
+    def test_stream_pin_true_reaches_the_runtime_as_true_on_cuda(
+        self, tmp_path, monkeypatch
+    ):
+        """#366 round-3 C3: on CPU `(stream_pin is True) and on_cuda` is False
+        whatever stream_pin holds, so a CPU assertion of `is False` is satisfied
+        identically by the real expression and by a hardcoded constant — it
+        cannot discriminate. This is the case that pins the other half of that
+        conjunction, and therefore the only one that fails when `require_pin` is
+        hardcoded to False."""
+        captured = self._run_on_simulated_cuda(
+            tmp_path, monkeypatch, "  stream_pin: true\n"
+        )
+        assert captured["require_pin"] is True
+
+    def test_unset_stream_pin_reaches_the_runtime_as_false_on_cuda(
+        self, tmp_path, monkeypatch
+    ):
+        """Control for the case above — otherwise a hardcoded `True` would pass
+        and the pair would prove nothing about the value."""
+        captured = self._run_on_simulated_cuda(tmp_path, monkeypatch, "")
+        assert captured["require_pin"] is False
 
     def test_auto_uses_ram_when_the_base_fits(self, tmp_path, monkeypatch):
         wrapper = self._run(
@@ -1453,6 +1574,50 @@ def _write_tiny_tokenizer(weights_dir):
         )
 
 
+class TestRequirePinSurvivesEveryHop:
+    """#366 round-3 C2: `require_pin` crosses two hops between the pre-flight and
+    the source constructor — `build_streamed_model -> install_streaming` and
+    `install_streaming -> _build_source`. Hardcoding `require_pin=False` at
+    EITHER left the whole suite green, because the only refusal test called
+    `_build_source` directly and so jumped over both. These drive the real chain
+    over the existing tiny-checkpoint harness. CPU-only."""
+
+    @staticmethod
+    def _fail_pinning(monkeypatch):
+        """Make page-locking fail the way a box out of pinnable RAM does.
+
+        Subclasses the REAL RamSource rather than replacing it with a stub: the
+        pageable construction has to actually work (the control below streams
+        through it), and `install_streaming` calls `RamSource.spec_from_shard`
+        before ever building a source."""
+        import soup_cli.utils.layer_stream_runtime as rt
+
+        class _FailsWhenPinned(rt.RamSource):
+            def __init__(self, shard_dir, n_layers, spec, *, pin=True):
+                if pin:
+                    raise RuntimeError("CUDA error: cannot allocate pinned memory")
+                super().__init__(shard_dir, n_layers, spec, pin=False)
+
+        monkeypatch.setattr(rt, "RamSource", _FailsWhenPinned)
+
+    def test_forced_pin_refuses_through_the_whole_real_chain(
+        self, tmp_path, monkeypatch
+    ):
+        self._fail_pinning(monkeypatch)
+        with pytest.raises(RuntimeError, match="stream_pin"):
+            _tiny_stream(tmp_path, pin=True, require_pin=True)
+
+    def test_the_same_failure_falls_back_silently_without_the_request(
+        self, tmp_path, monkeypatch
+    ):
+        """The control that makes the case above discriminating: the identical
+        page-lock failure must still fall back when nobody asked for the pin, so
+        the refusal is attributable to the flag and not to the failure."""
+        self._fail_pinning(monkeypatch)
+        _model, runtime, _weights = _tiny_stream(tmp_path, pin=True)
+        assert runtime.stats()["pinned"] is False
+
+
 class TestDiskTierConfig:
     def test_stream_source_disk_is_accepted(self):
         from soup_cli.config.loader import load_config_from_string
@@ -1584,7 +1749,7 @@ def _advice(**kw):
 # ==========================================================================
 def _tiny_stream(
     tmp_path, name="shards", seed=3, n_layers=3, device="cpu", tier="ram",
-    quant="none",
+    quant="none", pin=False, require_pin=False,
 ):
     """A streamed model over a real (tiny) on-disk Llama checkpoint."""
     import torch
@@ -1638,8 +1803,8 @@ def _tiny_stream(
     )
     model, runtime = build_streamed_model(
         model_id=str(weights), shard_dir=shards, index=index, lora_config=lora,
-        device=device, dtype="float32", buffers=2, pin=False, seed=seed,
-        tier=tier, quant=quant,
+        device=device, dtype="float32", buffers=2, pin=pin, seed=seed,
+        tier=tier, quant=quant, require_pin=require_pin,
     )
     return model, runtime, str(weights)
 

--- a/tests/test_v07203.py
+++ b/tests/test_v07203.py
@@ -1189,6 +1189,63 @@ class TestAutoTierFallback:
         wrapper._setup_streaming_transformers(cfg, cfg.training)
         return wrapper
 
+    @staticmethod
+    def _stub_build_streamed_model(monkeypatch, captured, *, tier="ram"):
+        """Intercept build_streamed_model so a CPU-only test can assert what the
+        pre-flight threaded into the runtime, without building a real model.
+
+        Patched on the SOURCE module because stream_setup imports it locally."""
+        from unittest.mock import MagicMock
+
+        import soup_cli.utils.layer_stream_runtime as rt
+
+        def fake_build(**kwargs):
+            captured.update(kwargs)
+            runtime = MagicMock()
+            runtime.tier = tier
+            runtime.stats.return_value = {
+                "tier": tier,
+                "store_bytes": 1_000_000_000,
+                "disk_bytes": 1_000_000_000,
+                "pinned": bool(kwargs.get("require_pin") or kwargs.get("pin")),
+                "buffers": 2,
+                "buffer_bytes": 4_000_000,
+                "n_layers": 2,
+            }
+            return MagicMock(), runtime
+
+        monkeypatch.setattr(rt, "build_streamed_model", fake_build)
+
+    def test_stream_pin_threads_require_pin_into_the_runtime_and_announces_cpu(
+        self, tmp_path, monkeypatch
+    ):
+        """#366 re-review blocker 2: prove the key REACHES the runtime call —
+        `captured` fails with KeyError if the require_pin= argument at
+        stream_setup.py is deleted, which is the mutation that previously left
+        the suite green. And blocker 1: on CPU pinning is inapplicable (no CUDA
+        device), so an explicit stream_pin=true is ANNOUNCED, not silently
+        dropped. CPU-only — build_streamed_model is stubbed."""
+        import soup_cli.trainer.stream_setup as ss
+
+        messages = []
+
+        class _RecordingConsole:
+            def print(self, *args, **_kwargs):
+                messages.append(" ".join(str(a) for a in args))
+
+        monkeypatch.setattr(ss, "console", _RecordingConsole())
+        captured = {}
+        self._stub_build_streamed_model(monkeypatch, captured)
+        self._run(
+            tmp_path, monkeypatch, free_ram=10_000_000_000, stream_source="auto",
+            device="cpu", extra_training_yaml="  stream_pin: true\n",
+        )
+        # The runtime call received require_pin (blocker 2) — False here because
+        # it is gated on a real CUDA device, which is the correct value on CPU.
+        assert captured["require_pin"] is False
+        # The explicit request was announced, not dropped (blocker 1).
+        assert any("no CUDA device" in m for m in messages), messages
+
     def test_auto_uses_ram_when_the_base_fits(self, tmp_path, monkeypatch):
         wrapper = self._run(
             tmp_path, monkeypatch, free_ram=10_000_000_000, stream_source="auto"


### PR DESCRIPTION
## What does this PR do?

Adds `training.stream_pin` so the layer-streaming pin decision is reachable from `soup.yaml`. Fixes #366.

Page-locking the streamed RAM store is chosen automatically by `decide_pinning`, and until now nothing could override it. While #331 was live (NF4 layers above ~165 MiB producing silently wrong gradients), `pin=False` was the *only* known mitigation — and it was measured bit-identical to a resident reference at every size tested — yet a user could not reach it from their config.

- `stream_pin: null` (default) — unchanged automatic behaviour: attempt a pinned store, fall back to pageable and announce the cost when the host cannot page-lock it.
- `stream_pin: false` — force the pageable store. The pre-flight panel states the throughput this costs (up to **6.56x** on Qwen2.5-32B NF4, **7.41x** on a synthetic) rather than absorbing it silently.
- `stream_pin: true` — force the pinned store and **refuse** the run, naming the store size, if the box cannot page-lock it, instead of degrading silently.
- Set while `stream_layers: false` → rejected as a footgun, exactly like the other `stream_*` keys.

The plan-level choice threads through `decide_pinning` / `build_stream_plan`; the runtime refusal threads as `require_pin` through `build_streamed_model → install_streaming → _build_source`.

## Type of change

- [x] New feature

## Test verification (RED → GREEN)

The streaming logic is torch-free at the planner level but the wiring tests drive the real
`build_streamed_model` chain, so the suite below is the full streaming area
(`tests/test_v07200.py` + `tests/test_v07203.py`): **316 passed, 12 skipped** with the
change, against **292 passed, 12 skipped** on `main`. Zero test lines removed.

Because the round-2/3 review established that a passing suite proves little here — an
assertion a hardcoded constant also satisfies cannot discriminate — the RED half is a
**mutation matrix** rather than a single failing run. Each mutation is applied to the
production code and the whole streaming area re-run; every one must fail, and the test it
fails is named:

| Mutation (RED) | Result | Killed by |
|---|---|---|
| `stream_setup.py` `stream_pin=tcfg.stream_pin` → `None` | **KILLED** | `test_stream_pin_false_makes_the_preflight_state_the_cost` |
| `stream_setup.py` `require_pin=(tcfg.stream_pin is True) and on_cuda` → `False` | **KILLED** | `test_stream_pin_true_reaches_the_runtime_as_true_on_cuda` |
| `build_streamed_model → install_streaming` `require_pin` → `False` | **KILLED** | `test_forced_pin_refuses_through_the_whole_real_chain` |
| `install_streaming → _build_source` `require_pin` → `False` | **KILLED** | same |
| delete the disk-tier announcement block | **KILLED** | `test_an_explicit_request_is_announced_not_dropped` |
| drop the `GB` store size from the RAM-tier refusal | **KILLED** | `test_the_refusal_names_the_store_size[64-2.15 GB]` |
| hardcode that store size to `1.07 GB` | **KILLED** | same (the two-size parametrization) |
| revert the forced-on plan note | **KILLED** | `test_stream_pin_true_is_recorded_in_the_plan_notes` |
| drop the RAM-tier restriction on that note | **KILLED** | `test_the_disk_tier_does_not_claim_a_page_locked_store` |

**GREEN** — clean run, same command:

```
tests/test_v07200.py + tests/test_v07203.py
316 passed, 12 skipped
```

## Checklist

- [x] `ruff check src/soup_cli/ tests/` passes (All checks passed!)
- [x] `pytest tests/test_v07200.py -v` streaming classes pass (43 passed for the streaming area, incl. the new tests)
- [x] Updated relevant docs — `docs/performance-and-quantization.md` (config block + footgun list), the `benchmarks/gate-h100-validation.md` note that said no escape hatch existed, and `CHANGELOG.md`

## Full local validation suite

Local replay of the CI job classes this change can affect:

```
== ruff check src/soup_cli/ tests/ (blocking CI job) ==
All checks passed!
== streaming area (tests/test_v07200.py + tests/test_v07203.py) ==
316 passed, 12 skipped        (main: 292 passed, 12 skipped)
== full suite (pytest tests/, repo addopts, --cov-fail-under=77) ==
41 failed, 17883 passed, 274 skipped     (main baseline: 41 failed, 17860 passed)
   -> identical failure identities; all 41 pre-existing and outside the streaming
      area (test_v0712.py x32, test_v0713.py x4, test_semantic_split.py x3,
      test_v07128.py, test_v07129.py). No new failure, +23 passing.
== changed production-line coverage ==
100% (24/24)
```

Not replayable on this box, and named rather than hidden: the windows/macOS matrix cells,
the 3.10/3.12 cells, `mlx-smoke` (needs Apple Silicon), and `actionlint` (needs Go).
