### PR TITLE
fix(tests): exclude license scanner from self-scanning (#449)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ reproducing 70+ versions of notes.
 
 ### Fixed
 
+- **`tests/test_no_foreign_license_headers.py` no longer flags its own docstring
+  example (#449 by @harshitthek in #450).** The module docstring's explanatory AGPL header
+  example started with `#` inside the 40-line scan window, causing `_scan_repo`
+  to match its own docstring once committed and tracked. `_scan_repo` now excludes
+  the test module itself from scanning, and the docstring example omits leading `#`.
+
 - **`soup data mix --live` handed every candidate proxy run a config it could
   not load (#442 by @blackcoderx in #445).** `_render_overlay_yaml` emitted `data.train` as a YAML
   list, the same shape #330 fixed in the recipe writer, but every `--live`

--- a/tests/test_no_foreign_license_headers.py
+++ b/tests/test_no_foreign_license_headers.py
@@ -2,8 +2,8 @@
 
 This project is Apache-2.0. Three times now a file has landed carrying
 
-    # SPDX-License-Identifier: AGPL-3.0-only
-    # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+    SPDX-License-Identifier: AGPL-3.0-only
+    Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 
 at the top -- twice in ``8e4f012`` (removed by hand) and a third time in
 ``3426f2c``, which **I merged without noticing**, having already been burned by
@@ -101,8 +101,11 @@ def _offending_lines(text: str) -> list[tuple[int, str, str]]:
 
 
 def _scan_repo() -> list[str]:
+    self_path = Path(__file__).resolve()
     problems: list[str] = []
     for path in _tracked_files():
+        if path.resolve() == self_path:
+            continue
         if path.suffix.lower() not in SCANNED_SUFFIXES:
             continue
         try:
@@ -197,4 +200,10 @@ class TestTheScannerCanActuallyFail:
         text = "\n".join(["# filler"] * HEADER_LINES) + (
             "\n# SPDX-License-Identifier: AGPL-3.0-only\n"
         )
+        assert _offending_lines(text) == []
+
+    def test_the_scanner_module_itself_passes(self):
+        """The scanner module must not flag its own docstring or header."""
+        target = Path(__file__).resolve()
+        text = io.open(target, encoding="utf-8", errors="replace").read()
         assert _offending_lines(text) == []


### PR DESCRIPTION
Closes #449 - Exclude test_no_foreign_license_headers.py from _scan_repo self-scanning
- Omit leading hash in docstring header example
- Add test_the_scanner_module_itself_passes regression unit test
- Add CHANGELOG entry under [Unreleased] Fixed

## What does this PR do?

<!-- Brief description of the change -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests

## Checklist

- [ ] `ruff check src/soup_cli/ tests/` passes
- [ ] `pytest tests/ -v` passes
- [ ] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed
~Harshit