### PR TITLE
fix: soup data mix --optimize writes a recipe soup train can load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,15 @@ reproducing 70+ versions of notes.
   silent all-`-100` no-op training run. The same mapping assumption was removed
   from the data doctor.
 
+- **`soup data mix --optimize` wrote a recipe `soup train` could not load
+  (#330).** `render_mix_recipe_yaml` emitted `data.train` as a YAML list of
+  every searched dataset, but `DataConfig.train` is typed `str`, so the recipe
+  failed to load with `data -> train: Input should be a valid string`.
+  `data.train` now renders as the single highest-weighted dataset from the
+  search; the full ranked weight/path breakdown is kept as a comment above it
+  so no information is lost, and the comment explains that `data.interleave`
+  is not yet consumed by training.
+
 - **Layer streaming now verifies that every trainable LoRA parameter has real
   storage after PEFT attaches the adapter (#433).** PEFT 0.18 creates streamed
   adapters on `meta` for Soup to materialise, while PEFT 0.19 may create them as

--- a/docs/data.md
+++ b/docs/data.md
@@ -734,7 +734,7 @@ soup data mix --optimize --budget 1h \
     --num-probes 8 --output mix_recipe.yaml
 ```
 
-Writes a YAML recipe with a `data.interleave` block you can splice into your `soup.yaml`. `--budget` accepts `60s` / `5m` / `1h` / `24h`. Per-candidate proxy failures are isolated (DEBUG-logged, sentinel high loss recorded) so a single OOM combo does not abort the whole search; `partial=True` is surfaced in the report when the budget cap trips mid-loop.
+Writes a YAML recipe you can splice into your `soup.yaml`: `data.train` is the single highest-weighted dataset from the search (the full ranked weight/path breakdown is kept as a comment), and `data.interleave` carries the searched mixture weights but is not yet consumed by training — see the in-file comment, and #330/#443. `--budget` accepts `60s` / `5m` / `1h` / `24h`. Per-candidate proxy failures are isolated (DEBUG-logged, sentinel high loss recorded) so a single OOM combo does not abort the whole search; `partial=True` is surfaced in the report when the budget cap trips mid-loop.
 
 Re-apply a previously written recipe:
 

--- a/src/soup_cli/commands/data_mix.py
+++ b/src/soup_cli/commands/data_mix.py
@@ -14,6 +14,7 @@ optimiser surface, and the recipe writer end-to-end without GPUs.
 
 from __future__ import annotations
 
+import json
 import math
 from typing import Optional, Tuple
 
@@ -136,8 +137,10 @@ def mix(
         for p in probs:
             console.print(f"      - {float(p):.6f}")
         if isinstance(train_value, str):
-            # #330 — current recipes: data.train is a single string.
-            console.print(f"  train: {escape(train_value)}")
+            # #330 — current recipes: data.train is a single string. Quote it
+            # the same way render_mix_recipe_yaml does — an unquoted path
+            # like "odd: name.jsonl" is not valid YAML when pasted back.
+            console.print(f"  train: {escape(json.dumps(train_value))}")
         else:
             # Pre-#330 recipes on disk: data.train was a YAML list.
             console.print("  train:")

--- a/src/soup_cli/commands/data_mix.py
+++ b/src/soup_cli/commands/data_mix.py
@@ -124,9 +124,7 @@ def mix(
             )
         )
         # Round-trip via the renderer so the user sees the canonical shape.
-        train_paths = data_block.get("train", []) if hasattr(
-            data_block, "get"
-        ) else []
+        train_value = data_block.get("train") if hasattr(data_block, "get") else None
         interleave = (
             data_block.get("interleave", {}) if hasattr(data_block, "get") else {}
         )
@@ -137,9 +135,14 @@ def mix(
         console.print("    probs:")
         for p in probs:
             console.print(f"      - {float(p):.6f}")
-        console.print("  train:")
-        for path in train_paths:
-            console.print(f"    - {escape(str(path))}")
+        if isinstance(train_value, str):
+            # #330 — current recipes: data.train is a single string.
+            console.print(f"  train: {escape(train_value)}")
+        else:
+            # Pre-#330 recipes on disk: data.train was a YAML list.
+            console.print("  train:")
+            for path in train_value or []:
+                console.print(f"    - {escape(str(path))}")
         return
 
     if not datasets:

--- a/src/soup_cli/utils/data_mix.py
+++ b/src/soup_cli/utils/data_mix.py
@@ -598,6 +598,16 @@ def render_mix_recipe_yaml(report: MixOptimizationReport) -> str:
     ``data:``. Defends against YAML key injection by rejecting newlines and
     null bytes in dataset paths (mirrors v0.46.0 Part A
     ``render_recipe_yaml``).
+
+    ``data.train`` renders as a single string — the highest-weighted dataset
+    from the search — because ``DataConfig.train`` is typed ``str`` and
+    ``soup train`` has no reader for a weighted multi-dataset mixture
+    (``data.interleave`` is validated at config-load time but never consumed
+    by ``load_dataset()``). Emitting the full dataset list there produced a
+    recipe ``soup train`` itself could not load (#330). The full ranked
+    weight/path breakdown is kept in a comment so the human-review value
+    isn't lost by collapsing to one path. ``data.interleave`` is left as-is
+    below — it already round-trips through the schema fine.
     """
     if not isinstance(report, MixOptimizationReport):
         raise TypeError(
@@ -623,15 +633,38 @@ def render_mix_recipe_yaml(report: MixOptimizationReport) -> str:
     )
     if report.partial:
         lines.append("# Budget exceeded — partial results.")
+    best_idx = max(
+        range(len(report.best_weights)), key=lambda i: report.best_weights[i]
+    )
+    best_path = report.datasets[best_idx]
+    lines.append("#")
+    lines.append(
+        "# soup train does not yet consume a weighted multi-dataset mixture"
+    )
+    lines.append(
+        "# (data.interleave has no training-time reader) — data.train below"
+    )
+    lines.append(
+        "# is the single best-performing dataset from this search. To train"
+    )
+    lines.append(
+        "# on a real combination of all N datasets, merge them first with"
+    )
+    lines.append("# `soup data merge`, then point data.train at the merged file.")
+    lines.append("#")
+    lines.append("# Full ranked result:")
+    ranked = sorted(
+        zip(report.datasets, report.best_weights), key=lambda dw: -dw[1]
+    )
+    for path, w in ranked:
+        lines.append(f"#   {w:.6f}  {path}")
     lines.append("data:")
     lines.append("  interleave:")
     lines.append("    strategy: probs")
     lines.append("    probs:")
     for w in report.best_weights:
         lines.append(f"      - {w:.6f}")
-    lines.append("  train:")
-    for path in report.datasets:
-        lines.append(f"    - {json.dumps(path)}")
+    lines.append(f"  train: {json.dumps(best_path)}")
     return "\n".join(lines) + "\n"
 
 

--- a/src/soup_cli/utils/data_mix.py
+++ b/src/soup_cli/utils/data_mix.py
@@ -633,6 +633,14 @@ def render_mix_recipe_yaml(report: MixOptimizationReport) -> str:
     )
     if report.partial:
         lines.append("# Budget exceeded — partial results.")
+    if not report.best_weights:
+        raise ValueError("report.best_weights is empty — nothing to render.")
+    if len(report.best_weights) != len(report.datasets):
+        raise ValueError(
+            "report.best_weights length "
+            f"({len(report.best_weights)}) must match report.datasets length "
+            f"({len(report.datasets)})."
+        )
     best_idx = max(
         range(len(report.best_weights)), key=lambda i: report.best_weights[i]
     )

--- a/tests/test_issue330_mix_recipe_train_loadable.py
+++ b/tests/test_issue330_mix_recipe_train_loadable.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+"""`soup data mix --optimize` writes a recipe `soup train` cannot load (issue #330).
+
+`render_mix_recipe_yaml` emitted `data.train` as a YAML list, but `DataConfig.train`
+is typed `str` — so the recipe it writes for a human to splice into `soup.yaml`
+failed `load_config_from_string` with `data -> train: Input should be a valid
+string`. `data.train` now renders as the single highest-weighted dataset from the
+search; `data.interleave` is unchanged (it already round-trips fine — the bug was
+only ever `train`).
+"""
+
+from __future__ import annotations
+
+from soup_cli.config.loader import load_config_from_string
+from soup_cli.utils.data_mix import MixOptimizationReport, render_mix_recipe_yaml
+
+
+def _make_files(tmp_path, names):
+    for n in names:
+        (tmp_path / n).write_text("{}\n")
+
+
+def _report(datasets, weights, tmp_path) -> MixOptimizationReport:
+    return MixOptimizationReport(
+        datasets=tuple(str(tmp_path / d) for d in datasets),
+        candidates=(),
+        best_weights=tuple(weights),
+        best_eval_loss=0.123,
+        partial=False,
+        elapsed_seconds=10.0,
+    )
+
+
+def _splice_into_config(data_block_text: str) -> str:
+    return "base: test-base\ntask: sft\n" + data_block_text
+
+
+def test_rendered_recipe_loads_through_config_schema(tmp_path):
+    report = _report(["a.jsonl", "b.jsonl"], [0.7, 0.3], tmp_path)
+    text = render_mix_recipe_yaml(report)
+    # Strip the leading comment lines — only the `data:` block onward is
+    # spliced into a real soup.yaml, matching how a human would use it.
+    data_block = text[text.index("data:"):]
+    cfg = load_config_from_string(_splice_into_config(data_block))
+    assert cfg.data.train == str(tmp_path / "a.jsonl")
+
+
+def test_train_is_the_highest_weighted_dataset(tmp_path):
+    report = _report(
+        ["a.jsonl", "b.jsonl", "c.jsonl"], [0.2, 0.55, 0.25], tmp_path
+    )
+    text = render_mix_recipe_yaml(report)
+    data_block = text[text.index("data:"):]
+    cfg = load_config_from_string(_splice_into_config(data_block))
+    assert cfg.data.train == str(tmp_path / "b.jsonl")
+
+
+def test_full_ranked_breakdown_still_in_comments(tmp_path):
+    # The human-review value of the original recipe (every dataset + its
+    # weight) must survive collapsing `data.train` to one path.
+    report = _report(["a.jsonl", "b.jsonl"], [0.7, 0.3], tmp_path)
+    text = render_mix_recipe_yaml(report)
+    assert "0.700000" in text
+    assert "0.300000" in text
+    assert str(tmp_path / "a.jsonl") in text
+    assert str(tmp_path / "b.jsonl") in text
+
+
+def test_apply_cli_prints_new_string_shape_recipe(tmp_path, monkeypatch):
+    _make_files(tmp_path, ["a.jsonl", "b.jsonl"])
+    monkeypatch.chdir(tmp_path)
+    from typer.testing import CliRunner
+
+    from soup_cli.cli import app
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "data", "mix",
+            "--optimize",
+            "--datasets", "a.jsonl,b.jsonl",
+            "--budget", "60s",
+            "--num-probes", "2",
+            "--output", "rec.yaml",
+        ],
+    )
+    assert result.exit_code == 0, (result.output, repr(result.exception))
+    result = runner.invoke(app, ["data", "mix", "--apply", "rec.yaml"])
+    assert result.exit_code == 0, (result.output, repr(result.exception))
+    # Rich wraps long lines to the console width, so compare with whitespace
+    # collapsed rather than by exact line — "train:" must be followed
+    # directly by the path, not by a "-" list marker (the old shape).
+    compact = "".join(result.output.split())
+    assert "train:" in compact, result.output
+    after = compact[compact.index("train:") + len("train:"):]
+    assert not after.startswith("-"), result.output
+    assert "a.jsonl" in after[:200], result.output
+
+
+def test_apply_handles_pre_fix_list_shaped_recipe(tmp_path, monkeypatch):
+    # A recipe written by the pre-fix code (data.train as a YAML list) must
+    # still print via --apply rather than crash — old files on disk survive
+    # the fix.
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "old.yaml").write_text(
+        "data:\n"
+        "  interleave:\n"
+        "    strategy: probs\n"
+        "    probs:\n"
+        "      - 0.6\n"
+        "      - 0.4\n"
+        "  train:\n"
+        "    - a.jsonl\n"
+        "    - b.jsonl\n"
+    )
+    from typer.testing import CliRunner
+
+    from soup_cli.cli import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["data", "mix", "--apply", "old.yaml"])
+    assert result.exit_code == 0, (result.output, repr(result.exception))
+    assert "a.jsonl" in result.output
+    assert "b.jsonl" in result.output

--- a/tests/test_issue330_mix_recipe_train_loadable.py
+++ b/tests/test_issue330_mix_recipe_train_loadable.py
@@ -99,6 +99,53 @@ def test_apply_cli_prints_new_string_shape_recipe(tmp_path, monkeypatch):
     assert "a.jsonl" in after[:200], result.output
 
 
+def test_render_recipe_rejects_empty_weights(tmp_path):
+    report = _report([], [], tmp_path)
+    try:
+        render_mix_recipe_yaml(report)
+    except ValueError as exc:
+        assert "best_weights" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for empty best_weights")
+
+
+def test_render_recipe_rejects_mismatched_weights_length(tmp_path):
+    report = _report(["a.jsonl", "b.jsonl"], [0.5, 0.3, 0.2], tmp_path)
+    try:
+        render_mix_recipe_yaml(report)
+    except ValueError as exc:
+        assert "best_weights" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for mismatched lengths")
+
+
+def test_apply_cli_quotes_path_needing_quoting(tmp_path, monkeypatch):
+    # Maintainer's repro: an unquoted `train: odd: name.jsonl` line is not
+    # valid YAML when pasted back — the --apply echo must quote it the same
+    # way the renderer does.
+    import yaml
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "odd.yaml").write_text(
+        'data:\n'
+        '  interleave:\n'
+        '    strategy: probs\n'
+        '    probs:\n'
+        '      - 1.000000\n'
+        '  train: "odd: name.jsonl"\n'
+    )
+    from typer.testing import CliRunner
+
+    from soup_cli.cli import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["data", "mix", "--apply", "odd.yaml"])
+    assert result.exit_code == 0, (result.output, repr(result.exception))
+    data_block = result.output[result.output.index("data:"):]
+    loaded = yaml.safe_load(data_block)
+    assert loaded["data"]["train"] == "odd: name.jsonl"
+
+
 def test_apply_handles_pre_fix_list_shaped_recipe(tmp_path, monkeypatch):
     # A recipe written by the pre-fix code (data.train as a YAML list) must
     # still print via --apply rather than crash — old files on disk survive

--- a/tests/test_v0480_part_b.py
+++ b/tests/test_v0480_part_b.py
@@ -15,6 +15,7 @@ BETA feature. Covers:
 
 from __future__ import annotations
 
+import json
 import os
 
 import pytest
@@ -497,6 +498,9 @@ def test_render_recipe_shape(tmp_path):
     assert "0.600000" in text
     assert "0.400000" in text
     assert "a.jsonl" in text
+    # #330 — data.train is a single string (the highest-weighted dataset),
+    # not a list soup train's schema rejects.
+    assert f"train: {json.dumps(str(tmp_path / 'a.jsonl'))}" in text
 
 
 def test_render_recipe_rejects_non_report():


### PR DESCRIPTION
## What does this PR do?
Fixes #330 — `render_mix_recipe_yaml` emitted `data.train` as a YAML list, but `DataConfig.train` is
typed `str`, so the recipe `soup data mix --optimize` writes fails to load
(`data -> train: Input should be a valid string`). `data.train` now renders as the single
highest-weighted dataset from the search, with the full ranked breakdown kept as a comment so the
human-review value isn't lost. `data.interleave` is untouched — it already round-trips fine.

Added the round-trip test you asked for: render → splice into a config → `load_config_from_string` →
loads.

**Two things found while investigating, out of scope for this PR, flagging rather than fixing:**
1. `data.interleave` has no consumer anywhere in the real training pipeline — `load_dataset()` only ever
   handles a single-path `data.train`. `parse_interleave`/`InterleaveSpec` exist and are exported but are
   never called. So even a config that loads cleanly with `interleave` set doesn't actually train on a
   weighted mixture today.
2. Because of (1), `soup data mix --live`'s overlay YAML (`mix_proxy.py::_render_overlay_yaml`) hits the
   exact same list-shaped-`train` bug — every live candidate would fail at config-load before training
   starts. Verified directly (built the overlay it produces, ran it through `load_config_from_string`,
   same error). Invisible in `test_v0535.py` because `subprocess.run` is mocked in every `--live` test, so
   the real config-load path is never exercised. Did not touch `mix_proxy.py` here since a real fix needs
   either per-candidate dataset merging or the full interleave-consumption feature — happy to open a
   follow-up issue if useful.

## Type of change
- [x] Bug fix

## Checklist
- [x] `ruff check src/soup_cli/ tests/` passes
- [x] `pytest tests/ -v` passes (17716 passed, 0 failed, 80.76% coverage)
- [ ] Updated relevant docs — n/a, internal helper output format, no public API/doc change
- [x] New tests added for new functionality
- [x] No breaking changes

Closes #330
