### PR TITLE
fix(eval): measure the leg-1 noise floor in the judge task modes (#403)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ reproducing 70+ versions of notes.
 
 ### Fixed
 
+- **`soup ship --noise-floor` now measures the leg-1 task axis in the judge modes,
+  so a judge-scored win smaller than the judge's own noise no longer counts (#403).**
+  The floor was measured in `--task-mode metric` only; `judge_score` / `pairwise`
+  printed a warning and left leg 1 at a 0.0 floor, i.e. the exact blindness the flag
+  exists to remove. It is now measured: `judge_score` scores the base side N times
+  through the judge, and `pairwise` judges the base model against itself (expected
+  win-rate 0.5, so the spread is directly measured, not inferred). Because those
+  repeats fold in the judge's own sampling noise, the floor is labelled
+  `decode + judge` on the panel and stamped `judge_inclusive` in the evidence/JSON
+  block so it is never read as a decode-only number. `--help` states the extra
+  judge-API cost.
+
 - **`kl_control` rewrote the trainer's β/kl_coef on every step, including a `hold`, so a
   non-acting run was numerically identical to `log_only` (#371).** `_run_bang_bang` called
   `_apply_coefficient` unconditionally; on a `hold` the controller writes back the value

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -178,7 +178,7 @@ soup ship ... --general-suite mmlu,gsm8k --baseline base.json  lm-eval leg-2 ove
 soup ship ... --emit-evidence ev.json  Re-serialise the scores as replayable --evidence input (output-is-input, #312) (v0.71.39)
 soup ship ... --config soup.yaml  Read eval.ship gate defaults; --evidence GATES on provenance, --emit-evidence STAMPS it (v0.71.39)
 soup ship ... --push owner/repo#N  Post the verdict as a GitHub PR comment (best-effort; never flips the exit code) (v0.71.39)
-soup ship ... --noise-floor N [--task-mode metric]  Re-run base model N times; per-axis floor = max-min spread; gate at max(threshold, floor); leg-1 metric-only (v0.73.2)
+soup ship ... --noise-floor N  Re-run base model N times; per-axis floor = max-min spread; gate at max(threshold, floor); leg-1 measured in every --task-mode (judge modes cost N judge passes, floor labelled decode+judge) (v0.73.2)
 soup card <registry-id> -o MODELCARD.md       HF model card from a registry entry: training config, evals, hashes, lineage, artifacts (v0.71.35)
 soup push --model ./out --repo you/m --card <registry-id>  Upload that registry-driven card as the README (HF only) (v0.71.35)
 soup ci init [--data d.jsonl --suite s.yaml --evidence ev.json] [--config soup.yaml] [--branch main --python 3.11] [--force]  Write .github/workflows/soup-gate.yml: data validate -> expect -> ship gate on every PR (v0.71.35); --config binds the gate to a committed config so it refuses stale evidence (v0.71.39)

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -428,11 +428,15 @@ actually measurable; a floor *below* it must never tighten the gate behind your 
 exceeds `--forgetting-threshold`, the run says so by name — that axis is now gated looser than you
 asked.
 
-**Scope and cost.** The leg-1 floor is measured in `--task-mode metric` **only**: in the judge modes
-a repeat would fold the judge's own sampling noise into a number presented as decode noise, so the
-run warns and leaves leg 1 at a 0.0 floor instead. Costs N extra base passes. Rejected with
-`--evidence` (there is nothing to re-run) — though a floor *recorded in* an evidence file is still
-applied.
+**Scope and cost.** The leg-1 floor is measured in **every** `--task-mode`. In `metric` it re-runs
+the offline scorer (decode-only noise). In `judge_score` the base side is scored N times through the
+judge; in `pairwise` the base model is judged against **itself** (expected win-rate 0.5 by
+construction, so the observed spread is a directly measured quantity rather than an inference). The
+two judge modes fold the judge's own sampling noise into the number, so that floor is labelled
+**decode + judge** on the panel and stamped `judge_inclusive` in the evidence/JSON — a reader must
+not mistake it for the leg-2 axes' decode-only floors. Cost: N extra base passes, and in the judge
+modes N × the judge API calls. Rejected with `--evidence` (there is nothing to re-run) — though a
+floor *recorded in* an evidence file is still applied.
 
 **Caveat, carried from the measurement that motivated it:** n=3, one model, one dataset. The floor
 **sizes** the effect; it does **not** calibrate a threshold, and nothing establishes what N is

--- a/src/soup_cli/commands/ship.py
+++ b/src/soup_cli/commands/ship.py
@@ -482,12 +482,16 @@ def _leg1_metric(
     return build_task_win("metric", base_acc, tuned_acc)
 
 
-def _leg1_judge(
-    base_gen: Callable[[str], str],
-    tuned_gen: Callable[[str], str],
-    task_eval: str,
-    judge_model: str,
-) -> TaskWin:
+def _build_judge_scorer(
+    task_eval: str, judge_model: str
+) -> Callable[[Callable[[str], str]], float]:
+    """A ``score(gen) -> [0, 1]`` scorer for one side of a judge_score leg.
+
+    Lifted out of ``_leg1_judge`` (was an inner closure) so the base side can be
+    scored on its own N times for the noise floor without also scoring the tuned
+    side (#403). The tasks are loaded and the evaluator built once, then reused
+    across every call.
+    """
     from soup_cli.eval.custom import load_eval_tasks
     from soup_cli.eval.gate import _parse_judge_url
     from soup_cli.eval.judge import JudgeEvaluator
@@ -524,7 +528,47 @@ def _leg1_judge(
         )
         return max(0.0, min(1.0, (overall - scale_min) / span))
 
-    return build_task_win("judge_score", _score(base_gen), _score(tuned_gen))
+    return _score
+
+
+def _leg1_judge(
+    base_gen: Callable[[str], str],
+    tuned_gen: Callable[[str], str],
+    task_eval: str,
+    judge_model: str,
+) -> TaskWin:
+    score = _build_judge_scorer(task_eval, judge_model)
+    return build_task_win("judge_score", score(base_gen), score(tuned_gen))
+
+
+def _build_pairwise_scorer(
+    task_eval: str, judge_model: str
+) -> Callable[[Callable[[str], str], Callable[[str], str]], float]:
+    """A ``winrate(gen_a, gen_b) -> [0, 1]`` scorer for a pairwise leg (#284).
+
+    Factored out of ``_leg1_pairwise`` so the noise floor can measure the base
+    model judged against ITSELF (``winrate(base_gen, base_gen)``), whose expected
+    value is 0.5 by construction — its spread over repeats is the combined
+    decode + judge noise, directly measured rather than inferred (#403). Tasks
+    and evaluator are built once and reused.
+    """
+    from soup_cli.eval.custom import load_eval_tasks
+    from soup_cli.eval.gate import _parse_judge_url
+    from soup_cli.eval.judge import JudgeEvaluator, pairwise_winrate
+
+    tasks = load_eval_tasks(task_eval)
+    if not tasks:
+        raise ValueError(f"task-eval file {task_eval!r} has no tasks")
+    provider, model, api_base = _parse_judge_url(judge_model)
+    evaluator = JudgeEvaluator(provider=provider, model=model, api_base=api_base)
+
+    def _winrate(
+        gen_a: Callable[[str], str], gen_b: Callable[[str], str]
+    ) -> float:
+        pairs = [(t.prompt, gen_a(t.prompt), gen_b(t.prompt)) for t in tasks]
+        return pairwise_winrate(pairs, evaluator)
+
+    return _winrate
 
 
 def _leg1_pairwise(
@@ -539,18 +583,8 @@ def _leg1_pairwise(
     which is better (swap-debiased). The tuned win-rate becomes leg 1, framed as
     ``TaskWin(base=0.5 coin-flip, tuned=win-rate)`` so ``won <=> win-rate > 0.5``.
     """
-    from soup_cli.eval.custom import load_eval_tasks
-    from soup_cli.eval.gate import _parse_judge_url
-    from soup_cli.eval.judge import JudgeEvaluator, pairwise_winrate
-
-    tasks = load_eval_tasks(task_eval)
-    if not tasks:
-        raise ValueError(f"task-eval file {task_eval!r} has no tasks")
-    provider, model, api_base = _parse_judge_url(judge_model)
-    evaluator = JudgeEvaluator(provider=provider, model=model, api_base=api_base)
-    pairs = [(t.prompt, base_gen(t.prompt), tuned_gen(t.prompt)) for t in tasks]
-    winrate = pairwise_winrate(pairs, evaluator)
-    return build_task_win("pairwise", 0.5, winrate)
+    winrate = _build_pairwise_scorer(task_eval, judge_model)
+    return build_task_win("pairwise", 0.5, winrate(base_gen, tuned_gen))
 
 
 def _extract_lm_score(bench_data: Mapping[str, object]) -> Optional[float]:
@@ -698,6 +732,57 @@ def _leg2_scores(
     return base_map, tuned_map
 
 
+def _build_task_floor_scorer(
+    task_mode: str,
+    base_gen: Callable[[str], str],
+    *,
+    base_id: str,
+    task_eval: str,
+    judge_model: Optional[str],
+) -> Callable[[], float]:
+    """A ``() -> float`` closure scoring the BASE side's leg-1 task axis once.
+
+    Built once (tasks / evaluator resolved a single time) and called per
+    noise-floor repeat so the spread reflects run-to-run variance, not setup.
+    The judge modes require a judge model; its presence is validated upstream in
+    ``_verdict_live``, so a missing one here is a programming error.
+    """
+    if task_mode == "metric":
+        from soup_cli.eval.custom import load_eval_tasks, run_eval
+
+        tasks = load_eval_tasks(task_eval)
+        if not tasks:
+            raise ValueError(f"task-eval file {task_eval!r} has no tasks")
+
+        def _metric_score() -> float:
+            return run_eval(base_id, tasks, generate_fn=base_gen).accuracy
+
+        return _metric_score
+
+    if not judge_model:
+        raise ValueError(f"--task-mode {task_mode} needs a judge model")
+
+    if task_mode == "judge_score":
+        judge_scorer = _build_judge_scorer(task_eval, judge_model)
+
+        def _judge_score() -> float:
+            return judge_scorer(base_gen)
+
+        return _judge_score
+
+    if task_mode == "pairwise":
+        pairwise_scorer = _build_pairwise_scorer(task_eval, judge_model)
+
+        def _pairwise_score() -> float:
+            # The base judged against itself: expected 0.5 by construction, so
+            # the spread over repeats is the combined decode + judge noise (#403).
+            return pairwise_scorer(base_gen, base_gen)
+
+        return _pairwise_score
+
+    raise ValueError(f"unknown task mode {task_mode!r}")
+
+
 def _measure_noise_floor(
     runs: int,
     suite_names: List[str],
@@ -706,6 +791,7 @@ def _measure_noise_floor(
     base_id: str,
     task_mode: str,
     task_eval: str,
+    judge_model: Optional[str],
     forgetting_threshold: float,
 ) -> NoiseFloor:
     """Re-run the BASE model ``runs`` times and return the measured spread.
@@ -716,12 +802,19 @@ def _measure_noise_floor(
     in that session sat inside the floor, so the gate was calling differences
     it could not resolve.
 
-    Coverage is deliberately partial and says so. Leg-2 axes are always
-    measured. The leg-1 task axis is measured **only in ``metric`` mode** — the
-    one leg-1 path that is offline and judge-free. In ``judge_score`` /
-    ``pairwise`` the repeats would fold the judge's own sampling noise into a
-    number presented as decode noise, which is publishing an inference as a
-    mechanism; the caller is warned instead and leg 1 keeps a 0.0 floor.
+    Leg-2 axes are always measured (decode-only). The leg-1 task axis is now
+    measured in every mode (#403):
+
+    - ``metric``: the offline scorer, re-run — decode-only noise.
+    - ``judge_score``: the base side scored N times through the judge.
+    - ``pairwise``: the base model judged against ITSELF, whose expected
+      win-rate is 0.5 by construction, so the spread is a directly measured
+      quantity, not an inference.
+
+    In the two judge modes the spread folds the judge's own sampling noise into
+    the number, so the returned floor is stamped ``judge_inclusive`` and never
+    presented as decode-only. That is why a judge-scored win smaller than the
+    judge's own noise no longer counts.
 
     A ``--baseline`` file is deliberately NOT consulted here even though the
     verdict path uses one: a stored number is not a repeat of this instrument,
@@ -736,14 +829,15 @@ def _measure_noise_floor(
             "[yellow]Warning:[/] --noise-floor measures bundled suites only; "
             f"no floor for {escape(', '.join(sorted(skipped)))}"
         )
-    measure_task = task_mode == "metric"
-    if not measure_task:
-        console.print(
-            f"[yellow]Warning:[/] --noise-floor does not measure the leg-1 task "
-            f"axis in --task-mode {escape(task_mode)} (a judge-backed repeat "
-            "would report the judge's sampling noise as decode noise); leg 1 "
-            "keeps a 0.0 floor."
-        )
+
+    judge_inclusive = task_mode in ("judge_score", "pairwise")
+    task_score = _build_task_floor_scorer(
+        task_mode,
+        base_gen,
+        base_id=base_id,
+        task_eval=task_eval,
+        judge_model=judge_model,
+    )
 
     samples: List[Dict[str, float]] = []
     for index in range(runs):
@@ -751,18 +845,10 @@ def _measure_noise_floor(
         run: Dict[str, float] = {}
         for name in bundled:
             run[name] = score_bundled_suite(name, base_gen)
-        if measure_task:
-            from soup_cli.eval.custom import load_eval_tasks, run_eval
-
-            tasks = load_eval_tasks(task_eval)
-            if not tasks:
-                raise ValueError(f"task-eval file {task_eval!r} has no tasks")
-            run[TASK_AXIS] = run_eval(
-                base_id, tasks, generate_fn=base_gen
-            ).accuracy
+        run[TASK_AXIS] = task_score()
         samples.append(run)
 
-    floor = compute_noise_floor(samples)
+    floor = compute_noise_floor(samples, judge_inclusive=judge_inclusive)
     if floor.floors and all(value == 0.0 for _name, value in floor.floors):
         console.print(
             "[dim]noise floor: every axis repeated exactly — this instrument "
@@ -866,6 +952,19 @@ def _verdict_live(
     tuned_id = tuned if tuned else base
     try:
         base_gen, tuned_gen = _resolve_generators(base, tuned, adapter, device)
+        # Judge modes need a judge model. Validate it BEFORE measuring the
+        # noise floor, which now scores the leg-1 task axis through the judge as
+        # well (#403) — a missing / malformed judge is a usage error (exit 2),
+        # not a runtime one discovered mid-measurement.
+        if task_mode == "judge_score":
+            if not judge_model:
+                _fail("--task-mode judge_score needs --judge-model <url>", _EXIT_USAGE)
+            _validate_judge_model_url(judge_model)
+        elif task_mode == "pairwise":
+            if not judge_model:
+                _fail("--task-mode pairwise needs --judge-model <url>", _EXIT_USAGE)
+            _validate_judge_model_url(judge_model)
+
         measured_floor: Optional[NoiseFloor] = None
         if noise_floor_runs is not None:
             measured_floor = _measure_noise_floor(
@@ -875,17 +974,12 @@ def _verdict_live(
                 base_id=base,
                 task_mode=task_mode,
                 task_eval=task_eval,
+                judge_model=judge_model,
                 forgetting_threshold=forgetting_threshold,
             )
         if task_mode == "judge_score":
-            if not judge_model:
-                _fail("--task-mode judge_score needs --judge-model <url>", _EXIT_USAGE)
-            _validate_judge_model_url(judge_model)
             task_win = _leg1_judge(base_gen, tuned_gen, task_eval, judge_model)
         elif task_mode == "pairwise":
-            if not judge_model:
-                _fail("--task-mode pairwise needs --judge-model <url>", _EXIT_USAGE)
-            _validate_judge_model_url(judge_model)
             task_win = _leg1_pairwise(base_gen, tuned_gen, task_eval, judge_model)
         else:
             task_win = _leg1_metric(base_gen, tuned_gen, base, tuned_id, task_eval)
@@ -1019,7 +1113,9 @@ def ship(
             f"{MAX_NOISE_FLOOR_RUNS}) to measure what this instrument can "
             "resolve, print it beside the verdict, and refuse to call any "
             "delta smaller than the measured floor significant. Costs N extra "
-            "base passes. Leg-1 floor is measured in --task-mode metric only."
+            "base passes. The leg-1 task floor is measured in every --task-mode; "
+            "in judge_score / pairwise each repeat is N extra JUDGE passes "
+            "(N x the judge API calls), and the floor is labelled decode + judge."
         ),
     ),
     judge_model: Optional[str] = typer.Option(

--- a/src/soup_cli/utils/ship_verdict.py
+++ b/src/soup_cli/utils/ship_verdict.py
@@ -160,10 +160,19 @@ class NoiseFloor:
     ``max - min`` of that axis's score across the repeats. A tuple of pairs
     rather than a dict so the dataclass stays genuinely immutable, mirroring
     ``ShipVerdict.benchmark_deltas``.
+
+    ``judge_inclusive`` marks the leg-1 task axis (``TASK_AXIS``) floor as
+    combined decode + judge noise rather than decode-only. It is set for
+    ``--task-mode judge_score`` / ``pairwise``, where the repeats fold the
+    judge's own sampling noise into the spread (#403). The leg-2 axes are always
+    decode-only, so this flag scopes to the one axis that can carry judge noise;
+    a reader must not mistake a judge-inclusive floor for a decode-only one.
+    Defaults ``False`` so the metric-mode path stays byte-identical.
     """
 
     runs: int
     floors: Tuple[Tuple[str, float], ...]
+    judge_inclusive: bool = False
 
     def of(self, axis: str) -> float:
         """This axis's measured floor, or ``0.0`` if it was never measured.
@@ -234,13 +243,18 @@ def _is_regressed(base: float, tuned: float, threshold: float) -> bool:
 # Builders (pure)
 # ---------------------------------------------------------------------------
 
-def compute_noise_floor(runs: Sequence[Mapping[str, object]]) -> NoiseFloor:
+def compute_noise_floor(
+    runs: Sequence[Mapping[str, object]], *, judge_inclusive: bool = False
+) -> NoiseFloor:
     """Measure the instrument's resolution from repeated BASE-model runs.
 
     Each element of ``runs`` is one ``{axis: score}`` map from an independent
     repeat of the same unchanged model. The floor of an axis is the spread
     (``max - min``) across those repeats — anything smaller than that is
     something this instrument cannot distinguish from itself.
+
+    ``judge_inclusive`` stamps the result as combined decode + judge noise (the
+    leg-1 task axis was measured through a judge); see ``NoiseFloor``.
 
     Refuses fewer than two runs (one sample has no spread, and reporting 0.0
     would present an unmeasured floor as a measured one) and refuses a ragged
@@ -272,7 +286,11 @@ def compute_noise_floor(runs: Sequence[Mapping[str, object]]) -> NoiseFloor:
             for run in runs_list
         ]
         floors.append((str(axis), round(max(values) - min(values), _DELTA_ROUND)))
-    return NoiseFloor(runs=len(runs_list), floors=tuple(floors))
+    return NoiseFloor(
+        runs=len(runs_list),
+        floors=tuple(floors),
+        judge_inclusive=judge_inclusive,
+    )
 
 
 def _floor_of(noise_floor: Optional[NoiseFloor], axis: str) -> float:
@@ -612,7 +630,17 @@ def _render_noise_floor(floor: NoiseFloor) -> Table:
     table.add_column("Floor", justify="right")
     if floor.floors:
         for name, value in floor.floors:
-            label = "leg 1 task" if name == TASK_AXIS else name
+            if name == TASK_AXIS:
+                # A judge-inclusive floor mixes decode noise with the judge's
+                # own sampling noise; say so, so it is never read as the
+                # decode-only number the leg-2 axes report (#403).
+                label = (
+                    "leg 1 task (decode + judge)"
+                    if floor.judge_inclusive
+                    else "leg 1 task"
+                )
+            else:
+                label = name
             table.add_row(escape(for_terminal(label)), f"{value:.4f}")
     else:
         table.add_row("[dim](none measured)[/]", "-")
@@ -694,10 +722,16 @@ def verdict_to_evidence(
     # could return the opposite decision. #312's property is that the output is
     # replayable as input, so the floor is part of the evidence, not decoration.
     if verdict.noise_floor is not None:
-        evidence["noise_floor"] = {
+        floor_block: Dict[str, object] = {
             "runs": verdict.noise_floor.runs,
             "floors": verdict.noise_floor.as_dict(),
         }
+        # Emitted only when True so a decode-only floor round-trips byte-for-byte
+        # (every pre-#403 evidence file). A judge-inclusive floor must carry the
+        # marker or the reader would replay it as decode-only.
+        if verdict.noise_floor.judge_inclusive:
+            floor_block["judge_inclusive"] = True
+        evidence["noise_floor"] = floor_block
     if provenance is not None:
         if not isinstance(provenance, Mapping):
             raise TypeError("provenance must be a mapping")
@@ -753,7 +787,12 @@ def noise_floor_from_evidence(payload: object) -> Optional[NoiseFloor]:
         if not (0.0 <= value <= 1.0):
             raise ValueError("a noise floor must be in [0.0, 1.0]")
         floors.append((name, value))
-    return NoiseFloor(runs=runs, floors=tuple(floors))
+    judge_inclusive = payload.get("judge_inclusive", False)
+    if not isinstance(judge_inclusive, bool):
+        raise ValueError("evidence.noise_floor.judge_inclusive must be a boolean")
+    return NoiseFloor(
+        runs=runs, floors=tuple(floors), judge_inclusive=judge_inclusive
+    )
 
 
 def floor_exceeds_threshold(
@@ -806,6 +845,9 @@ def verdict_to_dict(verdict: ShipVerdict) -> Dict[str, object]:
             else {
                 "runs": verdict.noise_floor.runs,
                 "floors": verdict.noise_floor.as_dict(),
+                # Always present so a programmatic reader can tell a judge-
+                # inclusive floor from a decode-only one without inference (#403).
+                "judge_inclusive": verdict.noise_floor.judge_inclusive,
             }
         ),
     }

--- a/tests/test_v07302.py
+++ b/tests/test_v07302.py
@@ -1165,10 +1165,25 @@ class TestStaleBaselineIsAnnounced:
         assert "Warning" not in _plain(capsys.readouterr().out)
 
 
+def _const_task_scorer(monkeypatch, value=0.5):
+    """Pin the leg-1 task-axis scorer to a constant.
+
+    Since #403 the task axis is measured in every mode (judge modes score it
+    through a live judge). A test that only cares about the leg-2 / warning
+    paths pins the task scorer here so it needs no judge, and the task axis
+    contributes a flat 0.0 spread.
+    """
+    monkeypatch.setattr(
+        "soup_cli.commands.ship._build_task_floor_scorer",
+        lambda *args, **kwargs: (lambda: value),
+    )
+
+
 class TestTheFloorWideningTheThresholdIsAnnounced:
-    def test_a_floor_above_the_threshold_warns(self, capsys):
+    def test_a_floor_above_the_threshold_warns(self, capsys, monkeypatch):
         from soup_cli.commands.ship import _measure_noise_floor
 
+        _const_task_scorer(monkeypatch)
         # The two repeats must genuinely disagree. An every-other-call flip does
         # NOT do that: mini_mmlu has an EVEN number of items, so the second
         # pass starts on the same parity and reproduces the first exactly —
@@ -1182,18 +1197,21 @@ class TestTheFloorWideningTheThresholdIsAnnounced:
 
         _measure_noise_floor(
             2, ["mini_mmlu"], gen, base_id="b", task_mode="judge_score",
-            task_eval="unused.jsonl", forgetting_threshold=0.0,
+            task_eval="unused.jsonl", judge_model="ollama://j",
+            forgetting_threshold=0.0,
         )
         out = _plain(capsys.readouterr().out)
         assert "exceeds" in out and "--forgetting-threshold" in out
 
-    def test_a_deterministic_instrument_does_not_warn(self, capsys):
+    def test_a_deterministic_instrument_does_not_warn(self, capsys, monkeypatch):
         """CONTROL. A zero floor never widens anything."""
         from soup_cli.commands.ship import _measure_noise_floor
 
+        _const_task_scorer(monkeypatch)
         floor = _measure_noise_floor(
             2, ["mini_mmlu"], lambda p: "B", base_id="b", task_mode="judge_score",
-            task_eval="unused.jsonl", forgetting_threshold=0.0,
+            task_eval="unused.jsonl", judge_model="ollama://j",
+            forgetting_threshold=0.0,
         )
         out = _plain(capsys.readouterr().out)
         assert all(value == 0.0 for _n, value in floor.floors)
@@ -1508,44 +1526,159 @@ class TestMeasureNoiseFloorBranches:
         )
         floor = _measure_noise_floor(
             2, ["mini_mmlu"], lambda p: "hi B", base_id="b", task_mode="metric",
-            task_eval="task.jsonl", forgetting_threshold=0.05,
+            task_eval="task.jsonl", judge_model=None, forgetting_threshold=0.05,
         )
         assert TASK_AXIS in dict(floor.floors)
+        # Metric mode is decode-only — the floor must NOT be stamped judge.
+        assert floor.judge_inclusive is False
 
-    def test_judge_mode_skips_the_leg_one_axis_and_says_so(self, capsys):
+    def test_judge_mode_measures_the_leg_one_axis(self, capsys, monkeypatch):
+        """#403 — judge modes now measure the task axis instead of warning and
+        leaving it at a 0.0 floor. Base RED: the old code skipped it."""
         from soup_cli.commands.ship import _measure_noise_floor
         from soup_cli.utils.ship_verdict import TASK_AXIS
 
+        _const_task_scorer(monkeypatch, value=0.5)
         floor = _measure_noise_floor(
             2, ["mini_mmlu"], lambda p: "B", base_id="b", task_mode="judge_score",
-            task_eval="unused.jsonl", forgetting_threshold=0.05,
+            task_eval="unused.jsonl", judge_model="ollama://j",
+            forgetting_threshold=0.05,
         )
-        assert TASK_AXIS not in dict(floor.floors)
+        assert TASK_AXIS in dict(floor.floors)
+        assert floor.judge_inclusive is True
         out = _plain(capsys.readouterr().out)
-        assert "does not measure the leg-1 task axis" in out
+        assert "does not measure the leg-1 task axis" not in out
 
-    def test_a_non_bundled_suite_is_reported_as_unmeasured(self, capsys):
+    def test_a_non_bundled_suite_is_reported_as_unmeasured(self, capsys, monkeypatch):
         """A silently-skipped axis reads as 'floor 0.0', i.e. as a measurement
         that was never taken."""
         from soup_cli.commands.ship import _measure_noise_floor
 
+        _const_task_scorer(monkeypatch)
         floor = _measure_noise_floor(
             2, ["mini_mmlu", "hellaswag"], lambda p: "B", base_id="b",
             task_mode="judge_score", task_eval="unused.jsonl",
-            forgetting_threshold=0.05,
+            judge_model="ollama://j", forgetting_threshold=0.05,
         )
         assert "hellaswag" not in dict(floor.floors)
         out = _plain(capsys.readouterr().out)
         assert "bundled suites only" in out and "hellaswag" in out
 
-    def test_a_deterministic_instrument_says_so(self, capsys):
+    def test_a_deterministic_instrument_says_so(self, capsys, monkeypatch):
         from soup_cli.commands.ship import _measure_noise_floor
 
+        _const_task_scorer(monkeypatch)
         _measure_noise_floor(
             2, ["mini_mmlu"], lambda p: "B", base_id="b", task_mode="judge_score",
-            task_eval="unused.jsonl", forgetting_threshold=0.05,
+            task_eval="unused.jsonl", judge_model="ollama://j",
+            forgetting_threshold=0.05,
         )
         assert "deterministic" in _plain(capsys.readouterr().out)
+
+
+class TestNoiseFloorJudgeModes:
+    """#403 — the leg-1 task floor is measured in the judge modes too, and the
+    result is stamped so it is never read as a decode-only number."""
+
+    def test_pairwise_floor_measures_the_base_against_itself(self, monkeypatch):
+        from soup_cli.commands import ship as ship_mod
+        from soup_cli.commands.ship import _measure_noise_floor
+        from soup_cli.utils.ship_verdict import TASK_AXIS
+
+        spread = iter([0.4, 0.6])
+
+        def fake_pairwise(task_eval, judge_model):
+            def winrate(gen_a, gen_b):
+                # The maintainer's design: the base judged against ITSELF.
+                assert gen_a is gen_b
+                return next(spread)
+
+            return winrate
+
+        monkeypatch.setattr(ship_mod, "_build_pairwise_scorer", fake_pairwise)
+        floor = _measure_noise_floor(
+            2, [], lambda p: "x", base_id="b", task_mode="pairwise",
+            task_eval="t.jsonl", judge_model="ollama://j",
+            forgetting_threshold=0.05,
+        )
+        assert floor.of(TASK_AXIS) == pytest.approx(0.2, abs=1e-9)
+        assert floor.judge_inclusive is True
+
+    def test_judge_score_floor_measures_the_base_side(self, monkeypatch):
+        from soup_cli.commands import ship as ship_mod
+        from soup_cli.commands.ship import _measure_noise_floor
+        from soup_cli.utils.ship_verdict import TASK_AXIS
+
+        spread = iter([0.3, 0.5])
+
+        def fake_judge(task_eval, judge_model):
+            return lambda gen: next(spread)
+
+        monkeypatch.setattr(ship_mod, "_build_judge_scorer", fake_judge)
+        floor = _measure_noise_floor(
+            2, [], lambda p: "x", base_id="b", task_mode="judge_score",
+            task_eval="t.jsonl", judge_model="ollama://j",
+            forgetting_threshold=0.05,
+        )
+        assert floor.of(TASK_AXIS) == pytest.approx(0.2, abs=1e-9)
+        assert floor.judge_inclusive is True
+
+    def test_a_judge_floor_is_never_read_as_decode_only(self):
+        """CONTROL (crit 3 + 5). A judge-inclusive floor is labelled and stamped
+        on every surface; a decode-only floor is not — a reader can always tell
+        them apart, so the judge floor is never silently reused as decode noise.
+        """
+        from io import StringIO
+
+        from rich.console import Console
+
+        from soup_cli.utils.ship_verdict import (
+            TASK_AXIS,
+            NoiseFloor,
+            ShipVerdict,
+            _render_noise_floor,
+            build_task_win,
+            noise_floor_from_evidence,
+            verdict_to_dict,
+            verdict_to_evidence,
+        )
+
+        judge = NoiseFloor(runs=3, floors=((TASK_AXIS, 0.2),), judge_inclusive=True)
+        decode = NoiseFloor(runs=3, floors=((TASK_AXIS, 0.2),), judge_inclusive=False)
+
+        def _table(floor):
+            buf = StringIO()
+            Console(file=buf, width=120, no_color=True).print(_render_noise_floor(floor))
+            return buf.getvalue()
+
+        # Panel label.
+        assert "decode + judge" in _table(judge)
+        assert "decode + judge" not in _table(decode)
+        assert "leg 1 task" in _table(decode)
+
+        def _verdict(floor):
+            return ShipVerdict(
+                decision="SHIP",
+                task_win=build_task_win("pairwise", 0.5, 0.7),
+                benchmark_deltas=(),
+                failed_rule=None,
+                forgetting_threshold=0.05,
+                soup_version="x",
+                noise_floor=floor,
+            )
+
+        # verdict_to_dict always carries the marker.
+        assert verdict_to_dict(_verdict(judge))["noise_floor"]["judge_inclusive"] is True
+        assert verdict_to_dict(_verdict(decode))["noise_floor"]["judge_inclusive"] is False
+
+        # Evidence stamps it only when True (a decode-only floor round-trips
+        # byte-for-byte), and it round-trips back through the reader.
+        ev_judge = verdict_to_evidence(_verdict(judge))["noise_floor"]
+        ev_decode = verdict_to_evidence(_verdict(decode))["noise_floor"]
+        assert ev_judge["judge_inclusive"] is True
+        assert "judge_inclusive" not in ev_decode
+        assert noise_floor_from_evidence(ev_judge).judge_inclusive is True
+        assert noise_floor_from_evidence(ev_decode).judge_inclusive is False
 
 
 class TestBuildMcqPrompt:
@@ -1630,6 +1763,9 @@ class TestNoiseFloorCliFlag:
         assert result.exit_code == 0, (result.output, repr(result.exception))
         plain = _plain(result.output)
         assert "--noise-floor" in plain
+        # #403 crit 4 — the judge modes cost N extra JUDGE passes; the help must
+        # say so. "JUDGE" (a single upper-case token) survives Rich line-wrap.
+        assert "JUDGE" in plain
 
     @pytest.mark.parametrize("bad", ["1", "0", "-3", "11"])
     def test_out_of_range_is_a_usage_error(self, bad, tmp_path):


### PR DESCRIPTION
## What does this PR do?

Fix #403 — `soup ship --noise-floor N` measured the leg-1 task axis **only** in
`--task-mode metric`. In `judge_score` and `pairwise` it printed a warning and
left leg 1 at a `0.0` floor, so a judge-scored win smaller than the judge's own
sampling noise still counted — the exact blindness the flag exists to remove,
on precisely the two modes (open-ended generation) where run-to-run variance is
largest.

The leg-1 task floor is now measured in **every** mode, following the
maintainer's proposed fix path:

- **`pairwise`** — the base model is judged against **itself**
  (`_build_pairwise_scorer` → `winrate(base_gen, base_gen)`). Its expected value
  is `0.5` by construction, so the spread over repeats is a *directly measured*
  combined decode + judge noise, not an inference.
- **`judge_score`** — the inner `_score(gen)` closure of `_leg1_judge` is lifted
  to a module-level `_build_judge_scorer`, so the base side is scored N times on
  its own.

Because the judge repeats fold in the judge's own sampling noise, the floor is
stamped `NoiseFloor.judge_inclusive`: it is labelled **`decode + judge`** on the
panel and in `verdict_to_dict` / the evidence block, so a reader can never
mistake it for the leg-2 axes' decode-only floors. The floor is still keyed
`__task__`, so `decide_ship` widens leg-1 against it automatically. `--help`
now states the extra judge-API cost.

**Backward compatible:** `judge_inclusive` defaults `False` and is emitted into
evidence *only when True*, so every pre-existing (metric / decode-only) evidence
file round-trips byte-for-byte; an unstamped floor reads back as `False`.

## Type of change

- [x] Bug fix

## Checklist

- [x] `ruff check src/soup_cli/ tests/` passes
- [x] `pytest tests/ -v` passes (torch-free area module `tests/test_v07302.py`: 178 pass)
- [x] Updated relevant docs (`docs/evaluation.md`, `docs/commands.md`) and `CHANGELOG.md`

## Test verification (RED → GREEN)

New/updated tests live in `tests/test_v07302.py` (the noise-floor area, per the
`#376` lineage). RED was observed on the unmodified target branch (`main`).

**RED — on unmodified `main`**, a `pairwise` `--noise-floor` repro shows the task
axis is never measured:

```
Warning: --noise-floor does not measure the leg-1 task axis in --task-mode
pairwise (a judge-backed repeat would report the judge's sampling noise as
decode noise); leg 1 keeps a 0.0 floor.
noise floor: base repeat 1/2
noise floor: base repeat 2/2
floors: {}
AssertionError: BUG #403: pairwise --noise-floor did NOT measure the leg-1 task axis
```

The new tests (`test_judge_mode_measures_the_leg_one_axis`,
`test_pairwise_floor_measures_the_base_against_itself`,
`test_judge_score_floor_measures_the_base_side`, the labelling/serialization
control, and the `--help` cost assertion) fail on `main` for the same reason
(the task axis is absent / the `judge_inclusive` field does not exist yet).

**GREEN — with the fix:**

```
tests/test_v07302.py .................................................. [100%]
178 passed in 2.82s
```

Full local suite for the touched area (ruff + module) is iso-or-better than the
`main` baseline: baseline `175 passed`, this branch `178 passed`, ruff clean on
both, no new failures.
