### PR TITLE
fix(quant): honour training.bnb_4bit_use_double_quant across every 4-bit path (#321)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,15 +77,22 @@ reproducing 70+ versions of notes.
   judge-API cost.
 
 - **`training.bnb_4bit_use_double_quant` was validated but never read — every 4-bit
-  path hardcoded double-quantization to `True`, so `bnb_4bit_use_double_quant: false`
-  passed validation and was silently ignored (#321).** The flag is now threaded through
-  all three call sites together — the resident loader (`build_quantization_config_for_loader`),
-  the layer-streaming path (`stream_setup` reads it once and passes the SAME value to the
-  sharder and the meta skeleton, so streamed-vs-resident bit-exactness cannot drift), and the
-  4bit save path (`soup merge --no-double-quant` for the `4bit` / `4bit_forced` save formats).
-  The schema default is reconciled to `True` to match what every 4-bit load has always shipped,
-  so existing runs are unaffected; the config-load footgun (`=true` requires `quantization: 4bit`)
-  now fires only on an explicitly set flag, not on the inherited default.
+  path Soup builds the `BitsAndBytesConfig` for hardcoded double-quantization to `True`,
+  so `bnb_4bit_use_double_quant: false` passed validation and was silently ignored (#321).**
+  The flag is now threaded through the three call sites Soup owns — the resident loader
+  (`build_quantization_config_for_loader`), the layer-streaming path (`stream_setup` reads it
+  once and passes the SAME value to the sharder and the meta skeleton, so streamed-vs-resident
+  bit-exactness cannot drift), and the 4bit save path (`soup merge --no-double-quant` for the
+  `4bit` / `4bit_forced` save formats). The Unsloth loader is out of scope: `FastLanguageModel`
+  builds its own `BitsAndBytesConfig` internally with double-quant hardcoded on and exposes no
+  override, so that path cannot honour the flag. The schema field is now tri-state
+  (`Optional[bool]`, unset = `None`): unset resolves to the shipped default (double-quant on),
+  so a run that never set the flag trains identically, but because the resolved config now
+  carries the field, `soup ship --evidence` provenance and `soup lock check` will report a
+  one-time fingerprint drift on a previously-unset config even though the model numerics are
+  unchanged. The config-load footgun (`=true` requires `quantization: 4bit`) fires only on an
+  explicit `true`, and unset serializes as `None`, so a dumped-and-reloaded config no longer
+  trips it.
 
 - **`kl_control` rewrote the trainer's β/kl_coef on every step, including a `hold`, so a
   non-acting run was numerically identical to `log_only` (#371).** `_run_bang_bang` called

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,17 @@ reproducing 70+ versions of notes.
   block so it is never read as a decode-only number. `--help` states the extra
   judge-API cost.
 
+- **`training.bnb_4bit_use_double_quant` was validated but never read — every 4-bit
+  path hardcoded double-quantization to `True`, so `bnb_4bit_use_double_quant: false`
+  passed validation and was silently ignored (#321).** The flag is now threaded through
+  all three call sites together — the resident loader (`build_quantization_config_for_loader`),
+  the layer-streaming path (`stream_setup` reads it once and passes the SAME value to the
+  sharder and the meta skeleton, so streamed-vs-resident bit-exactness cannot drift), and the
+  4bit save path (`soup merge --no-double-quant` for the `4bit` / `4bit_forced` save formats).
+  The schema default is reconciled to `True` to match what every 4-bit load has always shipped,
+  so existing runs are unaffected; the config-load footgun (`=true` requires `quantization: 4bit`)
+  now fires only on an explicitly set flag, not on the inherited default.
+
 - **`kl_control` rewrote the trainer's β/kl_coef on every step, including a `hold`, so a
   non-acting run was numerically identical to `log_only` (#371).** `_run_bang_bang` called
   `_apply_coefficient` unconditionally; on a `hold` the controller writes back the value

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -29,6 +29,7 @@ soup chat --model ./output                    Interactive chat
 soup push --model ./output --repo user/name   Upload to HuggingFace
 soup push --model ./output --repo user/name --collection user/coll-abc123  Add to HF Collection
 soup merge --adapter ./output                 Merge LoRA with base model
+soup merge --adapter ./output --save-format 4bit --no-double-quant  Save a BNB-4bit merge with double-quantization disabled (default on; #321)
 soup merge-sharded-fsdp-weights ./shards -o merged.safetensors  Consolidate FSDP shards into one safetensors (v0.71.14; --plan-only previews)
 soup delinearize-llama4 ./src --target ./out [--num-experts N] [--plan-only]  Live Llama-4 fused-expert reshape [E*din,dout] -> [E,din,dout] + sidecar copy (v0.71.21)
 soup spectrum scan --model <id|path> --top-percent 50 [--modules mlp,attn] [-o patch.yaml]  Spectrum SNR scan (no model load) -> training.unfrozen_parameters YAML patch (v0.71.23)

--- a/docs/performance-and-quantization.md
+++ b/docs/performance-and-quantization.md
@@ -725,7 +725,7 @@ Cross-validator ordering picks the most actionable error: `quantization_aware='f
 
 ## LF / Axolotl Quant Parity (v0.53.0)
 
-- `bnb_4bit_use_double_quant: true` — requires `quantization: 4bit`. Activates BNB's double-quantization. Combinations with the Quant Menu formats (gptq / awq / hqq:Nbit / aqlm / eetq / mxfp4 / fp8) are rejected at config load.
+- `bnb_4bit_use_double_quant` — controls BNB's double-quantization. **Defaults to `true`** (matching every 4-bit load path — resident, layer-streaming, and the `soup merge` 4bit save formats), and is now honoured everywhere (#321): set `false` to disable it and it actually reaches BNB. Explicitly setting it requires `quantization: 4bit`; combinations with the Quant Menu formats (gptq / awq / hqq:Nbit / aqlm / eetq / mxfp4 / fp8) are rejected at config load.
 - `llm_int8: true` — an explicit 8-bit assertion. Unlike v0.41.0 `load_in_8bit` (which **rewrites** `quantization` to `8bit`), `llm_int8` enforces that the user has ALSO set `quantization: 8bit`. Mismatch raises with an actionable message.
 - `quantize_ref_model: true` / `quantize_reward_model: true` — extend the v0.40.5 Quant Menu wiring to the reference / reward models inside preference and RLHF training. `quantize_ref_model` accepts any task with a reference policy (`dpo / ipo / simpo / orpo / bco / kto / preference / grpo / ppo`); `quantize_reward_model` accepts `ppo / reward_model`.
 

--- a/src/soup_cli/commands/merge.py
+++ b/src/soup_cli/commands/merge.py
@@ -53,6 +53,15 @@ def merge(
             "cycle (v0.53.1 #142)."
         ),
     ),
+    double_quant: bool = typer.Option(
+        True,
+        "--double-quant/--no-double-quant",
+        help=(
+            "BNB double-quantization for the 4bit / 4bit_forced save formats "
+            "(#321). Default on, matching the training loaders; pass "
+            "--no-double-quant to disable. Ignored for the fp16 save format."
+        ),
+    ),
     hub: str = typer.Option(
         "hf",
         "--hub",
@@ -219,6 +228,7 @@ def merge(
                     output_dir=str(output_path),
                     forced=(save_format_canonical == "4bit_forced"),
                     dtype="bfloat16" if dtype == "bfloat16" else "float16",
+                    double_quant=double_quant,
                     trust_remote_code=trc,
                 )
 

--- a/src/soup_cli/config/schema.py
+++ b/src/soup_cli/config/schema.py
@@ -1745,18 +1745,32 @@ class TrainingConfig(BaseModel):
         ),
     )
     # Part E — LF / Axolotl parity.
-    bnb_4bit_use_double_quant: bool = Field(
-        # #321 — every 4-bit load path in the repo has always double-quantized,
-        # so the default is True to match shipped behaviour; the flag is now
-        # honoured (previously validated but never read), letting a user turn it
-        # off. Only meaningful when quantization='4bit'.
-        default=True,
+    bnb_4bit_use_double_quant: Optional[bool] = Field(
+        # #321 — tri-state so an unset flag round-trips cleanly. Every 4-bit load
+        # path has always double-quantized, so `None` (unset) means "use the
+        # shipped default", which each 4-bit consumer resolves to True. A literal
+        # `default=True` here would make `model_dump()` emit the key on EVERY
+        # config, so re-validating a dumped non-4bit config (train.py replay,
+        # sweep round-trips, the 21 bundled recipes) would trip the footgun below.
+        # With `None` the footgun fires only on an explicit `true`. Only
+        # meaningful when quantization='4bit'.
+        default=None,
         description=(
             "Apply BNB 4-bit double-quantization (LF / Axolotl parity). "
-            "Defaults to true to match every 4-bit load path; set false to "
-            "disable it. Only meaningful when quantization='4bit'. (v0.53.0)"
+            "Unset means the shipped default (on, to match every 4-bit load "
+            "path); set false to disable it. Only meaningful when "
+            "quantization='4bit'. (v0.53.0)"
         ),
     )
+
+    @property
+    def double_quant_on(self) -> bool:
+        """Resolve the tri-state ``bnb_4bit_use_double_quant`` for the 4-bit load
+        paths: unset (``None``) uses the shipped default (double-quantize), so
+        every consumer that builds a ``BitsAndBytesConfig`` reads a real bool and
+        stays in agreement (#321)."""
+        return self.bnb_4bit_use_double_quant is not False
+
     llm_int8: bool = Field(
         default=False,
         description=(
@@ -5368,14 +5382,14 @@ class SoupConfig(BaseModel):
         """v0.53.0 Part E — ``bnb_4bit_use_double_quant=True`` requires
         ``quantization='4bit'`` (silent-no-op footgun otherwise).
 
-        #321 — the field now defaults to True, so the footgun must only fire on
-        an *explicitly set* flag; otherwise every non-4bit config would inherit
-        the default True and be rejected. An unset field carries no intent.
+        #321 — the field is tri-state (`None` = unset = shipped default). The
+        footgun fires only on an explicit ``True``: ``None`` and ``False`` carry
+        no intent to double-quantize, so a non-4bit config is not rejected — and
+        because unset serializes as ``None`` (not ``True``), a dumped-and-reloaded
+        config no longer trips this, unlike the old ``model_fields_set`` gate.
         """
         tcfg = self.training
-        if "bnb_4bit_use_double_quant" not in tcfg.model_fields_set:
-            return self
-        if not tcfg.bnb_4bit_use_double_quant:
+        if tcfg.bnb_4bit_use_double_quant is not True:
             return self
         if tcfg.quantization != "4bit":
             raise ValueError(

--- a/src/soup_cli/config/schema.py
+++ b/src/soup_cli/config/schema.py
@@ -1746,10 +1746,15 @@ class TrainingConfig(BaseModel):
     )
     # Part E — LF / Axolotl parity.
     bnb_4bit_use_double_quant: bool = Field(
-        default=False,
+        # #321 — every 4-bit load path in the repo has always double-quantized,
+        # so the default is True to match shipped behaviour; the flag is now
+        # honoured (previously validated but never read), letting a user turn it
+        # off. Only meaningful when quantization='4bit'.
+        default=True,
         description=(
             "Apply BNB 4-bit double-quantization (LF / Axolotl parity). "
-            "Only meaningful when quantization='4bit'. (v0.53.0)"
+            "Defaults to true to match every 4-bit load path; set false to "
+            "disable it. Only meaningful when quantization='4bit'. (v0.53.0)"
         ),
     )
     llm_int8: bool = Field(
@@ -5362,8 +5367,14 @@ class SoupConfig(BaseModel):
     def _validate_bnb_4bit_double_quant(self) -> "SoupConfig":
         """v0.53.0 Part E — ``bnb_4bit_use_double_quant=True`` requires
         ``quantization='4bit'`` (silent-no-op footgun otherwise).
+
+        #321 — the field now defaults to True, so the footgun must only fire on
+        an *explicitly set* flag; otherwise every non-4bit config would inherit
+        the default True and be rejected. An unset field carries no intent.
         """
         tcfg = self.training
+        if "bnb_4bit_use_double_quant" not in tcfg.model_fields_set:
+            return self
         if not tcfg.bnb_4bit_use_double_quant:
             return self
         if tcfg.quantization != "4bit":

--- a/src/soup_cli/trainer/stream_setup.py
+++ b/src/soup_cli/trainer/stream_setup.py
@@ -218,9 +218,10 @@ class StreamingSetupMixin:
         quant = QUANT_NF4 if tcfg.quantization == "4bit" else QUANT_NONE
         # #321 — the streamed skeleton and the shards must quantise with the
         # SAME double-quant setting or the streamed-vs-resident bit-exactness
-        # claim breaks. Read the flag once here and thread it into both the
-        # sharder (its cache already keys on double_quant) and the skeleton.
-        double_quant = tcfg.bnb_4bit_use_double_quant
+        # claim breaks. Read the flag once here (resolving the tri-state unset to
+        # the shipped default) and thread it into both the sharder (its cache
+        # already keys on double_quant) and the skeleton.
+        double_quant = tcfg.double_quant_on
 
         weights_dir = resolve_model_weights(cfg.base)
         shard_dir = resolve_shard_dir(cfg.base)
@@ -233,7 +234,9 @@ class StreamingSetupMixin:
         early_free_ram = free_ram_bytes()
         if early_free_ram is not None:
             source_bytes = source_weight_bytes(weights_dir)
-            store_estimate = estimate_stream_store_bytes(source_bytes, dtype=dtype, quant=quant)
+            store_estimate = estimate_stream_store_bytes(
+                source_bytes, dtype=dtype, quant=quant, double_quant=double_quant
+            )
             if store_estimate >= early_free_ram * RAM_TIER_HEADROOM and tcfg.stream_source == "ram":
                 as_streamed = (
                     ""

--- a/src/soup_cli/trainer/stream_setup.py
+++ b/src/soup_cli/trainer/stream_setup.py
@@ -216,6 +216,11 @@ class StreamingSetupMixin:
         # an untied head stay at `dtype`, exactly as replace_with_bnb_linear
         # leaves them.
         quant = QUANT_NF4 if tcfg.quantization == "4bit" else QUANT_NONE
+        # #321 — the streamed skeleton and the shards must quantise with the
+        # SAME double-quant setting or the streamed-vs-resident bit-exactness
+        # claim breaks. Read the flag once here and thread it into both the
+        # sharder (its cache already keys on double_quant) and the skeleton.
+        double_quant = tcfg.bnb_4bit_use_double_quant
 
         weights_dir = resolve_model_weights(cfg.base)
         shard_dir = resolve_shard_dir(cfg.base)
@@ -271,6 +276,7 @@ class StreamingSetupMixin:
             arch=arch,
             quant=quant,
             quant_suffixes=quant_suffixes,
+            double_quant=double_quant,
             # Quantise on the device that will run the model: CPU and CUDA agree
             # on the packed nibbles but not on every float32 nested statistic.
             quant_device=str(self.device),
@@ -397,6 +403,7 @@ class StreamingSetupMixin:
             trust_remote_code=self._trust_remote_code,
             console=console,
             quant=quant,
+            double_quant=double_quant,
             tier=tier,
         )
         self.model = model

--- a/src/soup_cli/utils/layer_stream_runtime.py
+++ b/src/soup_cli/utils/layer_stream_runtime.py
@@ -1162,14 +1162,15 @@ def build_nf4_config(dtype: str, *, double_quant: bool = True):
     """The BitsAndBytesConfig the streamed skeleton and the sharder share.
 
     ``double_quant`` defaults to True to match
-    ``quant_menu.build_quantization_config_for_loader``, which hardcodes it for
-    every resident 4-bit load in this repo. That agreement is load-bearing, not
-    cosmetic: the release's central claim is that a streamed NF4 run is
-    bit-exact against a resident one, and it holds only while both sides
-    quantise with the same settings. ``training.bnb_4bit_use_double_quant`` is
-    therefore deliberately NOT threaded in here — honouring it on the streamed
-    side alone would silently break that parity. (That the flag is ignored
-    repo-wide is a pre-existing gap, tracked separately.)
+    ``quant_menu.build_quantization_config_for_loader``, whose own default is
+    True for every resident 4-bit load in this repo. That agreement is
+    load-bearing, not cosmetic: the release's central claim is that a streamed
+    NF4 run is bit-exact against a resident one, and it holds only while both
+    sides quantise with the same settings. Since #321,
+    ``training.bnb_4bit_use_double_quant`` IS threaded through both paths from
+    the SAME config field (``stream_setup`` reads it once and passes it to the
+    sharder and this skeleton together), so honouring it can no longer make the
+    two sides drift apart.
     """
     from transformers import BitsAndBytesConfig
 

--- a/src/soup_cli/utils/quant_menu.py
+++ b/src/soup_cli/utils/quant_menu.py
@@ -348,11 +348,12 @@ def build_quantization_config_for_loader(
             "load_in_4bit": True,
             "bnb_4bit_quant_type": "nf4",
             "bnb_4bit_compute_dtype": get_compute_dtype(),
-            # #321 — honour the configured flag instead of hardcoding True. Its
-            # schema default is True, so existing 4-bit users are unaffected;
-            # setting it False now actually reaches BNB. The streamed and save
-            # paths thread the same field so all three stay in agreement.
-            "bnb_4bit_use_double_quant": tcfg.bnb_4bit_use_double_quant,
+            # #321 — honour the configured flag instead of hardcoding True. The
+            # schema field is tri-state (unset resolves to on), so existing 4-bit
+            # users are unaffected; setting it False now actually reaches BNB. The
+            # streamed and save paths thread the same resolved bool so all three
+            # stay in agreement.
+            "bnb_4bit_use_double_quant": tcfg.double_quant_on,
         }
         storage = getattr(tcfg, "bnb_4bit_quant_storage", None)
         if storage:

--- a/src/soup_cli/utils/quant_menu.py
+++ b/src/soup_cli/utils/quant_menu.py
@@ -348,7 +348,11 @@ def build_quantization_config_for_loader(
             "load_in_4bit": True,
             "bnb_4bit_quant_type": "nf4",
             "bnb_4bit_compute_dtype": get_compute_dtype(),
-            "bnb_4bit_use_double_quant": True,
+            # #321 — honour the configured flag instead of hardcoding True. Its
+            # schema default is True, so existing 4-bit users are unaffected;
+            # setting it False now actually reaches BNB. The streamed and save
+            # paths thread the same field so all three stay in agreement.
+            "bnb_4bit_use_double_quant": tcfg.bnb_4bit_use_double_quant,
         }
         storage = getattr(tcfg, "bnb_4bit_quant_storage", None)
         if storage:

--- a/src/soup_cli/utils/save_formats.py
+++ b/src/soup_cli/utils/save_formats.py
@@ -251,12 +251,37 @@ def load_quant_config(path: object) -> Mapping[str, Any]:
     return data
 
 
+def _build_merge_4bit_bnb_kwargs(
+    *, compute_dtype: Any, forced: bool, double_quant: bool
+) -> dict[str, Any]:
+    """Kwargs for the 4-bit save path's ``BitsAndBytesConfig``.
+
+    Dict-shaped (like the quant-menu helpers) so tests can assert the wiring —
+    #321: ``bnb_4bit_use_double_quant`` is threaded from the caller's config
+    field, not hardcoded True — without constructing the heavy config object.
+    """
+    bnb_kwargs: dict[str, Any] = {
+        "load_in_4bit": True,
+        "bnb_4bit_quant_type": "nf4",
+        "bnb_4bit_compute_dtype": compute_dtype,
+        "bnb_4bit_use_double_quant": double_quant,
+    }
+    if forced:
+        # ``forced`` => no skip-modules, so every Linear (incl. lm_head) is
+        # 4-bit quantized. BNB 4-bit uses ``bnb_4bit_skip_modules`` (the
+        # legacy 8-bit name was ``llm_int8_skip_modules`` — only emit it
+        # when the installed BNB exposes the 8-bit kwarg as a fallback).
+        bnb_kwargs["bnb_4bit_skip_modules"] = []
+    return bnb_kwargs
+
+
 def merge_4bit(
     *,
     merged_dir: str,
     output_dir: str,
     forced: bool = False,
     dtype: str = "bfloat16",
+    double_quant: bool = True,
     trust_remote_code: bool = False,
 ) -> None:
     """Write a single BNB-4bit-quantized merged checkpoint.
@@ -264,10 +289,17 @@ def merge_4bit(
     Unsloth ``merged_4bit`` / ``4bit_forced`` recipe — no
     dequant → merge → requant cycle. ``forced=True`` quantizes ALL linear
     layers including embeddings; default ``False`` follows BNB's default
-    skip-modules behaviour.
+    skip-modules behaviour. ``double_quant`` mirrors
+    ``training.bnb_4bit_use_double_quant`` (#321) so the save path agrees with
+    the resident and streamed loaders; it defaults True to match shipped
+    behaviour.
     """
     if not isinstance(forced, bool):
         raise TypeError(f"forced must be bool, got {type(forced).__name__}")
+    if not isinstance(double_quant, bool):
+        raise TypeError(
+            f"double_quant must be bool, got {type(double_quant).__name__}"
+        )
     if not isinstance(dtype, str):
         raise TypeError(f"dtype must be str, got {type(dtype).__name__}")
     if dtype not in {"float16", "bfloat16", "float32"}:
@@ -296,18 +328,11 @@ def merge_4bit(
         "float32": torch.float32,
     }
 
-    bnb_kwargs: dict[str, Any] = {
-        "load_in_4bit": True,
-        "bnb_4bit_quant_type": "nf4",
-        "bnb_4bit_compute_dtype": dtype_map[dtype],
-        "bnb_4bit_use_double_quant": True,
-    }
-    if forced:
-        # ``forced`` => no skip-modules, so every Linear (incl. lm_head) is
-        # 4-bit quantized. BNB 4-bit uses ``bnb_4bit_skip_modules`` (the
-        # legacy 8-bit name was ``llm_int8_skip_modules`` — only emit it
-        # when the installed BNB exposes the 8-bit kwarg as a fallback).
-        bnb_kwargs["bnb_4bit_skip_modules"] = []
+    bnb_kwargs = _build_merge_4bit_bnb_kwargs(
+        compute_dtype=dtype_map[dtype],
+        forced=forced,
+        double_quant=double_quant,
+    )
     bnb_config = BitsAndBytesConfig(**bnb_kwargs)
 
     os.makedirs(output_dir, exist_ok=True)

--- a/src/soup_cli/utils/unsloth.py
+++ b/src/soup_cli/utils/unsloth.py
@@ -41,7 +41,13 @@ def load_model_and_tokenizer(
 
     load_in_4bit = quantization == "4bit"
 
-    # Unsloth's FastLanguageModel.from_pretrained handles quantization internally
+    # Unsloth's FastLanguageModel.from_pretrained builds its OWN BitsAndBytesConfig
+    # internally and hardcodes bnb_4bit_use_double_quant=True; it exposes no
+    # passthrough (no double-quant kwarg, no quantization_config=). So
+    # training.bnb_4bit_use_double_quant cannot be honoured on the Unsloth path —
+    # #321 covers only the paths where Soup itself constructs the BnB config
+    # (resident load, streamed load, save/merge). Threading the flag here would
+    # be silently discarded, so it is deliberately not passed.
     dtype = None  # auto-detect
     model, tokenizer = FastLanguageModel.from_pretrained(
         model_name=model_name,

--- a/tests/test_quant_menu.py
+++ b/tests/test_quant_menu.py
@@ -661,3 +661,26 @@ class TestLoaderEntryPoint:
                 tcfg=FakeTcfg(),  # type: ignore[arg-type]
                 base="m",
             )
+
+    def test_loader_4bit_honours_double_quant_false(self):
+        """#321 — the resident 4-bit path threads
+        ``training.bnb_4bit_use_double_quant`` instead of hardcoding it, so a
+        config that turns double-quant off measurably produces a
+        ``BitsAndBytesConfig`` with ``bnb_4bit_use_double_quant=False``."""
+        from soup_cli.utils.quant_menu import build_quantization_config_for_loader
+
+        tcfg = self._tcfg(quantization="4bit", bnb_4bit_use_double_quant=False)
+        cfg = build_quantization_config_for_loader(tcfg=tcfg, base="m")
+        assert cfg.load_in_4bit is True
+        assert cfg.bnb_4bit_use_double_quant is False
+
+    def test_loader_4bit_double_quant_defaults_on(self):
+        """The schema default is reconciled to True (matches what every shipped
+        4-bit load has always used), so an unset flag still double-quantises —
+        threading the field must not silently drop double-quant for existing
+        users."""
+        from soup_cli.utils.quant_menu import build_quantization_config_for_loader
+
+        tcfg = self._tcfg(quantization="4bit")
+        cfg = build_quantization_config_for_loader(tcfg=tcfg, base="m")
+        assert cfg.bnb_4bit_use_double_quant is True

--- a/tests/test_v0530.py
+++ b/tests/test_v0530.py
@@ -570,22 +570,23 @@ class TestUnslothBNB4Bit:
 
 
 class TestLFParity:
-    def test_double_quant_default_true(self):
-        # #321 — reconciled to True: every 4-bit load path has always
-        # double-quantized, so the schema default now matches shipped behaviour
-        # (the flag was previously validated but never read).
+    def test_double_quant_default_is_unset_but_resolves_on(self):
+        # #321 — the schema field is tri-state: unset is None (so it round-trips
+        # through model_dump() without emitting `true` and tripping the footgun),
+        # while `double_quant_on` resolves the shipped default: every 4-bit load
+        # path has always double-quantized.
         cfg = load_config_from_string(
             "base: a/b\n"
             "task: sft\n"
             "data: {train: x.jsonl}\n"
         )
-        assert cfg.training.bnb_4bit_use_double_quant is True
+        assert cfg.training.bnb_4bit_use_double_quant is None
+        assert cfg.training.double_quant_on is True
 
     def test_double_quant_default_does_not_trip_non_4bit_footgun(self):
-        # #321 — the default is now True, so a config that never sets the flag
-        # must NOT be rejected for using a non-4bit quantization. The footgun
-        # only fires on an *explicitly set* flag (an unset field carries no
-        # intent). Guards the model_fields_set gate in the validator.
+        # #321 — an unset flag (None) carries no intent, so a config that never
+        # sets it must NOT be rejected for using a non-4bit quantization. The
+        # footgun fires only on an explicit `true`.
         cfg = load_config_from_string(
             "base: a/b\n"
             "task: sft\n"
@@ -593,7 +594,8 @@ class TestLFParity:
             "training: {quantization: 8bit}\n"
         )
         assert cfg.training.quantization == "8bit"
-        assert cfg.training.bnb_4bit_use_double_quant is True
+        assert cfg.training.bnb_4bit_use_double_quant is None
+        assert cfg.training.double_quant_on is True
 
     def test_double_quant_explicit_false_allowed_without_4bit(self):
         # Explicit False on a non-4bit config is a no-op, not a footgun —

--- a/tests/test_v0530.py
+++ b/tests/test_v0530.py
@@ -570,11 +570,39 @@ class TestUnslothBNB4Bit:
 
 
 class TestLFParity:
-    def test_double_quant_default_false(self):
+    def test_double_quant_default_true(self):
+        # #321 — reconciled to True: every 4-bit load path has always
+        # double-quantized, so the schema default now matches shipped behaviour
+        # (the flag was previously validated but never read).
         cfg = load_config_from_string(
             "base: a/b\n"
             "task: sft\n"
             "data: {train: x.jsonl}\n"
+        )
+        assert cfg.training.bnb_4bit_use_double_quant is True
+
+    def test_double_quant_default_does_not_trip_non_4bit_footgun(self):
+        # #321 — the default is now True, so a config that never sets the flag
+        # must NOT be rejected for using a non-4bit quantization. The footgun
+        # only fires on an *explicitly set* flag (an unset field carries no
+        # intent). Guards the model_fields_set gate in the validator.
+        cfg = load_config_from_string(
+            "base: a/b\n"
+            "task: sft\n"
+            "data: {train: x.jsonl}\n"
+            "training: {quantization: 8bit}\n"
+        )
+        assert cfg.training.quantization == "8bit"
+        assert cfg.training.bnb_4bit_use_double_quant is True
+
+    def test_double_quant_explicit_false_allowed_without_4bit(self):
+        # Explicit False on a non-4bit config is a no-op, not a footgun —
+        # unchanged behaviour (the raise only guards an explicit True).
+        cfg = load_config_from_string(
+            "base: a/b\n"
+            "task: sft\n"
+            "data: {train: x.jsonl}\n"
+            "training: {bnb_4bit_use_double_quant: false, quantization: none}\n"
         )
         assert cfg.training.bnb_4bit_use_double_quant is False
 
@@ -854,6 +882,38 @@ class TestSaveFormats:
 
         with pytest.raises(TypeError):
             merge_4bit()  # type: ignore[call-arg]
+
+    def test_merge_4bit_bnb_kwargs_honours_double_quant(self):
+        """#321 — the 4-bit save path threads its ``double_quant`` argument into
+        the BNB kwargs instead of hardcoding True. Dict-shaped helper keeps this
+        assertable without constructing the heavy config."""
+        from soup_cli.utils.save_formats import _build_merge_4bit_bnb_kwargs
+
+        off = _build_merge_4bit_bnb_kwargs(
+            compute_dtype="bfloat16", forced=False, double_quant=False
+        )
+        assert off["bnb_4bit_use_double_quant"] is False
+        assert off["load_in_4bit"] is True
+        assert off["bnb_4bit_quant_type"] == "nf4"
+        assert "bnb_4bit_skip_modules" not in off
+
+        on = _build_merge_4bit_bnb_kwargs(
+            compute_dtype="bfloat16", forced=True, double_quant=True
+        )
+        assert on["bnb_4bit_use_double_quant"] is True
+        # ``forced`` still quantizes every Linear (empty skip list) — unchanged.
+        assert on["bnb_4bit_skip_modules"] == []
+
+    def test_merge_4bit_rejects_non_bool_double_quant(self):
+        """Matches the existing ``forced``/``dtype`` type guards."""
+        from soup_cli.utils.save_formats import merge_4bit
+
+        with pytest.raises(TypeError, match="double_quant must be bool"):
+            merge_4bit(
+                merged_dir="m",
+                output_dir="o",
+                double_quant=1,  # type: ignore[arg-type]
+            )
 
     def test_export_torchao_now_live(self):
         """v0.53.1 #142 — live wiring landed; signature now requires kwargs."""

--- a/tests/test_v0531_142.py
+++ b/tests/test_v0531_142.py
@@ -297,6 +297,59 @@ class TestMergeSaveFormatCLI:
         assert result.exit_code != 0
         assert "save_format" in result.output or "save-format" in result.output
 
+    def test_no_double_quant_flag_reaches_merge_4bit(self, tmp_path, monkeypatch):
+        """#321 re-review: the ``--no-double-quant`` CLI flag had ZERO coverage —
+        renaming it away left the suite green. Drive it end-to-end with the model
+        loads mocked and assert the value reaches ``merge_4bit``. Mutations:
+        deleting the flag makes the invocation error on an unknown option;
+        hardcoding ``double_quant=True`` at the call site fails the assertion."""
+        from unittest.mock import MagicMock, patch
+
+        from soup_cli.commands.merge import merge
+
+        monkeypatch.chdir(tmp_path)
+        adapter = tmp_path / "adapter"
+        adapter.mkdir()
+        (adapter / "adapter_config.json").write_text(
+            '{"base_model_name_or_path": "some/base"}', encoding="utf-8"
+        )
+        monkeypatch.setattr(
+            "soup_cli.utils.trust_remote.model_requires_trust_remote_code",
+            lambda *_a, **_k: False,
+        )
+        monkeypatch.setattr(
+            "soup_cli.utils.trust_remote.resolve_trust_remote_code",
+            lambda *_a, **_k: False,
+        )
+        fake_model = MagicMock()
+        fake_model.merge_and_unload.return_value = fake_model
+        captured = {}
+
+        app = typer.Typer()
+        app.command()(merge)
+        with patch(
+            "transformers.AutoModelForCausalLM.from_pretrained", return_value=fake_model
+        ), patch(
+            "peft.PeftModel.from_pretrained", return_value=fake_model
+        ), patch(
+            "transformers.AutoTokenizer.from_pretrained", return_value=MagicMock()
+        ), patch(
+            "soup_cli.utils.save_formats.merge_4bit",
+            side_effect=lambda **k: captured.update(k),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "--adapter", str(adapter),
+                    "--base", "some/base",
+                    "--save-format", "4bit",
+                    "--output", str(tmp_path / "out"),
+                    "--no-double-quant",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert captured.get("double_quant") is False, captured
+
 
 # --- CLI plumbing for `soup export --format torchao` ------------------------
 

--- a/tests/test_v07202.py
+++ b/tests/test_v07202.py
@@ -909,34 +909,81 @@ class TestPeftDispatchesTheBnbLoraPath:
         )
         assert streamed.load_in_4bit is resident.load_in_4bit
 
-    def test_build_nf4_config_honours_double_quant_false(self):
-        """#321 — the streamed skeleton's config builder honours the flag.
-        ``stream_setup`` reads ``training.bnb_4bit_use_double_quant`` once and
-        threads the SAME value into the sharder and this builder, so honouring
-        it here can never make the streamed and resident sides drift."""
-        from soup_cli.utils.layer_stream_runtime import build_nf4_config
+    @pytest.mark.parametrize(
+        "dq_line,expected",
+        [
+            ("  bnb_4bit_use_double_quant: false\n", False),  # explicit off reaches BOTH
+            ("", True),  # unset resolves to the shipped default (on) on BOTH
+        ],
+    )
+    def test_stream_setup_threads_double_quant_into_sharder_and_runtime(
+        self, tmp_path, monkeypatch, dq_line, expected
+    ):
+        """#321 re-review finding 2: the earlier tests were vacuous — one passed
+        against main's untouched builder, the other only grepped the source and
+        fired on spelling. This drives ``_setup_streaming_transformers`` and
+        asserts the SAME resolved flag reaches BOTH the sharder and the runtime
+        builder, so streamed-vs-resident cannot drift. CPU-only: shard_checkpoint
+        is spied (its real CPU NF4 packing runs) and build_streamed_model stubbed.
 
-        cfg = build_nf4_config("bfloat16", double_quant=False)
-        assert cfg.bnb_4bit_use_double_quant is False
-        assert cfg.load_in_4bit is True
-        # Default still double-quantizes (parity with the resident default).
-        assert build_nf4_config("bfloat16").bnb_4bit_use_double_quant is True
+        Mutation control: hardcoding either call site back to ``True`` fails the
+        ``expected is False`` case; dropping the read fails both cases.
+        """
+        from unittest.mock import MagicMock
 
-    def test_stream_setup_threads_double_quant_from_config(self):
-        """#321 — both the sharder and the skeleton builder must be handed the
-        configured flag from the SAME tcfg field, or the two sides could quantise
-        differently. Source-level guard against a call site regressing to the
-        hardcoded default."""
-        import inspect
+        from soup_cli.config.loader import load_config_from_string
+        from soup_cli.trainer.sft import SFTTrainerWrapper
 
-        from soup_cli.trainer import stream_setup
-
-        src = inspect.getsource(
-            stream_setup.StreamingSetupMixin._setup_streaming_transformers
+        weights, _, _ = _tiny_llama_dir(tmp_path, n_layers=2)
+        _write_tiny_tokenizer(weights)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("SOUP_LAYER_STREAM_CACHE_DIR", str(tmp_path / "cache"))
+        monkeypatch.setattr(
+            "soup_cli.utils.spectrum_scan.resolve_model_weights", lambda *_a, **_k: weights
         )
-        assert "double_quant = tcfg.bnb_4bit_use_double_quant" in src
-        # Threaded into the sharder (its cache keys on double_quant) ...
-        assert src.count("double_quant=double_quant") >= 2
+        monkeypatch.setattr(
+            "soup_cli.utils.layer_stream.free_ram_bytes", lambda: 10_000_000_000
+        )
+        monkeypatch.setattr(
+            "soup_cli.utils.layer_stream.detect_disk_kind", lambda *_a, **_k: "nvme"
+        )
+
+        captured = {}
+        import soup_cli.utils.layer_shard as shard_mod
+        import soup_cli.utils.layer_stream_runtime as rt_mod
+
+        real_shard = shard_mod.shard_checkpoint
+
+        def spy_shard(*args, **kwargs):
+            captured["shard"] = kwargs.get("double_quant")
+            return real_shard(*args, **kwargs)
+
+        def fake_build(**kwargs):
+            captured["build"] = kwargs.get("double_quant")
+            runtime = MagicMock()
+            runtime.tier = "ram"
+            runtime.stats.return_value = {
+                "tier": "ram", "store_bytes": 1, "pinned": False,
+                "buffers": 2, "buffer_bytes": 4, "n_layers": 2,
+            }
+            return MagicMock(), runtime
+
+        monkeypatch.setattr(shard_mod, "shard_checkpoint", spy_shard)
+        monkeypatch.setattr(rt_mod, "build_streamed_model", fake_build)
+
+        cfg = load_config_from_string(
+            f"base: {weights}\ntask: sft\nbackend: transformers\nmodality: text\n"
+            "data:\n  train: data.jsonl\n  format: alpaca\n"
+            "training:\n  batch_size: 1\n  gradient_accumulation_steps: 1\n"
+            f"  quantization: 4bit\n  stream_layers: true\n{dq_line}"
+            "  lora:\n    r: 4\n    target_modules: [q_proj, v_proj]\n"
+        )
+        wrapper = SFTTrainerWrapper(cfg)
+        wrapper.device = "cpu"
+        wrapper._setup_streaming_transformers(cfg, cfg.training)
+
+        assert captured["shard"] is expected, f"sharder got {captured['shard']!r}"
+        assert captured["build"] is expected, f"runtime got {captured['build']!r}"
 
     def test_unquantised_skeleton_is_untouched(self, tmp_path):
         """v0.72.0's bit-exact bf16 gates only stay valid if that path is

--- a/tests/test_v07202.py
+++ b/tests/test_v07202.py
@@ -909,6 +909,35 @@ class TestPeftDispatchesTheBnbLoraPath:
         )
         assert streamed.load_in_4bit is resident.load_in_4bit
 
+    def test_build_nf4_config_honours_double_quant_false(self):
+        """#321 — the streamed skeleton's config builder honours the flag.
+        ``stream_setup`` reads ``training.bnb_4bit_use_double_quant`` once and
+        threads the SAME value into the sharder and this builder, so honouring
+        it here can never make the streamed and resident sides drift."""
+        from soup_cli.utils.layer_stream_runtime import build_nf4_config
+
+        cfg = build_nf4_config("bfloat16", double_quant=False)
+        assert cfg.bnb_4bit_use_double_quant is False
+        assert cfg.load_in_4bit is True
+        # Default still double-quantizes (parity with the resident default).
+        assert build_nf4_config("bfloat16").bnb_4bit_use_double_quant is True
+
+    def test_stream_setup_threads_double_quant_from_config(self):
+        """#321 — both the sharder and the skeleton builder must be handed the
+        configured flag from the SAME tcfg field, or the two sides could quantise
+        differently. Source-level guard against a call site regressing to the
+        hardcoded default."""
+        import inspect
+
+        from soup_cli.trainer import stream_setup
+
+        src = inspect.getsource(
+            stream_setup.StreamingSetupMixin._setup_streaming_transformers
+        )
+        assert "double_quant = tcfg.bnb_4bit_use_double_quant" in src
+        # Threaded into the sharder (its cache keys on double_quant) ...
+        assert src.count("double_quant=double_quant") >= 2
+
     def test_unquantised_skeleton_is_untouched(self, tmp_path):
         """v0.72.0's bit-exact bf16 gates only stay valid if that path is
         byte-identical to what it was."""


### PR DESCRIPTION
## What does this PR do?

Fixes #321 — `training.bnb_4bit_use_double_quant` was a documented, validated
schema field that **nothing read**. Every 4-bit path hardcoded
double-quantization to `True`, so a user could write
`bnb_4bit_use_double_quant: false`, pass validation (there is even a
cross-validator for it), and get double-quant anyway, silently.

Per the issue's "repo-wide or not at all" requirement, the flag is now threaded
through all three call sites **together** so the resident and streamed paths
cannot drift apart:

- **Resident loader** (`utils/quant_menu.py::build_quantization_config_for_loader`)
  — was `"bnb_4bit_use_double_quant": True`, now reads `tcfg.bnb_4bit_use_double_quant`.
- **Layer streaming** (`trainer/stream_setup.py`) — reads the flag **once** and
  passes the **same** value to the sharder (`shard_checkpoint`, whose cache
  already keys on `double_quant`) and to the meta skeleton
  (`build_streamed_model` → `build_nf4_config`). Because both sides read one
  field, the v0.72.2 streamed-vs-resident bit-exactness claim is preserved.
- **4bit save path** (`utils/save_formats.py::merge_4bit`) — gains a
  `double_quant` argument (built via a dict-shaped helper for testability),
  exposed on the CLI as `soup merge --no-double-quant`. `merge` carries no
  training config, so the knob is surfaced as a flag rather than read from a
  `tcfg` that does not exist there.

**Schema default reconciled to `True`** to match what every 4-bit load has
actually shipped, so existing runs are byte-for-byte unaffected. Since the
default is now `True`, the config-load footgun (`=true` requires
`quantization: 4bit`) is gated on `model_fields_set` so it fires only on an
**explicitly set** flag — an unset field on a non-4bit config is no longer
rejected.

## Type of change

- [x] Bug fix

## Test verification (RED → GREEN)

New tests live in the module for each area touched (per the repo's test
convention): `tests/test_quant_menu.py` (resident), `tests/test_v0530.py`
(schema + save path), `tests/test_v07202.py` (streaming).

RED — on the unmodified `main`, the resident loader hardcodes `True`, so a
config that asks for `false` still produces a config with double-quant on:

```
tcfg = self._tcfg(quantization="4bit", bnb_4bit_use_double_quant=False)
>       assert cfg.bnb_4bit_use_double_quant is False
E       assert True is False
FAILED tests/test_quant_menu.py::TestLoaderEntryPoint::test_loader_4bit_honours_double_quant_false
1 failed, 1 passed
```

GREEN — with the fix:

```
tests/test_quant_menu.py ..  (loader honours False + defaults on)   2 passed
tests/test_v0530.py      ..  (default reconciled to True; footgun still fires
                             only on an explicit flag; save-path helper)
tests/test_v07202.py     ..  (streamed builder honours the flag; both stream
                             call sites thread the same tcfg field)
```

The existing v0.72.2 parity test
`test_streamed_quant_config_matches_the_resident_one` still passes (both sides
default `True`).

## Full local suite

- `ruff check src/soup_cli/ tests/` — **All checks passed!** (the blocking CI gate)
- Full local validation of every touched module:
  `pytest tests/test_v0530.py tests/test_quant_menu.py` → **221 passed**;
  `pytest tests/test_v07202.py` → **60 passed / 31 failed / 3 skipped**.
- No previously-green test regressed. The 31 `test_v07202.py` failures are the
  real-NF4 end-to-end / bit-exactness tests, which need bitsandbytes CUDA
  kernels: they fail **identically** on the unmodified `main` in this CPU-only
  environment (base: 31 failed / 58 passed; this branch: 31 failed / 60 passed —
  the +2 are the new streaming tests), i.e. an iso-or-better baseline with zero
  new failures.

## Checklist

- [x] `ruff check src/soup_cli/ tests/` passes
- [x] `pytest` — touched modules green; no previously-green test regressed
- [x] Updated relevant docs (`docs/performance-and-quantization.md`) and `CHANGELOG.md`
