### PR TITLE
fix(layer-stream): make gemm repeat selection deterministic and recor…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ reproducing 70+ versions of notes.
 
 ### Fixed
 
+- **`measure_gemm_tflops` now records per-repeat samples and
+  `test_takes_the_best_repeat_not_the_first` verifies best-of-N selection within
+  a single measurement (#444 by @harshitthek in #451).** Comparing two separate
+  probe calls taken at different moments caused intermittent test failures on
+  developer GPU machines under background contention. `GemmCeiling` now preserves
+  `samples: tuple[float, ...]` and the test asserts `max(samples)` selection
+  deterministically.
+
 - **Duck-typed tokenizer mappings no longer raise a misleading error, and
   `data_doctor` shares the public `coerce_token_ids` helper (#441 by @AchuthReddy-16 in #447, part 2 found by @emre155).** A dict-like
   output that is not registered as `collections.abc.Mapping` used to be iterated

--- a/src/soup_cli/utils/layer_stream_runtime.py
+++ b/src/soup_cli/utils/layer_stream_runtime.py
@@ -865,6 +865,7 @@ class GemmCeiling:
     tflops: float
     sm_clock_mhz: Optional[int]
     size: int
+    samples: tuple[float, ...] = ()
 
 
 def sm_clock_mhz() -> Optional[int]:
@@ -935,7 +936,7 @@ def measure_gemm_tflops(
         return None
     if not torch.cuda.is_available():
         return None
-    best = 0.0
+    samples: list[float] = []
     try:
         left = torch.randn(size, size, device=device, dtype=torch.bfloat16)
         right = torch.randn(size, size, device=device, dtype=torch.bfloat16)
@@ -952,14 +953,22 @@ def measure_gemm_tflops(
             torch.cuda.synchronize()
             seconds = start.elapsed_time(end) / 1000.0
             if seconds > 0:
-                best = max(best, 2.0 * (size**3) * iters / seconds / 1e12)
+                samples.append(2.0 * (size**3) * iters / seconds / 1e12)
         del left, right
         torch.cuda.empty_cache()
     except (RuntimeError, torch.cuda.OutOfMemoryError):
         return None
+    if not samples:
+        return None
+    best = max(samples)
     if best <= 0:
         return None
-    return GemmCeiling(tflops=best, sm_clock_mhz=sm_clock_mhz(), size=size)
+    return GemmCeiling(
+        tflops=best,
+        sm_clock_mhz=sm_clock_mhz(),
+        size=size,
+        samples=tuple(samples),
+    )
 
 
 @dataclass(frozen=True)

--- a/tests/test_v07203.py
+++ b/tests/test_v07203.py
@@ -490,17 +490,196 @@ class TestMeasuredGemmCeiling:
 
     def test_takes_the_best_repeat_not_the_first(self):
         """A ceiling's noise is ONE-SIDED — contention, a cold clock and thermal
-        throttling only ever make an achievable rate look slower. Measured: at
-        2048 the probe spread 38% across five repeats and ramped monotonically
-        upward, which is how a first-repeat probe reported 3.54 TFLOPS in one
-        session and 6.75 in another at the same reported clock."""
+        throttling only ever make an achievable rate look slower. Taking the best
+        repeat must return max(samples) and include all repeat measurements."""
         from soup_cli.utils.layer_stream_runtime import measure_gemm_tflops
 
-        one = measure_gemm_tflops(device="cuda", reps=1)
-        many = measure_gemm_tflops(device="cuda", reps=4)
-        assert one is not None and many is not None
-        # best-of-4 can only be >= a single sample, up to run-to-run noise
-        assert many.tflops >= one.tflops * 0.9
+        got = measure_gemm_tflops(device="cuda", reps=4)
+        assert got is not None
+        assert len(got.samples) == 4
+        assert got.tflops == max(got.samples)
+        assert got.tflops >= got.samples[0]
+        assert got.tflops >= max(got.samples[1:])
+
+
+class TestIssue444BestRepeatSelection:
+    """Regression tests for #444: deterministic repeat selection in measure_gemm_tflops."""
+
+    def test_gemm_ceiling_defaults_samples_to_empty_tuple(self) -> None:
+        from soup_cli.utils.layer_stream_runtime import GemmCeiling
+
+        ceiling = GemmCeiling(tflops=10.5, sm_clock_mhz=1200, size=4096)
+        assert ceiling.tflops == 10.5
+        assert ceiling.sm_clock_mhz == 1200
+        assert ceiling.size == 4096
+        assert ceiling.samples == ()
+
+    def test_selection_picks_maximum_repeat_not_first_or_last(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Synthetic benchmark proving best-of-N selects max(samples) deterministically."""
+        import sys
+
+        from soup_cli.utils import layer_stream_runtime
+
+        elapsed_sequence = [100.0, 20.0, 50.0, 40.0]
+        call_idx = 0
+
+        class _MockEvent:
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+            def record(self) -> None:
+                pass
+
+            def elapsed_time(self, other: object) -> float:
+                nonlocal call_idx
+                val = elapsed_sequence[call_idx % len(elapsed_sequence)]
+                call_idx += 1
+                return val
+
+        class _MockCuda:
+            @staticmethod
+            def is_available() -> bool:
+                return True
+
+            @staticmethod
+            def synchronize() -> None:
+                pass
+
+            @staticmethod
+            def empty_cache() -> None:
+                pass
+
+            Event = _MockEvent
+            OutOfMemoryError = RuntimeError
+
+        class _MockTensor:
+            def __matmul__(self, other: object) -> "_MockTensor":
+                return self
+
+        class _MockTorch:
+            bfloat16 = "bfloat16"
+            cuda = _MockCuda
+
+            @staticmethod
+            def randn(*args: object, **kwargs: object) -> _MockTensor:
+                return _MockTensor()
+
+        monkeypatch.setitem(sys.modules, "torch", _MockTorch)
+        monkeypatch.setattr(layer_stream_runtime, "sm_clock_mhz", lambda: 1500)
+
+        res = layer_stream_runtime.measure_gemm_tflops(
+            device="cuda", iters=8, reps=4, size=4096
+        )
+        assert res is not None
+        assert len(res.samples) == 4
+        # Repeat index 1 (20ms) is 5x faster than repeat index 0 (100ms)
+        assert res.samples[1] > res.samples[0]
+        assert res.tflops == max(res.samples)
+        assert res.tflops == res.samples[1]
+        assert res.tflops != res.samples[0]
+        assert res.tflops != res.samples[-1]
+
+    def test_zero_elapsed_timing_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Degenerate timing (seconds <= 0) must return None without raising."""
+        import sys
+
+        from soup_cli.utils import layer_stream_runtime
+
+        class _MockEvent:
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+            def record(self) -> None:
+                pass
+
+            def elapsed_time(self, other: object) -> float:
+                return 0.0
+
+        class _MockCuda:
+            @staticmethod
+            def is_available() -> bool:
+                return True
+
+            @staticmethod
+            def synchronize() -> None:
+                pass
+
+            @staticmethod
+            def empty_cache() -> None:
+                pass
+
+            Event = _MockEvent
+            OutOfMemoryError = RuntimeError
+
+        class _MockTensor:
+            def __matmul__(self, other: object) -> "_MockTensor":
+                return self
+
+        class _MockTorch:
+            bfloat16 = "bfloat16"
+            cuda = _MockCuda
+
+            @staticmethod
+            def randn(*args: object, **kwargs: object) -> _MockTensor:
+                return _MockTensor()
+
+        monkeypatch.setitem(sys.modules, "torch", _MockTorch)
+        got = layer_stream_runtime.measure_gemm_tflops(device="cuda", reps=4)
+        assert got is None
+
+    def test_zero_iters_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Degenerate iters=0 must yield non-positive rates and return None."""
+        import sys
+
+        from soup_cli.utils import layer_stream_runtime
+
+        class _MockEvent:
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+            def record(self) -> None:
+                pass
+
+            def elapsed_time(self, other: object) -> float:
+                return 10.0
+
+        class _MockCuda:
+            @staticmethod
+            def is_available() -> bool:
+                return True
+
+            @staticmethod
+            def synchronize() -> None:
+                pass
+
+            @staticmethod
+            def empty_cache() -> None:
+                pass
+
+            Event = _MockEvent
+            OutOfMemoryError = RuntimeError
+
+        class _MockTensor:
+            def __matmul__(self, other: object) -> "_MockTensor":
+                return self
+
+        class _MockTorch:
+            bfloat16 = "bfloat16"
+            cuda = _MockCuda
+
+            @staticmethod
+            def randn(*args: object, **kwargs: object) -> _MockTensor:
+                return _MockTensor()
+
+        monkeypatch.setitem(sys.modules, "torch", _MockTorch)
+        got = layer_stream_runtime.measure_gemm_tflops(device="cuda", iters=0, reps=4)
+        assert got is None
 
 
 class TestBatchSizeIsSupported:


### PR DESCRIPTION
Resolves #444.

## Problem & Mechanism

`tests/test_v07203.py::TestMeasuredGemmCeiling::test_takes_the_best_repeat_not_the_first` failed intermittently on GPU developer boxes under load (observed 3 failures in 16 runs during parallel test execution).

### Root Cause
The old test compared two separate, asynchronous GPU probe calls taken at different moments in time ($t_1$ vs $t_2$):
```python
one = measure_gemm_tflops(device="cuda", reps=1)   # Time t_1
many = measure_gemm_tflops(device="cuda", reps=4)  # Time t_2
assert many.tflops >= one.tflops * 0.9
```
Under concurrent machine activity or background GPU contention, the `reps=1` probe could land in a quiet execution window while the `reps=4` run was interrupted or throttled. The 10% tolerance was an arbitrary guess at noise spread and failed whenever contention between $t_1$ and $t_2$ exceeded 10%.

## What Changed

Rather than widening the tolerance (which would hide real regressions and allow a broken first-repeat selection to pass), we test the true invariant **within a single probe call**:

1. **`GemmCeiling` preserves per-repeat samples:**
   - Added `samples: tuple[float, ...] = ()` to the `GemmCeiling` frozen dataclass (`src/soup_cli/utils/layer_stream_runtime.py`).
   - `measure_gemm_tflops` now appends each iteration's calculated rate into `samples: list[float]` and passes `samples=tuple(samples)`.
   - All existing downstream consumers (`stream_setup.py`, `layer_stream.py`) continue reading `.tflops` and `.sm_clock_mhz` with 100% backwards compatibility.

2. **Single-Probe Invariant Assertion:**
   - Updated `test_takes_the_best_repeat_not_the_first` in `tests/test_v07203.py` to assert best-of-N selection within a single measurement:
     ```python
     got = measure_gemm_tflops(device="cuda", reps=4)
     assert got is not None
     assert len(got.samples) == 4
     assert got.tflops == max(got.samples)
     assert got.tflops >= got.samples[0]
     ```
   - Eliminates 100% of inter-call race conditions and background load flakiness.

3. **Deterministic Unit Tests & Mutation Kills:**
   - Added `TestIssue444BestRepeatSelection` in `tests/test_v07203.py` with host-independent mocking of CUDA event timings (`[100ms, 20ms, 50ms, 40ms]`).
   - Verifies that `measure_gemm_tflops` selects the 20ms peak rate (`res.tflops == res.samples[1]`).
   - Verified that mutating the implementation to return `samples[0]` (first repeat) or `samples[-1]` (last repeat) fails deterministically.

4. **House Standards & Changelog:**
   - Added entry to `CHANGELOG.md` under `[Unreleased] Fixed`.

## Verification

- **Unit Suite:** `pytest tests/test_v07203.py` $\to$ `TestIssue444BestRepeatSelection` passes 100%.
- **Mutation Proof:** Mutating `best = max(samples)` to `best = samples[0]` or `best = samples[-1]` fails deterministically.
- **Hygiene:** `ruff check src/ tests/ docs/` clean (0 warnings / 0 errors).
- **Zero API Breakage:** Audited all callers in `src/soup_cli/trainer/stream_setup.py` and `tests/test_v07203.py`.
