### PR TITLE
fix(env): flag installed packages that violate soup's declared bounds (#368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,10 +86,6 @@ reproducing 70+ versions of notes.
   is wrong; it prints what it overrode beside what was detected. Disk detection
   may write a small scratch file next to the streamed shards to run the probe.
 
-### Fixed
-
-### Fixed
-
 - **The one-active-execution cap could double-book after a server restart (#402).**
   `ExecutionManager._active_run_id` is in-memory, so a restarted MCP server
   started with an empty slot, saw free capacity, and would launch a second
@@ -99,8 +95,6 @@ reproducing 70+ versions of notes.
   new execution across restarts, while a stale record whose process is gone
   frees the slot rather than wedging it shut. `docs/commands.md` now states the
   actual scope of the cap.
-
-### Fixed
 
 - **`soup ship --noise-floor` now measures the leg-1 task axis in the judge modes,
   so a judge-scored win smaller than the judge's own noise no longer counts (#403).**
@@ -131,6 +125,16 @@ reproducing 70+ versions of notes.
   unchanged. The config-load footgun (`=true` requires `quantization: 4bit`) fires only on an
   explicit `true`, and unset serializes as `None`, so a dumped-and-reloaded config no longer
   trips it.
+- **`soup env check` now flags an installed package that violates Soup's own
+  declared version bound (#368).** `pip install "soup-cli[serve-fast]"` (vllm)
+  into a training venv silently downgrades `torch` and pushes `transformers`
+  past the `<5.0.0` cap declared in `[train]`, producing an environment Soup's
+  own metadata says is unsupported with no warning at any point. `env check`
+  now audits the installed versions against the bounds read from package
+  metadata — not a hardcoded copy, since a second copy of the cap is exactly the
+  drift this catches — and exits 3 when one is violated, independent of any lock
+  file. `docs/serving-and-export.md` states the separate-environment guidance
+  for `[serve-fast]`.
 
 - **`kl_control` rewrote the trainer's β/kl_coef on every step, including a `hold`, so a
   non-acting run was numerically identical to `log_only` (#371).** `_run_bang_bang` called

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,14 +127,21 @@ reproducing 70+ versions of notes.
   trips it.
 - **`soup env check` now flags an installed package that violates Soup's own
   declared version bound (#368).** `pip install "soup-cli[serve-fast]"` (vllm)
-  into a training venv silently downgrades `torch` and pushes `transformers`
-  past the `<5.0.0` cap declared in `[train]`, producing an environment Soup's
-  own metadata says is unsupported with no warning at any point. `env check`
-  now audits the installed versions against the bounds read from package
-  metadata — not a hardcoded copy, since a second copy of the cap is exactly the
-  drift this catches — and exits 3 when one is violated, independent of any lock
-  file. `docs/serving-and-export.md` states the separate-environment guidance
-  for `[serve-fast]`.
+  into a training venv silently pushes `transformers` past the `<5.0.0` cap Soup
+  declares, producing an environment Soup's own metadata says is unsupported with
+  no warning at any point. `env check` audits installed versions against the
+  bounds read from package metadata — not a hardcoded copy, since a second copy
+  of the cap is exactly the drift this catches — and exits 3 when one is violated,
+  independent of any lock file. Only the CORE bounds (those that apply to every
+  install) are enforced: an `extra == "X"` requirement is Soup's bound only when
+  `[X]` was opted into, which the running environment cannot confirm, so its
+  marker is evaluated and it is skipped rather than raised as a false positive,
+  and a package is counted once even when its bound is restated under several
+  extras. The bounds audit no longer short-circuits the lock diagnostic (both
+  print). `packaging` is a declared dependency now — the audit degraded to a
+  silent "clean" without it, the wrong direction for a checker.
+  `docs/serving-and-export.md` states the separate-environment guidance for
+  `[serve-fast]`.
 
 - **`kl_control` rewrote the trainer's β/kl_coef on every step, including a `hold`, so a
   non-acting run was numerically identical to `log_only` (#371).** `_run_bang_bang` called

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,12 +132,17 @@ reproducing 70+ versions of notes.
   no warning at any point. `env check` audits installed versions against the
   bounds read from package metadata — not a hardcoded copy, since a second copy
   of the cap is exactly the drift this catches — and exits 3 when one is violated,
-  independent of any lock file. Only the CORE bounds (those that apply to every
-  install) are enforced: an `extra == "X"` requirement is Soup's bound only when
-  `[X]` was opted into, which the running environment cannot confirm, so its
-  marker is evaluated and it is skipped rather than raised as a false positive,
-  and a package is counted once even when its bound is restated under several
-  extras. The bounds audit no longer short-circuits the lock diagnostic (both
+  independent of any lock file. An `extra == "X"` requirement is Soup's bound
+  only when `[X]` was opted into, which the running environment cannot confirm,
+  so its marker is evaluated and it is skipped rather than raised as a false
+  positive — except for the ABI-relevant `TRACKED_PACKAGES` set, which since the
+  v0.71.0 deps-split lives in metadata *only* under `extra == "train"/"all"/
+  "dev"` and therefore includes the `transformers <5.0.0` case #368 was reported
+  about. A package is counted once even when its bound is restated under several
+  extras. If `packaging` is somehow unimportable the audit still degrades to a
+  clean report so `env check` keeps working, but now says so rather than
+  reporting a silent clean it never verified. The bounds audit no longer
+  short-circuits the lock diagnostic (both
   print). `packaging` is a declared dependency now — the audit degraded to a
   silent "clean" without it, the wrong direction for a checker.
   `docs/serving-and-export.md` states the separate-environment guidance for

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -259,7 +259,7 @@ soup tunability --dataset <jsonl> [--candidates a,b,c]   Probe candidate bases +
 soup tunability --dataset <jsonl> --live [--device cpu]  LIVE per-candidate LoRA probe (loads each repo)
 soup plan --config soup.yaml                             Pre-flight summary + write soup.tfstate
 soup apply --config soup.yaml [--dry-run]                Lock-and-execute; refuses on drift (exit 3)
-soup env lock | status | check                           Hermetic env lockfile + ABI drift detection (exit 3)
+soup env lock | status | check                           Hermetic env lockfile + ABI drift + declared-bound violation detection (exit 3)
 soup env fix [--format uv-pip|requirements] [--output req.txt]  Render a reproducible install plan from soup-env.lock (print-only)
 soup completions bash | zsh | fish                       Shell completion script (sourceable via eval)
 soup license-advisor --target b2c|defense|embedded       Recommend license-clean base for deploy target

--- a/docs/serving-and-export.md
+++ b/docs/serving-and-export.md
@@ -251,8 +251,15 @@ soup serve --model ./output --kv-cache-type q8_0   # 8-bit quantized cache (need
 
 Use [vLLM](https://github.com/vllm-project/vllm) for significantly better throughput in production:
 
+> **Install `[serve-fast]` in a separate environment from `[train]`.** Their
+> resolutions are genuinely incompatible today — `pip install vllm` into a
+> training venv silently downgrades `torch` and pushes `transformers` past
+> Soup's own `<5.0.0` cap. `soup env check` now flags an installed package that
+> violates this distribution's declared bounds (exit code 3), so you can catch a
+> contaminated venv before a run relies on it.
+
 ```bash
-# Install vLLM support
+# Install vLLM support (in its own environment, not the training one)
 pip install "soup-cli[serve-fast]"
 
 # Start with vLLM backend

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,11 @@ dependencies = [
     "pyyaml>=6.0",
     "huggingface-hub>=0.16.0",
     "plotext>=5.2.0",
+    # `env check` reads declared bounds via packaging (Requirement/marker/version).
+    # It ships with pip and is pulled in transitively, but `env check` degrades to
+    # a silent "clean" without it — the wrong direction for a checker — so it is
+    # declared explicitly (#368 review).
+    "packaging>=21.0",
 ]
 
 [project.optional-dependencies]

--- a/src/soup_cli/commands/env.py
+++ b/src/soup_cli/commands/env.py
@@ -135,25 +135,12 @@ def env_check_cmd(
     # transformers/torch downgrade even for a user who never ran `soup env lock`
     # (#368). The bound is read from package metadata, not a hardcoded copy.
     bounds = current_declared_bounds_check()
-    if not bounds.ok:
-        rows = "\n".join(
-            f"- {escape(v.name)} {escape(v.installed)} violates declared bound "
-            f"{escape(v.specifier)}"
-            + (f" (extra: {escape(v.extra)})" if v.extra else "")
-            for v in bounds.violations
-        )
-        console.print(
-            Panel(
-                f"[red]{bounds.violation_count} package(s) violate this "
-                f"distribution's own declared bounds:[/]\n{rows}\n\n"
-                "[yellow]Install '[serve-fast]' in a separate environment from "
-                "'[train]' — their resolutions are incompatible today.[/]",
-                title="env check",
-                border_style="red",
-            )
-        )
-        raise typer.Exit(DRIFT_EXIT_CODE)
 
+    # #368 review finding 5 — run the lock diagnostic REGARDLESS of the bounds
+    # outcome, so a bounds violation no longer hides "no lock file" / ABI drift.
+    # `lock_exit` records the lock half's exit code (None = clean); the bounds
+    # violation takes precedence at the end but is printed after the lock line.
+    lock_exit = None
     try:
         locked = read_lock(lock_path)
     except FileNotFoundError:
@@ -161,32 +148,53 @@ def env_check_cmd(
             f"[red]No lock file at {escape(lock_path)}; "
             "run `soup env lock` first.[/]"
         )
-        raise typer.Exit(1) from None
+        lock_exit = 1
     except (TypeError, ValueError) as exc:
         console.print(f"[red]{escape(str(exc))}[/]")
-        raise typer.Exit(2) from exc
+        lock_exit = 2
+    else:
+        current = snapshot_env()
+        report = check_abi_compat(locked, current)
+        if report.ok:
+            console.print(
+                Panel(
+                    "[green]ABI-clean.[/] No drift detected.",
+                    title="env check",
+                    border_style="green",
+                )
+            )
+        else:
+            body = "\n".join(f"- {escape(c)}" for c in report.changes)
+            console.print(
+                Panel(
+                    f"[red]{report.drift_count} ABI-sensitive drift(s):[/]\n{body}",
+                    title="env check",
+                    border_style="red",
+                )
+            )
+            lock_exit = DRIFT_EXIT_CODE
 
-    current = snapshot_env()
-    report = check_abi_compat(locked, current)
-    if report.ok:
+    if not bounds.ok:
+        rows = "\n".join(
+            f"- {escape(v.name)} {escape(v.installed)} violates declared bound "
+            f"{escape(v.specifier)}"
+            for v in bounds.violations
+        )
         console.print(
             Panel(
-                "[green]ABI-clean.[/] No drift detected.",
+                f"[red]{bounds.violation_count} package(s) violate this "
+                f"distribution's own declared bounds:[/]\n{rows}\n\n"
+                "[yellow]A later install (e.g. `pip install vllm`) likely moved "
+                "these packages outside the range soup-cli declares. Reinstall "
+                "soup-cli, or pin the listed package(s) back into range.[/]",
                 title="env check",
-                border_style="green",
+                border_style="red",
             )
         )
-        return
+        raise typer.Exit(DRIFT_EXIT_CODE)
 
-    body = "\n".join(f"- {escape(c)}" for c in report.changes)
-    console.print(
-        Panel(
-            f"[red]{report.drift_count} ABI-sensitive drift(s):[/]\n{body}",
-            title="env check",
-            border_style="red",
-        )
-    )
-    raise typer.Exit(DRIFT_EXIT_CODE)
+    if lock_exit is not None:
+        raise typer.Exit(lock_exit)
 
 
 @env_app.command("fix")

--- a/src/soup_cli/commands/env.py
+++ b/src/soup_cli/commands/env.py
@@ -20,6 +20,7 @@ from rich.table import Table
 from soup_cli.utils.env_lock import (
     DEFAULT_LOCK_FILE,
     check_abi_compat,
+    current_declared_bounds_check,
     read_lock,
     render_install_plan,
     snapshot_env,
@@ -29,6 +30,10 @@ from soup_cli.utils.env_lock import (
 from soup_cli.utils.paths import is_under_cwd
 
 console = Console()
+
+# Both an ABI drift against the lock and an installed package violating Soup's
+# own declared dependency bound exit with this code (#368).
+DRIFT_EXIT_CODE = 3
 
 env_app = typer.Typer(
     name="env",
@@ -125,6 +130,30 @@ def env_check_cmd(
     ),
 ) -> None:
     """Compare the current env against the lock and report drift."""
+    # Audit installed packages against Soup's OWN declared bounds first — this
+    # is independent of any lock file, so it catches the `pip install vllm`
+    # transformers/torch downgrade even for a user who never ran `soup env lock`
+    # (#368). The bound is read from package metadata, not a hardcoded copy.
+    bounds = current_declared_bounds_check()
+    if not bounds.ok:
+        rows = "\n".join(
+            f"- {escape(v.name)} {escape(v.installed)} violates declared bound "
+            f"{escape(v.specifier)}"
+            + (f" (extra: {escape(v.extra)})" if v.extra else "")
+            for v in bounds.violations
+        )
+        console.print(
+            Panel(
+                f"[red]{bounds.violation_count} package(s) violate this "
+                f"distribution's own declared bounds:[/]\n{rows}\n\n"
+                "[yellow]Install '[serve-fast]' in a separate environment from "
+                "'[train]' — their resolutions are incompatible today.[/]",
+                title="env check",
+                border_style="red",
+            )
+        )
+        raise typer.Exit(DRIFT_EXIT_CODE)
+
     try:
         locked = read_lock(lock_path)
     except FileNotFoundError:
@@ -157,7 +186,7 @@ def env_check_cmd(
             border_style="red",
         )
     )
-    raise typer.Exit(3)
+    raise typer.Exit(DRIFT_EXIT_CODE)
 
 
 @env_app.command("fix")

--- a/src/soup_cli/utils/env_lock.py
+++ b/src/soup_cli/utils/env_lock.py
@@ -34,7 +34,6 @@ import hashlib
 import json
 import os
 import platform as _platform
-import re
 import sys
 from dataclasses import dataclass
 from typing import Iterable, Mapping, Optional, Tuple
@@ -161,9 +160,6 @@ class AbiCheck:
 
 # Distribution whose declared bounds `check_declared_bounds` audits — Soup's own.
 _SELF_DIST = "soup-cli"
-# Matches the `extra == "name"` marker importlib.metadata attaches to an
-# optional-dependency requirement, so a violation can name the extra it came from.
-_EXTRA_MARKER_RE = re.compile(r'extra\s*==\s*["\']([A-Za-z0-9._-]+)["\']')
 
 
 @dataclass(frozen=True)
@@ -227,6 +223,7 @@ def check_declared_bounds(
     # (a core dependency), so it is present wherever Soup runs. If it somehow is
     # not, the audit degrades to "clean" rather than breaking `env check`.
     try:
+        from packaging.markers import UndefinedEnvironmentName
         from packaging.requirements import InvalidRequirement, Requirement
         from packaging.utils import canonicalize_name
         from packaging.version import InvalidVersion
@@ -236,6 +233,7 @@ def check_declared_bounds(
     installed_by_key = {canonicalize_name(k): v for k, v in installed.items()}
 
     violations: list[BoundViolation] = []
+    seen: set[str] = set()
     for raw in requirements:
         try:
             req = Requirement(raw)
@@ -243,7 +241,20 @@ def check_declared_bounds(
             continue
         if not req.specifier:
             continue
-        have = installed_by_key.get(canonicalize_name(req.name))
+        # #368 review — EVALUATE the marker, don't just name it. A requirement
+        # gated behind `extra == "X"` is only Soup's declared bound when the user
+        # opted into `soup-cli[X]`; evaluating in the base environment (no extra
+        # active) deselects it, so a package installed for other reasons (e.g.
+        # wandb) is not a false-positive violation, and the same core package
+        # re-listed under several extras collapses to its one un-gated bound.
+        if req.marker is not None:
+            try:
+                if not req.marker.evaluate({"extra": ""}):
+                    continue
+            except UndefinedEnvironmentName:
+                continue
+        key = canonicalize_name(req.name)
+        have = installed_by_key.get(key)
         if have is None:
             continue
         try:
@@ -252,13 +263,17 @@ def check_declared_bounds(
             continue
         if satisfied:
             continue
-        extra_match = _EXTRA_MARKER_RE.search(str(req.marker)) if req.marker else None
+        # Canonical-name dedup: count each violating package once even if its
+        # (un-gated) bound is stated more than once in metadata (#368 review).
+        if key in seen:
+            continue
+        seen.add(key)
         violations.append(
             BoundViolation(
                 name=req.name,
                 installed=have,
                 specifier=str(req.specifier),
-                extra=extra_match.group(1) if extra_match else None,
+                extra=None,
             )
         )
 
@@ -276,6 +291,11 @@ def current_declared_bounds_check(dist_name: str = _SELF_DIST) -> BoundsCheck:
     versions via ``importlib.metadata``. An absent distribution (e.g. running
     from source without an install) yields a clean report — there is no
     declared metadata to audit against.
+
+    The bounds come from the *installed* metadata, which on an editable checkout
+    can lag the working tree (a `pip install -e .` snapshot). A cap you just
+    tightened in ``pyproject.toml`` is only enforced here after a reinstall —
+    #368 review.
     """
     try:
         from importlib.metadata import PackageNotFoundError, requires

--- a/src/soup_cli/utils/env_lock.py
+++ b/src/soup_cli/utils/env_lock.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import datetime as _dt
 import hashlib
 import json
+import logging
 import os
 import platform as _platform
 import sys
@@ -39,6 +40,17 @@ from dataclasses import dataclass
 from typing import Iterable, Mapping, Optional, Tuple
 
 from soup_cli.utils.paths import atomic_write_text, is_under_cwd
+
+_LOG = logging.getLogger(__name__)
+
+# Emitted when the declared-bounds audit cannot run at all. It still degrades to
+# a clean report so `env check` keeps working, but a checker that reports clean
+# without having checked must say so (#368 review).
+_PACKAGING_MISSING_WARNING = (
+    "packaging is not importable, so the declared-bounds audit was skipped; "
+    "`soup env check` cannot confirm installed versions against Soup's own "
+    "declared bounds. Reinstall soup-cli to restore it."
+)
 
 DEFAULT_LOCK_FILE = "soup-env.lock"
 _MAX_NAME_LEN = 256
@@ -50,6 +62,14 @@ _MAX_ENTRIES = 4096
 
 # Source allowlist — defends against schema drift on read.
 _VALID_SOURCES = frozenset({"pip", "conda", "system", "wheel", "unknown"})
+
+# Extras that make up a Soup TRAINING install — the environment #368 is about
+# (a training venv later contaminated by `pip install "soup-cli[serve-fast]"`).
+# `[all]` and `[dev]` both re-declare `soup-cli[train,...]`, which pip flattens,
+# so metadata restates the training bounds under each of these three. `[mlx]` is
+# deliberately NOT here: it declares `transformers>=5.0.0` against `[train]`'s
+# `<5.0.0`, an incompatibility by design that no single environment satisfies.
+_TRAINING_INSTALL_EXTRAS: Tuple[str, ...] = ("train", "all", "dev")
 
 # ABI-sensitive packages — drift here is most likely to break training.
 TRACKED_PACKAGES: Tuple[str, ...] = (
@@ -219,18 +239,22 @@ def check_declared_bounds(
     ``[train]`` dependency you never installed is not drift. An unparseable
     requirement or version is skipped rather than crashing the diagnostic.
     """
-    # ``packaging`` ships with pip/setuptools and is pulled in by huggingface-hub
-    # (a core dependency), so it is present wherever Soup runs. If it somehow is
-    # not, the audit degrades to "clean" rather than breaking `env check`.
+    # ``packaging`` is a declared core dependency (#368 review), so it is present
+    # wherever Soup runs. If it somehow is not, the audit still degrades to
+    # "clean" rather than breaking `env check` — but it says so first: a checker
+    # that silently reports clean when it could not run is the wrong failure
+    # direction (#368 review).
     try:
         from packaging.markers import UndefinedEnvironmentName
         from packaging.requirements import InvalidRequirement, Requirement
         from packaging.utils import canonicalize_name
         from packaging.version import InvalidVersion
-    except ImportError:  # pragma: no cover — packaging virtually always present
+    except ImportError:  # pragma: no cover — packaging is a declared dependency
+        _LOG.warning(_PACKAGING_MISSING_WARNING)
         return BoundsCheck(ok=True, violation_count=0, violations=())
 
     installed_by_key = {canonicalize_name(k): v for k, v in installed.items()}
+    tracked_keys = {canonicalize_name(name) for name in TRACKED_PACKAGES}
 
     violations: list[BoundViolation] = []
     seen: set[str] = set()
@@ -245,15 +269,35 @@ def check_declared_bounds(
         # gated behind `extra == "X"` is only Soup's declared bound when the user
         # opted into `soup-cli[X]`; evaluating in the base environment (no extra
         # active) deselects it, so a package installed for other reasons (e.g.
-        # wandb) is not a false-positive violation, and the same core package
-        # re-listed under several extras collapses to its one un-gated bound.
-        if req.marker is not None:
+        # wandb) is not a false-positive violation.
+        #
+        # ...except for the ABI-relevant set under a TRAINING extra. Since the
+        # v0.71.0 deps-split, `transformers`, `torch` and `trl` live in metadata
+        # ONLY under `extra == "train"/"all"/"dev"`, so deselecting every gated
+        # requirement also deselected the `transformers <5.0.0` case #368 was
+        # filed about — leaving `typer` as the single bound this could ever fire
+        # on.
+        #
+        # The extra scope is load-bearing, not decoration: a tracked NAME alone
+        # is not enough, because `[mlx]` declares `transformers>=5.0.0` against
+        # `[train]`'s `<5.0.0`. Those two are deliberately incompatible, so
+        # enforcing both would make EVERY installed transformers violate exactly
+        # one of them — a false positive on every machine.
+        def selects(marker, extra: str) -> bool:
             try:
-                if not req.marker.evaluate({"extra": ""}):
-                    continue
+                return bool(marker.evaluate({"extra": extra}))
             except UndefinedEnvironmentName:
-                continue
+                return False
+
         key = canonicalize_name(req.name)
+        if req.marker is not None:
+            selected = selects(req.marker, "")
+            if not selected and key in tracked_keys:
+                selected = any(
+                    selects(req.marker, extra) for extra in _TRAINING_INSTALL_EXTRAS
+                )
+            if not selected:
+                continue
         have = installed_by_key.get(key)
         if have is None:
             continue
@@ -263,8 +307,9 @@ def check_declared_bounds(
             continue
         if satisfied:
             continue
-        # Canonical-name dedup: count each violating package once even if its
-        # (un-gated) bound is stated more than once in metadata (#368 review).
+        # Canonical-name dedup: count each violating package once even though a
+        # tracked bound is restated under every extra that pulls it in — metadata
+        # lists `transformers` under `train`, `all` AND `dev` (#368 review).
         if key in seen:
             continue
         seen.add(key)
@@ -297,10 +342,11 @@ def current_declared_bounds_check(dist_name: str = _SELF_DIST) -> BoundsCheck:
     tightened in ``pyproject.toml`` is only enforced here after a reinstall —
     #368 review.
     """
-    try:
-        from importlib.metadata import PackageNotFoundError, requires
-    except ImportError:  # pragma: no cover — py < 3.8
-        return BoundsCheck(ok=True, violation_count=0, violations=())
+    # `requires-python = ">=3.10"`, so `importlib.metadata` is always importable
+    # here; guarding it would be an unreachable branch that silently reports
+    # clean (#368 review).
+    from importlib.metadata import PackageNotFoundError, requires
+
     try:
         reqs = requires(dist_name)
     except PackageNotFoundError:
@@ -310,7 +356,8 @@ def current_declared_bounds_check(dist_name: str = _SELF_DIST) -> BoundsCheck:
 
     try:
         from packaging.requirements import InvalidRequirement, Requirement
-    except ImportError:  # pragma: no cover — packaging virtually always present
+    except ImportError:  # pragma: no cover — packaging is a declared dependency
+        _LOG.warning(_PACKAGING_MISSING_WARNING)
         return BoundsCheck(ok=True, violation_count=0, violations=())
 
     installed: dict[str, str] = {}

--- a/src/soup_cli/utils/env_lock.py
+++ b/src/soup_cli/utils/env_lock.py
@@ -34,9 +34,10 @@ import hashlib
 import json
 import os
 import platform as _platform
+import re
 import sys
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Iterable, Mapping, Optional, Tuple
 
 from soup_cli.utils.paths import atomic_write_text, is_under_cwd
 
@@ -156,6 +157,155 @@ class AbiCheck:
         for entry in self.changes:
             if not isinstance(entry, str):
                 raise TypeError("changes entries must be str")
+
+
+# Distribution whose declared bounds `check_declared_bounds` audits — Soup's own.
+_SELF_DIST = "soup-cli"
+# Matches the `extra == "name"` marker importlib.metadata attaches to an
+# optional-dependency requirement, so a violation can name the extra it came from.
+_EXTRA_MARKER_RE = re.compile(r'extra\s*==\s*["\']([A-Za-z0-9._-]+)["\']')
+
+
+@dataclass(frozen=True)
+class BoundViolation:
+    """One installed package that violates Soup's own declared version bound."""
+
+    name: str
+    installed: str
+    specifier: str
+    extra: Optional[str]
+
+    def __post_init__(self) -> None:
+        _check_non_empty_str(self.name, "name", max_len=_MAX_NAME_LEN)
+        _check_non_empty_str(self.installed, "installed", max_len=_MAX_VERSION_LEN)
+        _check_non_empty_str(self.specifier, "specifier", max_len=_MAX_VERSION_LEN)
+        if self.extra is not None:
+            _check_non_empty_str(self.extra, "extra", max_len=_MAX_NAME_LEN)
+
+
+@dataclass(frozen=True)
+class BoundsCheck:
+    """Outcome of auditing installed packages against Soup's declared bounds."""
+
+    ok: bool
+    violation_count: int
+    violations: Tuple[BoundViolation, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.ok, bool):
+            raise TypeError("ok must be bool")
+        if isinstance(self.violation_count, bool) or not isinstance(
+            self.violation_count, int
+        ):
+            raise TypeError("violation_count must be int")
+        if self.violation_count < 0:
+            raise ValueError("violation_count must be >= 0")
+        if not isinstance(self.violations, tuple):
+            raise TypeError("violations must be a tuple of BoundViolation")
+        for entry in self.violations:
+            if not isinstance(entry, BoundViolation):
+                raise TypeError("every violation must be BoundViolation")
+
+
+def check_declared_bounds(
+    requirements: Iterable[str],
+    installed: Mapping[str, str],
+) -> BoundsCheck:
+    """Flag any *installed* package whose version violates Soup's declared bound.
+
+    ``requirements`` are raw PEP 508 strings exactly as
+    ``importlib.metadata.requires`` returns them, so the bound is read from
+    package metadata and never a hardcoded second copy — that second copy is
+    the drift this is meant to catch (#368). ``installed`` maps package name to
+    the installed version.
+
+    A requirement whose package is *not* installed is skipped: an optional
+    ``[train]`` dependency you never installed is not drift. An unparseable
+    requirement or version is skipped rather than crashing the diagnostic.
+    """
+    # ``packaging`` ships with pip/setuptools and is pulled in by huggingface-hub
+    # (a core dependency), so it is present wherever Soup runs. If it somehow is
+    # not, the audit degrades to "clean" rather than breaking `env check`.
+    try:
+        from packaging.requirements import InvalidRequirement, Requirement
+        from packaging.utils import canonicalize_name
+        from packaging.version import InvalidVersion
+    except ImportError:  # pragma: no cover — packaging virtually always present
+        return BoundsCheck(ok=True, violation_count=0, violations=())
+
+    installed_by_key = {canonicalize_name(k): v for k, v in installed.items()}
+
+    violations: list[BoundViolation] = []
+    for raw in requirements:
+        try:
+            req = Requirement(raw)
+        except InvalidRequirement:
+            continue
+        if not req.specifier:
+            continue
+        have = installed_by_key.get(canonicalize_name(req.name))
+        if have is None:
+            continue
+        try:
+            satisfied = req.specifier.contains(have, prereleases=True)
+        except InvalidVersion:
+            continue
+        if satisfied:
+            continue
+        extra_match = _EXTRA_MARKER_RE.search(str(req.marker)) if req.marker else None
+        violations.append(
+            BoundViolation(
+                name=req.name,
+                installed=have,
+                specifier=str(req.specifier),
+                extra=extra_match.group(1) if extra_match else None,
+            )
+        )
+
+    return BoundsCheck(
+        ok=not violations,
+        violation_count=len(violations),
+        violations=tuple(violations),
+    )
+
+
+def current_declared_bounds_check(dist_name: str = _SELF_DIST) -> BoundsCheck:
+    """Audit the *running* environment against ``dist_name``'s declared bounds.
+
+    Reads the requirement strings from installed metadata and the installed
+    versions via ``importlib.metadata``. An absent distribution (e.g. running
+    from source without an install) yields a clean report — there is no
+    declared metadata to audit against.
+    """
+    try:
+        from importlib.metadata import PackageNotFoundError, requires
+    except ImportError:  # pragma: no cover — py < 3.8
+        return BoundsCheck(ok=True, violation_count=0, violations=())
+    try:
+        reqs = requires(dist_name)
+    except PackageNotFoundError:
+        return BoundsCheck(ok=True, violation_count=0, violations=())
+    if not reqs:
+        return BoundsCheck(ok=True, violation_count=0, violations=())
+
+    try:
+        from packaging.requirements import InvalidRequirement, Requirement
+    except ImportError:  # pragma: no cover — packaging virtually always present
+        return BoundsCheck(ok=True, violation_count=0, violations=())
+
+    installed: dict[str, str] = {}
+    for raw in reqs:
+        try:
+            name = Requirement(raw).name
+        except InvalidRequirement:
+            continue
+        if name in installed:
+            continue
+        ver = _detect_package_version(name)
+        if ver is not None:
+            installed[name] = ver
+
+    return check_declared_bounds(reqs, installed)
 
 
 def _detect_cuda_version() -> Optional[str]:
@@ -448,12 +598,16 @@ def check_abi_compat(a: EnvLock, b: EnvLock) -> AbiCheck:
 
 __all__ = [
     "AbiCheck",
+    "BoundViolation",
+    "BoundsCheck",
     "DEFAULT_LOCK_FILE",
     "EnvEntry",
     "EnvLock",
     "TRACKED_PACKAGES",
     "check_abi_compat",
+    "check_declared_bounds",
     "compute_env_hash",
+    "current_declared_bounds_check",
     "read_lock",
     "render_install_plan",
     "snapshot_env",

--- a/tests/test_v0640_part_c.py
+++ b/tests/test_v0640_part_c.py
@@ -721,3 +721,112 @@ def test_cli_env_lock_null_byte_output_rejected(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     result = runner.invoke(app, ["env", "lock", "--output", "a\x00b"])
     assert result.exit_code == 2, result.output
+
+
+# ---------------------------------------------------------------------------
+# check_declared_bounds — an installed package that violates soup-cli's OWN
+# declared version bound (#368). Reads the bound from package metadata, never
+# from a hardcoded copy, so it also catches every future instance of the shape.
+# ---------------------------------------------------------------------------
+
+# The exact strings importlib.metadata.requires("soup-cli") returns for the
+# [train] extra — the transformers cap is the one #368 was reported against.
+_TRAIN_REQS = (
+    'torch>=2.0.0; extra == "train"',
+    'transformers>=4.36.0,<5.0.0; extra == "train"',
+    'peft>=0.7.0; extra == "train"',
+)
+
+
+def test_check_declared_bounds_flags_package_over_cap():
+    from soup_cli.utils.env_lock import check_declared_bounds
+
+    # `pip install vllm` moved transformers to 5.14.1, past the <5.0.0 cap.
+    report = check_declared_bounds(
+        _TRAIN_REQS, {"transformers": "5.14.1", "torch": "2.11.0"}
+    )
+    assert not report.ok
+    assert report.violation_count == 1
+    (v,) = report.violations
+    assert v.name == "transformers"
+    assert v.installed == "5.14.1"
+    # The bound is quoted from the requirement string, not a second hardcoded
+    # copy of `<5.0.0` — that second copy is exactly the drift this catches.
+    assert "<5.0.0" in v.specifier
+    assert v.extra == "train"
+
+
+def test_check_declared_bounds_control_compliant_passes():
+    from soup_cli.utils.env_lock import check_declared_bounds
+
+    # Control: an in-bounds environment passes, so the check cannot be
+    # satisfied by always failing.
+    report = check_declared_bounds(
+        _TRAIN_REQS, {"transformers": "4.57.6", "torch": "2.13.0", "peft": "0.7.0"}
+    )
+    assert report.ok
+    assert report.violation_count == 0
+    assert report.violations == ()
+
+
+def test_check_declared_bounds_skips_uninstalled_extra():
+    from soup_cli.utils.env_lock import check_declared_bounds
+
+    # A [train] package you never installed is not drift — only installed
+    # packages that violate a bound are reported.
+    report = check_declared_bounds(_TRAIN_REQS, {"typer": "0.19.0"})
+    assert report.ok
+
+
+def test_check_declared_bounds_reads_bound_from_given_requirements():
+    from soup_cli.utils.env_lock import check_declared_bounds
+
+    # Proof the bound is data-driven: change ONLY the requirement string and
+    # the same installed version flips from compliant to violating.
+    installed = {"widget": "2.0.0"}
+    assert check_declared_bounds(('widget<3.0.0; extra == "x"',), installed).ok
+    bad = check_declared_bounds(('widget<2.0.0; extra == "x"',), installed)
+    assert not bad.ok
+    assert bad.violations[0].name == "widget"
+
+
+def test_check_declared_bounds_ignores_unparseable_requirement():
+    from soup_cli.utils.env_lock import check_declared_bounds
+
+    # A malformed requirement line must not crash the diagnostic.
+    report = check_declared_bounds(("!!! not a requirement",), {"x": "1.0.0"})
+    assert report.ok
+
+
+def test_current_declared_bounds_check_returns_bounds_check():
+    from soup_cli.utils.env_lock import BoundsCheck, current_declared_bounds_check
+
+    # Reading the real distribution metadata never raises; an uninstalled or
+    # packaging-less environment degrades to a clean report.
+    report = current_declared_bounds_check("this-distribution-does-not-exist")
+    assert isinstance(report, BoundsCheck)
+    assert report.ok
+
+
+def test_cli_env_check_declared_bound_violation_exits_3(tmp_path, monkeypatch):
+    from soup_cli.cli import app
+    from soup_cli.commands import env as env_cmd
+    from soup_cli.utils.env_lock import BoundsCheck, BoundViolation
+
+    monkeypatch.chdir(tmp_path)
+    violation = BoundViolation(
+        name="transformers",
+        installed="5.14.1",
+        specifier=">=4.36.0,<5.0.0",
+        extra="train",
+    )
+    monkeypatch.setattr(
+        env_cmd,
+        "current_declared_bounds_check",
+        lambda: BoundsCheck(ok=False, violation_count=1, violations=(violation,)),
+    )
+    # No lock file present, yet the declared-bound violation is still caught
+    # (the vllm-downgrade scenario: the user never ran `soup env lock`).
+    result = runner.invoke(app, ["env", "check"])
+    assert result.exit_code == 3, result.output
+    assert "transformers" in result.output

--- a/tests/test_v0640_part_c.py
+++ b/tests/test_v0640_part_c.py
@@ -729,21 +729,28 @@ def test_cli_env_lock_null_byte_output_rejected(tmp_path, monkeypatch):
 # from a hardcoded copy, so it also catches every future instance of the shape.
 # ---------------------------------------------------------------------------
 
-# The exact strings importlib.metadata.requires("soup-cli") returns for the
-# [train] extra — the transformers cap is the one #368 was reported against.
-# A CORE requirement (no extra marker): the bound that applies to EVERY install
-# and the one a later `pip install` actually violates. #368 review finding 2:
-# only these are enforced — an extra-gated bound is Soup's declared bound only
-# when the user opted into that extra, which the running environment cannot
-# confirm, so it must not raise a false positive.
-_CORE_TRANSFORMERS = ("transformers>=4.36.0,<5.0.0",)
+# A SYNTHETIC un-gated requirement, kept because it is the smallest input that
+# exercises the un-gated path. It is deliberately NOT what real metadata looks
+# like: since the v0.71.0 deps-split, `importlib.metadata.requires("soup-cli")`
+# lists `transformers` only under `extra == "train"/"all"/"dev"`, so no un-gated
+# transformers row exists — see `_TRAIN_TRANSFORMERS` for the real shape and the
+# tests that cover #368 end to end.
+_UNGATED_TRANSFORMERS = ("transformers>=4.36.0,<5.0.0",)
+
+# The real shape: the `transformers` cap #368 was reported against, exactly as
+# metadata states it — gated behind the extras that pull it in.
+_TRAIN_TRANSFORMERS = (
+    'transformers>=4.36.0,<5.0.0; extra == "train"',
+    'transformers>=4.36.0,<5.0.0; extra == "all"',
+    'transformers>=4.36.0,<5.0.0; extra == "dev"',
+)
 
 
 def test_check_declared_bounds_flags_core_bound_over_cap():
     from soup_cli.utils.env_lock import check_declared_bounds
 
     # `pip install vllm` moved transformers to 5.14.1, past the core <5.0.0 cap.
-    report = check_declared_bounds(_CORE_TRANSFORMERS, {"transformers": "5.14.1"})
+    report = check_declared_bounds(_UNGATED_TRANSFORMERS, {"transformers": "5.14.1"})
     assert not report.ok
     assert report.violation_count == 1
     (v,) = report.violations
@@ -759,7 +766,7 @@ def test_check_declared_bounds_control_compliant_passes():
 
     # Control: an in-bounds environment passes, so the check cannot be
     # satisfied by always failing.
-    report = check_declared_bounds(_CORE_TRANSFORMERS, {"transformers": "4.57.6"})
+    report = check_declared_bounds(_UNGATED_TRANSFORMERS, {"transformers": "4.57.6"})
     assert report.ok
     assert report.violations == ()
 
@@ -769,7 +776,7 @@ def test_check_declared_bounds_skips_uninstalled_package():
 
     # A package you never installed is not drift — only installed packages that
     # violate a bound are reported.
-    report = check_declared_bounds(_CORE_TRANSFORMERS, {"typer": "0.19.0"})
+    report = check_declared_bounds(_UNGATED_TRANSFORMERS, {"typer": "0.19.0"})
     assert report.ok
 
 
@@ -805,9 +812,8 @@ def test_extra_gated_bound_not_opted_into_is_not_flagged():
 
 
 def test_core_bound_counted_once_despite_extra_duplicates():
-    # #368 review finding 4: metadata lists a core package under the base deps
-    # AND under several extras. The violation is counted ONCE (the core bound);
-    # the extra-gated copies are evaluated away, not summed into the count.
+    # #368 review finding 4: metadata restates the same bound under the base
+    # deps AND under several extras. The violation is counted ONCE.
     from soup_cli.utils.env_lock import check_declared_bounds
 
     reqs = (
@@ -819,6 +825,85 @@ def test_core_bound_counted_once_despite_extra_duplicates():
     report = check_declared_bounds(reqs, {"transformers": "5.14.1"})
     assert report.violation_count == 1
     assert report.violations[0].name == "transformers"
+
+
+def test_extra_gated_tracked_bound_is_enforced():
+    # #368 review blocker: since the v0.71.0 deps-split, the `transformers`
+    # <5.0.0 cap exists in metadata ONLY under `extra == "train"/"all"/"dev"`.
+    # Deselecting every gated requirement made the case #368 was FILED ABOUT
+    # unreachable — measured as `ok=True, violation_count=0` against real
+    # installed metadata. A TRACKED_PACKAGES name keeps its bound enforced.
+    from soup_cli.utils.env_lock import check_declared_bounds
+
+    report = check_declared_bounds(_TRAIN_TRANSFORMERS, {"transformers": "5.14.1"})
+    assert not report.ok, report
+    assert report.violation_count == 1
+    (v,) = report.violations
+    assert v.name == "transformers"
+    assert v.installed == "5.14.1"
+    assert "<5.0.0" in v.specifier
+
+
+def test_extra_gated_untracked_bound_stays_deselected():
+    # The other half of the blocker fix: enforcing extra-gated bounds must NOT
+    # reintroduce the false positive it replaced. `wandb` is installed out of
+    # range but is not in TRACKED_PACKAGES, so it stays deselected.
+    from soup_cli.utils.env_lock import TRACKED_PACKAGES, check_declared_bounds
+
+    assert "wandb" not in {p.lower() for p in TRACKED_PACKAGES}
+    reqs = ('wandb>=0.15.0,<0.18.0; extra == "wandb"',)
+    report = check_declared_bounds(reqs, {"wandb": "0.19.1"})
+    assert report.ok, report.violations
+
+
+def test_mlx_only_bound_on_tracked_package_is_not_enforced():
+    # A tracked NAME is not sufficient to enforce a gated bound. `[mlx]` declares
+    # `transformers>=5.0.0` against `[train]`'s `<5.0.0` — deliberately
+    # incompatible extras. Enforcing both by name would make EVERY installed
+    # transformers violate exactly one of them, a false positive on every
+    # machine. Only the training-install extras lift the marker.
+    from soup_cli.utils.env_lock import check_declared_bounds
+
+    mlx_only = ('transformers>=5.0.0; extra == "mlx"',)
+    # A version the [train] cap is happy with, that the [mlx] floor is not.
+    assert check_declared_bounds(mlx_only, {"transformers": "4.57.6"}).ok
+
+    # And the two together resolve to the training bound alone, not to "both
+    # bounds violated".
+    both = _TRAIN_TRANSFORMERS + mlx_only
+    assert check_declared_bounds(both, {"transformers": "4.57.6"}).ok
+    breached = check_declared_bounds(both, {"transformers": "5.14.1"})
+    assert breached.violation_count == 1
+    assert "<5.0.0" in breached.violations[0].specifier
+
+
+def test_extra_gated_tracked_bound_counted_once_across_extras():
+    # #368 review finding: the dedup guard was dead while every gated row was
+    # evaluated away. Enforcing tracked bounds brings the duplicates back —
+    # metadata states the SAME transformers bound under train, all AND dev —
+    # so the guard is now load-bearing. Deleting it makes this fail with 3.
+    from soup_cli.utils.env_lock import check_declared_bounds
+
+    assert len(_TRAIN_TRANSFORMERS) == 3
+    report = check_declared_bounds(_TRAIN_TRANSFORMERS, {"transformers": "5.14.1"})
+    assert report.violation_count == 1
+
+
+def test_declared_bounds_warns_when_packaging_missing(caplog, monkeypatch):
+    # #368 review: `packaging` is a declared core dependency now, so it should
+    # never be absent — but if it is, the audit must not report a silent clean.
+    # A checker that says "clean" without having checked fails the wrong way.
+    import logging
+
+    from soup_cli.utils.env_lock import check_declared_bounds
+
+    monkeypatch.setitem(sys.modules, "packaging.markers", None)
+    with caplog.at_level(logging.WARNING, logger="soup_cli.utils.env_lock"):
+        report = check_declared_bounds(_UNGATED_TRANSFORMERS, {"transformers": "5.14.1"})
+    # Still degrades to clean so `env check` keeps working...
+    assert report.ok
+    # ...but says so, naming the audit it could not run.
+    assert any("declared-bounds audit was skipped" in r.message for r in caplog.records)
 
 
 def test_current_declared_bounds_check_returns_bounds_check_for_absent_dist():
@@ -874,3 +959,28 @@ def test_cli_env_check_declared_bound_violation_exits_3(tmp_path, monkeypatch):
     assert "declared bounds" in result.output
     assert "lock" in result.output.lower()
     assert "transformers" in result.output
+
+
+def test_cli_env_check_bound_violation_escapes_rich_markup(tmp_path, monkeypatch):
+    # #368 review: the escape() calls were unasserted — stripping every one of
+    # them still passed. A package name carrying Rich markup must render
+    # LITERALLY, not be swallowed as a style tag.
+    from soup_cli.cli import app
+    from soup_cli.commands import env as env_cmd
+    from soup_cli.utils.env_lock import BoundsCheck, BoundViolation
+
+    monkeypatch.chdir(tmp_path)
+    violation = BoundViolation(
+        name="[bold]evil[/bold]",
+        installed="5.14.1",
+        specifier=">=4.36.0,<5.0.0",
+        extra=None,
+    )
+    monkeypatch.setattr(
+        env_cmd,
+        "current_declared_bounds_check",
+        lambda: BoundsCheck(ok=False, violation_count=1, violations=(violation,)),
+    )
+    result = runner.invoke(app, ["env", "check"])
+    assert result.exit_code == 3, result.output
+    assert "[bold]evil[/bold]" in result.output

--- a/tests/test_v0640_part_c.py
+++ b/tests/test_v0640_part_c.py
@@ -731,29 +731,27 @@ def test_cli_env_lock_null_byte_output_rejected(tmp_path, monkeypatch):
 
 # The exact strings importlib.metadata.requires("soup-cli") returns for the
 # [train] extra — the transformers cap is the one #368 was reported against.
-_TRAIN_REQS = (
-    'torch>=2.0.0; extra == "train"',
-    'transformers>=4.36.0,<5.0.0; extra == "train"',
-    'peft>=0.7.0; extra == "train"',
-)
+# A CORE requirement (no extra marker): the bound that applies to EVERY install
+# and the one a later `pip install` actually violates. #368 review finding 2:
+# only these are enforced — an extra-gated bound is Soup's declared bound only
+# when the user opted into that extra, which the running environment cannot
+# confirm, so it must not raise a false positive.
+_CORE_TRANSFORMERS = ("transformers>=4.36.0,<5.0.0",)
 
 
-def test_check_declared_bounds_flags_package_over_cap():
+def test_check_declared_bounds_flags_core_bound_over_cap():
     from soup_cli.utils.env_lock import check_declared_bounds
 
-    # `pip install vllm` moved transformers to 5.14.1, past the <5.0.0 cap.
-    report = check_declared_bounds(
-        _TRAIN_REQS, {"transformers": "5.14.1", "torch": "2.11.0"}
-    )
+    # `pip install vllm` moved transformers to 5.14.1, past the core <5.0.0 cap.
+    report = check_declared_bounds(_CORE_TRANSFORMERS, {"transformers": "5.14.1"})
     assert not report.ok
     assert report.violation_count == 1
     (v,) = report.violations
     assert v.name == "transformers"
     assert v.installed == "5.14.1"
-    # The bound is quoted from the requirement string, not a second hardcoded
-    # copy of `<5.0.0` — that second copy is exactly the drift this catches.
+    # The bound is quoted from the requirement string, not a hardcoded copy of
+    # `<5.0.0` — that second copy is exactly the drift this catches.
     assert "<5.0.0" in v.specifier
-    assert v.extra == "train"
 
 
 def test_check_declared_bounds_control_compliant_passes():
@@ -761,20 +759,17 @@ def test_check_declared_bounds_control_compliant_passes():
 
     # Control: an in-bounds environment passes, so the check cannot be
     # satisfied by always failing.
-    report = check_declared_bounds(
-        _TRAIN_REQS, {"transformers": "4.57.6", "torch": "2.13.0", "peft": "0.7.0"}
-    )
+    report = check_declared_bounds(_CORE_TRANSFORMERS, {"transformers": "4.57.6"})
     assert report.ok
-    assert report.violation_count == 0
     assert report.violations == ()
 
 
-def test_check_declared_bounds_skips_uninstalled_extra():
+def test_check_declared_bounds_skips_uninstalled_package():
     from soup_cli.utils.env_lock import check_declared_bounds
 
-    # A [train] package you never installed is not drift — only installed
-    # packages that violate a bound are reported.
-    report = check_declared_bounds(_TRAIN_REQS, {"typer": "0.19.0"})
+    # A package you never installed is not drift — only installed packages that
+    # violate a bound are reported.
+    report = check_declared_bounds(_CORE_TRANSFORMERS, {"typer": "0.19.0"})
     assert report.ok
 
 
@@ -784,8 +779,8 @@ def test_check_declared_bounds_reads_bound_from_given_requirements():
     # Proof the bound is data-driven: change ONLY the requirement string and
     # the same installed version flips from compliant to violating.
     installed = {"widget": "2.0.0"}
-    assert check_declared_bounds(('widget<3.0.0; extra == "x"',), installed).ok
-    bad = check_declared_bounds(('widget<2.0.0; extra == "x"',), installed)
+    assert check_declared_bounds(("widget<3.0.0",), installed).ok
+    bad = check_declared_bounds(("widget<2.0.0",), installed)
     assert not bad.ok
     assert bad.violations[0].name == "widget"
 
@@ -798,14 +793,61 @@ def test_check_declared_bounds_ignores_unparseable_requirement():
     assert report.ok
 
 
-def test_current_declared_bounds_check_returns_bounds_check():
+def test_extra_gated_bound_not_opted_into_is_not_flagged():
+    # #368 review finding 2: a package required only under `extra == "wandb"`
+    # that the running environment never opted into is NOT a violation, even when
+    # it is installed and out of range — the marker is EVALUATED, not just named.
+    from soup_cli.utils.env_lock import check_declared_bounds
+
+    reqs = ('wandb>=0.15.0,<0.18.0; extra == "wandb"',)
+    report = check_declared_bounds(reqs, {"wandb": "0.19.1"})
+    assert report.ok, report.violations
+
+
+def test_core_bound_counted_once_despite_extra_duplicates():
+    # #368 review finding 4: metadata lists a core package under the base deps
+    # AND under several extras. The violation is counted ONCE (the core bound);
+    # the extra-gated copies are evaluated away, not summed into the count.
+    from soup_cli.utils.env_lock import check_declared_bounds
+
+    reqs = (
+        "transformers>=4.36.0,<5.0.0",
+        'transformers>=4.36.0,<5.0.0; extra == "all"',
+        'transformers>=4.36.0,<5.0.0; extra == "dev"',
+        'transformers>=4.36.0,<5.0.0; extra == "train"',
+    )
+    report = check_declared_bounds(reqs, {"transformers": "5.14.1"})
+    assert report.violation_count == 1
+    assert report.violations[0].name == "transformers"
+
+
+def test_current_declared_bounds_check_returns_bounds_check_for_absent_dist():
     from soup_cli.utils.env_lock import BoundsCheck, current_declared_bounds_check
 
-    # Reading the real distribution metadata never raises; an uninstalled or
-    # packaging-less environment degrades to a clean report.
+    # An uninstalled or packaging-less environment degrades to a clean report.
     report = current_declared_bounds_check("this-distribution-does-not-exist")
     assert isinstance(report, BoundsCheck)
     assert report.ok
+
+
+def test_current_declared_bounds_check_real_path_detects_violation(monkeypatch):
+    # #368 review finding 1: exercise the REAL detection path end to end —
+    # requires() → installed versions → check. Making the function a no-op, or
+    # dropping the version lookup, fails this.
+    import importlib.metadata as md
+
+    from soup_cli.utils import env_lock
+
+    monkeypatch.setattr(md, "requires", lambda dist: ["transformers>=4.36.0,<5.0.0"])
+    monkeypatch.setattr(
+        env_lock,
+        "_detect_package_version",
+        lambda name: "5.14.1" if name == "transformers" else None,
+    )
+    report = env_lock.current_declared_bounds_check("soup-cli")
+    assert not report.ok
+    assert report.violation_count == 1
+    assert report.violations[0].name == "transformers"
 
 
 def test_cli_env_check_declared_bound_violation_exits_3(tmp_path, monkeypatch):
@@ -818,15 +860,17 @@ def test_cli_env_check_declared_bound_violation_exits_3(tmp_path, monkeypatch):
         name="transformers",
         installed="5.14.1",
         specifier=">=4.36.0,<5.0.0",
-        extra="train",
+        extra=None,
     )
     monkeypatch.setattr(
         env_cmd,
         "current_declared_bounds_check",
         lambda: BoundsCheck(ok=False, violation_count=1, violations=(violation,)),
     )
-    # No lock file present, yet the declared-bound violation is still caught
-    # (the vllm-downgrade scenario: the user never ran `soup env lock`).
+    # No lock file present: the bound violation is caught AND the "no lock file"
+    # diagnostic still prints — neither short-circuits the other (finding 5).
     result = runner.invoke(app, ["env", "check"])
     assert result.exit_code == 3, result.output
+    assert "declared bounds" in result.output
+    assert "lock" in result.output.lower()
     assert "transformers" in result.output


### PR DESCRIPTION
## Summary

Fix #368 — `soup env check` now flags an installed package whose version
violates Soup's **own declared** dependency bound.

`pip install "soup-cli[serve-fast]"` (vllm) into a training venv silently
downgrades `torch` and pushes `transformers` past the `<5.0.0` cap declared in
the `[train]` extra. The user ends up in an environment Soup's own metadata says
is unsupported, produced by a Soup-documented command, with no warning at any
point.

- New pure helper `check_declared_bounds(requirements, installed)` in
  `utils/env_lock.py` audits installed versions against the bounds read from
  the raw PEP 508 requirement strings — i.e. from package metadata via
  `importlib.metadata.requires`, **never a hardcoded copy of the cap** (a second
  copy is exactly the drift this is meant to catch). A not-installed optional
  dependency is not drift; an unparseable requirement/version degrades to
  "skip", never a crash.
- `current_declared_bounds_check()` reads the running distribution's metadata
  and installed versions. An absent distribution degrades to a clean report, so
  `env check` never breaks; a missing `packaging` degrades to clean **and logs a
  warning**, because a checker that reports clean without having checked must
  say so.
- `soup env check` runs the audit **before** the lock read, so the vllm scenario
  is caught even for a user who never ran `soup env lock`. A violation exits `3`,
  consistent with the existing ABI-drift behaviour (now a named
  `DRIFT_EXIT_CODE`).

## Which requirements are enforced

Since v0.71.0's deps-split, `transformers`, `torch` and `trl` exist in metadata
**only** under `extra == "train"/"all"/"dev"`. So a marker gate alone cannot be
the selector — evaluating with `{"extra": ""}` fixes the `wandb` false positive
but also deselects the very packages #368 is about. An extra-gated requirement
is therefore enforced when **both** hold:

1. its canonical name is in `TRACKED_PACKAGES` (which does not list `wandb`), **and**
2. its marker selects under `_TRAINING_INSTALL_EXTRAS = ("train", "all", "dev")`.

Condition 2 is load-bearing, not decoration. Gating on the **name alone**
re-enables `transformers>=5.0.0; extra == "mlx"` alongside `[train]`'s
`<5.0.0`. Those two are deliberately incompatible, so every installed
`transformers` would violate exactly one of them — a false positive on every
machine. `[mlx]` is excluded, pinned by
`test_mlx_only_bound_on_tracked_package_is_not_enforced`.

Measured after the fix (74 requirements rebuilt from `pyproject.toml` the way
pip writes them into `METADATA`):

```
transformers 5.14.1 (#368 case)  ->  ok=False  violations=('transformers',)
transformers/torch/trl 9.9.9     ->  ok=False  violations=('transformers', 'trl')
wandb out of bounds only         ->  ok=True   violations=()      # not tracked, no false positive
compliant training venv          ->  ok=True   violations=()      # control
torch 1.0.0 (downgrade)          ->  ok=False  violations=('torch',)
```

`torch` is absent from the second row on purpose: it is declared `torch>=2.0.0`
with no upper cap, so `9.9.9` genuinely satisfies it.

## Acceptance criteria

- [x] A venv where `transformers` violates the declared cap is detected and
      reported by `soup env check` (exit 3).
- [x] The bound is read from package metadata, not a hardcoded copy.
- [x] A control: a compliant environment passes (the check cannot be satisfied
      by always failing).
- [x] `docs/serving-and-export.md` states the separate-environment guidance for
      `[serve-fast]`.

## Test verification (RED → GREEN)

Tests live in the area module `tests/test_v0640_part_c.py` (the `soup env`
Part C module). Torch-free; run with
`PYTHONPATH=src pytest tests/test_v0640_part_c.py -o addopts=""`.

**Round 1 — the feature.** RED on unmodified `main` (feature absent):

```
tests/test_v0640_part_c.py::test_check_declared_bounds_flags_package_over_cap
E   ImportError: cannot import name 'BoundsCheck' from 'soup_cli.utils.env_lock'
...
7 failed, 59 deselected
```

GREEN with the fix: `7 passed, 59 deselected in 0.90s`.

**Round 2 — the review fixes.** RED on the reviewed commit `2f0d62c`, with only
the new tests applied:

```
FAILED tests/test_v0640_part_c.py::test_extra_gated_tracked_bound_is_enforced
FAILED tests/test_v0640_part_c.py::test_extra_gated_tracked_bound_counted_once_across_extras
FAILED tests/test_v0640_part_c.py::test_declared_bounds_warns_when_packaging_missing
3 failed, 3 passed, 68 deselected in 0.96s
```

GREEN after the fix: `6 passed, 68 deselected in 0.86s`.

## Full local suite

`ruff check src/soup_cli/ tests/` + the full area module, same command on every
side:

| commit | ruff | `tests/test_v0640_part_c.py` |
|---|---|---|
| upstream `main` | clean | 58 passed, 1 failed |
| reviewed `2f0d62c` | clean | 68 passed, 1 failed |
| this branch `ab2f93f` | clean | **74 passed**, 1 failed |

Iso-or-better: the same single failure on every side, never a new one, and every
test added by this change is green. That failure is
`test_cli_env_fix_renders_plan`, pre-existing and unrelated — it reproduces on
unmodified `upstream/main` (Rich truncates the `env fix` panel when stdout is
not a tty, so `"uv pip install"` never appears in the captured output).

## Files changed

| File | Change |
|------|--------|
| `src/soup_cli/utils/env_lock.py` | `BoundViolation`/`BoundsCheck`, `check_declared_bounds`, `current_declared_bounds_check`; `_TRAINING_INSTALL_EXTRAS` scoping; warning when `packaging` is missing |
| `src/soup_cli/commands/env.py` | audit installed deps against declared bounds in `env check`; `DRIFT_EXIT_CODE`; Rich-escaped package names |
| `tests/test_v0640_part_c.py` | 16 new tests (violation, compliant control, uninstalled-skip, data-driven bound, unparseable-skip, CLI exit 3, extra-gated enforcement, `[mlx]` non-regression, cross-extra dedup, Rich escaping, missing-`packaging` warning) |
| `docs/serving-and-export.md`, `docs/commands.md` | separate-environment guidance for `[serve-fast]`; env-check note |
| `CHANGELOG.md` | `### Fixed` entry |
