### PR TITLE
feat(registry): link BOM/attestation to soup card via registry artifact kinds (#309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ reproducing 70+ versions of notes.
   `mlx-lm` import, the PyTorch/TRL training stack is absent, and a one-step real
   CLI SFT run completes. This hardens the runtime boundary; it does not claim to
   resolve the still-unpinned torch-present hang reported in #394.
+- **`soup card` now links the ML-BOM and the in-toto/SLSA attestation — they are
+  first-class registry artifact kinds (#309).** `bom` and `attestation` were the
+  two compliance documents `soup card` could not surface: `RegistryStore` had no
+  such kinds, so there was no way to attach them. Added both to the valid-kind
+  set and a `--attach-to-registry <id>` flag to `soup bom emit` and
+  `soup attest emit` (mirroring the existing `--attach-to-registry` pattern);
+  once attached they appear in the card's artifact table for free. The flag
+  needs `--output` — with none, the document is emitted to stdout and a warning
+  notes nothing was attached.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,9 +49,10 @@ reproducing 70+ versions of notes.
   such kinds, so there was no way to attach them. Added both to the valid-kind
   set and a `--attach-to-registry <id>` flag to `soup bom emit` and
   `soup attest emit` (mirroring the existing `--attach-to-registry` pattern);
-  once attached they appear in the card's artifact table for free. The flag
-  needs `--output` — with none, the document is emitted to stdout and a warning
-  notes nothing was attached.
+  once attached they appear in the card's artifact table for free. Signed
+  attestations also attach the detached `.sig` sidecar. The flag needs
+  `--output` (omitting it exits 2), and a requested registry attachment failure
+  exits 1 after preserving files already emitted.
 
 ### Fixed
 

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -64,10 +64,17 @@ soup audit-log rotate        # force a rotation pass
 soup registry push --run-id <run-id> --name my-model --tag v1
 
 soup bom emit --name my-model --base-sha <hex> --config-sha <hex> \
-    --energy energy.json --format both       # CycloneDX + SPDX
+    --energy energy.json --format both -o my-model.bom \
+    --attach-to-registry my-model:v1         # CycloneDX + SPDX, linked to the entry
 soup attest emit --stage train --subject my-model --sha <hex> \
-    --sign ed25519 --key key.pem             # in-toto + SLSA-3
+    --sign ed25519 --key key.pem -o my-model.attest.json \
+    --attach-to-registry my-model:v1         # in-toto + SLSA-3, linked to the entry
 ```
+
+`--attach-to-registry` registers the emitted BOM / attestation as `bom` /
+`attestation` artifacts on the entry, so the model card (step 7) links them
+alongside the other artifacts. It needs `--output`; without it the documents
+are emitted to stdout and nothing is attached.
 
 ## 5. Sign, scan, and verify the artifact
 
@@ -87,7 +94,7 @@ soup airgap-bundle --model ./output --output my-model.tar --repro-receipt receip
 
 Turn the registry entry into a provenance-rich `MODELCARD.md` — base model,
 training config, eval scorecard, config/data hashes, lineage, and every
-registered artifact:
+registered artifact — including the BOM and attestation attached in step 4:
 
 ```bash
 soup card my-model:v1 -o MODELCARD.md

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -63,7 +63,8 @@ soup audit-log rotate        # force a rotation pass
 ```bash
 soup registry push --run-id <run-id> --name my-model --tag v1
 
-soup bom emit --name my-model --base-sha <hex> --config-sha <hex> \
+soup bom emit --name my-model --base-model <model-id> \
+    --base-sha <hex> --config-sha <hex> \
     --energy energy.json --format both -o my-model.bom \
     --attach-to-registry my-model:v1         # CycloneDX + SPDX, linked to the entry
 soup attest emit --stage train --subject my-model --sha <hex> \
@@ -72,9 +73,10 @@ soup attest emit --stage train --subject my-model --sha <hex> \
 ```
 
 `--attach-to-registry` registers the emitted BOM / attestation as `bom` /
-`attestation` artifacts on the entry, so the model card (step 7) links them
-alongside the other artifacts. It needs `--output`; without it the documents
-are emitted to stdout and nothing is attached.
+`attestation` artifacts on the entry. Signed attestations include their `.sig`
+sidecar, so the model card (step 7) links every file needed for verification.
+The option needs `--output`; omitting it is a usage error. A registry lookup or
+attachment failure exits non-zero while leaving the emitted files on disk.
 
 ## 5. Sign, scan, and verify the artifact
 

--- a/src/soup_cli/commands/attest.py
+++ b/src/soup_cli/commands/attest.py
@@ -21,6 +21,10 @@ from soup_cli.utils.attest import (
 
 console = Console()
 
+_SIGNATURE_SUFFIX = ".sig"
+_EXIT_ATTACH_FAILED = 1
+_EXIT_USAGE = 2
+
 app = typer.Typer(
     no_args_is_help=True,
     help="In-toto + SLSA-3 attestations per Soup Can stage (v0.59.0).",
@@ -95,9 +99,10 @@ def emit_cmd(
     if output is None:
         if attach_to_registry is not None:
             console.print(
-                "[yellow]Warning:[/] --attach-to-registry needs --output "
-                "(nothing written to attach); skipping attach."
+                "[red]--attach-to-registry needs --output "
+                "(nothing written to attach).[/]"
             )
+            raise typer.Exit(_EXIT_USAGE)
         console.print(text)
         console.print(f"[dim]signature backend: {escape(sig['backend'])}[/]")
         if sig.get("signature"):
@@ -106,8 +111,9 @@ def emit_cmd(
 
     try:
         written = write_attestation(st, output)
+        written_paths = [written]
         if sig.get("backend") == "ed25519" and sig.get("signature"):
-            _write_sig_sidecar(output, sig)
+            written_paths.append(_write_sig_sidecar(output, sig))
     except (TypeError, ValueError) as exc:
         console.print(f"[red]Write failed: {escape(str(exc))}[/]")
         raise typer.Exit(2)
@@ -116,33 +122,36 @@ def emit_cmd(
         f"[dim](signature: {escape(sig['backend'])})[/]"
     )
     if attach_to_registry is not None:
-        _attach_attestation(attach_to_registry, written)
+        _attach_attestation(attach_to_registry, written_paths)
 
 
-def _attach_attestation(registry_id: str, path: str) -> None:
-    """Attach an emitted attestation statement to a registry entry.
+def _attach_attestation(registry_id: str, paths: list[str]) -> None:
+    """Attach an emitted attestation statement and signature to a registry entry.
 
-    Mirrors ``soup shrink --attach-to-registry``: a registry lookup / attach
-    failure is a warning, never fatal to the emit (the statement is on disk).
+    A requested registry attachment is part of command success: lookup or
+    attachment failures exit non-zero after leaving the statement on disk.
     """
     try:
         from soup_cli.registry.attach import attach_artifact
     except ImportError as exc:
         console.print(
-            f"[yellow]Warning:[/] could not import registry attach helper: {escape(str(exc))}"
+            f"[red]Error:[/] could not import registry attach helper: {escape(str(exc))}"
         )
-        return
-    try:
-        attach_artifact(registry_id, path=path, kind="attestation")
-    except Exception as exc:  # noqa: BLE001
-        console.print(f"[yellow]Warning:[/] could not attach to registry: {escape(str(exc))}")
-        return
-    console.print(
-        f"[green]Attached[/] attestation to registry entry [bold]{escape(registry_id)}[/]"
-    )
+        raise typer.Exit(_EXIT_ATTACH_FAILED) from exc
+    for path in paths:
+        try:
+            attach_artifact(registry_id, path=path, kind="attestation")
+        except Exception as exc:  # noqa: BLE001
+            console.print(f"[red]Error:[/] could not attach to registry: {escape(str(exc))}")
+            raise typer.Exit(_EXIT_ATTACH_FAILED) from exc
+        else:
+            console.print(
+                f"[green]Attached[/] attestation to registry entry "
+                f"[bold]{escape(registry_id)}[/]"
+            )
 
 
-def _write_sig_sidecar(output: str, sig: dict) -> None:
+def _write_sig_sidecar(output: str, sig: dict) -> str:
     """Atomic write of the ``<output>.sig`` JSON sidecar (cwd-contained)."""
     from soup_cli.utils.paths import atomic_write_text
 
@@ -155,7 +164,12 @@ def _write_sig_sidecar(output: str, sig: dict) -> None:
         indent=2,
         sort_keys=True,
     )
-    atomic_write_text(body, output + ".sig", prefix=".attest-sig.", suffix=".json.tmp")
+    return atomic_write_text(
+        body,
+        output + _SIGNATURE_SUFFIX,
+        prefix=".attest-sig.",
+        suffix=".json.tmp",
+    )
 
 
 @app.command("verify")

--- a/src/soup_cli/commands/attest.py
+++ b/src/soup_cli/commands/attest.py
@@ -55,6 +55,10 @@ def emit_cmd(
     output: Optional[str] = typer.Option(
         None, "--output", "-o", help="Output file path (cwd-contained).",
     ),
+    attach_to_registry: Optional[str] = typer.Option(
+        None, "--attach-to-registry",
+        help="Attach the emitted attestation statement to a registry entry id (needs --output).",
+    ),
 ) -> None:
     """Emit a per-stage in-toto/SLSA-3 attestation.
 
@@ -89,6 +93,11 @@ def emit_cmd(
         raise typer.Exit(2)
 
     if output is None:
+        if attach_to_registry is not None:
+            console.print(
+                "[yellow]Warning:[/] --attach-to-registry needs --output "
+                "(nothing written to attach); skipping attach."
+            )
         console.print(text)
         console.print(f"[dim]signature backend: {escape(sig['backend'])}[/]")
         if sig.get("signature"):
@@ -105,6 +114,31 @@ def emit_cmd(
     console.print(
         f"[green]Wrote attestation[/] -> {escape(written)} "
         f"[dim](signature: {escape(sig['backend'])})[/]"
+    )
+    if attach_to_registry is not None:
+        _attach_attestation(attach_to_registry, written)
+
+
+def _attach_attestation(registry_id: str, path: str) -> None:
+    """Attach an emitted attestation statement to a registry entry.
+
+    Mirrors ``soup shrink --attach-to-registry``: a registry lookup / attach
+    failure is a warning, never fatal to the emit (the statement is on disk).
+    """
+    try:
+        from soup_cli.registry.attach import attach_artifact
+    except ImportError as exc:
+        console.print(
+            f"[yellow]Warning:[/] could not import registry attach helper: {escape(str(exc))}"
+        )
+        return
+    try:
+        attach_artifact(registry_id, path=path, kind="attestation")
+    except Exception as exc:  # noqa: BLE001
+        console.print(f"[yellow]Warning:[/] could not attach to registry: {escape(str(exc))}")
+        return
+    console.print(
+        f"[green]Attached[/] attestation to registry entry [bold]{escape(registry_id)}[/]"
     )
 
 

--- a/src/soup_cli/commands/bom.py
+++ b/src/soup_cli/commands/bom.py
@@ -17,6 +17,9 @@ from soup_cli.utils.paths import enforce_under_cwd_and_no_symlink
 
 console = Console()
 
+_EXIT_ATTACH_FAILED = 1
+_EXIT_USAGE = 2
+
 app = typer.Typer(
     no_args_is_help=True,
     help="Emit CycloneDX ML-BOM + SPDX AI BOMs from registry entries (v0.59.0).",
@@ -141,9 +144,10 @@ def emit_cmd(
         # Print to stdout — nothing on disk to attach.
         if attach_to_registry is not None:
             console.print(
-                "[yellow]Warning:[/] --attach-to-registry needs --output "
-                "(nothing written to attach); skipping attach."
+                "[red]--attach-to-registry needs --output "
+                "(nothing written to attach).[/]"
             )
+            raise typer.Exit(_EXIT_USAGE)
         console.print(render_bom(entry, fmt_lc))
         return
 
@@ -162,23 +166,22 @@ def emit_cmd(
 def _attach_bom(registry_id: str, paths: list[str]) -> None:
     """Attach emitted BOM file(s) to a registry entry as kind ``bom``.
 
-    Mirrors the post-hoc attach pattern of ``soup shrink --attach-to-registry``:
-    a registry lookup / attach failure is surfaced as a warning and never fatal
-    to the emit itself (the BOM is already on disk).
+    A requested registry attachment is part of command success: lookup or
+    attachment failures exit non-zero after leaving the BOM on disk.
     """
     try:
         from soup_cli.registry.attach import attach_artifact
     except ImportError as exc:
         console.print(
-            f"[yellow]Warning:[/] could not import registry attach helper: {escape(str(exc))}"
+            f"[red]Error:[/] could not import registry attach helper: {escape(str(exc))}"
         )
-        return
+        raise typer.Exit(_EXIT_ATTACH_FAILED) from exc
     for path in paths:
         try:
             attach_artifact(registry_id, path=path, kind="bom")
         except Exception as exc:  # noqa: BLE001
-            console.print(f"[yellow]Warning:[/] could not attach to registry: {escape(str(exc))}")
-            continue
+            console.print(f"[red]Error:[/] could not attach to registry: {escape(str(exc))}")
+            raise typer.Exit(_EXIT_ATTACH_FAILED) from exc
         console.print(
             f"[green]Attached[/] bom to registry entry [bold]{escape(registry_id)}[/] "
             f"[dim]({escape(path)})[/]"

--- a/src/soup_cli/commands/bom.py
+++ b/src/soup_cli/commands/bom.py
@@ -55,6 +55,10 @@ def emit_cmd(
         None, "--energy", "-e",
         help="Path to energy measurement JSON.",
     ),
+    attach_to_registry: Optional[str] = typer.Option(
+        None, "--attach-to-registry",
+        help="Attach the emitted BOM file(s) to a registry entry id (needs --output).",
+    ),
 ) -> None:
     """Emit a CycloneDX + SPDX BOM from CLI-supplied SHAs."""
     fmt_lc = fmt.lower()
@@ -129,10 +133,17 @@ def emit_cmd(
             f"[green]Wrote CycloneDX BOM[/] -> {escape(cdx_path)}\n"
             f"[green]Wrote SPDX BOM[/] -> {escape(spdx_path)}"
         )
+        if attach_to_registry is not None:
+            _attach_bom(attach_to_registry, [cdx_path, spdx_path])
         return
 
     if output is None:
-        # Print to stdout.
+        # Print to stdout — nothing on disk to attach.
+        if attach_to_registry is not None:
+            console.print(
+                "[yellow]Warning:[/] --attach-to-registry needs --output "
+                "(nothing written to attach); skipping attach."
+            )
         console.print(render_bom(entry, fmt_lc))
         return
 
@@ -144,3 +155,31 @@ def emit_cmd(
     console.print(
         f"[green]Wrote BOM ({fmt_lc})[/] -> {escape(written)}"
     )
+    if attach_to_registry is not None:
+        _attach_bom(attach_to_registry, [written])
+
+
+def _attach_bom(registry_id: str, paths: list[str]) -> None:
+    """Attach emitted BOM file(s) to a registry entry as kind ``bom``.
+
+    Mirrors the post-hoc attach pattern of ``soup shrink --attach-to-registry``:
+    a registry lookup / attach failure is surfaced as a warning and never fatal
+    to the emit itself (the BOM is already on disk).
+    """
+    try:
+        from soup_cli.registry.attach import attach_artifact
+    except ImportError as exc:
+        console.print(
+            f"[yellow]Warning:[/] could not import registry attach helper: {escape(str(exc))}"
+        )
+        return
+    for path in paths:
+        try:
+            attach_artifact(registry_id, path=path, kind="bom")
+        except Exception as exc:  # noqa: BLE001
+            console.print(f"[yellow]Warning:[/] could not attach to registry: {escape(str(exc))}")
+            continue
+        console.print(
+            f"[green]Attached[/] bom to registry entry [bold]{escape(registry_id)}[/] "
+            f"[dim]({escape(path)})[/]"
+        )

--- a/src/soup_cli/registry/store.py
+++ b/src/soup_cli/registry/store.py
@@ -52,6 +52,10 @@ _VALID_KINDS = frozenset(
         "grace_codebook",
         # v0.71.29 — depth-prune + distill-heal shrink reports.
         "shrink_report",
+        # #309 — provenance documents surfaced by `soup card`: the ML-BOM
+        # (`soup bom emit`) and the in-toto/SLSA attestation (`soup attest emit`).
+        "bom",
+        "attestation",
     }
 )
 _VALID_RELATIONS = frozenset(

--- a/tests/test_v07135.py
+++ b/tests/test_v07135.py
@@ -1016,3 +1016,132 @@ class TestLlamaCppHomeAnchor:
         assert Path(found).resolve() == llama.resolve()
         # and no stray .soup litter in the working directory
         assert not (workdir / ".soup").exists()
+
+
+# --------------------------------------------------------------------------- #
+# #309 — BOM / attestation as registry artifact kinds, surfaced by `soup card`
+# --------------------------------------------------------------------------- #
+_SHA64_A = "a" * 64
+_SHA64_B = "b" * 64
+_SHA64_C = "c" * 64
+
+
+class TestBomAttestRegistryKinds:
+    """`soup bom emit` / `soup attest emit` can attach their output to a
+    registry entry as first-class artifact kinds, and `soup card` lists them —
+    closing the one gap in the otherwise self-contained provenance story."""
+
+    def test_add_artifact_accepts_bom_and_attestation(self, tmp_path, monkeypatch):
+        from soup_cli.registry.store import _VALID_KINDS, RegistryStore
+
+        assert "bom" in _VALID_KINDS
+        assert "attestation" in _VALID_KINDS
+
+        monkeypatch.chdir(tmp_path)
+        db = tmp_path / "reg.db"
+        bom = tmp_path / "m.cdx.json"
+        bom.write_text("{}", encoding="utf-8")
+        att = tmp_path / "m.attest.json"
+        att.write_text("{}", encoding="utf-8")
+        with RegistryStore(db_path=db) as store:
+            eid = store.push(name="m", tag="v1", base_model="b", task="sft",
+                             run_id=None, config={"base": "b"}, notes=None)
+            store.add_artifact(entry_id=eid, kind="bom", path=str(bom))
+            store.add_artifact(entry_id=eid, kind="attestation", path=str(att))
+            kinds = {a["kind"] for a in store.get_artifacts(eid)}
+        assert {"bom", "attestation"} <= kinds
+
+    def test_bom_emit_attaches_to_registry(self, tmp_path, monkeypatch):
+        from soup_cli.cli import app
+        from soup_cli.registry.store import RegistryStore
+
+        db = tmp_path / "reg.db"
+        eid = _make_entry(db)
+        monkeypatch.setenv("SOUP_REGISTRY_DB_PATH", str(db))
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, [
+            "bom", "emit", "--name", "m", "--base-model", "b",
+            "--base-sha", _SHA64_A, "--config-sha", _SHA64_B,
+            "-o", "bom.cdx.json", "--attach-to-registry", eid,
+        ])
+        assert result.exit_code == 0, (result.output, repr(result.exception))
+        with RegistryStore(db_path=db) as store:
+            arts = store.get_artifacts(eid)
+        assert [a["kind"] for a in arts] == ["bom"]
+        assert arts[0]["path"].endswith("bom.cdx.json")
+
+    def test_bom_emit_both_attaches_each_file(self, tmp_path, monkeypatch):
+        from soup_cli.cli import app
+        from soup_cli.registry.store import RegistryStore
+
+        db = tmp_path / "reg.db"
+        eid = _make_entry(db)
+        monkeypatch.setenv("SOUP_REGISTRY_DB_PATH", str(db))
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, [
+            "bom", "emit", "--name", "m", "--base-model", "b",
+            "--base-sha", _SHA64_A, "--config-sha", _SHA64_B,
+            "--format", "both", "-o", "bom", "--attach-to-registry", eid,
+        ])
+        assert result.exit_code == 0, (result.output, repr(result.exception))
+        with RegistryStore(db_path=db) as store:
+            names = sorted(os.path.basename(a["path"]) for a in store.get_artifacts(eid))
+        assert names == ["bom.cdx.json", "bom.spdx.json"]
+
+    def test_bom_emit_attach_without_output_warns_and_skips(self, tmp_path, monkeypatch):
+        from soup_cli.cli import app
+        from soup_cli.registry.store import RegistryStore
+
+        db = tmp_path / "reg.db"
+        eid = _make_entry(db)
+        monkeypatch.setenv("SOUP_REGISTRY_DB_PATH", str(db))
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, [
+            "bom", "emit", "--name", "m", "--base-model", "b",
+            "--base-sha", _SHA64_A, "--config-sha", _SHA64_B,
+            "--attach-to-registry", eid,  # no --output -> nothing to attach
+        ])
+        assert result.exit_code == 0, (result.output, repr(result.exception))
+        assert "attach-to-registry needs --output" in _clean(result.output)
+        with RegistryStore(db_path=db) as store:
+            assert store.get_artifacts(eid) == []
+
+    def test_attest_emit_attaches_to_registry(self, tmp_path, monkeypatch):
+        from soup_cli.cli import app
+        from soup_cli.registry.store import RegistryStore
+
+        db = tmp_path / "reg.db"
+        eid = _make_entry(db)
+        monkeypatch.setenv("SOUP_REGISTRY_DB_PATH", str(db))
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, [
+            "attest", "emit", "--stage", "train", "--subject", "m",
+            "--sha", _SHA64_C, "-o", "att.json", "--attach-to-registry", eid,
+        ])
+        assert result.exit_code == 0, (result.output, repr(result.exception))
+        with RegistryStore(db_path=db) as store:
+            arts = store.get_artifacts(eid)
+        assert [a["kind"] for a in arts] == ["attestation"]
+        assert arts[0]["path"].endswith("att.json")
+
+    def test_card_lists_attached_bom_and_attestation(self, tmp_path, monkeypatch):
+        from soup_cli.cli import app
+
+        db = tmp_path / "reg.db"
+        monkeypatch.chdir(tmp_path)
+        bom = tmp_path / "m.cdx.json"
+        bom.write_text("{}", encoding="utf-8")
+        att = tmp_path / "m.attest.json"
+        att.write_text("{}", encoding="utf-8")
+        eid = _make_entry(db, with_artifact=("bom", str(bom)))
+        from soup_cli.registry.store import RegistryStore
+        with RegistryStore(db_path=db) as store:
+            store.add_artifact(entry_id=eid, kind="attestation", path=str(att))
+        monkeypatch.setenv("SOUP_REGISTRY_DB_PATH", str(db))
+        result = runner.invoke(app, ["card", eid, "-o", "CARD.md"])
+        assert result.exit_code == 0, (result.output, repr(result.exception))
+        card = (tmp_path / "CARD.md").read_text(encoding="utf-8")
+        assert "m.cdx.json" in card
+        assert "m.attest.json" in card
+        assert "bom" in card
+        assert "attestation" in card

--- a/tests/test_v07135.py
+++ b/tests/test_v07135.py
@@ -13,6 +13,7 @@ import os
 import re
 
 import pytest
+import typer
 import yaml
 from typer.testing import CliRunner
 
@@ -1088,7 +1089,7 @@ class TestBomAttestRegistryKinds:
             names = sorted(os.path.basename(a["path"]) for a in store.get_artifacts(eid))
         assert names == ["bom.cdx.json", "bom.spdx.json"]
 
-    def test_bom_emit_attach_without_output_warns_and_skips(self, tmp_path, monkeypatch):
+    def test_bom_emit_attach_without_output_is_usage_error(self, tmp_path, monkeypatch):
         from soup_cli.cli import app
         from soup_cli.registry.store import RegistryStore
 
@@ -1101,7 +1102,7 @@ class TestBomAttestRegistryKinds:
             "--base-sha", _SHA64_A, "--config-sha", _SHA64_B,
             "--attach-to-registry", eid,  # no --output -> nothing to attach
         ])
-        assert result.exit_code == 0, (result.output, repr(result.exception))
+        assert result.exit_code == 2, (result.output, repr(result.exception))
         assert "attach-to-registry needs --output" in _clean(result.output)
         with RegistryStore(db_path=db) as store:
             assert store.get_artifacts(eid) == []
@@ -1123,6 +1124,130 @@ class TestBomAttestRegistryKinds:
             arts = store.get_artifacts(eid)
         assert [a["kind"] for a in arts] == ["attestation"]
         assert arts[0]["path"].endswith("att.json")
+
+    def test_signed_attest_emit_attaches_signature_sidecar(self, tmp_path, monkeypatch):
+        from soup_cli.cli import app
+        from soup_cli.commands import attest as attest_cmd
+        from soup_cli.registry.store import RegistryStore
+
+        db = tmp_path / "reg.db"
+        eid = _make_entry(db)
+        monkeypatch.setenv("SOUP_REGISTRY_DB_PATH", str(db))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(
+            attest_cmd,
+            "sign_attestation",
+            lambda *_args, **_kwargs: {
+                "backend": "ed25519",
+                "signature": "signed",
+                "public_key": "public",
+            },
+        )
+        result = runner.invoke(app, [
+            "attest", "emit", "--stage", "train", "--subject", "m",
+            "--sha", _SHA64_C, "--sign", "ed25519", "--key", "key.pem",
+            "-o", "signed.attest.json", "--attach-to-registry", eid,
+        ])
+        assert result.exit_code == 0, (result.output, repr(result.exception))
+        with RegistryStore(db_path=db) as store:
+            paths = sorted(os.path.basename(artifact["path"])
+                           for artifact in store.get_artifacts(eid))
+        assert paths == ["signed.attest.json", "signed.attest.json.sig"]
+
+    def test_attest_emit_attach_without_output_is_usage_error(self, tmp_path, monkeypatch):
+        from soup_cli.cli import app
+        from soup_cli.registry.store import RegistryStore
+
+        db = tmp_path / "reg.db"
+        eid = _make_entry(db)
+        monkeypatch.setenv("SOUP_REGISTRY_DB_PATH", str(db))
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, [
+            "attest", "emit", "--stage", "train", "--subject", "m",
+            "--sha", _SHA64_C, "--attach-to-registry", eid,
+        ])
+        assert result.exit_code == 2, (result.output, repr(result.exception))
+        assert "attach-to-registry needs --output" in _clean(result.output)
+        with RegistryStore(db_path=db) as store:
+            assert store.get_artifacts(eid) == []
+
+    @pytest.mark.parametrize("command_args,output_name", [
+        ([
+            "bom", "emit", "--name", "m", "--base-model", "b",
+            "--base-sha", _SHA64_A, "--config-sha", _SHA64_B,
+        ], "failed.bom.json"),
+        ([
+            "attest", "emit", "--stage", "train", "--subject", "m",
+            "--sha", _SHA64_C,
+        ], "failed.attest.json"),
+    ])
+    def test_emit_registry_failure_exits_one_and_preserves_output(
+        self, tmp_path, monkeypatch, command_args, output_name,
+    ):
+        from soup_cli.cli import app
+
+        monkeypatch.setenv("SOUP_REGISTRY_DB_PATH", str(tmp_path / "reg.db"))
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, [
+            *command_args, "--output", output_name,
+            "--attach-to-registry", "missing-entry",
+        ])
+        assert result.exit_code == 1, (result.output, repr(result.exception))
+        assert "could not attach to registry" in _clean(result.output)
+        assert (tmp_path / output_name).is_file()
+
+    @pytest.mark.parametrize("command_module,helper_name", [
+        ("soup_cli.commands.attest", "_attach_attestation"),
+        ("soup_cli.commands.bom", "_attach_bom"),
+    ])
+    def test_attach_helpers_fail_when_registry_helper_is_unavailable(
+        self, monkeypatch, capsys, command_module, helper_name,
+    ):
+        import builtins
+        import importlib
+
+        module = importlib.import_module(command_module)
+        real_import = builtins.__import__
+
+        def unavailable_registry_helper(name, *args, **kwargs):
+            if name == "soup_cli.registry.attach":
+                raise ImportError("registry unavailable")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", unavailable_registry_helper)
+        with pytest.raises(typer.Exit) as exc_info:
+            getattr(module, helper_name)("entry-id", ["artifact.json"])
+        assert exc_info.value.exit_code == 1
+        assert "could not import registry attach helper" in _clean(capsys.readouterr().out)
+
+    @pytest.mark.parametrize("command_module,helper_name", [
+        ("soup_cli.commands.attest", "_attach_attestation"),
+        ("soup_cli.commands.bom", "_attach_bom"),
+    ])
+    def test_attach_helpers_fail_after_attach_failure(
+        self, monkeypatch, capsys, command_module, helper_name,
+    ):
+        import importlib
+
+        from soup_cli.registry import attach as registry_attach
+
+        module = importlib.import_module(command_module)
+        attached = []
+
+        def attach_or_fail(_registry_id, *, path, kind):
+            if not attached:
+                attached.append((path, kind))
+                raise ValueError("registry unavailable")
+            attached.append((path, kind))
+
+        monkeypatch.setattr(registry_attach, "attach_artifact", attach_or_fail)
+        with pytest.raises(typer.Exit) as exc_info:
+            getattr(module, helper_name)("entry-id", ["first.json", "second.json"])
+        assert exc_info.value.exit_code == 1
+        assert attached == [
+            ("first.json", "attestation" if "attest" in command_module else "bom"),
+        ]
+        assert "could not attach to registry" in _clean(capsys.readouterr().out)
 
     def test_card_lists_attached_bom_and_attestation(self, tmp_path, monkeypatch):
         from soup_cli.cli import app


### PR DESCRIPTION
## Summary

Fix #309

`soup card <registry-id>` renders every registered artifact, but ML-BOM and
attestation outputs could not be registered. This adds `bom` and `attestation`
artifact kinds and `--attach-to-registry <id>` to `soup bom emit` and
`soup attest emit`.

Signed attestations register both the statement JSON and detached `.sig`
sidecar, so every file required by `soup attest verify` remains reachable from
the registry-backed card. BOM `--format both` similarly registers both emitted
formats. Because attachment was explicitly requested, a lookup/attach failure
now exits 1; omitting the required output path exits 2. Emitted files remain on
disk on a registry failure.

The compliance walkthrough and changelog are updated for the new flow.

## Test verification (RED → GREEN)

Reviewer follow-up RED on the rebased PR head (`e830c59`):

```text
assert ['signed.attest.json'] ==
       ['signed.attest.json', 'signed.attest.json.sig']
1 failed
```

GREEN after attaching every emitted attestation file:

```text
1 passed
```

Attach-failure contract RED on the same prior PR head:

```text
Wrote BOM (cyclonedx) -> failed.bom.json
Warning: could not attach to registry: registry entry not found: missing-entry
assert 0 == 1

Wrote attestation -> failed.attest.json
Warning: could not attach to registry: registry entry not found: missing-entry
assert 0 == 1
```

GREEN after making an explicitly requested attachment part of command success:

```text
2 passed
```

The complete compliance/card area module and changed-line coverage gate:

```text
upstream main: 95 passed
PR before follow-up: 101 passed
PR after follow-up: 109 passed
ruff check src/soup_cli/ tests/: passed
changed production-line coverage: 100% (47/47)
```

The six original tests still provide the initial feature RED → GREEN proof
(6 failed on unmodified main, 6 passed with the feature). The follow-up adds
the signed-sidecar regression plus focused controls for usage and end-to-end
attach-failure exit/file-preservation behavior.

## Files changed

| File | Change |
|------|--------|
| `src/soup_cli/registry/store.py` | accept `bom` and `attestation` artifact kinds |
| `src/soup_cli/commands/bom.py` | attach one or both emitted BOM files |
| `src/soup_cli/commands/attest.py` | attach the statement and signed `.sig` sidecar |
| `docs/compliance.md` | attach walkthrough and verification-file note |
| `CHANGELOG.md` | unreleased feature entry |
| `tests/test_v07135.py` | registry, CLI, failure-path, signature, and card regressions |
