### PR TITLE
test(stream): pin non-LoRA meta guard scope

### DIFF
--- a/tests/test_issue433_meta_adapter_guard.py
+++ b/tests/test_issue433_meta_adapter_guard.py
@@ -72,6 +72,23 @@ class TestAdapterMaterializationPostcondition:
         model = _adapter_model(adapter_device="meta", adapter_trainable=False)
         assert_trainable_adapters_materialized(model)
 
+    def test_trainable_meta_non_lora_parameter_is_out_of_scope(self):
+        import torch
+        import torch.nn as nn
+
+        from soup_cli.utils.layer_stream_runtime import (
+            assert_trainable_adapters_materialized,
+        )
+
+        class _Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.classifier_weight = nn.Parameter(
+                    torch.empty(2, 2, device="meta"), requires_grad=True
+                )
+
+        assert_trainable_adapters_materialized(_Model())
+
 
 def test_streamed_build_refuses_a_materializer_that_skips_a_meta_adapter(monkeypatch):
     """Negative control: stub the capability and force the failure state.


### PR DESCRIPTION
## Summary

- add the missing mutation control for the adapter materialization postcondition
- prove a trainable non-`lora_*` parameter on `meta` remains outside the guard's deliberate scope
- prevent a future broadening of the predicate from causing spurious streamed-build refusals

## Context

This is the LOW, non-blocking follow-up identified in the merge review for #435. Dropping the `"lora_" in name` predicate previously survived the suite; the new control fails under that mutation and passes with the intended implementation.

## Impact

Test-only. Runtime behavior is unchanged.

## Verification

- `python -m pytest -q --no-cov tests/test_issue433_meta_adapter_guard.py tests/test_v07200.py tests/test_v07202.py` — 262 passed, 5 skipped
- `ruff check src/soup_cli/ tests/` — clean
