### PR TITLE
fix(data): handle BatchEncoding loss-mask outputs safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,15 @@ reproducing 70+ versions of notes.
 
 ### Fixed
 
+- **Assistant-only masking no longer mistakes `BatchEncoding` keys for token
+  ids (#430).** Tokenizer mapping outputs are read through `input_ids`, and
+  tensor-like ids are normalised to Python integers before they reach the
+  collator; missing or non-integer ids now fail loudly instead of building a
+  garbage label mask. A template that returns an all-zero assistant mask while
+  assistant messages exist now falls back to incremental rendering, avoiding a
+  silent all-`-100` no-op training run. The same mapping assumption was removed
+  from the data doctor.
+
 - **Layer streaming now verifies that every trainable LoRA parameter has real
   storage after PEFT attaches the adapter (#433).** PEFT 0.18 creates streamed
   adapters on `meta` for Soup to materialise, while PEFT 0.19 may create them as

--- a/src/soup_cli/data/loss_mask.py
+++ b/src/soup_cli/data/loss_mask.py
@@ -12,7 +12,10 @@ Two strategies:
 
 1. **Preferred**: ``tokenizer.apply_chat_template(..., return_assistant_tokens_mask=True,
    return_dict=True)``. Available on HF templates that declare ``{% generation %}``
-   markers. Honest, exact, no heuristic.
+   markers. Mapping outputs such as ``BatchEncoding`` are read through
+   ``input_ids`` and tensor-like ids/masks are normalised to Python integers.
+   If assistant messages are present but the returned mask is all zero, this
+   path is rejected so the fallback can avoid a silent all-``-100`` training row.
 
 2. **Fallback**: Render ``messages[:i]`` vs ``messages[:i+1]`` for each turn and
    take the token delta. The delta is the new turn's tokens (prefix + content +
@@ -27,9 +30,49 @@ Two strategies:
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from operator import index
 from typing import Any, Optional, Sequence
 
 IGNORE_INDEX = -100
+_MISSING = object()
+
+
+def _coerce_int_list(
+    values: Any, *, field: str, allow_bool: bool = False
+) -> list[int]:
+    """Return a one-dimensional tokenizer sequence as Python ``int`` values."""
+    try:
+        items = list(values)
+    except TypeError as exc:
+        raise ValueError(
+            f"tokenizer returned invalid {field}; expected a sequence of integers"
+        ) from exc
+
+    result: list[int] = []
+    for position, item in enumerate(items):
+        if isinstance(item, bool) and not allow_bool:
+            raise ValueError(
+                f"tokenizer returned non-integer {field}[{position}]={item!r}"
+            )
+        try:
+            item = index(item)
+        except TypeError as exc:
+            raise ValueError(
+                f"tokenizer returned non-integer {field}[{position}]={item!r}"
+            ) from exc
+        result.append(int(item))
+    return result
+
+
+def _coerce_token_ids(out: Any) -> list[int]:
+    """Extract and normalise token ids from a sequence or mapping output."""
+    values = out
+    if isinstance(out, Mapping):
+        values = out.get("input_ids", _MISSING)
+        if values is _MISSING:
+            raise ValueError("tokenizer output mapping has no 'input_ids'")
+    return _coerce_int_list(values, field="input_ids")
 
 
 def _validate_max_length(max_length: int) -> None:
@@ -61,19 +104,34 @@ def _apply_template_with_mask(
     except TypeError:
         # Old HF that doesn't recognise return_assistant_tokens_mask.
         return None
-    if not isinstance(out, dict):
+    if not isinstance(out, Mapping):
         return None
     masks = out.get("assistant_masks")
-    ids = out.get("input_ids")
-    if masks is None or ids is None:
+    if masks is None:
         return None
-    if len(masks) != len(ids):
+    try:
+        ids = _coerce_token_ids(out)
+        mask = _coerce_int_list(
+            masks, field="assistant_masks", allow_bool=True
+        )
+    except ValueError:
         return None
-    return list(ids), list(masks)
+    if len(mask) != len(ids):
+        return None
+    if any(msg.get("role") == "assistant" for msg in messages) and not any(mask):
+        # Some templates accept the mask kwargs but have no {% generation %}
+        # markers. Trusting their all-zero mask would silently train no tokens.
+        return None
+    return ids, mask
 
 
 def _tokenize_only(tokenizer: Any, messages: Sequence[dict]) -> list[int]:
-    """Render and tokenize ``messages``; never let HF auto-prepend BOS again."""
+    """Render ``messages`` into Python int ids without auto-prepending BOS.
+
+    Mapping outputs (including ``BatchEncoding``) are read through
+    ``input_ids``. Tensor-like sequences are normalised element by element;
+    missing or non-integer ids raise instead of flowing into a collator.
+    """
     try:
         out = tokenizer.apply_chat_template(
             messages,
@@ -88,9 +146,7 @@ def _tokenize_only(tokenizer: Any, messages: Sequence[dict]) -> list[int]:
             tokenize=True,
             add_generation_prompt=False,
         )
-    if isinstance(out, dict):
-        return list(out.get("input_ids", []))
-    return list(out)
+    return _coerce_token_ids(out)
 
 
 def _truncate(
@@ -131,7 +187,9 @@ def build_assistant_only_labels(
 
     Raises:
         ValueError: empty messages, non-positive max_length, or tokenizer
-            lacking a chat_template.
+            lacking a chat_template or returning invalid token ids. When a
+            template reports an all-zero assistant mask despite assistant
+            messages, Soup falls back to incremental rendering instead.
         TypeError: ``include_eot`` not bool.
     """
     if not isinstance(include_eot, bool):

--- a/src/soup_cli/utils/data_doctor.py
+++ b/src/soup_cli/utils/data_doctor.py
@@ -258,7 +258,11 @@ def _build_row_labels(
     actually train on for a given ``soup.yaml``. Raises on a row the
     template can't render — callers decide whether to skip or propagate.
     """
-    from soup_cli.data.loss_mask import build_assistant_only_labels, build_per_message_train_labels
+    from soup_cli.data.loss_mask import (
+        _coerce_token_ids,
+        build_assistant_only_labels,
+        build_per_message_train_labels,
+    )
 
     if train_on_messages_with_train_field:
         return build_per_message_train_labels(messages, tokenizer, max_length=max_length)
@@ -266,9 +270,11 @@ def _build_row_labels(
         return build_assistant_only_labels(
             messages, tokenizer, max_length=max_length, include_eot=include_eot
         )
-    ids = tokenizer.apply_chat_template(messages, tokenize=True, add_generation_prompt=False)
-    if isinstance(ids, dict):
-        ids = ids.get("input_ids", [])
+    ids = _coerce_token_ids(
+        tokenizer.apply_chat_template(
+            messages, tokenize=True, add_generation_prompt=False
+        )
+    )
     # Truncate to max_length like the other two strategies (both delegate
     # to data.loss_mask._truncate) — otherwise legacy_text is the only path
     # where --show-mask can render more tokens than the trainer actually
@@ -361,7 +367,7 @@ def check_generation_markers(tokenizer: Any) -> DoctorCheck:
             probe, tokenize=True, add_generation_prompt=False,
             return_assistant_tokens_mask=True, return_dict=True,
         )
-        has_markers = isinstance(out, dict) and bool(out.get("assistant_masks")) and any(
+        has_markers = isinstance(out, Mapping) and bool(out.get("assistant_masks")) and any(
             out["assistant_masks"]
         )
     except Exception:  # noqa: BLE001 — any failure means no usable markers
@@ -609,6 +615,7 @@ def check_truncation_risk(
             name="truncation_risk", verdict="OK", message="skipped (no chat_template)"
         )
 
+    from soup_cli.data.loss_mask import _coerce_token_ids
     from soup_cli.utils.tail_latency import percentile
 
     lengths: List[float] = []
@@ -617,13 +624,13 @@ def check_truncation_risk(
         if not messages:
             continue
         try:
-            ids = tokenizer.apply_chat_template(
-                messages, tokenize=True, add_generation_prompt=False
+            ids = _coerce_token_ids(
+                tokenizer.apply_chat_template(
+                    messages, tokenize=True, add_generation_prompt=False
+                )
             )
         except Exception:  # noqa: BLE001 — render failures are reported by template_render
             continue
-        if isinstance(ids, dict):
-            ids = ids.get("input_ids", [])
         lengths.append(float(len(ids)))
     if not lengths:
         return DoctorCheck(name="truncation_risk", verdict="OK", message="no rows to measure")

--- a/tests/test_assistant_mask.py
+++ b/tests/test_assistant_mask.py
@@ -69,6 +69,34 @@ class _FakeTokenizer:
         return ids
 
 
+class _StaticTokenizer:
+    def __init__(self, output):
+        self.output = output
+
+    def apply_chat_template(self, *_args, **_kwargs):
+        return self.output
+
+
+class _BatchEncodingTokenizer(_FakeTokenizer):
+    def __init__(self, *, zero_mask: bool = False):
+        super().__init__()
+        self.zero_mask = zero_mask
+        self.fallback_calls = 0
+
+    def apply_chat_template(self, messages, **kwargs):
+        from transformers import BatchEncoding
+
+        _text, ids, mask = self._render(messages)
+        if kwargs.get("return_assistant_tokens_mask"):
+            if self.zero_mask:
+                mask = [0] * len(ids)
+            return BatchEncoding(
+                {"input_ids": ids, "assistant_masks": mask}
+            )
+        self.fallback_calls += 1
+        return BatchEncoding({"input_ids": ids})
+
+
 # ---------------------------------------------------------------------------
 # Schema field
 # ---------------------------------------------------------------------------
@@ -161,6 +189,48 @@ class TestPreferredPath:
         assert len(out["labels"]) == 128
         assert len(out["attention_mask"]) == 128
 
+    def test_real_batch_encoding_is_accepted(self):
+        from soup_cli.data.loss_mask import IGNORE_INDEX, build_assistant_only_labels
+
+        tok = _BatchEncodingTokenizer()
+        out = build_assistant_only_labels(
+            [
+                {"role": "user", "content": "Q"},
+                {"role": "assistant", "content": "A"},
+            ],
+            tok,
+        )
+
+        assert tok.fallback_calls == 0
+        assert any(label != IGNORE_INDEX for label in out["labels"])
+        assert all(type(token_id) is int for token_id in out["input_ids"])
+
+    def test_all_zero_mask_with_assistant_falls_back(self):
+        from soup_cli.data.loss_mask import IGNORE_INDEX, build_assistant_only_labels
+
+        tok = _BatchEncodingTokenizer(zero_mask=True)
+        out = build_assistant_only_labels(
+            [
+                {"role": "user", "content": "Q"},
+                {"role": "assistant", "content": "A"},
+            ],
+            tok,
+        )
+
+        assert tok.fallback_calls > 0
+        assert any(label != IGNORE_INDEX for label in out["labels"])
+
+    def test_all_zero_mask_without_assistant_is_valid(self):
+        from soup_cli.data.loss_mask import IGNORE_INDEX, build_assistant_only_labels
+
+        tok = _BatchEncodingTokenizer(zero_mask=True)
+        out = build_assistant_only_labels(
+            [{"role": "user", "content": "Q"}], tok
+        )
+
+        assert tok.fallback_calls == 0
+        assert all(label == IGNORE_INDEX for label in out["labels"])
+
 
 class TestFallbackPath:
     """When tokenizer does NOT support ``return_assistant_tokens_mask``."""
@@ -215,6 +285,100 @@ class TestFallbackPath:
         assert labels[-1] == IGNORE_INDEX  # newline
         assert labels[-2] == IGNORE_INDEX  # '2'
         assert labels[-3] == IGNORE_INDEX  # 'Q'
+
+
+class TestTokenIdNormalisation:
+    def test_real_batch_encoding_returns_values_not_mapping_keys(self):
+        from transformers import BatchEncoding
+
+        from soup_cli.data.loss_mask import _tokenize_only
+
+        encoded = BatchEncoding({"input_ids": [1, 2, 3]})
+        assert not isinstance(encoded, dict)
+
+        ids = _tokenize_only(
+            _StaticTokenizer(encoded), [{"role": "user", "content": "Q"}]
+        )
+        assert ids == [1, 2, 3]
+        assert all(type(token_id) is int for token_id in ids)
+
+    def test_tensor_ids_are_normalised_to_python_ints(self):
+        import torch
+
+        from soup_cli.data.loss_mask import _tokenize_only
+
+        ids = _tokenize_only(
+            _StaticTokenizer(torch.tensor([4, 5, 6])),
+            [{"role": "user", "content": "Q"}],
+        )
+        assert ids == [4, 5, 6]
+        assert all(type(token_id) is int for token_id in ids)
+
+    def test_missing_input_ids_raises(self):
+        from transformers import BatchEncoding
+
+        from soup_cli.data.loss_mask import _tokenize_only
+
+        with pytest.raises(ValueError, match="input_ids"):
+            _tokenize_only(
+                _StaticTokenizer(BatchEncoding({"attention_mask": [1, 1]})),
+                [{"role": "user", "content": "Q"}],
+            )
+
+    def test_non_integer_token_ids_raise(self):
+        from transformers import BatchEncoding
+
+        from soup_cli.data.loss_mask import _tokenize_only
+
+        with pytest.raises(ValueError, match="non-integer input_ids"):
+            _tokenize_only(
+                _StaticTokenizer(
+                    BatchEncoding({"input_ids": ["input_ids"]})
+                ),
+                [{"role": "user", "content": "Q"}],
+            )
+
+
+class TestTokenizerMappingAudit:
+    @staticmethod
+    def _messages():
+        return [
+            {"role": "user", "content": "Q"},
+            {"role": "assistant", "content": "A"},
+        ]
+
+    def test_show_mask_path_accepts_real_batch_encoding(self):
+        from soup_cli.utils.data_doctor import _build_row_labels
+
+        messages = self._messages()
+        built = _build_row_labels(
+            _BatchEncodingTokenizer(),
+            messages,
+            max_length=16,
+            train_on_responses_only=False,
+            train_on_messages_with_train_field=False,
+            include_eot=False,
+        )
+
+        assert built["input_ids"]
+        assert all(type(token_id) is int for token_id in built["input_ids"])
+
+    def test_generation_marker_check_accepts_real_batch_encoding(self):
+        from soup_cli.utils.data_doctor import check_generation_markers
+
+        assert check_generation_markers(_BatchEncodingTokenizer()).verdict == "OK"
+
+    def test_truncation_check_measures_batch_encoding_values(self):
+        from soup_cli.utils.data_doctor import check_truncation_risk
+
+        result = check_truncation_risk(
+            _BatchEncodingTokenizer(),
+            [{"messages": self._messages()}],
+            max_length=1,
+        )
+
+        assert result.verdict == "MAJOR"
+        assert "p95 length = 1 tokens" not in result.message
 
 
 class TestPerMessageTrainField:


### PR DESCRIPTION
Closes #430.

## What changed

- Read tokenizer mappings, including real `transformers.BatchEncoding` objects, through `input_ids` in both assistant-mask paths.
- Normalise tensor-like ids and masks to Python integers. Missing or non-integer token ids now raise instead of reaching the collator.
- Reject an all-zero assistant mask when assistant messages exist, then use the existing incremental-rendering fallback so the row does not silently become all `-100`.
- Apply the same mapping handling to `data doctor` generation-marker checks, mask previews, and truncation-risk measurements.
- Document the two behaviour decisions in `loss_mask.py` and add an Unreleased changelog entry.

## Root cause and impact

`BatchEncoding` implements `Mapping` through `UserDict`, but it is not a `dict`. The previous fallback called `list(out)`, which returned mapping keys such as `['input_ids']` instead of token ids. Those strings could travel as far as the training collator before failing, or corrupt assistant-only label construction.

Some chat templates also accept the assistant-mask arguments without declaring `{% generation %}` markers. They return a mask containing only zeros. When assistant messages are present, trusting that result creates a no-op training row with every label set to `-100`; this change falls back rather than accepting it.

## Validation

- `219 passed, 1 skipped` across `test_assistant_mask.py`, `test_v07127.py`, and `test_formats.py`
- `ruff check src/soup_cli tests` passes
- Mutation checks confirm the tests fail when any of these changes is reverted: preferred-path `Mapping` support, the all-zero-mask guard, and each of the three `data doctor` consumers
- The full local suite reached `721 passed` before an installed FastAPI/Starlette incompatibility failed `test_tool_python_endpoint_requires_bearer_when_token_set`. The same test fails with the same traceback on an isolated checkout of current `origin/main`; the PR CI will provide the clean-environment result.

## Submission context

This branch was already being prepared locally when #438 opened. I am submitting it after the maintainer invited both implementations to be reviewed on their merits. I'm not asking for precedence over #438, and the current #426 no longer contains these changes.
