### PR TITLE
feat: add DeepSeek V4 Flash GRPO recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ reproducing 70+ versions of notes.
   `Qwen/Qwen3.5-4B-Base` (#278).** The recipe uses plaintext data, one epoch,
   QLoRA 4-bit quantization, and the established continued-pretraining defaults.
 
+- **A ready-made `deepseek-v4-flash-grpo` recipe for GRPO reasoning training
+  with `deepseek-ai/DeepSeek-V4-Flash` (#279).** The recipe combines the
+  established GRPO defaults with MoE LoRA and gradient checkpointing.
+
 ### Fixed
 
 - **A run whose watcher died was reported `running` forever (#401).**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ src/soup_cli/
   experiment/         - SQLite experiment tracking
   eval/               - Eval platform (custom tasks, LLM judge, human eval, leaderboard)
   migrate/            - Config migration (LLaMA-Factory, Axolotl, Unsloth)
-  recipes/            - Ready-made configs for popular models (143 recipes)
+  recipes/            - Ready-made configs for popular models (144 recipes)
   autopilot/          - Zero-config decision engine (v0.25.0)
   registry/           - Model Registry (hashing, store, diff, attach) (v0.26.0 + v0.33.0)
   cans/               - Shareable .can artifact format + run/publish orchestrator (v0.26.0 + v0.33.0)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -150,7 +150,7 @@ soup migrate --from llamafactory config.yaml  Import config from LLaMA-Factory
 soup migrate --from axolotl config.yml        Import config from Axolotl
 soup migrate --from unsloth notebook.ipynb    Import config from Unsloth notebook
 soup migrate --from llamafactory c.yaml --dry-run  Preview without writing
-soup recipes list                             List all 143 ready-made recipes
+soup recipes list                             List all 144 ready-made recipes
 soup recipes show llama3.1-8b-sft            Print recipe YAML
 soup recipes use llama3.1-8b-sft             Copy recipe to soup.yaml
 soup recipes search "reasoning"              Search by keyword/task/size

--- a/docs/serving-and-export.md
+++ b/docs/serving-and-export.md
@@ -505,7 +505,7 @@ soup ui
 
 **Pages:**
 - **Dashboard** — view all experiment runs, loss charts, system info, multi-run comparison
-- **New Training** — create configs from templates or 143 ready-made recipes, validate, start training with live SSE log streaming and progress bar
+- **New Training** — create configs from templates or 144 ready-made recipes, validate, start training with live SSE log streaming and progress bar
 - **Data Explorer** — browse and inspect datasets (JSONL, JSON, CSV, Parquet)
 - **Model Chat** — chat with streaming responses, configurable temperature/top_p/max_tokens, system prompt, adapter selection, markdown rendering, chat export
 
@@ -514,7 +514,7 @@ soup ui
 - **Enhanced Metrics** — 2x2 chart grid (loss, LR, grad_norm, throughput) + GPU memory chart, eval results table
 - **Multi-Run Compare** — overlay loss curves from up to 5 runs side-by-side
 - **Chat Upgrade** — SSE streaming via proxy, typing indicator, cancel button, markdown renderer (bold, italic, code blocks), chat export as JSON
-- **Config Builder** — recipe dropdown (143 recipes), config schema API for dynamic form generation
+- **Config Builder** — recipe dropdown (144 recipes), config schema API for dynamic form generation
 
 **Security:** The Web UI generates a random auth token at startup (printed to console). All mutating endpoints (start/stop training, delete runs, inspect data, validate config) require `Authorization: Bearer <token>` header. CORS is restricted to the served origin. Data inspection is sandboxed to the working directory.
 

--- a/src/soup_cli/recipes/catalog.py
+++ b/src/soup_cli/recipes/catalog.py
@@ -48,7 +48,7 @@ def search_recipes(
 
 
 # ---------------------------------------------------------------------------
-# Recipe catalog (143 recipes)
+# Recipe catalog (144 recipes)
 # ---------------------------------------------------------------------------
 
 RECIPES: Dict[str, RecipeMeta] = {
@@ -4100,6 +4100,40 @@ training:
   quantization: 4bit
   moe_lora: true
   moe_aux_loss_coeff: 0.01
+
+output: ./output
+""",
+    ),
+    "deepseek-v4-flash-grpo": RecipeMeta(
+        model="deepseek-ai/DeepSeek-V4-Flash",
+        task="grpo",
+        size="N/A",
+        tags=("deepseek", "deepseek-v4", "grpo", "reasoning", "moe"),
+        description="DeepSeek V4 Flash MoE GRPO reasoning training (MIT, efficiency-tier)",
+        yaml_str="""\
+base: deepseek-ai/DeepSeek-V4-Flash
+task: grpo
+
+data:
+  train: ./data/reasoning_train.jsonl
+  format: auto
+  max_length: 8192
+
+training:
+  epochs: 3
+  lr: 1e-5
+  batch_size: 1
+  gradient_accumulation_steps: 16
+  lora:
+    r: 16
+    alpha: 32
+    target_modules: auto
+  quantization: 4bit
+  grpo_beta: 0.1
+  num_generations: 4
+  reward_fn: accuracy
+  moe_lora: true
+  gradient_checkpointing: true
 
 output: ./output
 """,

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -252,6 +252,47 @@ class TestIssue278Qwen35PretrainRecipe:
         )
 
 
+class TestIssue279DeepSeekV4FlashGrpoRecipe:
+    """Regression coverage for the deepseek-v4-flash-grpo recipe."""
+
+    def test_recipe_loads_with_expected_grpo_moe_shape(self) -> None:
+        from soup_cli.config.loader import load_config_from_string
+        from soup_cli.recipes.catalog import get_recipe
+
+        recipe = get_recipe("deepseek-v4-flash-grpo")
+        assert recipe is not None
+        assert recipe.model == "deepseek-ai/DeepSeek-V4-Flash"
+        assert recipe.task == "grpo"
+
+        config = load_config_from_string(recipe.yaml_str)
+        assert config.base == "deepseek-ai/DeepSeek-V4-Flash"
+        assert config.task == "grpo"
+        assert config.training.grpo_beta == 0.1
+        assert config.training.num_generations == 4
+        assert config.training.reward_fn == "accuracy"
+        assert config.training.moe_lora is True
+        assert config.training.gradient_checkpointing is True
+
+    def test_show_and_use_recipe(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        show_result = runner.invoke(app, ["recipes", "show", "deepseek-v4-flash-grpo"])
+        assert show_result.exit_code == 0
+        assert "deepseek-ai/DeepSeek-V4-Flash" in show_result.output
+
+        monkeypatch.chdir(tmp_path)
+        use_result = runner.invoke(
+            app,
+            ["recipes", "use", "deepseek-v4-flash-grpo", "--yes"],
+        )
+        assert use_result.exit_code == 0
+        assert "deepseek-ai/DeepSeek-V4-Flash" in (tmp_path / "soup.yaml").read_text(
+            encoding="utf-8"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Part A: v0.25.0 new model recipes (Llama 4, Qwen 3, Gemma 3, DeepSeek V3)
 # ---------------------------------------------------------------------------
@@ -299,7 +340,7 @@ class TestV025NewRecipes:
             assert cfg.base == recipe.model
             assert cfg.task == recipe.task
 
-    def test_catalog_size_is_143(self):
+    def test_catalog_size_is_144(self):
         """Total catalog size — grew with each release.
 
         v0.25.0 shipped 43 recipes (29 + 9 Part A + 2 Part B tools + 3 Part E MLX).
@@ -315,10 +356,11 @@ class TestV025NewRecipes:
         v0.71.31 added 1 (online-dpo-smollm2-135m) -> 138.
         v0.71.32 added 3 (whisper-tiny/base/large-v3-asr) + 1 (smolvlm-256m-sft) -> 142.
         Issue #278 added 1 (qwen3.5-4b-pretrain) -> 143.
+        Issue #279 added 1 (deepseek-v4-flash-grpo) -> 144.
         """
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 143
+        assert len(RECIPES) == 144
 
     def test_new_recipes_searchable(self):
         """Search returns the new recipes via keyword/task filter."""

--- a/tests/test_v07124.py
+++ b/tests/test_v07124.py
@@ -269,8 +269,8 @@ class TestGlm5RepoIdFix:
 
 
 class TestCatalogCount:
-    def test_total_recipe_count_is_143(self) -> None:
-        assert len(RECIPES) == 143
+    def test_total_recipe_count_is_144(self) -> None:
+        assert len(RECIPES) == 144
 
     def test_list_recipes_matches_dict(self) -> None:
         assert len(list_recipes()) == len(RECIPES)

--- a/tests/test_v07130.py
+++ b/tests/test_v07130.py
@@ -737,10 +737,10 @@ class TestRecipes:
         assert cfg.training.rollout_backend == "openenv"
         assert cfg.training.rollout_func.startswith("soup_cli.envs.")
 
-    def test_catalog_size_is_143(self):
+    def test_catalog_size_is_144(self):
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 143
+        assert len(RECIPES) == 144
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_v07132.py
+++ b/tests/test_v07132.py
@@ -950,7 +950,7 @@ class TestAsrRecipes:
         assert cfg.task == "sft"
         assert cfg.modality == "vision"
 
-    def test_catalog_size_is_143(self):
+    def test_catalog_size_is_144(self):
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 143
+        assert len(RECIPES) == 144


### PR DESCRIPTION
## What does this PR do?

Adds the ready-made `deepseek-v4-flash-grpo` recipe requested in #279 for the verified Hugging Face repository `deepseek-ai/DeepSeek-V4-Flash`.

The recipe follows the established GRPO + MoE pattern from `qwen3-30b-a3b-reasoning-grpo`:

- GRPO with `grpo_beta: 0.1`, four generations, and the accuracy reward
- QLoRA 4-bit training with `moe_lora: true`
- gradient checkpointing, batch size 1, and gradient accumulation 16
- reasoning JSONL data at a maximum sequence length of 8192

It also adds literal repository-ID and `SoupConfig` regression coverage, exercises `soup recipes show/use`, updates every exact catalog-count assertion from 143 to 144, and updates the matching docs and changelog.

Closes #279.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [x] Tests

## Verification

- `pytest tests/test_recipes_v031.py tests/test_recipes.py -v --tb=short --no-cov` — **1209 passed**
- catalog count guards across `test_v07124.py`, `test_v07130.py`, and `test_v07132.py` — **6 passed**
- `ruff check src/soup_cli/ tests/` — **All checks passed**
- `git diff --check` — clean
- Hugging Face API: exact ID returned HTTP 200 with `id=deepseek-ai/DeepSeek-V4-Flash`, `pipeline_tag=text-generation`, `DeepseekV4ForCausalLM`, and MIT license
- Negative control: deliberately invalid DeepSeek repository ID returned HTTP 401

## Checklist

- [x] Recipe YAML loads as a real `SoupConfig`
- [x] `soup recipes show/use deepseek-v4-flash-grpo` work
- [x] Exact Hugging Face repository ID is pinned by regression tests
- [x] All live catalog counts and relevant documentation are updated
