### PR TITLE
fix(stream): verify adapter materialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,15 @@ reproducing 70+ versions of notes.
 
 ### Fixed
 
+- **Layer streaming now verifies that every trainable LoRA parameter has real
+  storage after PEFT attaches the adapter (#433).** PEFT 0.18 creates streamed
+  adapters on `meta` for Soup to materialise, while PEFT 0.19 may create them as
+  real tensors immediately, so `materialize_meta_adapters()` returning `0`
+  cannot distinguish a healthy no-op from a missed adapter. The streamed build
+  now enforces the actual postcondition and refuses to install the runtime if a
+  trainable `lora_*` parameter remains on `meta`, naming the stranded parameter
+  instead of allowing a silent no-training run.
+
 - **`soup train --no-reexec` now prints the flags you actually typed (#372).**
   The advisory `accelerate launch` command is derived from the same argv the
   auto-reexec would have used, so `--fsdp` / `--deepspeed` / `--config` (and the

--- a/docs/performance-and-quantization.md
+++ b/docs/performance-and-quantization.md
@@ -402,6 +402,12 @@ output: ./output
 > If that prints anything, the adapter is affected. From v0.72.1 a streamed adapter is byte-for-byte in the same layout as an ordinary LoRA run.
 
 **Troubleshooting:**
+- **"trainable LoRA parameters remain on the meta device"** — PEFT attached an
+  adapter without real storage and Soup refused the run before installing the
+  streaming runtime. This guard is deliberately based on the final parameter
+  state rather than on how many tensors Soup materialised: some PEFT versions
+  create real adapters themselves. Include the PEFT version and the named
+  parameter from the error when reporting this.
 - **"layer streaming needs the base to fit in RAM"** — the base is larger than free RAM. Set `stream_source: auto` to fall back to the NVMe disk tier, free RAM, or pick a smaller base.
 - **"layer streaming needs NVMe or more RAM … the detected disk is 'hdd'"** on a fast cloud disk — a virtio device reports `rotational=1` with no media hint. Detection now measures the disk when the flag is unreliable; if it still misreads yours, set `training.stream_disk_kind: nvme` to force the tier on (`ssd`/`hdd` force it off).
 - **"could not page-lock the base … falling back to a PAGEABLE RAM store"** — expected on a busy machine. Training continues, more slowly. Close other applications to keep the pinned store.

--- a/src/soup_cli/utils/layer_stream_runtime.py
+++ b/src/soup_cli/utils/layer_stream_runtime.py
@@ -1361,6 +1361,11 @@ def materialize_meta_adapters(model: Any, *, seed: int = 0, device: str = "cuda"
     build that device is ``meta``, so the adapters have no storage: the
     optimizer happily accepts them and the run trains nothing. Re-initialise
     with PEFT's own scheme (A ~ kaiming_uniform, B = 0).
+
+    The return value is the number of parameters materialised, not a success
+    signal.  In particular, zero is healthy when PEFT created real adapter
+    tensors itself.  Call :func:`assert_trainable_adapters_materialized` after
+    this function to enforce the actual postcondition.
     """
     import torch
     import torch.nn as nn
@@ -1380,6 +1385,33 @@ def materialize_meta_adapters(model: Any, *, seed: int = 0, device: str = "cuda"
             module._parameters[pname] = nn.Parameter(data.to(device), requires_grad=True)
             count += 1
     return count
+
+
+def assert_trainable_adapters_materialized(model: Any) -> None:
+    """Refuse a streamed build whose trainable LoRA tensors have no storage.
+
+    Decoder weights deliberately remain on ``meta`` under layer streaming, so
+    the invariant is restricted to trainable ``lora_*`` parameters.  It is a
+    postcondition rather than an interpretation of
+    :func:`materialize_meta_adapters`' return count: PEFT versions differ on
+    whether adapters need materialising, but both must leave real tensors.
+    """
+    stranded = [
+        name
+        for name, param in model.named_parameters()
+        if param.requires_grad and "lora_" in name and param.is_meta
+    ]
+    if not stranded:
+        return
+
+    preview = ", ".join(stranded[:4])
+    remainder = len(stranded) - 4
+    if remainder > 0:
+        preview += f", ... (+{remainder} more)"
+    raise RuntimeError(
+        "trainable LoRA parameters remain on the meta device after adapter "
+        f"materialization: {preview}. Refusing to train adapters without storage."
+    )
 
 
 # ==========================================================================
@@ -1625,6 +1657,7 @@ def build_streamed_model(
         param.requires_grad = False
     model = get_peft_model(model, lora_config)
     materialize_meta_adapters(model, seed=seed, device=device)
+    assert_trainable_adapters_materialized(model)
     runtime = install_streaming(
         model,
         shard_dir=shard_dir,

--- a/tests/test_issue433_meta_adapter_guard.py
+++ b/tests/test_issue433_meta_adapter_guard.py
@@ -1,0 +1,128 @@
+"""#433 — adapter materialisation must be verified by its postcondition.
+
+PEFT 0.18 creates LoRA parameters on ``meta`` in a streamed build, while PEFT
+0.19 creates them with real storage.  ``materialize_meta_adapters`` therefore
+returns zero for the newer, healthy path as well as for any path where no
+parameter was repaired.  The count cannot distinguish those outcomes.
+
+These tests assert the decision with the PEFT behaviour stubbed.  In
+particular, the negative control deliberately leaves a trainable LoRA parameter
+on ``meta`` and proves the streamed build refuses it by name.  That keeps the
+guard testable on the repository's pinned PEFT and on CPU-only CI.
+"""
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+def _adapter_model(*, adapter_device: str, adapter_trainable: bool = True):
+    import torch
+    import torch.nn as nn
+
+    class _AdapterModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.base_weight = nn.Parameter(
+                torch.empty(1, device="meta"), requires_grad=False
+            )
+            self.lora_A = nn.Parameter(
+                torch.empty(2, 2, device=adapter_device),
+                requires_grad=adapter_trainable,
+            )
+
+    return _AdapterModel()
+
+
+class TestAdapterMaterializationPostcondition:
+    def test_zero_materialized_is_valid_when_adapter_is_already_real(self):
+        from soup_cli.utils.layer_stream_runtime import (
+            assert_trainable_adapters_materialized,
+            materialize_meta_adapters,
+        )
+
+        model = _adapter_model(adapter_device="cpu")
+        assert materialize_meta_adapters(model, device="cpu") == 0
+        assert_trainable_adapters_materialized(model)
+
+    def test_frozen_meta_base_is_deliberately_ignored(self):
+        from soup_cli.utils.layer_stream_runtime import (
+            assert_trainable_adapters_materialized,
+        )
+
+        model = _adapter_model(adapter_device="cpu")
+        assert model.base_weight.is_meta
+        assert_trainable_adapters_materialized(model)
+
+    def test_trainable_meta_adapter_fails_and_names_the_parameter(self):
+        from soup_cli.utils.layer_stream_runtime import (
+            assert_trainable_adapters_materialized,
+        )
+
+        model = _adapter_model(adapter_device="meta")
+        with pytest.raises(RuntimeError, match=r"lora_A"):
+            assert_trainable_adapters_materialized(model)
+
+    def test_frozen_meta_adapter_is_not_part_of_the_training_invariant(self):
+        from soup_cli.utils.layer_stream_runtime import (
+            assert_trainable_adapters_materialized,
+        )
+
+        model = _adapter_model(adapter_device="meta", adapter_trainable=False)
+        assert_trainable_adapters_materialized(model)
+
+
+def test_streamed_build_refuses_a_materializer_that_skips_a_meta_adapter(monkeypatch):
+    """Negative control: stub the capability and force the failure state.
+
+    This test drives the real ``build_streamed_model`` call site.  If the
+    postcondition is removed or placed before PEFT attaches the adapter, the
+    install sentinel is reached and the test fails.
+    """
+    import torch
+    import torch.nn as nn
+
+    import soup_cli.utils.layer_stream_runtime as runtime
+
+    class _Skeleton(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.base_weight = nn.Parameter(torch.empty(1, device="meta"))
+
+    model = _Skeleton()
+
+    def fake_get_peft_model(base, _config):
+        base.lora_A = nn.Parameter(torch.empty(2, 2, device="meta"))
+        return base
+
+    fake_peft = ModuleType("peft")
+    fake_peft.get_peft_model = fake_get_peft_model
+    monkeypatch.setitem(sys.modules, "peft", fake_peft)
+    monkeypatch.setattr(runtime, "build_meta_skeleton", lambda *_a, **_kw: model)
+    monkeypatch.setattr(
+        runtime,
+        "materialize_extras",
+        lambda *_a, **_kw: SimpleNamespace(codes={}),
+    )
+    monkeypatch.setattr(runtime, "materialize_meta_adapters", lambda *_a, **_kw: 0)
+
+    install_reached = False
+
+    def fake_install(*_args, **_kwargs):
+        nonlocal install_reached
+        install_reached = True
+        return object()
+
+    monkeypatch.setattr(runtime, "install_streaming", fake_install)
+
+    with pytest.raises(RuntimeError, match=r"lora_A"):
+        runtime.build_streamed_model(
+            model_id="fake/model",
+            shard_dir="unused",
+            index=object(),
+            lora_config=object(),
+            device="cpu",
+            dtype="float32",
+        )
+    assert install_reached is False


### PR DESCRIPTION
## Summary

- verify the post-PEFT adapter state before installing the streaming runtime
- accept the healthy PEFT 0.19 shape where `materialize_meta_adapters()` returns zero because adapters already have storage
- refuse any trainable `lora_*` parameter still on `meta`, naming the stranded parameter
- document the new failure and the return-count ambiguity

## Root cause

`materialize_meta_adapters()` returns how many tensors Soup allocated, but PEFT versions disagree on whether allocation is needed. PEFT 0.18 creates meta adapters for Soup to materialize; PEFT 0.19 may create real adapters itself. A return value of zero therefore cannot distinguish a healthy no-op from a missed adapter.

The streamed build now checks the actual postcondition instead of interpreting that count as a guard. The existing integer return remains unchanged for compatibility.

## Regression coverage

The new tests synthesize both PEFT outcomes so they run on the repository's pinned PEFT and CPU-only CI:

- zero materialized + already-real adapter passes
- frozen meta base weights remain valid
- a trainable meta adapter fails and names `lora_A`
- the real `build_streamed_model()` call site is driven with a deliberately inert materializer, proving the guard fires before runtime installation

This implementation does not depend on the still-missing direct `is_meta` measurement under PEFT 0.19; `lesterppo` can confirm that environment separately without changing the invariant.

## Verification

- `ruff check src/soup_cli/ tests/`
- focused issue tests: 5 passed
- v0.72.0 streaming + #385 decision tests: 189 passed, 6 skipped
- v0.72.3 streaming tests: 132 passed, 10 skipped
- full non-smoke suite: 17,779 passed, 258 skipped, 5 deselected
- total coverage: 80.83% (required: 77%)

Closes #433
