### PR TITLE
fix: disambiguate Windows STILL_ACTIVE (259) exit code from a live process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,19 @@ reproducing 70+ versions of notes.
   trainable `lora_*` parameter remains on `meta`, naming the stranded parameter
   instead of allowing a silent no-training run.
 
+- **Windows process liveness misread a process that exited with code 259 as
+  still running, forever (#424).** `GetExitCodeProcess` returns `STILL_ACTIVE`
+  (259) for a genuinely running process, but 259 is also a legal exit code, so
+  a child that exited *with* 259 was indistinguishable from one still running.
+  That silently defeated `ExperimentTracker`'s reconcile-on-read (#401) and
+  could wedge the MCP server's one-active-execution cap (#402) shut, refusing
+  every subsequent execution with no error an operator could act on. The check
+  now waits on the process handle with `WaitForSingleObject(handle, 0)`, which
+  is signalled the instant the process exits regardless of its exit code,
+  falling back to the exit-code read only if the wait itself fails. The two
+  byte-identical copies of this primitive in `experiment/tracker.py` and
+  `mcp_server/execution.py` are now one shared `utils/process_liveness.py`.
+
 - **`soup train --no-reexec` now prints the flags you actually typed (#372).**
   The advisory `accelerate launch` command is derived from the same argv the
   auto-reexec would have used, so `--fsdp` / `--deepspeed` / `--config` (and the

--- a/src/soup_cli/experiment/tracker.py
+++ b/src/soup_cli/experiment/tracker.py
@@ -13,12 +13,12 @@ import json
 import os
 import secrets
 import sqlite3
-import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
 from soup_cli.utils.constants import EXPERIMENTS_DB, SOUP_DIR
+from soup_cli.utils.process_liveness import process_is_alive as _process_is_alive
 
 # Run status values this module reconciles. A watcher that never unwound (its
 # daemon thread was killed when the MCP server exited) leaves the run at
@@ -27,85 +27,6 @@ from soup_cli.utils.constants import EXPERIMENTS_DB, SOUP_DIR
 # mistaken for success. See issue #401.
 _STATUS_RUNNING = "running"
 _STATUS_TERMINATED = "terminated"
-
-# Windows liveness constants (see _windows_process_is_alive). GetExitCodeProcess
-# returns STILL_ACTIVE for a running process; a failed OpenProcess distinguishes
-# a missing pid (ERROR_INVALID_PARAMETER) from one we merely cannot open
-# (ERROR_ACCESS_DENIED — it exists).
-_WIN_STILL_ACTIVE = 259
-_WIN_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
-_WIN_ERROR_ACCESS_DENIED = 5
-
-
-def _windows_process_is_alive(pid: int) -> bool:
-    """Liveness check for Windows, where ``os.kill(pid, 0)`` cannot be used.
-
-    On Windows ``CTRL_C_EVENT`` is ``0``, so ``os.kill(pid, 0)`` routes signal 0
-    to ``GenerateConsoleCtrlEvent`` — it sends a console Ctrl+C to the process
-    group and never checks existence (it raises KeyboardInterrupt in-process
-    instead). Query the process directly: open a limited-information handle and
-    read its exit code — a live process reads ``STILL_ACTIVE`` (259). A failed
-    open means the pid is gone (ERROR_INVALID_PARAMETER) unless it is only
-    ERROR_ACCESS_DENIED, which means the process exists but we lack rights.
-    """
-    import ctypes
-    from ctypes import wintypes
-
-    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
-    kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
-    kernel32.OpenProcess.restype = wintypes.HANDLE
-    kernel32.GetExitCodeProcess.argtypes = [
-        wintypes.HANDLE,
-        ctypes.POINTER(wintypes.DWORD),
-    ]
-    kernel32.GetExitCodeProcess.restype = wintypes.BOOL
-    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
-
-    handle = kernel32.OpenProcess(
-        _WIN_PROCESS_QUERY_LIMITED_INFORMATION, False, pid
-    )
-    if not handle:
-        return ctypes.get_last_error() == _WIN_ERROR_ACCESS_DENIED
-    try:
-        exit_code = wintypes.DWORD()
-        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
-            return True  # opened but could not query — assume alive (conservative)
-        return exit_code.value == _WIN_STILL_ACTIVE
-    finally:
-        kernel32.CloseHandle(handle)
-
-
-def _process_is_alive(pid: int) -> bool:
-    """Return True if a process with this PID currently exists.
-
-    POSIX uses signal 0 — a genuine existence/permission check that delivers no
-    signal: a PID owned by another user raises PermissionError and counts as
-    alive; only a missing process (ProcessLookupError / ESRCH) is dead. Any
-    other OSError is treated as not-alive so a corrupt record reconciles instead
-    of sticking on 'running' forever.
-
-    Windows needs a different primitive entirely: ``os.kill(pid, 0)`` there
-    sends a console Ctrl+C (``CTRL_C_EVENT == 0``) rather than checking
-    existence, so liveness goes through OpenProcess + GetExitCodeProcess (see
-    ``_windows_process_is_alive``).
-
-    Known limitation — PID reuse: a dead run whose PID has since been recycled
-    by an unrelated process reads as alive forever, so reconciliation never
-    fires for it. That is inherent to PID-liveness (a recorded process
-    start-time comparison would be needed to close it) and is out of scope for
-    issue #401.
-    """
-    if sys.platform == "win32":
-        return _windows_process_is_alive(pid)
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    except OSError:
-        return False
-    return True
 
 _SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS runs (
@@ -188,7 +109,6 @@ CREATE INDEX IF NOT EXISTS idx_forgetting_run_id ON forgetting_eval(run_id);
 
 def _get_db_path() -> Path:
     """Return path to experiments DB, creating parent dir if needed."""
-    import os
 
     # Allow override via env var (useful for tests and CI)
     env_path = os.environ.get("SOUP_DB_PATH")

--- a/src/soup_cli/mcp_server/execution.py
+++ b/src/soup_cli/mcp_server/execution.py
@@ -8,7 +8,6 @@ import os
 import secrets
 import stat
 import subprocess
-import sys
 import threading
 import time
 from dataclasses import dataclass
@@ -16,6 +15,7 @@ from pathlib import Path
 
 from soup_cli.experiment.tracker import ExperimentTracker, generate_run_id
 from soup_cli.utils.paths import atomic_write_text, enforce_under_cwd_and_no_symlink
+from soup_cli.utils.process_liveness import process_is_alive as _pid_is_alive
 
 TOKEN_TTL_SECONDS = 5 * 60
 DEFAULT_MAX_TREE_FILES = 10_000
@@ -27,77 +27,6 @@ DEFAULT_MAX_TREE_BYTES = 10 * 1024 * 1024 * 1024  # 10 GiB
 # as _STATUS_RUNNING. A recorded run only counts as active while its pid is
 # alive, so a stale record whose process is gone never blocks execution forever.
 _STATUS_RUNNING = "running"
-
-# Windows liveness constants (see _windows_pid_is_alive). GetExitCodeProcess
-# returns STILL_ACTIVE for a running process; a failed OpenProcess with only
-# ERROR_ACCESS_DENIED means the pid exists but we lack rights to open it.
-_WIN_STILL_ACTIVE = 259
-_WIN_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
-_WIN_ERROR_ACCESS_DENIED = 5
-
-
-def _windows_pid_is_alive(pid: int) -> bool:
-    """Liveness check for Windows, where ``os.kill(pid, 0)`` cannot be used.
-
-    On Windows ``CTRL_C_EVENT`` is ``0``, so ``os.kill(pid, 0)`` routes signal 0
-    to ``GenerateConsoleCtrlEvent`` — it sends a console Ctrl+C to the process
-    group and never checks existence. Query the process instead: open a
-    limited-information handle and read its exit code — a live process reads
-    ``STILL_ACTIVE`` (259). A failed open means the pid is gone unless it is only
-    ERROR_ACCESS_DENIED, which means the process exists but we lack rights.
-    """
-    import ctypes
-    from ctypes import wintypes
-
-    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
-    kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
-    kernel32.OpenProcess.restype = wintypes.HANDLE
-    kernel32.GetExitCodeProcess.argtypes = [
-        wintypes.HANDLE,
-        ctypes.POINTER(wintypes.DWORD),
-    ]
-    kernel32.GetExitCodeProcess.restype = wintypes.BOOL
-    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
-
-    handle = kernel32.OpenProcess(
-        _WIN_PROCESS_QUERY_LIMITED_INFORMATION, False, pid
-    )
-    if not handle:
-        return ctypes.get_last_error() == _WIN_ERROR_ACCESS_DENIED
-    try:
-        exit_code = wintypes.DWORD()
-        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
-            return True  # opened but could not query — assume alive (conservative)
-        return exit_code.value == _WIN_STILL_ACTIVE
-    finally:
-        kernel32.CloseHandle(handle)
-
-
-def _pid_is_alive(pid: int) -> bool:
-    """Return True if a process with this PID currently exists.
-
-    POSIX uses signal 0 — a genuine existence/permission check delivering no
-    signal: a PID owned by another user raises PermissionError and counts as
-    alive; only a missing process (ProcessLookupError / ESRCH) is dead. Any
-    other OSError is treated as not-alive so a corrupt record does not wedge the
-    capacity gate shut.
-
-    Windows needs a different primitive: ``os.kill(pid, 0)`` there sends a
-    console Ctrl+C (``CTRL_C_EVENT == 0``) rather than checking existence, so
-    liveness goes through OpenProcess + GetExitCodeProcess (see
-    ``_windows_pid_is_alive``).
-    """
-    if sys.platform == "win32":
-        return _windows_pid_is_alive(pid)
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    except OSError:
-        return False
-    return True
 
 
 class ExecutionError(ValueError):

--- a/src/soup_cli/utils/process_liveness.py
+++ b/src/soup_cli/utils/process_liveness.py
@@ -1,0 +1,123 @@
+"""Cross-platform process-liveness check, shared by the experiment tracker and
+the MCP execution manager (issue #424).
+
+Extracted from ``experiment/tracker.py::_windows_process_is_alive`` and
+``mcp_server/execution.py::_windows_pid_is_alive`` — the two were byte-identical
+copies whose docstrings had already started to diverge. ``utils/adapter_fuse.py``
+is the precedent for pulling a duplicated primitive out from under two callers
+before they drift further.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Windows liveness constants. GetExitCodeProcess returns STILL_ACTIVE for a
+# running process, but STILL_ACTIVE (259) is also a LEGAL process exit code —
+# a process that exits *with* code 259 used to be indistinguishable from one
+# still running by exit-code alone. WaitForSingleObject is the disambiguator:
+# the process handle becomes signalled the instant the process terminates,
+# independent of what its exit code was.
+_WIN_STILL_ACTIVE = 259
+_WIN_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+_WIN_SYNCHRONIZE = 0x00100000
+_WIN_ERROR_ACCESS_DENIED = 5
+_WIN_WAIT_OBJECT_0 = 0x0
+_WIN_WAIT_TIMEOUT = 0x102
+
+
+def _windows_process_is_alive(pid: int) -> bool:
+    """Liveness check for Windows, where ``os.kill(pid, 0)`` cannot be used.
+
+    On Windows ``CTRL_C_EVENT`` is ``0``, so ``os.kill(pid, 0)`` routes signal 0
+    to ``GenerateConsoleCtrlEvent`` — it sends a console Ctrl+C to the process
+    group and never checks existence (it raises KeyboardInterrupt in-process
+    instead). Query the process directly: open a handle with
+    ``PROCESS_QUERY_LIMITED_INFORMATION | SYNCHRONIZE`` (``WaitForSingleObject``
+    needs ``SYNCHRONIZE`` on top of the query right, or the wait itself fails)
+    and wait on it with a zero timeout — the handle becomes signalled
+    (``WAIT_OBJECT_0``) the instant the process exits, whatever its exit code.
+    A failed open means the pid is gone (ERROR_INVALID_PARAMETER) unless it is
+    only ERROR_ACCESS_DENIED, which means the process exists but we lack rights.
+
+    ``GetExitCodeProcess`` alone cannot make this call: it reports ``STILL_ACTIVE``
+    (259) for a running process, but 259 is also a legal exit code, so a process
+    that exits *with* 259 would read as alive forever (issue #424). It is kept
+    here only as a fallback for the case where the wait itself fails.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.GetExitCodeProcess.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(wintypes.DWORD),
+    ]
+    kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+    kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+    kernel32.WaitForSingleObject.restype = wintypes.DWORD
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+
+    handle = kernel32.OpenProcess(
+        _WIN_PROCESS_QUERY_LIMITED_INFORMATION | _WIN_SYNCHRONIZE, False, pid
+    )
+    if not handle:
+        return ctypes.get_last_error() == _WIN_ERROR_ACCESS_DENIED
+    try:
+        wait_result = kernel32.WaitForSingleObject(handle, 0)
+        if wait_result == _WIN_WAIT_OBJECT_0:
+            # Signalled: the process has exited, regardless of its exit code.
+            return False
+        if wait_result == _WIN_WAIT_TIMEOUT:
+            # Not signalled within 0ms: still running.
+            return True
+        # WAIT_FAILED or an unexpected value — fall back to the exit-code read.
+        exit_code = wintypes.DWORD()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+            return True  # opened but could not query — assume alive (conservative)
+        return exit_code.value == _WIN_STILL_ACTIVE
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+def process_is_alive(pid: int) -> bool:
+    """Return True if a process with this PID currently exists.
+
+    POSIX uses signal 0 — a genuine existence/permission check that delivers no
+    signal: a PID owned by another user raises PermissionError and counts as
+    alive; only a missing process (ProcessLookupError / ESRCH) is dead. Any
+    other OSError is treated as not-alive so a corrupt record does not wedge a
+    caller (reconcile-on-read, the MCP capacity gate) shut forever.
+
+    Windows needs a different primitive entirely: ``os.kill(pid, 0)`` there
+    sends a console Ctrl+C (``CTRL_C_EVENT == 0``) rather than checking
+    existence, so liveness goes through OpenProcess + WaitForSingleObject (see
+    ``_windows_process_is_alive``).
+
+    A non-int, bool, or non-positive ``pid`` returns False rather than reaching
+    either platform primitive: on POSIX, ``os.kill(0, 0)`` targets the caller's
+    own process group and would read permanently alive, and on any platform a
+    corrupt/invalid pid must not be able to crash a caller (issue #424).
+
+    Known limitation — PID reuse: a dead run whose PID has since been recycled
+    by an unrelated process reads as alive forever, so reconciliation never
+    fires for it. That is inherent to PID-liveness (a recorded process
+    start-time comparison would be needed to close it) and is out of scope for
+    issue #424.
+    """
+    if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+        return False
+    if sys.platform == "win32":
+        return _windows_process_is_alive(pid)
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True

--- a/tests/test_issue402_restart_capacity.py
+++ b/tests/test_issue402_restart_capacity.py
@@ -86,7 +86,7 @@ def test_capacity_check_rejects_a_dead_pid_without_help_from_reconcile(
 
     #407 rewrites a stale 'running' row on read, so by the time
     `_live_persisted_run` inspects `status` the dead row is already terminal —
-    which means its `_pid_is_alive` guard is never the thing under test.
+    which means its `process_is_alive` guard is never the thing under test.
     Measured: deleting that guard passes all 41 MCP tests. Here reconcile is
     neutralised so the row stays 'running' with a dead pid, leaving the cap's
     own check as the only thing that can reject it. The two are each other's

--- a/tests/test_issue424_windows_liveness.py
+++ b/tests/test_issue424_windows_liveness.py
@@ -1,0 +1,94 @@
+"""Windows STILL_ACTIVE (259) exit-code ambiguity in process liveness (issue #424).
+
+`GetExitCodeProcess` reports `STILL_ACTIVE` (259) for a running process, but 259
+is also a legal process exit code — a process that exits *with* 259 used to be
+indistinguishable from one still running and read ALIVE forever. The fix uses
+`WaitForSingleObject(handle, 0)`: the process handle becomes signalled the
+instant the process exits, independent of its exit code.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from unittest.mock import patch
+
+import pytest
+
+from soup_cli.experiment import tracker as tracker_module
+from soup_cli.mcp_server import execution as execution_module
+from soup_cli.utils.process_liveness import process_is_alive
+
+_STILL_ACTIVE_EXIT_CODE = 259
+
+_WIN32_ONLY = pytest.mark.skipif(
+    sys.platform != "win32", reason="exercises the Windows-only liveness primitive"
+)
+
+
+@_WIN32_ONLY
+def test_exit_code_259_reads_as_dead():
+    """The exact #424 repro: a process that exits with code 259 must read DEAD."""
+    proc = subprocess.Popen(
+        [sys.executable, "-c", f"import sys; sys.exit({_STILL_ACTIVE_EXIT_CODE})"]
+    )
+    proc.wait()
+    assert proc.returncode == _STILL_ACTIVE_EXIT_CODE
+
+    assert process_is_alive(proc.pid) is False
+
+
+@_WIN32_ONLY
+def test_control_ordinary_exit_code_reads_as_dead():
+    """CONTROL: an ordinary exit code must also read DEAD (sanity check)."""
+    proc = subprocess.Popen([sys.executable, "-c", "import sys; sys.exit(0)"])
+    proc.wait()
+
+    assert process_is_alive(proc.pid) is False
+
+
+@_WIN32_ONLY
+def test_control_live_process_reads_as_alive():
+    """CONTROL: a genuinely running process must still read ALIVE."""
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        # Give it a moment to actually start before checking.
+        time.sleep(0.2)
+        assert process_is_alive(proc.pid) is True
+    finally:
+        proc.terminate()
+        proc.wait()
+
+
+@_WIN32_ONLY
+def test_win32_never_falls_back_to_os_kill():
+    """A revert to `os.kill(pid, 0)` on Windows must fail this test by name,
+    not by the whole CI matrix dying with a stray KeyboardInterrupt (`os.kill`
+    with signal 0 sends a console Ctrl+C on Windows rather than checking
+    existence).
+    """
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        time.sleep(0.2)
+        with patch("soup_cli.utils.process_liveness.os.kill") as mock_kill:
+            process_is_alive(proc.pid)
+        mock_kill.assert_not_called()
+    finally:
+        proc.terminate()
+        proc.wait()
+
+
+@pytest.mark.parametrize(
+    "bad_pid", ["not-a-pid", 0, -1, True, False, None, 3.5]
+)
+def test_invalid_pid_returns_false_not_raise(bad_pid):
+    """A non-int, bool, or non-positive pid must not crash a caller."""
+    assert process_is_alive(bad_pid) is False
+
+
+def test_tracker_and_execution_share_one_primitive():
+    """Both call sites must go through the same shared primitive, not two
+    copies that can drift (the original defect this issue reports)."""
+    assert tracker_module._process_is_alive is process_is_alive
+    assert execution_module._pid_is_alive is process_is_alive


### PR DESCRIPTION
## What does this PR do?
Fixes #424 — on Windows, `GetExitCodeProcess` reports `STILL_ACTIVE` (259) for a running process, but
259 is also a legal exit code, so a process that *exits with* 259 was indistinguishable from one still
running and read ALIVE forever. That could leave issue #401's reconcile-on-read permanently unable to
fire, and could wedge #402's one-active-execution capacity gate shut.

Fix: use `WaitForSingleObject(handle, 0)` as the authoritative signal — the process handle becomes
signalled the instant the process exits, independent of its exit code — falling back to the existing
`GetExitCodeProcess` read only if the wait itself fails. (The handle also needs `SYNCHRONIZE` added to
`PROCESS_QUERY_LIMITED_INFORMATION`, or `WaitForSingleObject` fails and silently falls through to the
old buggy path — caught by the new test before it could ship that way.)

Also folds in the issue's other findings while touching this code:
- Extracted the byte-identical liveness primitive that was duplicated in `experiment/tracker.py` and
  `mcp_server/execution.py` into one shared `utils/process_liveness.py` (their docstrings had already
  started to diverge), following the extraction precedent in `utils/adapter_fuse.py`.
- Added an `isinstance(pid, int) and pid > 0` guard so a corrupt/non-int pid can't crash `soup runs`
  (also closes the POSIX `pid=0` self-process-group anomaly noted in the issue).
- Added a Windows-only regression test asserting the win32 path never falls through to `os.kill`, so a
  revert to `os.kill(pid, 0)` fails that test by name instead of by the whole Windows CI matrix dying
  with a stray `KeyboardInterrupt`.

Verified locally on Windows: reproduced the exit-259 false-ALIVE read against the pre-fix code, confirmed
it flips after the fix. Full suite: 17674 passed, 393 skipped, 0 failed (80.75% coverage).

## Type of change
- [x] Bug fix

## Checklist
- [x] `ruff check src/soup_cli/ tests/` passes
- [x] `pytest tests/ -v` passes
- [ ] Updated relevant docs — n/a, internal-only helper, no user-facing behavior/doc change
- [x] New tests added for new functionality
- [x] No breaking changes

Closes #424
