### PR TITLE
feat: add Qwen3.5 4B pretrain recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ reproducing 70+ versions of notes.
   the flag is; it follows `forgetting_threshold` in being excluded from the
   recipe `config_sha`, so setting a floor never invalidates evidence.
 
+- **A ready-made `qwen3.5-4b-pretrain` recipe for continued pre-training of
+  `Qwen/Qwen3.5-4B-Base` (#278).** The recipe uses plaintext data, one epoch,
+  QLoRA 4-bit quantization, and the established continued-pretraining defaults.
+
 ### Fixed
 
 - **A run whose watcher died was reported `running` forever (#401).**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ src/soup_cli/
   experiment/         - SQLite experiment tracking
   eval/               - Eval platform (custom tasks, LLM judge, human eval, leaderboard)
   migrate/            - Config migration (LLaMA-Factory, Axolotl, Unsloth)
-  recipes/            - Ready-made configs for popular models (142 recipes)
+  recipes/            - Ready-made configs for popular models (143 recipes)
   autopilot/          - Zero-config decision engine (v0.25.0)
   registry/           - Model Registry (hashing, store, diff, attach) (v0.26.0 + v0.33.0)
   cans/               - Shareable .can artifact format + run/publish orchestrator (v0.26.0 + v0.33.0)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -150,7 +150,7 @@ soup migrate --from llamafactory config.yaml  Import config from LLaMA-Factory
 soup migrate --from axolotl config.yml        Import config from Axolotl
 soup migrate --from unsloth notebook.ipynb    Import config from Unsloth notebook
 soup migrate --from llamafactory c.yaml --dry-run  Preview without writing
-soup recipes list                             List all 142 ready-made recipes
+soup recipes list                             List all 143 ready-made recipes
 soup recipes show llama3.1-8b-sft            Print recipe YAML
 soup recipes use llama3.1-8b-sft             Copy recipe to soup.yaml
 soup recipes search "reasoning"              Search by keyword/task/size

--- a/docs/serving-and-export.md
+++ b/docs/serving-and-export.md
@@ -505,7 +505,7 @@ soup ui
 
 **Pages:**
 - **Dashboard** — view all experiment runs, loss charts, system info, multi-run comparison
-- **New Training** — create configs from templates or 142 ready-made recipes, validate, start training with live SSE log streaming and progress bar
+- **New Training** — create configs from templates or 143 ready-made recipes, validate, start training with live SSE log streaming and progress bar
 - **Data Explorer** — browse and inspect datasets (JSONL, JSON, CSV, Parquet)
 - **Model Chat** — chat with streaming responses, configurable temperature/top_p/max_tokens, system prompt, adapter selection, markdown rendering, chat export
 
@@ -514,7 +514,7 @@ soup ui
 - **Enhanced Metrics** — 2x2 chart grid (loss, LR, grad_norm, throughput) + GPU memory chart, eval results table
 - **Multi-Run Compare** — overlay loss curves from up to 5 runs side-by-side
 - **Chat Upgrade** — SSE streaming via proxy, typing indicator, cancel button, markdown renderer (bold, italic, code blocks), chat export as JSON
-- **Config Builder** — recipe dropdown (142 recipes), config schema API for dynamic form generation
+- **Config Builder** — recipe dropdown (143 recipes), config schema API for dynamic form generation
 
 **Security:** The Web UI generates a random auth token at startup (printed to console). All mutating endpoints (start/stop training, delete runs, inspect data, validate config) require `Authorization: Bearer <token>` header. CORS is restricted to the served origin. Data inspection is sandboxed to the working directory.
 

--- a/src/soup_cli/recipes/catalog.py
+++ b/src/soup_cli/recipes/catalog.py
@@ -48,7 +48,7 @@ def search_recipes(
 
 
 # ---------------------------------------------------------------------------
-# Recipe catalog (142 recipes)
+# Recipe catalog (143 recipes)
 # ---------------------------------------------------------------------------
 
 RECIPES: Dict[str, RecipeMeta] = {
@@ -3820,6 +3820,35 @@ training:
   lora:
     r: 16
     alpha: 32
+    target_modules: auto
+  quantization: 4bit
+
+output: ./output
+""",
+    ),
+    "qwen3.5-4b-pretrain": RecipeMeta(
+        model="Qwen/Qwen3.5-4B-Base",
+        task="pretrain",
+        size="4B",
+        tags=("qwen", "qwen3.5", "pretrain", "continued", "domain"),
+        description="Qwen 3.5 4B Base continued pre-training (Apache-2.0)",
+        yaml_str="""\
+base: Qwen/Qwen3.5-4B-Base
+task: pretrain
+
+data:
+  train: ./data/corpus.jsonl
+  format: plaintext
+  max_length: 4096
+
+training:
+  epochs: 1
+  lr: 1e-4
+  batch_size: auto
+  gradient_accumulation_steps: 8
+  lora:
+    r: 32
+    alpha: 64
     target_modules: auto
   quantization: 4bit
 

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -1,5 +1,6 @@
 """Tests for soup recipes — ready-made configs for popular models."""
 
+from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
@@ -213,6 +214,44 @@ class TestRecipesCLI:
         assert "recipes" in result.output.lower()
 
 
+class TestIssue278Qwen35PretrainRecipe:
+    """Regression coverage for the qwen3.5-4b-pretrain recipe."""
+
+    def test_recipe_loads_with_expected_pretrain_shape(self) -> None:
+        from soup_cli.config.loader import load_config_from_string
+        from soup_cli.recipes.catalog import get_recipe
+
+        recipe = get_recipe("qwen3.5-4b-pretrain")
+        assert recipe is not None
+        assert recipe.model == "Qwen/Qwen3.5-4B-Base"
+        assert recipe.task == "pretrain"
+
+        config = load_config_from_string(recipe.yaml_str)
+        assert config.base == recipe.model
+        assert config.task == "pretrain"
+        assert config.data.format == "plaintext"
+        assert config.training.epochs == 1
+
+    def test_show_and_use_recipe(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        show_result = runner.invoke(app, ["recipes", "show", "qwen3.5-4b-pretrain"])
+        assert show_result.exit_code == 0
+        assert "Qwen/Qwen3.5-4B-Base" in show_result.output
+
+        monkeypatch.chdir(tmp_path)
+        use_result = runner.invoke(
+            app,
+            ["recipes", "use", "qwen3.5-4b-pretrain", "--yes"],
+        )
+        assert use_result.exit_code == 0
+        assert "Qwen/Qwen3.5-4B-Base" in (tmp_path / "soup.yaml").read_text(
+            encoding="utf-8"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Part A: v0.25.0 new model recipes (Llama 4, Qwen 3, Gemma 3, DeepSeek V3)
 # ---------------------------------------------------------------------------
@@ -260,7 +299,7 @@ class TestV025NewRecipes:
             assert cfg.base == recipe.model
             assert cfg.task == recipe.task
 
-    def test_catalog_size_is_142(self):
+    def test_catalog_size_is_143(self):
         """Total catalog size — grew with each release.
 
         v0.25.0 shipped 43 recipes (29 + 9 Part A + 2 Part B tools + 3 Part E MLX).
@@ -275,10 +314,11 @@ class TestV025NewRecipes:
         v0.71.30 added 3 (grpo-env-calculator/retrieval-qa/guess-number) -> 137.
         v0.71.31 added 1 (online-dpo-smollm2-135m) -> 138.
         v0.71.32 added 3 (whisper-tiny/base/large-v3-asr) + 1 (smolvlm-256m-sft) -> 142.
+        Issue #278 added 1 (qwen3.5-4b-pretrain) -> 143.
         """
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 142
+        assert len(RECIPES) == 143
 
     def test_new_recipes_searchable(self):
         """Search returns the new recipes via keyword/task filter."""

--- a/tests/test_v07124.py
+++ b/tests/test_v07124.py
@@ -269,8 +269,8 @@ class TestGlm5RepoIdFix:
 
 
 class TestCatalogCount:
-    def test_total_recipe_count_is_142(self) -> None:
-        assert len(RECIPES) == 142
+    def test_total_recipe_count_is_143(self) -> None:
+        assert len(RECIPES) == 143
 
     def test_list_recipes_matches_dict(self) -> None:
         assert len(list_recipes()) == len(RECIPES)

--- a/tests/test_v07130.py
+++ b/tests/test_v07130.py
@@ -737,10 +737,10 @@ class TestRecipes:
         assert cfg.training.rollout_backend == "openenv"
         assert cfg.training.rollout_func.startswith("soup_cli.envs.")
 
-    def test_catalog_size_is_142(self):
+    def test_catalog_size_is_143(self):
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 142
+        assert len(RECIPES) == 143
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_v07132.py
+++ b/tests/test_v07132.py
@@ -950,7 +950,7 @@ class TestAsrRecipes:
         assert cfg.task == "sft"
         assert cfg.modality == "vision"
 
-    def test_catalog_size_is_142(self):
+    def test_catalog_size_is_143(self):
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 142
+        assert len(RECIPES) == 143


### PR DESCRIPTION
## What does this PR do?

Adds the `qwen3.5-4b-pretrain` ready-made recipe for continued pre-training of
`Qwen/Qwen3.5-4B-Base`.

- follows the established `qwen2.5-7b-pretrain` shape with plaintext data, one
  epoch, QLoRA 4-bit quantization, and continued-pretraining defaults
- adds regression coverage for metadata, config loading, and the `recipes show`
  and `recipes use` CLI flows
- updates catalog-count assertions and user-facing documentation from 142 to
  143 recipes
- records the addition in the changelog

The Hugging Face repository ID was verified through the Hub API.

Closes #278

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [x] Tests

## Validation

- `pytest tests/test_recipes.py -q --no-cov` — 31 passed
- focused catalog integrity/count checks — 6 passed
- `ruff check src/soup_cli/ tests/` — passed
- Hugging Face Hub lookup returned `Qwen/Qwen3.5-4B-Base`
- `git diff --check` — passed

The isolated recipe suite uses `--no-cov` because the repository's 77% global
coverage threshold is designed for the full test suite; all 31 recipe tests
themselves pass.

## Checklist

- [x] `ruff check src/soup_cli/ tests/` passes
- [ ] `pytest tests/ -v` passes (focused recipe and catalog suites pass locally;
  the full training-stack matrix is left to CI)
- [x] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed
