### PR TITLE
fix: soup data mix --live hands each proxy run a config it can load (#442)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,15 @@ reproducing 70+ versions of notes.
   so no information is lost, and the comment explains that `data.interleave`
   is not yet consumed by training.
 
+- **`soup data mix --live` handed every candidate proxy run a config it could
+  not load (#442).** `_render_overlay_yaml` emitted `data.train` as a YAML
+  list, the same shape #330 fixed in the recipe writer, but every `--live`
+  test mocked `subprocess.run` so nothing ever loaded the overlay through the
+  schema — a config the tool could not itself load read as a passing feature.
+  `data.train` now renders as the single highest-weighted dataset in each
+  candidate, mirroring #330's fix, with a comment noting which dataset was
+  picked and why.
+
 - **Layer streaming now verifies that every trainable LoRA parameter has real
   storage after PEFT attaches the adapter (#433 reported by @lesterppo, fixed by @Faisal01011 in #435 and #437).** PEFT 0.18 creates streamed
   adapters on `meta` for Soup to materialise, while PEFT 0.19 may create them as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ reproducing 70+ versions of notes.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`soup data mix --live` handed every candidate proxy run a config it could
+  not load (#442 by @blackcoderx in #445).** `_render_overlay_yaml` emitted `data.train` as a YAML
+  list, the same shape #330 fixed in the recipe writer, but every `--live`
+  test mocked `subprocess.run` so nothing ever loaded the overlay through the
+  schema — a config the tool could not itself load read as a passing feature.
+  `data.train` now renders as the single highest-weighted dataset in each
+  candidate, mirroring #330's fix, with a comment noting which dataset was
+  picked and why.
+
 ## [0.73.3] - 2026-08-18
 
 ### Added
@@ -91,15 +102,6 @@ reproducing 70+ versions of notes.
   search; the full ranked weight/path breakdown is kept as a comment above it
   so no information is lost, and the comment explains that `data.interleave`
   is not yet consumed by training.
-
-- **`soup data mix --live` handed every candidate proxy run a config it could
-  not load (#442).** `_render_overlay_yaml` emitted `data.train` as a YAML
-  list, the same shape #330 fixed in the recipe writer, but every `--live`
-  test mocked `subprocess.run` so nothing ever loaded the overlay through the
-  schema — a config the tool could not itself load read as a passing feature.
-  `data.train` now renders as the single highest-weighted dataset in each
-  candidate, mirroring #330's fix, with a comment noting which dataset was
-  picked and why.
 
 - **Layer streaming now verifies that every trainable LoRA parameter has real
   storage after PEFT attaches the adapter (#433 reported by @lesterppo, fixed by @Faisal01011 in #435 and #437).** PEFT 0.18 creates streamed

--- a/src/soup_cli/utils/mix_proxy.py
+++ b/src/soup_cli/utils/mix_proxy.py
@@ -173,6 +173,16 @@ def _render_overlay_yaml(
     We round-trip via ``yaml.safe_load`` / ``yaml.safe_dump`` to defeat any
     accidental key collisions; weights + datasets are sanitised above so the
     output cannot inject keys (the renderer emits scalars only).
+
+    ``data.train`` renders as a single string — the highest-weighted dataset
+    in *this* candidate — because ``DataConfig.train`` is typed ``str`` and
+    ``soup train`` has no reader for a weighted multi-dataset mixture
+    (``data.interleave`` is validated at config-load time but never consumed
+    by ``load_dataset()``). Emitting the full dataset list here produced a
+    proxy-run config ``soup train`` itself could not load (#330's defect in
+    this module's own renderer — #442). ``data.interleave`` is still written
+    below so the searched mixture isn't lost, with a comment noting which
+    dataset was picked and why.
     """
     import yaml  # noqa: PLC0415
 
@@ -183,12 +193,35 @@ def _render_overlay_yaml(
     if not isinstance(data_block, dict):
         data_block = {}
         raw["data"] = data_block
-    data_block["train"] = list(datasets)
+    best_idx = max(range(len(weights)), key=lambda i: weights[i])
+    data_block["train"] = datasets[best_idx]
     data_block["interleave"] = {
         "strategy": "probs",
         "probs": [float(w) for w in weights],
     }
-    return yaml.safe_dump(raw, sort_keys=False)
+    dumped = yaml.safe_dump(raw, sort_keys=False)
+
+    # Insert an explanatory comment directly above the `train:` line inside
+    # the `data:` block — a targeted line insert, not a value edit, so it
+    # can't touch anything the schema will parse.
+    lines = dumped.split("\n")
+    data_idx = next((i for i, ln in enumerate(lines) if ln == "data:"), -1)
+    if data_idx >= 0:
+        for i in range(data_idx + 1, len(lines)):
+            ln = lines[i]
+            if ln and not ln.startswith(" "):
+                break  # left the data: block
+            if ln.startswith("  train:"):
+                lines.insert(
+                    i,
+                    f"  # picked {datasets[best_idx]!r} (weight "
+                    f"{weights[best_idx]:.6f}, highest in this candidate) — "
+                    "soup train has no reader for a weighted multi-dataset "
+                    "mixture, see #330/#442/#443",
+                )
+                break
+        dumped = "\n".join(lines)
+    return dumped
 
 
 def _read_final_eval_loss(

--- a/tests/test_v0535.py
+++ b/tests/test_v0535.py
@@ -516,6 +516,28 @@ def test_overlay_yaml_loads_through_config_schema(tmp_path):
     assert cfg.data.train == "b.jsonl"
 
 
+def test_overlay_comment_does_not_drift_from_train_value(tmp_path):
+    # Maintainer's review of #442: the comment spliced above `train:` names
+    # which dataset was picked, but nothing tied that claim to the actual
+    # value — it could vanish (mutation: delete the insertion block) or lie
+    # (mutation: comment names datasets[0] while train: keeps best_idx) and
+    # every other test still passes. Tying the assertion to the *parsed
+    # config's* value rather than the renderer's own variable is what makes
+    # the second mutation fail here.
+    from soup_cli.utils.mix_proxy import _render_overlay_yaml
+
+    base_text = _make_base_yaml(tmp_path).read_text(encoding="utf-8")
+    overlay = _render_overlay_yaml(
+        base_text, ("a.jsonl", "b.jsonl"), (0.3, 0.7)
+    )
+    cfg = load_config_from_string(overlay)
+    lines = overlay.split("\n")
+    idx = next(i for i, ln in enumerate(lines) if ln.startswith("  train:"))
+    comment = lines[idx - 1]
+    assert comment.lstrip().startswith("#")  # fails if the block is deleted
+    assert repr(cfg.data.train) in comment  # fails if the comment lies
+
+
 def test_proxy_happy_path_reads_tracker(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     base = _make_base_yaml(tmp_path)

--- a/tests/test_v0535.py
+++ b/tests/test_v0535.py
@@ -495,6 +495,27 @@ def test_proxy_timeout_raises_runtimeerror(tmp_path, monkeypatch):
             )
 
 
+def test_overlay_yaml_loads_through_config_schema(tmp_path):
+    # #442 — same defect #330 fixed in the recipe writer, in the second
+    # renderer: `_render_overlay_yaml` emitted `data.train` as a YAML list,
+    # but `DataConfig.train` is typed `str`, so every `--live` candidate got
+    # handed a config it could not load. Every other test in this section
+    # mocks `subprocess.run`, so this is the one that actually loads the
+    # *returned string* through the real schema — it fails if the renderer
+    # regresses to a list. (A fully unmocked `--live` run needs a real
+    # training subprocess/GPU and isn't practical in this suite; the
+    # remaining `--live` coverage below intentionally mocks `subprocess.run`
+    # and asserts orchestration instead.)
+    from soup_cli.utils.mix_proxy import _render_overlay_yaml
+
+    base_text = _make_base_yaml(tmp_path).read_text(encoding="utf-8")
+    overlay = _render_overlay_yaml(
+        base_text, ("a.jsonl", "b.jsonl"), (0.3, 0.7)
+    )
+    cfg = load_config_from_string(overlay)
+    assert cfg.data.train == "b.jsonl"
+
+
 def test_proxy_happy_path_reads_tracker(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     base = _make_base_yaml(tmp_path)


### PR DESCRIPTION
Fixes #442.

Same defect #330 fixed in the recipe writer, found in the second renderer while
working that issue: `_render_overlay_yaml` (used by `soup data mix --live` to
build the temp config each candidate proxy run trains against) emitted
`data.train` as a YAML list, but `DataConfig.train` is typed `str` — so every
`--live` candidate got handed a config it could not load.

Every `--live` test in `test_v0535.py` mocks `subprocess.run`, so the overlay
gets built and handed straight to a mock — nothing ever loaded it through the
real schema, which is how this shipped green in the first place.

**Fix:** `data.train` now renders as the single highest-weighted dataset in
each candidate (same choice #330 made), with a comment above it noting which
dataset was picked and why. `data.interleave` is left as-is — still written,
still not consumed by training, same status quo as the recipe writer.

**Test:** `test_overlay_yaml_loads_through_config_schema` loads the *returned
string* through `load_config_from_string` — it fails if the renderer
regresses to a list-shaped `train`, unlike the existing mocked tests. Confirmed
it fails pre-fix with the same `data -> train: Input should be a valid string`
error before the fix, passes after.

Deliberately not touching #443 (`data.interleave` has no training-time
consumer) here — that's the bigger, separate decision this issue explicitly
defers to it.
