### PR TITLE
perf(callbacks): defer TrainerCallback resolution to first access (#320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,16 @@ reproducing 70+ versions of notes.
 - **A repo-wide documentation ratchet to guarantee declared recipe counts stay synchronized with the catalog (#453 by @harshitthek in #457).**
   Derives the expected count dynamically from `len(RECIPES)` and scans all declared documentation sites, preventing silent Git auto-merge drift across sequential recipe additions.
 
+### Changed
+
+- **Lazy callback builders now self-import their callback class names so runtime
+  lookup never raises `NameError` while preserving lazy heavy-dependency loading
+  (#320 by @AchuthReddy-16 in #455).** `build_echo_trap_callback`,
+  `build_reward_hack_callback`, `build_minillm_callback`,
+  `build_rl_checkpoint_callback`, and `build_push_callback` now resolve their
+  callback types through local module imports in the builder body, and the
+  regression suite adds subprocess coverage for all five builder calls.
+
 ### Fixed
 
 - **`cut_ce.py` and `liger.py` now normalize path separators and match architecture

--- a/src/soup_cli/monitoring/callback.py
+++ b/src/soup_cli/monitoring/callback.py
@@ -3,15 +3,12 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from rich.console import Console
-from transformers import (
-    TrainerCallback,
-    TrainerControl,
-    TrainerState,
-    TrainingArguments,
-)
+
+if TYPE_CHECKING:
+    from transformers import TrainerControl, TrainerState, TrainingArguments
 
 from soup_cli.monitoring.display import TrainingDisplay
 
@@ -19,7 +16,17 @@ logger = logging.getLogger(__name__)
 console = Console()
 
 
-class SoupTrainerCallback(TrainerCallback):
+def _get_trainer_callback_base():
+    """Lazy-resolve ``transformers.TrainerCallback``."""
+    try:
+        from transformers import TrainerCallback
+
+        return TrainerCallback
+    except ImportError:
+        return object
+
+
+class _SoupTrainerCallback_body:  # noqa: N801
     """Bridges HF Trainer events to Soup's Rich live display and experiment tracker."""
 
     def __init__(
@@ -565,3 +572,22 @@ class SoupTrainerCallback(TrainerCallback):
             f"({new_batch}, {new_accum}). "
             f"Restart training with the new pair to take effect."
         )
+
+
+_LAZY_CALLBACKS = {
+    "SoupTrainerCallback": _SoupTrainerCallback_body,
+}
+_BODY_SKIP = frozenset(("__dict__", "__weakref__"))
+
+
+def __getattr__(name: str):  # PEP 562
+    body = _LAZY_CALLBACKS.get(name)
+    if body is not None:
+        base = _get_trainer_callback_base()
+        ns = {k: v for k, v in vars(body).items() if k not in _BODY_SKIP}
+        cls = type(name, (base,), ns)
+        cls.__module__ = __name__
+        cls.__qualname__ = name
+        globals()[name] = cls
+        return cls
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/soup_cli/monitoring/curriculum_callback.py
+++ b/src/soup_cli/monitoring/curriculum_callback.py
@@ -59,7 +59,7 @@ _VALID_CURRICULUM_METRICS = frozenset({"length", "perplexity", "loss"})
 _SIGNAL_WINDOW = 512
 
 __all__ = [
-    "DynamicCurriculumCallback",
+    "DynamicCurriculumCallback",  # noqa: F822
     "_is_rank_zero",
     "_pick_bucket",
 ]
@@ -140,7 +140,7 @@ def _try_import_callback_base():
         return object
 
 
-class DynamicCurriculumCallback(_try_import_callback_base()):  # type: ignore[misc]
+class _DynamicCurriculumCallback_body:  # type: ignore[misc]  # noqa: N801
     """HF TrainerCallback emitting dynamic curriculum bucket-weight history.
 
     BETA: the callback is live in v0.53.5 but the sampler-side consumer
@@ -510,3 +510,22 @@ class DynamicCurriculumCallback(_try_import_callback_base()):  # type: ignore[mi
                 os.unlink(tmp_path)
             except OSError:
                 pass
+
+
+_LAZY_CALLBACKS = {
+    "DynamicCurriculumCallback": _DynamicCurriculumCallback_body,
+}
+_BODY_SKIP = frozenset(("__dict__", "__weakref__"))
+
+
+def __getattr__(name: str):  # PEP 562
+    body = _LAZY_CALLBACKS.get(name)
+    if body is not None:
+        base = _try_import_callback_base()
+        ns = {k: v for k, v in vars(body).items() if k not in _BODY_SKIP}
+        cls = type(name, (base,), ns)
+        cls.__module__ = __name__
+        cls.__qualname__ = name
+        globals()[name] = cls
+        return cls
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/soup_cli/monitoring/grpo_stability_callback.py
+++ b/src/soup_cli/monitoring/grpo_stability_callback.py
@@ -145,12 +145,7 @@ def filter_zero_advantage(advantages, *, eps: float = 1e-8) -> Any:
 
 
 def _get_trainer_callback_base():
-    """Lazy-resolve ``transformers.TrainerCallback`` (v0.53.11 review fix).
-
-    Project policy: every callback inherits TrainerCallback so HF Trainer
-    discovers it via the callback handler. We resolve at class-body
-    evaluation time so module import does not pull transformers.
-    """
+    """Lazy-resolve ``transformers.TrainerCallback``."""
     try:
         from transformers import TrainerCallback
 
@@ -159,10 +154,7 @@ def _get_trainer_callback_base():
         return object
 
 
-_TrainerCallbackBase = _get_trainer_callback_base()
-
-
-class GRPOStabilityCallback(_TrainerCallbackBase):  # type: ignore[misc, valid-type]
+class _GRPOStabilityCallback_body:  # type: ignore[misc, valid-type]  # noqa: N801
     """HF TrainerCallback that wires v0.50.0 Part D stability knobs.
 
     Lazy-inherits ``transformers.TrainerCallback`` so the module is
@@ -325,3 +317,22 @@ class GRPOStabilityCallback(_TrainerCallbackBase):  # type: ignore[misc, valid-t
             if entry:
                 log_history.append(entry)
         return control
+
+
+_LAZY_CALLBACKS = {
+    "GRPOStabilityCallback": _GRPOStabilityCallback_body,
+}
+_BODY_SKIP = frozenset(("__dict__", "__weakref__"))
+
+
+def __getattr__(name: str):  # PEP 562
+    body = _LAZY_CALLBACKS.get(name)
+    if body is not None:
+        base = _get_trainer_callback_base()
+        ns = {k: v for k, v in vars(body).items() if k not in _BODY_SKIP}
+        cls = type(name, (base,), ns)
+        cls.__module__ = __name__
+        cls.__qualname__ = name
+        globals()[name] = cls
+        return cls
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/soup_cli/monitoring/hf_push.py
+++ b/src/soup_cli/monitoring/hf_push.py
@@ -15,7 +15,10 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from soup_cli.monitoring.hf_push import HFPushCallback
 
 from soup_cli.utils.hf import get_hf_api, resolve_endpoint, resolve_token, validate_repo_id
 
@@ -56,7 +59,7 @@ def _try_import_callback_base():
         return object
 
 
-class HFPushCallback(_try_import_callback_base()):  # type: ignore[misc]
+class _HFPushCallback_body:  # type: ignore[misc]  # noqa: N801
     """Real HF ``TrainerCallback`` auto-pusher.
 
     Subclasses the lazily-resolved ``TrainerCallback`` so it inherits the no-op
@@ -327,7 +330,7 @@ def build_push_callback(
     output_dir: str,
     explicit_token: Optional[str] = None,
     private: bool = False,
-) -> Optional[HFPushCallback]:
+) -> Optional["HFPushCallback"]:
     """Factory that resolves token/endpoint and builds the callback.
 
     Returns None when no HF token is available — the caller logs and skips
@@ -343,6 +346,8 @@ def build_push_callback(
         logger.warning("HF_ENDPOINT invalid (%s); skipping auto-push", exc)
         return None
 
+    from soup_cli.monitoring.hf_push import HFPushCallback
+
     return HFPushCallback(
         repo_id=repo_id,
         token=token,
@@ -350,3 +355,22 @@ def build_push_callback(
         output_dir=output_dir,
         private=private,
     )
+
+
+_LAZY_CALLBACKS = {
+    "HFPushCallback": _HFPushCallback_body,
+}
+_BODY_SKIP = frozenset(("__dict__", "__weakref__"))
+
+
+def __getattr__(name: str):  # PEP 562
+    body = _LAZY_CALLBACKS.get(name)
+    if body is not None:
+        base = _try_import_callback_base()
+        ns = {k: v for k, v in vars(body).items() if k not in _BODY_SKIP}
+        cls = type(name, (base,), ns)
+        cls.__module__ = __name__
+        cls.__qualname__ = name
+        globals()[name] = cls
+        return cls
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/soup_cli/utils/echo_trap.py
+++ b/src/soup_cli/utils/echo_trap.py
@@ -25,7 +25,12 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import Iterable, Optional, Sequence
+from typing import TYPE_CHECKING, Iterable, Optional, Sequence
+
+if TYPE_CHECKING:
+    from soup_cli.utils.echo_trap import EchoTrapCallback
+
+
 
 VERDICTS: tuple[str, ...] = ("OK", "WARN", "TRAP")
 _VALID_VERDICTS: frozenset[str] = frozenset(VERDICTS)
@@ -300,7 +305,7 @@ def _split_whitespace(text: str) -> list[str]:
 
 
 def _get_trainer_callback_base():
-    """Lazy-resolve ``transformers.TrainerCallback`` (mirror v0.53.11)."""
+    """Lazy-resolve ``transformers.TrainerCallback``."""
     try:
         from transformers import TrainerCallback
 
@@ -309,10 +314,7 @@ def _get_trainer_callback_base():
         return object
 
 
-_TrainerCallbackBase = _get_trainer_callback_base()
-
-
-class EchoTrapCallback(_TrainerCallbackBase):  # type: ignore[misc, valid-type]
+class _EchoTrapCallback_body:  # type: ignore[misc, valid-type]  # noqa: N801
     """Live HF TrainerCallback for echo-trap detection (v0.71.11 #240).
 
     Reads the GRPO step's generated completions (via the shared
@@ -458,6 +460,8 @@ def build_echo_trap_callback(
     at the public boundary (mirrors v0.50.0 / v0.61.0 fail-fast policy),
     then returns an :class:`EchoTrapCallback`.
     """
+    from soup_cli.utils.echo_trap import EchoTrapCallback
+
     return EchoTrapCallback(
         threshold=threshold,
         halt_on_trap=halt_on_trap,
@@ -473,7 +477,7 @@ def build_echo_trap_callback(
 # without circular dependencies.
 __all__ = [
     "VERDICTS",
-    "EchoTrapCallback",
+    "EchoTrapCallback",  # noqa: F822
     "EchoTrapReport",
     "build_echo_trap_callback",
     "classify_echo_signal",
@@ -489,3 +493,22 @@ TrajectoryTokens = Sequence[str]
 TrajectoryBatch = Iterable[TrajectoryTokens]
 TokenIdTrajectory = Sequence[int]
 TokenIdTrajectoryBatch = Iterable[TokenIdTrajectory]
+
+
+_LAZY_CALLBACKS = {
+    "EchoTrapCallback": _EchoTrapCallback_body,
+}
+_BODY_SKIP = frozenset(("__dict__", "__weakref__"))
+
+
+def __getattr__(name: str):  # PEP 562
+    body = _LAZY_CALLBACKS.get(name)
+    if body is not None:
+        base = _get_trainer_callback_base()
+        ns = {k: v for k, v in vars(body).items() if k not in _BODY_SKIP}
+        cls = type(name, (base,), ns)
+        cls.__module__ = __name__
+        cls.__qualname__ = name
+        globals()[name] = cls
+        return cls
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/soup_cli/utils/lisa.py
+++ b/src/soup_cli/utils/lisa.py
@@ -101,7 +101,7 @@ def locate_decoder_layer_indices(model: Any) -> list[int]:
     return sorted(seen)
 
 
-class LisaCallback(_try_import_callback_base()):  # type: ignore[misc]
+class _LisaCallback_body:  # type: ignore[misc]  # noqa: N801
     """HF ``TrainerCallback`` implementing LISA layer sampling.
 
     Subclasses the lazily-resolved ``TrainerCallback`` so it inherits the no-op
@@ -211,3 +211,22 @@ class LisaCallback(_try_import_callback_base()):  # type: ignore[misc]
                     state[param] = {}
         except Exception:  # noqa: BLE001 — optimizer state shape varies (DS/FSDP)
             return
+
+
+_LAZY_CALLBACKS = {
+    "LisaCallback": _LisaCallback_body,
+}
+_BODY_SKIP = frozenset(("__dict__", "__weakref__"))
+
+
+def __getattr__(name: str):  # PEP 562
+    body = _LAZY_CALLBACKS.get(name)
+    if body is not None:
+        base = _try_import_callback_base()
+        ns = {k: v for k, v in vars(body).items() if k not in _BODY_SKIP}
+        cls = type(name, (base,), ns)
+        cls.__module__ = __name__
+        cls.__qualname__ = name
+        globals()[name] = cls
+        return cls
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/soup_cli/utils/minillm.py
+++ b/src/soup_cli/utils/minillm.py
@@ -29,7 +29,10 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from soup_cli.utils.minillm import MiniLLMCallback
 
 _MAX_ANCHOR_PATH_LEN = 4096
 _MAX_ANCHOR_ROW_BYTES = 1_000_000
@@ -422,7 +425,7 @@ def minillm_on_policy_rollout(
 
 
 def _get_trainer_callback_base():
-    """Lazy-resolve ``transformers.TrainerCallback`` (mirror v0.53.11)."""
+    """Lazy-resolve ``transformers.TrainerCallback``."""
     try:
         from transformers import TrainerCallback
 
@@ -431,10 +434,7 @@ def _get_trainer_callback_base():
         return object
 
 
-_TrainerCallbackBase = _get_trainer_callback_base()
-
-
-class MiniLLMCallback(_TrainerCallbackBase):  # type: ignore[misc, valid-type]
+class _MiniLLMCallback_body:  # type: ignore[misc, valid-type]  # noqa: N801
     """Live MiniLLM helper + HF TrainerCallback (v0.71.11 #237).
 
     Carries the :class:`MiniLLMConfig` and provides the loss terms the
@@ -622,4 +622,25 @@ def build_minillm_callback(
         raise TypeError(
             f"config must be MiniLLMConfig, got {type(config).__name__}"
         )
+    from soup_cli.utils.minillm import MiniLLMCallback
+
     return MiniLLMCallback(config, tokenizer=tokenizer, temperature=temperature)
+
+
+_LAZY_CALLBACKS = {
+    "MiniLLMCallback": _MiniLLMCallback_body,
+}
+_BODY_SKIP = frozenset(("__dict__", "__weakref__"))
+
+
+def __getattr__(name: str):  # PEP 562
+    body = _LAZY_CALLBACKS.get(name)
+    if body is not None:
+        base = _get_trainer_callback_base()
+        ns = {k: v for k, v in vars(body).items() if k not in _BODY_SKIP}
+        cls = type(name, (base,), ns)
+        cls.__module__ = __name__
+        cls.__qualname__ = name
+        globals()[name] = cls
+        return cls
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/soup_cli/utils/relora.py
+++ b/src/soup_cli/utils/relora.py
@@ -119,7 +119,7 @@ def _try_import_callback_base():
         return object
 
 
-class ReLoRACallback(_try_import_callback_base()):  # type: ignore[misc]
+class _ReLoRACallback_body:  # type: ignore[misc]  # noqa: N801
     """HF ``TrainerCallback`` that magnitude-prunes LoRA weights every N steps.
 
     Subclasses the lazily-resolved ``TrainerCallback`` so it inherits the no-op
@@ -194,3 +194,22 @@ class ReLoRACallback(_try_import_callback_base()):  # type: ignore[misc]
             # Optimizer state structure varies (DeepSpeed / FSDP wrap it);
             # silent best-effort is the documented Axolotl behaviour too.
             return
+
+
+_LAZY_CALLBACKS = {
+    "ReLoRACallback": _ReLoRACallback_body,
+}
+_BODY_SKIP = frozenset(("__dict__", "__weakref__"))
+
+
+def __getattr__(name: str):  # PEP 562
+    body = _LAZY_CALLBACKS.get(name)
+    if body is not None:
+        base = _try_import_callback_base()
+        ns = {k: v for k, v in vars(body).items() if k not in _BODY_SKIP}
+        cls = type(name, (base,), ns)
+        cls.__module__ = __name__
+        cls.__qualname__ = name
+        globals()[name] = cls
+        return cls
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/soup_cli/utils/reward_hack_control.py
+++ b/src/soup_cli/utils/reward_hack_control.py
@@ -775,8 +775,8 @@ class MitigationLogWriter:
 def _get_trainer_callback_base():
     """Lazy-resolve ``transformers.TrainerCallback`` (mirror reward_hacking.py).
 
-    Resolved once at class-definition time so this module imports on a
-    torch-less interpreter (falls back to ``object``).
+    Called on first access to the callback class (via PEP 562 ``__getattr__``),
+    NOT at module scope — so importing this module no longer pulls transformers.
     """
     try:
         from transformers import TrainerCallback
@@ -786,10 +786,7 @@ def _get_trainer_callback_base():
         return object
 
 
-_TrainerCallbackBase = _get_trainer_callback_base()
-
-
-class RewardHackMitigationCallback(_TrainerCallbackBase):  # type: ignore[misc, valid-type]
+class _RewardHackMitigationCallback_body:  # type: ignore[misc, valid-type]  # noqa: N801
     """Closed-loop reward-hacking mitigation HF TrainerCallback (v0.71.26).
 
     Reads the shared :class:`~soup_cli.utils.rl_signal_buffer.RLSignalBuffer`
@@ -1178,3 +1175,22 @@ class RewardHackMitigationCallback(_TrainerCallbackBase):  # type: ignore[misc, 
                     exc,
                 )
             return control
+
+
+_LAZY_CALLBACKS = {
+    "RewardHackMitigationCallback": _RewardHackMitigationCallback_body,
+}
+_BODY_SKIP = frozenset(("__dict__", "__weakref__"))
+
+
+def __getattr__(name: str):  # PEP 562
+    body = _LAZY_CALLBACKS.get(name)
+    if body is not None:
+        base = _get_trainer_callback_base()
+        ns = {k: v for k, v in vars(body).items() if k not in _BODY_SKIP}
+        cls = type(name, (base,), ns)
+        cls.__module__ = __name__
+        cls.__qualname__ = name
+        globals()[name] = cls
+        return cls
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/soup_cli/utils/reward_hacking.py
+++ b/src/soup_cli/utils/reward_hacking.py
@@ -35,7 +35,10 @@ from __future__ import annotations
 import math
 import types
 from dataclasses import dataclass
-from typing import Any, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Optional, Sequence
+
+if TYPE_CHECKING:
+    from soup_cli.utils.reward_hacking import RewardHackCallback
 
 _MAX_DETECTOR_NAME_LEN = 32
 _MAX_RM_ENSEMBLE_SIZE = 32
@@ -356,10 +359,10 @@ def _health_from_signal(detector: str, raw_signal: float) -> float:
 
 
 def _get_trainer_callback_base():
-    """Lazy-resolve ``transformers.TrainerCallback`` (mirror v0.53.11).
+    """Lazy-resolve ``transformers.TrainerCallback``.
 
-    Resolved at module-import-of-class time so a torch-less environment can
-    still import this utility module (falls back to ``object``).
+    Called on first access to the callback class (via PEP 562 ``__getattr__``),
+    NOT at module scope — so importing this module no longer pulls transformers.
     """
     try:
         from transformers import TrainerCallback
@@ -369,10 +372,7 @@ def _get_trainer_callback_base():
         return object
 
 
-_TrainerCallbackBase = _get_trainer_callback_base()
-
-
-class RewardHackCallback(_TrainerCallbackBase):  # type: ignore[misc, valid-type]
+class _RewardHackCallback_body:  # type: ignore[misc, valid-type]  # noqa: N801
     """Live HF TrainerCallback for the reward-hacking detector (v0.71.11 #235).
 
     Reads the per-completion rewards a GRPO step produced (via the shared
@@ -599,9 +599,30 @@ def build_reward_hack_callback(
     at the public boundary (mirrors v0.50.0 / v0.61.0 fail-fast policy),
     then returns a :class:`RewardHackCallback`.
     """
+    from soup_cli.utils.reward_hacking import RewardHackCallback
+
     return RewardHackCallback(
         detector=detector,
         halt_on_hack=halt_on_hack,
         baseline_signal=baseline_signal,
         buffer=buffer,
     )
+
+
+_LAZY_CALLBACKS = {
+    "RewardHackCallback": _RewardHackCallback_body,
+}
+_BODY_SKIP = frozenset(("__dict__", "__weakref__"))
+
+
+def __getattr__(name: str):  # PEP 562
+    body = _LAZY_CALLBACKS.get(name)
+    if body is not None:
+        base = _get_trainer_callback_base()
+        ns = {k: v for k, v in vars(body).items() if k not in _BODY_SKIP}
+        cls = type(name, (base,), ns)
+        cls.__module__ = __name__
+        cls.__qualname__ = name
+        globals()[name] = cls
+        return cls
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/soup_cli/utils/rl_checkpoint.py
+++ b/src/soup_cli/utils/rl_checkpoint.py
@@ -30,7 +30,10 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from soup_cli.utils.rl_checkpoint import RLCheckpointCallback
 
 logger = logging.getLogger(__name__)
 
@@ -197,16 +200,13 @@ class RLCheckpointState:
 
 
 def _get_trainer_callback_base():
-    """Lazy-resolve ``transformers.TrainerCallback`` (mirror v0.53.11)."""
+    """Lazy-resolve ``transformers.TrainerCallback``."""
     try:
         from transformers import TrainerCallback
 
         return TrainerCallback
     except ImportError:
         return object
-
-
-_TrainerCallbackBase = _get_trainer_callback_base()
 
 
 def _step_number(name: str) -> int:
@@ -244,7 +244,7 @@ def _is_main_process() -> bool:
     return True
 
 
-class RLCheckpointCallback(_TrainerCallbackBase):  # type: ignore[misc, valid-type]
+class _RLCheckpointCallback_body:  # type: ignore[misc, valid-type]  # noqa: N801
     """Live HF TrainerCallback for mid-epoch RL checkpoints (v0.71.11 #238).
 
     Saves an RL-aware checkpoint every ``save_every_steps`` steps under
@@ -475,9 +475,30 @@ def build_rl_checkpoint_callback(
         )
     if output_dir is None:
         raise ValueError("output_dir is required to build the RL checkpoint callback")
+    from soup_cli.utils.rl_checkpoint import RLCheckpointCallback
+
     return RLCheckpointCallback(
         config,
         output_dir=output_dir,
         task=task,
         soup_version=soup_version,
     )
+
+
+_LAZY_CALLBACKS = {
+    "RLCheckpointCallback": _RLCheckpointCallback_body,
+}
+_BODY_SKIP = frozenset(("__dict__", "__weakref__"))
+
+
+def __getattr__(name: str):  # PEP 562
+    body = _LAZY_CALLBACKS.get(name)
+    if body is not None:
+        base = _get_trainer_callback_base()
+        ns = {k: v for k, v in vars(body).items() if k not in _BODY_SKIP}
+        cls = type(name, (base,), ns)
+        cls.__module__ = __name__
+        cls.__qualname__ = name
+        globals()[name] = cls
+        return cls
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/test_cli_startup_is_light.py
+++ b/tests/test_cli_startup_is_light.py
@@ -195,6 +195,46 @@ def test_light_command_invocation_stays_light(argv: list[str]):
     assert not leaked, f"`soup {' '.join(argv)}` pulled in {leaked}"
 
 
+@pytest.mark.parametrize(
+    "module",
+    [
+        "soup_cli.utils.reward_hack_control",
+        "soup_cli.utils.reward_hacking",
+        "soup_cli.utils.echo_trap",
+        "soup_cli.utils.minillm",
+        "soup_cli.utils.rl_checkpoint",
+        "soup_cli.utils.relora",
+        "soup_cli.utils.lisa",
+        "soup_cli.monitoring.hf_push",
+        "soup_cli.monitoring.curriculum_callback",
+        "soup_cli.monitoring.grpo_stability_callback",
+        "soup_cli.monitoring.callback",
+    ],
+)
+def test_callback_module_imports_without_transformers(module: str):
+    """Each TrainerCallback module must be importable without pulling transformers.
+
+    These modules used to resolve the TrainerCallback base at class-definition
+    time, eagerly importing transformers (and therefore torch) at module scope.
+    Issue #320 deferred class construction via PEP 562 ``__getattr__``.
+    """
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            f"import sys, {module}; "
+            "print(','.join(sorted(m for m in "
+            f"{HEAVY!r} if m in sys.modules)))",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert proc.returncode == 0, (proc.stdout, proc.stderr)
+    leaked = [m for m in proc.stdout.strip().split(",") if m]
+    assert not leaked, f"{module} pulled in {leaked} at import time"
+
+
 def test_stress_sentinel_matches_the_controller():
     """``reward_stress`` copies the sentinel rather than importing it.
 

--- a/tests/test_issue308_callback_subclass.py
+++ b/tests/test_issue308_callback_subclass.py
@@ -12,15 +12,12 @@ after ``on_train_begin`` — before the first optimizer step).
 fix: both must be real ``TrainerCallback`` subclasses, so they inherit the no-op
 defaults for the ~13 unimplemented events.
 
-The subclassing is done via ``_try_import_callback_base()``. That factory looks
-lazy but is **called at class-definition time**, i.e. at module import — so these
-modules are NOT transformers-free at import time, contrary to what this docstring
-claimed until v0.72.2. Measured: ``import soup_cli.utils.relora`` pulls
-transformers + torch (~4.4s). Harmless here (the trainer path loads transformers
-anyway), but it made ``soup --help`` 5x slower the moment a *light* command
-imported one of these modules — see #320 and
-``tests/test_cli_startup_is_light.py``, which enforces the real invariant at
-runtime instead of asserting a syntactic property the AST cannot verify.
+The subclassing is done via ``_try_import_callback_base()`` (or the equivalent
+``_get_trainer_callback_base()``). Since #320, the factory is no longer called at
+class-definition time: the callback class is built lazily via PEP 562
+``__getattr__`` on first access, so importing the module no longer pulls
+transformers or torch. ``tests/test_cli_startup_is_light.py`` enforces this
+invariant at runtime with ``test_callback_module_imports_without_transformers``.
 """
 
 from __future__ import annotations

--- a/tests/test_issue320_lazy_callback_import.py
+++ b/tests/test_issue320_lazy_callback_import.py
@@ -1,0 +1,136 @@
+"""Issue #320 — TrainerCallback modules must not import transformers at module scope.
+
+Eleven modules resolved their TrainerCallback base at class-definition time,
+eagerly importing transformers (and therefore torch) on every module import.
+The fix defers class construction via PEP 562 ``__getattr__``: importing the
+module no longer pulls transformers; the callback class is built on first
+attribute access, inheriting from the real ``TrainerCallback`` (or ``object``
+when transformers is absent).
+
+This suite verifies:
+1. Each callback class is still a real ``TrainerCallback`` subclass (the #308
+   property — HF's CallbackHandler dispatches events via ``getattr``).
+2. Each callback still inherits the no-op stubs for unimplemented events.
+3. The lazy class is cached (same object on repeated access).
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+
+import pytest
+
+CALLBACK_MODULES = [
+    ("soup_cli.utils.reward_hack_control", "RewardHackMitigationCallback"),
+    ("soup_cli.utils.reward_hacking", "RewardHackCallback"),
+    ("soup_cli.utils.echo_trap", "EchoTrapCallback"),
+    ("soup_cli.utils.minillm", "MiniLLMCallback"),
+    ("soup_cli.utils.rl_checkpoint", "RLCheckpointCallback"),
+    ("soup_cli.utils.relora", "ReLoRACallback"),
+    ("soup_cli.utils.lisa", "LisaCallback"),
+    ("soup_cli.monitoring.hf_push", "HFPushCallback"),
+    ("soup_cli.monitoring.curriculum_callback", "DynamicCurriculumCallback"),
+    ("soup_cli.monitoring.grpo_stability_callback", "GRPOStabilityCallback"),
+    ("soup_cli.monitoring.callback", "SoupTrainerCallback"),
+]
+
+
+def _ids(params):
+    return [f"{m}.{c}" for m, c in params]
+
+
+@pytest.mark.parametrize("mod_path,cls_name", CALLBACK_MODULES, ids=_ids(CALLBACK_MODULES))
+def test_callback_is_trainer_callback_subclass(mod_path, cls_name):
+    """The lazily-built class must be a real TrainerCallback subclass."""
+    try:
+        from transformers import TrainerCallback
+    except ImportError:
+        pytest.skip("transformers not installed")
+    mod = importlib.import_module(mod_path)
+    cls = getattr(mod, cls_name)
+    assert issubclass(cls, TrainerCallback), (
+        f"{cls_name} is not a TrainerCallback subclass; bases = {cls.__bases__}"
+    )
+
+
+@pytest.mark.parametrize("mod_path,cls_name", CALLBACK_MODULES, ids=_ids(CALLBACK_MODULES))
+def test_callback_has_noop_event_stubs(mod_path, cls_name):
+    """Each callback must inherit no-op stubs for all Trainer lifecycle events."""
+    try:
+        from transformers import TrainerCallback  # noqa: F401
+    except ImportError:
+        pytest.skip("transformers not installed")
+    mod = importlib.import_module(mod_path)
+    cls = getattr(mod, cls_name)
+    for event in (
+        "on_epoch_begin",
+        "on_epoch_end",
+        "on_train_begin",
+        "on_train_end",
+        "on_step_begin",
+        "on_step_end",
+        "on_log",
+        "on_save",
+        "on_evaluate",
+        "on_prediction_step",
+    ):
+        assert hasattr(cls, event), f"{cls_name} missing {event}"
+
+
+@pytest.mark.parametrize("mod_path,cls_name", CALLBACK_MODULES, ids=_ids(CALLBACK_MODULES))
+def test_lazy_class_is_cached(mod_path, cls_name):
+    """Repeated access must return the same class object (cached in globals)."""
+    mod = importlib.import_module(mod_path)
+    first = getattr(mod, cls_name)
+    second = getattr(mod, cls_name)
+    assert first is second, f"{cls_name} was rebuilt on second access"
+
+
+@pytest.mark.parametrize(
+    "module,builder_call",
+    [
+        (
+            "soup_cli.utils.echo_trap",
+            "m.build_echo_trap_callback(threshold=0.5)",
+        ),
+        (
+            "soup_cli.utils.reward_hacking",
+            "m.build_reward_hack_callback(detector='info_rm')",
+        ),
+        (
+            "soup_cli.utils.minillm",
+            "m.build_minillm_callback(m.MiniLLMConfig())",
+        ),
+        (
+            "soup_cli.utils.rl_checkpoint",
+            "m.build_rl_checkpoint_callback("
+            "m.RLCheckpointConfig(save_every_steps=1), output_dir='out')",
+        ),
+        (
+            "soup_cli.monitoring.hf_push",
+            "m.build_push_callback("
+            "repo_id='user/repo', output_dir='out', explicit_token='tok')",
+        ),
+    ],
+)
+def test_builder_invocation_no_nameerror_in_subprocess(module: str, builder_call: str):
+    """Builder calls must resolve lazy callback names without NameError."""
+    probe = (
+        "import importlib\n"
+        f"m = importlib.import_module('{module}')\n"
+        "try:\n"
+        f"    {builder_call}\n"
+        "except NameError as exc:\n"
+        "    raise SystemExit(f'NAMEERROR:{exc}')\n"
+        "print('OK')\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, (proc.stdout, proc.stderr)
+    assert "NAMEERROR:" not in proc.stdout + proc.stderr


### PR DESCRIPTION
## What does this PR do?

Fixes #320.

Eleven callback modules resolved `TrainerCallback` while their classes were being defined. This eagerly imported `transformers` and `torch` whenever those modules were imported.

This PR creates the callback classes lazily through module-level `__getattr__`. The training dependencies are now loaded only when a callback class is first accessed. The resolved class is cached, so later access returns the same class without rebuilding it.

Regression tests cover lazy imports, subclass behavior, no-op dependency stubs, and class caching.

## Type of change

* [x] Bug fix
* [ ] New feature
* [x] Refactor / cleanup
* [ ] Documentation
* [x] Tests

## Checklist

* [x] `ruff check src/soup_cli/ tests/` passes
* [x] `pytest tests/ -v` passes
* [x] Updated relevant docs if needed: no documentation changes required

