### PR TITLE
harden: keep the SFT import off the MLX dispatch route

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,27 @@ jobs:
         run: |
           mypy || echo "::warning title=mypy::Type issues reported (non-blocking baseline — see the log above)"
 
+  mlx-smoke:
+    # #394: prove the documented standalone install on an Apple Silicon runner.
+    # Keep this separate from the main matrix because `.[dev]` deliberately
+    # installs the PyTorch/TRL stack and would hide an accidental MLX dependency.
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install only the MLX runtime and smoke-test dependency
+        run: pip install -e ".[mlx]" pytest
+      - name: Verify the PyTorch training stack is absent
+        run: >-
+          python -c "import importlib.util;
+          names=('torch','trl','datasets','peft','accelerate','bitsandbytes');
+          present=[name for name in names if importlib.util.find_spec(name)];
+          assert not present, f'unexpected training dependencies: {present}'"
+      - name: Run one-step MLX SFT through the real CLI
+        run: pytest -o addopts= -m smoke -k mlx_sft_smoke -q tests/test_smoke_train.py
+
   test:
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,10 @@ jobs:
           python-version: "3.12"
       - name: Install only the MLX runtime and smoke-test dependency
         run: pip install -e ".[mlx]" pytest
-      - name: Verify the PyTorch training stack is absent
-        run: >-
-          python -c "import importlib.util;
-          names=('torch','trl','datasets','peft','accelerate','bitsandbytes');
-          present=[name for name in names if importlib.util.find_spec(name)];
-          assert not present, f'unexpected training dependencies: {present}'"
+      - name: Verify MLX imports and the PyTorch training stack is absent
+        run: |
+          python -c "import mlx.core, mlx_lm; print(mlx.core.__version__, mlx_lm.__version__)"
+          python -c "import importlib.util; names=('torch','trl','datasets','peft','accelerate','bitsandbytes'); present=[name for name in names if importlib.util.find_spec(name)]; assert not present, f'unexpected training dependencies: {present}'"
       - name: Run one-step MLX SFT through the real CLI
         run: pytest -o addopts= -m smoke -k mlx_sft_smoke -q tests/test_smoke_train.py
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@ reproducing 70+ versions of notes.
   with `deepseek-ai/DeepSeek-V4-Flash` (#279).** The recipe combines the
   established GRPO defaults with MoE LoRA and gradient checkpointing.
 
+### Changed
+
+- **The MLX SFT dispatch route no longer imports the Transformers SFT wrapper
+  before choosing a backend (#431 by @Shutaru).** The wrapper is import-light
+  today, but the standalone `soup-cli[mlx]` runtime no longer depends on it
+  remaining so. An additive Apple Silicon CI job verifies that `mlx` and
+  `mlx-lm` import, the PyTorch/TRL training stack is absent, and a one-step real
+  CLI SFT run completes. This hardens the runtime boundary; it does not claim to
+  resolve the still-unpinned torch-present hang reported in #394.
+
 ### Fixed
 
 - **A run whose watcher died was reported `running` forever (#401).**

--- a/docs/backends-and-ops.md
+++ b/docs/backends-and-ops.md
@@ -88,6 +88,11 @@ Transformers backend. A Hugging Face `datasets` source or streaming dataset
 still needs `datasets` because that data source owns the dependency; the local
 file path below does not.
 
+Known limitation: until [#423](https://github.com/MakazhanAlpamys/Soup/issues/423)
+lands, this standalone path can misidentify Apple Silicon as CPU and silently
+rewrite `training.quantization: 4bit` to `none`; verify the printed pre-flight
+configuration before relying on a 4-bit run.
+
 ```yaml
 base: mlx-community/Llama-3.2-3B-Instruct-4bit
 task: sft

--- a/docs/backends-and-ops.md
+++ b/docs/backends-and-ops.md
@@ -82,6 +82,12 @@ Fine-tune on M1-M4 Macs via Apple's [MLX](https://github.com/ml-explore/mlx) fra
 pip install "soup-cli[mlx]"
 ```
 
+For SFT with local JSONL, JSON, or CSV data, `[mlx]` is a standalone install:
+do not add `[train]`. The latter is the PyTorch/TRL stack used by the
+Transformers backend. A Hugging Face `datasets` source or streaming dataset
+still needs `datasets` because that data source owns the dependency; the local
+file path below does not.
+
 ```yaml
 base: mlx-community/Llama-3.2-3B-Instruct-4bit
 task: sft

--- a/docs/models.md
+++ b/docs/models.md
@@ -100,7 +100,7 @@ no PyTorch. Add `[train]` to fine-tune, or install other extras only when you ne
 | `fast` | `pip install "soup-cli[fast]"` | Unsloth backend (2-5x faster, lower VRAM) |
 | `vision` | `pip install "soup-cli[vision]"` | Vision / multimodal fine-tuning (Pillow) |
 | `audio` | `pip install "soup-cli[audio]"` | Audio / speech fine-tuning (librosa, soundfile) |
-| `mlx` | `pip install "soup-cli[mlx]"` | Apple Silicon backend (mlx, mlx-lm) |
+| `mlx` | `pip install "soup-cli[mlx]"` | Standalone Apple Silicon SFT backend for local data; `[train]` is not required |
 | `qat` | `pip install "soup-cli[qat]"` | Quantization-Aware Training (torchao) |
 | `serve` | `pip install "soup-cli[serve]"` | Inference server (FastAPI + uvicorn) |
 | `serve-fast` | `pip install "soup-cli[serve-fast]"` | vLLM inference backend (2-4x throughput) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,13 @@ audio = ["librosa>=0.10.0", "soundfile>=0.12.0"]
 awq = ["autoawq>=0.2.0"]
 gptq = ["auto-gptq>=0.7.0"]
 sglang = ["sglang>=0.2.0", "fastapi>=0.104.0", "uvicorn>=0.24.0"]
-mlx = ["mlx>=0.20.0", "mlx-lm>=0.31.3"]
+mlx = [
+    "mlx>=0.20.0",
+    "mlx-lm>=0.31.3",
+    # mlx-lm imports transformers at runtime; keep the standalone contract from
+    # depending on that transitive requirement remaining undeclared here.
+    "transformers>=5.0.0",
+]
 cce = ["cut-cross-entropy>=24.10.0"]
 tui = ["textual>=0.50.0"]
 # v0.53.8 #89 — bundle MLflow / SwanLab / Trackio for `--tracker` users.

--- a/src/soup_cli/commands/train.py
+++ b/src/soup_cli/commands/train.py
@@ -16,7 +16,6 @@ from rich.panel import Panel
 from soup_cli.config.loader import load_config
 from soup_cli.data.loader import load_dataset
 from soup_cli.monitoring.display import TrainingDisplay
-from soup_cli.trainer.sft import SFTTrainerWrapper
 from soup_cli.utils.gpu import detect_device, get_gpu_info
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only, no runtime import
@@ -1436,6 +1435,11 @@ def train(
 
         trainer_wrapper = AsrTrainerWrapper(cfg, **trainer_kwargs)
     else:
+        # Keep the transformers/TRL SFT surface outside the backend-first MLX
+        # route. The wrapper is import-light today, but importing it eagerly
+        # makes an MLX-only install depend on that remaining true forever.
+        from soup_cli.trainer.sft import SFTTrainerWrapper
+
         trainer_wrapper = SFTTrainerWrapper(cfg, **trainer_kwargs)
     trainer_wrapper.setup(dataset)
 

--- a/tests/test_issue394_mlx_runtime_isolation.py
+++ b/tests/test_issue394_mlx_runtime_isolation.py
@@ -1,0 +1,118 @@
+"""Runtime regression coverage for the standalone ``soup-cli[mlx]`` path (#394)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+TRAIN_EXTRA_ROOTS = (
+    "torch",
+    "datasets",
+    "trl",
+    "peft",
+    "accelerate",
+    "bitsandbytes",
+)
+
+
+def test_mlx_cli_route_does_not_touch_transformers_training_stack(tmp_path: Path) -> None:
+    """The real CLI must reach the MLX wrapper without importing ``[train]``.
+
+    The two handled torch probes in ``utils.gpu`` are tracked separately by #423.
+    Blocking them here models an MLX-only environment and lets this test pin the
+    #394 boundary: local data loading and backend dispatch must reach ``_require_mlx``
+    without attempting datasets, TRL, PEFT, accelerate, or bitsandbytes.
+    """
+    data_path = tmp_path / "train.jsonl"
+    data_path.write_text(
+        json.dumps(
+            {
+                "messages": [
+                    {"role": "user", "content": "Say hi"},
+                    {"role": "assistant", "content": "Hi"},
+                ]
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "soup.yaml"
+    config_path.write_text(
+        "base: mlx-community/tiny\n"
+        "task: sft\n"
+        "backend: mlx\n"
+        "data:\n"
+        f"  train: {json.dumps(str(data_path))}\n"
+        "  format: chatml\n"
+        "  val_split: 0\n"
+        "training:\n"
+        "  epochs: 1\n"
+        "  lr: 0.0002\n"
+        "  batch_size: 1\n"
+        "  quantization: none\n"
+        f"output: {json.dumps(str(tmp_path / 'out'))}\n",
+        encoding="utf-8",
+    )
+
+    probe = f"""
+import importlib.abc
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+blocked = []
+blocked_roots = {TRAIN_EXTRA_ROOTS!r}
+
+class BlockTrainingStack(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        root = fullname.partition('.')[0]
+        if root in blocked_roots or root == 'mlx':
+            blocked.append(root)
+            raise ModuleNotFoundError(f'blocked by #394 probe: {{fullname}}', name=fullname)
+        return None
+
+sys.meta_path.insert(0, BlockTrainingStack())
+
+from typer.testing import CliRunner
+from soup_cli.cli import app
+
+with patch('pathlib.Path.home', return_value=Path({str(tmp_path)!r})):
+    result = CliRunner().invoke(
+        app,
+        ['train', '--config', {str(config_path)!r}, '--yes'],
+    )
+payload = {{
+    'exit_code': result.exit_code,
+    'exception': str(result.exception) if result.exception else '',
+    'blocked': blocked,
+    'loaded': sorted(root for root in blocked_roots if root in sys.modules),
+    'sft_loaded': 'soup_cli.trainer.sft' in sys.modules,
+}}
+print('SOUP394|' + json.dumps(payload, sort_keys=True))
+"""
+    env = os.environ.copy()
+    source_root = str(Path(__file__).parents[1] / "src")
+    env["PYTHONPATH"] = source_root + os.pathsep + env.get("PYTHONPATH", "")
+    proc = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        cwd=tmp_path,
+        env=env,
+    )
+
+    assert proc.returncode == 0, (proc.stdout, proc.stderr)
+    marked = [line for line in proc.stdout.splitlines() if line.startswith("SOUP394|")]
+    assert len(marked) == 1, (proc.stdout, proc.stderr)
+    payload = json.loads(marked[0].removeprefix("SOUP394|"))
+    assert payload["exit_code"] == 1
+    assert "MLX backend requires" in payload["exception"]
+    assert payload["loaded"] == []
+    assert set(payload["blocked"]) <= {"torch", "mlx"}
+    assert "mlx" in payload["blocked"]
+    assert payload["sft_loaded"] is False

--- a/tests/test_issue394_mlx_runtime_isolation.py
+++ b/tests/test_issue394_mlx_runtime_isolation.py
@@ -89,7 +89,6 @@ payload = {{
     'exit_code': result.exit_code,
     'exception': str(result.exception) if result.exception else '',
     'blocked': blocked,
-    'loaded': sorted(root for root in blocked_roots if root in sys.modules),
     'sft_loaded': 'soup_cli.trainer.sft' in sys.modules,
 }}
 print('SOUP394|' + json.dumps(payload, sort_keys=True))
@@ -112,7 +111,6 @@ print('SOUP394|' + json.dumps(payload, sort_keys=True))
     payload = json.loads(marked[0].removeprefix("SOUP394|"))
     assert payload["exit_code"] == 1
     assert "MLX backend requires" in payload["exception"]
-    assert payload["loaded"] == []
     assert set(payload["blocked"]) <= {"torch", "mlx"}
     assert "mlx" in payload["blocked"]
     assert payload["sft_loaded"] is False

--- a/tests/test_smoke_train.py
+++ b/tests/test_smoke_train.py
@@ -102,6 +102,40 @@ output: {output_dir}
 
 
 @pytest.fixture
+def mlx_sft_config_yaml(tmp_path: Path, tiny_train_data: Path) -> Path:
+    """Create a one-step MLX SFT config with a public tiny Llama fixture."""
+    config_path = tmp_path / "soup_mlx.yaml"
+    output_dir = tmp_path / "output_mlx"
+    config_path.write_text(
+        f"""base: hf-internal-testing/tiny-random-LlamaForCausalLM
+task: sft
+backend: mlx
+
+data:
+  train: {tiny_train_data}
+  format: chatml
+  val_split: 0.0
+  max_length: 64
+
+training:
+  epochs: 1
+  lr: 5e-4
+  batch_size: 4
+  lora:
+    r: 4
+    alpha: 8
+  quantization: none
+  save_steps: 999
+  logging_steps: 1
+
+output: {output_dir}
+""",
+        encoding="utf-8",
+    )
+    return config_path
+
+
+@pytest.fixture
 def dpo_config_yaml(tmp_path: Path, tiny_dpo_data: Path) -> Path:
     """Create a minimal DPO config for smoke testing with tiny-gpt2."""
     config_path = tmp_path / "soup_dpo.yaml"
@@ -171,6 +205,27 @@ def test_sft_smoke(sft_config_yaml: Path):
     # 6. Check output
     output_dir = Path(result["output_dir"])
     assert output_dir.exists()
+    assert (output_dir / "adapter_config.json").exists()
+
+
+def test_mlx_sft_smoke(mlx_sft_config_yaml: Path):
+    """Run ``soup train`` through real MLX/MLX-LM without the PyTorch stack."""
+    pytest.importorskip("mlx.core")
+    pytest.importorskip("mlx_lm")
+
+    from typer.testing import CliRunner
+
+    from soup_cli.cli import app
+
+    result = CliRunner().invoke(
+        app,
+        ["train", "--config", str(mlx_sft_config_yaml), "--yes"],
+    )
+
+    assert result.exit_code == 0, (result.output, result.exception)
+    assert "MLX training complete" in result.output
+    output_dir = mlx_sft_config_yaml.parent / "output_mlx"
+    assert (output_dir / "adapters.safetensors").exists()
     assert (output_dir / "adapter_config.json").exists()
 
 


### PR DESCRIPTION
## What changed

- Keep the Transformers SFT wrapper import behind the non-MLX dispatch path.
- Add a CLI regression test for the standalone MLX runtime boundary.
- Add an Apple Silicon CI smoke job that explicitly verifies `mlx` and `mlx_lm` imports, confirms that the PyTorch/TRL training stack is absent, and runs a one-step MLX SFT command.
- Document the current MLX device-detection limitation tracked in #423.
- Declare the runtime `transformers` dependency directly in the `[mlx]` extra.
- Add an unreleased changelog entry.

## Why

The SFT wrapper is import-light today, but the MLX dispatch route should not depend on it remaining that way. This change hardens the standalone MLX runtime boundary against future imports of the PyTorch/TRL training stack.

## Scope

This PR does not claim to resolve either reported variant of #394. In particular, the torch-present hang remains unpinned and #394 should remain open pending a stack dump or a reliable reproducer.

The incorrect Apple Silicon device detection and possible `4bit` to `none` rewrite remain tracked separately in #423.

## Validation

- Targeted runtime-isolation tests: 24 passed
- Packaging and metadata tests: 26 passed
- Ruff: passed
- Workflow YAML and `pyproject.toml`: parsed successfully