### PR TITLE
feat(data): wire data.interleave into training-time dataset loading (#443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ reproducing 70+ versions of notes.
   quantization). `epochs: 1` and `max_length: 8192` are taken from the SFT
   sibling rather than the smaller qwen defaults, which suit a 754B MoE better.
 
-- **`data.interleave` is now wired into training-time dataset loading (#443 by @blackcoderx in #TODO-PR).**
+- **`data.interleave` is now wired into training-time dataset loading (#443 by @blackcoderx in #460).**
   `parse_interleave`/`InterleaveSpec` have been schema-validated and unit-tested since
   v0.42.0, but `load_dataset()` never called them — every multi-dataset mixture request
   silently trained on nothing but `data.train`'s single path, the same gap #330 and #442

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,21 @@ reproducing 70+ versions of notes.
   quantization). `epochs: 1` and `max_length: 8192` are taken from the SFT
   sibling rather than the smaller qwen defaults, which suit a 754B MoE better.
 
+- **`data.interleave` is now wired into training-time dataset loading (#443 by @blackcoderx in #TODO-PR).**
+  `parse_interleave`/`InterleaveSpec` have been schema-validated and unit-tested since
+  v0.42.0, but `load_dataset()` never called them — every multi-dataset mixture request
+  silently trained on nothing but `data.train`'s single path, the same gap #330 and #442
+  papered over in their respective renderers. `DataConfig.train` now accepts `str |
+  list[str]`; a list of `>= 2` local file paths combines via `data.interleave`
+  (`concat` / `under` / `over` / `{strategy: probs, probs: [...]}`) into one row set
+  before the existing `val_split` line in `_finalize` runs, so a single path stays
+  byte-identical. `interleave` is local-files-only: `training.packing` /
+  `training.multipack` and `data.streaming` / an HF-hub dataset name are all rejected
+  at config-parse time with a message naming the reason (streaming/hub-dataset
+  interleaving is follow-up #459). Both the `soup data mix --optimize` recipe writer
+  and the `--live` overlay renderer emit the real N-dataset mixture again instead of
+  collapsing to one path.
+
 ### Fixed
 
 - **`cut_ce.py` and `liger.py` now normalize path separators and match architecture

--- a/docs/data.md
+++ b/docs/data.md
@@ -522,13 +522,22 @@ data:
   shards: 4
 ```
 
-**Multi-dataset interleave:**
+**Multi-dataset interleave** (v0.42.0 schema, wired into training-time loading in #443):
 
 ```yaml
 data:
+  train:
+    - dolma.jsonl
+    - wikipedia.jsonl
   interleave: { strategy: probs, probs: [0.7, 0.3] }   # also: concat / under / over
   eval_on_each_dataset: true
 ```
+
+`data.train` as a list requires `data.interleave` (and vice versa); entries must be local
+file paths only — no remote URIs / HF-hub dataset names (that combination is
+[#459](https://github.com/MakazhanAlpamys/Soup/issues/459)). `training.packing` /
+`training.multipack` and `data.streaming` must all be off. With the `probs` strategy,
+`len(data.train)` must equal `len(probs)`.
 
 **Vocab expansion + advanced masking:**
 
@@ -734,7 +743,7 @@ soup data mix --optimize --budget 1h \
     --num-probes 8 --output mix_recipe.yaml
 ```
 
-Writes a YAML recipe you can splice into your `soup.yaml`: `data.train` is the single highest-weighted dataset from the search (the full ranked weight/path breakdown is kept as a comment), and `data.interleave` carries the searched mixture weights but is not yet consumed by training — see the in-file comment, and #330/#443. `--budget` accepts `60s` / `5m` / `1h` / `24h`. Per-candidate proxy failures are isolated (DEBUG-logged, sentinel high loss recorded) so a single OOM combo does not abort the whole search; `partial=True` is surfaced in the report when the budget cap trips mid-loop.
+Writes a YAML recipe you can splice into your `soup.yaml`: `data.train` renders as the full ranked dataset list (index-aligned with `data.interleave.probs`), and `data.interleave` carries the searched mixture weights — as of #443, `data.interleave` is fully wired into training-time dataset loading, so `soup train` consumes the real N-dataset mixture this search found rather than collapsing to one path. `--budget` accepts `60s` / `5m` / `1h` / `24h`. Per-candidate proxy failures are isolated (DEBUG-logged, sentinel high loss recorded) so a single OOM combo does not abort the whole search; `partial=True` is surfaced in the report when the budget cap trips mid-loop.
 
 Re-apply a previously written recipe:
 

--- a/src/soup_cli/commands/cost.py
+++ b/src/soup_cli/commands/cost.py
@@ -39,6 +39,27 @@ def _get_dataset_size(cfg) -> tuple[int, bool]:
     the default because the dataset could not be read; callers should warn.
     """
     train_path = cfg.data.train
+
+    # #443 — data.interleave: sum row counts across every local dataset
+    # rather than treating cfg.data.train as one path.
+    if isinstance(train_path, list):
+        from soup_cli.data.loader import load_raw_data
+
+        total = 0
+        any_estimated = False
+        for p in train_path:
+            entry_path = Path(p)
+            if entry_path.exists():
+                try:
+                    total += len(load_raw_data(entry_path))
+                    continue
+                except (OSError, ValueError, KeyError):
+                    pass
+            any_estimated = True
+            total += _DEFAULT_DATASET_SIZE
+        split = 1.0 - cfg.data.val_split
+        return int(total * split), any_estimated
+
     path = Path(train_path)
 
     # Local file

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -2308,6 +2308,24 @@ def _push_dataset_non_hf(
 
 # --- v0.42.0 Part C / F: AOT preprocess + document ingestion ---------------
 
+
+def _cache_key_dataset_path(cfg) -> str:
+    """Dataset-path input fed to make_preprocess_cache_key (#443 list-aware).
+
+    A list data.train folds data.interleave's strategy/probs into the key
+    too, since the same file set under a different mixture must not
+    collide on a stale, mis-mixed cache entry. Extracted as its own
+    function so it can be exercised directly by
+    tests/test_issue443_interleave_wiring.py's enumerating test.
+    """
+    if isinstance(cfg.data.train, list):
+        return json.dumps(
+            {"train": cfg.data.train, "interleave": cfg.data.interleave},
+            sort_keys=True,
+        )
+    return cfg.data.train
+
+
 @app.command(name="preprocess")
 def preprocess_dataset(
     config_path: str = typer.Argument(
@@ -2354,18 +2372,10 @@ def preprocess_dataset(
         )
         raise typer.Exit(1)
 
-    if isinstance(cfg.data.train, list):
-        # #443 — fold data.interleave into the cache key: the same file
-        # set with a different strategy/probs must not collide on a
-        # stale, mis-mixed cache entry.
-        dataset_path = json.dumps(
-            {"train": cfg.data.train, "interleave": cfg.data.interleave},
-            sort_keys=True,
-        )
-        train_display = ", ".join(cfg.data.train)
-    else:
-        dataset_path = cfg.data.train
-        train_display = cfg.data.train
+    dataset_path = _cache_key_dataset_path(cfg)
+    train_display = (
+        ", ".join(cfg.data.train) if isinstance(cfg.data.train, list) else cfg.data.train
+    )
     cache_key = make_preprocess_cache_key(
         dataset_path=dataset_path,
         tokenizer_name=cfg.base,

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -2354,14 +2354,26 @@ def preprocess_dataset(
         )
         raise typer.Exit(1)
 
+    if isinstance(cfg.data.train, list):
+        # #443 — fold data.interleave into the cache key: the same file
+        # set with a different strategy/probs must not collide on a
+        # stale, mis-mixed cache entry.
+        dataset_path = json.dumps(
+            {"train": cfg.data.train, "interleave": cfg.data.interleave},
+            sort_keys=True,
+        )
+        train_display = ", ".join(cfg.data.train)
+    else:
+        dataset_path = cfg.data.train
+        train_display = cfg.data.train
     cache_key = make_preprocess_cache_key(
-        dataset_path=cfg.data.train,
+        dataset_path=dataset_path,
         tokenizer_name=cfg.base,
         max_length=cfg.data.max_length,
         format_name=cfg.data.format,
     )
     target = Path(out_real) / cache_key
-    console.print(f"[cyan]Dataset:[/] {cfg.data.train}")
+    console.print(f"[cyan]Dataset:[/] {train_display}")
     console.print(f"[cyan]Tokenizer:[/] {cfg.base}")
     console.print(f"[cyan]max_length:[/] {cfg.data.max_length}")
     console.print(f"[cyan]Cache key:[/] {cache_key}")

--- a/src/soup_cli/commands/data_mix.py
+++ b/src/soup_cli/commands/data_mix.py
@@ -137,12 +137,16 @@ def mix(
         for p in probs:
             console.print(f"      - {float(p):.6f}")
         if isinstance(train_value, str):
-            # #330 — current recipes: data.train is a single string. Quote it
+            # Legacy single-string recipes (#330/#442-era, or a search over
+            # exactly one dataset): data.train is a single string. Quote it
             # the same way render_mix_recipe_yaml does — an unquoted path
             # like "odd: name.jsonl" is not valid YAML when pasted back.
             console.print(f"  train: {escape(json.dumps(train_value))}")
         else:
-            # Pre-#330 recipes on disk: data.train was a YAML list.
+            # #443 — current recipes: data.train is the full dataset list,
+            # index-aligned with data.interleave.probs, now that soup train
+            # actually consumes the mixture. (Also matches pre-#330 recipes
+            # on disk, which happened to be list-shaped by accident.)
             console.print("  train:")
             for path in train_value or []:
                 console.print(f"    - {escape(str(path))}")

--- a/src/soup_cli/commands/ship.py
+++ b/src/soup_cli/commands/ship.py
@@ -303,7 +303,24 @@ def _compute_provenance(cfg: "SoupConfig") -> Dict[str, str]:
         prov["base_model"] = base
     data = cfg.data.train
     if data:
-        data_sha = _safe_hash_file(data, _MAX_DATA_SHA_BYTES)
+        if isinstance(data, list):
+            # #443 — data.interleave: combine per-file hashes into one
+            # data_sha. Order preserved (not sorted) since reordering the
+            # list is a real semantic change — it realigns data.interleave
+            # .probs to different files.
+            import hashlib
+
+            shas = [
+                sha for p in data
+                if (sha := _safe_hash_file(p, _MAX_DATA_SHA_BYTES)) is not None
+            ]
+            data_sha = (
+                hashlib.sha256("\x1e".join(shas).encode()).hexdigest()
+                if shas
+                else None
+            )
+        else:
+            data_sha = _safe_hash_file(data, _MAX_DATA_SHA_BYTES)
         if data_sha is not None:
             prov["data_sha"] = data_sha
     return prov

--- a/src/soup_cli/commands/train.py
+++ b/src/soup_cli/commands/train.py
@@ -1639,15 +1639,22 @@ def _write_annex_xi(out_path: str, run_id: str, cfg, *, energy=None) -> None:
     modality = getattr(cfg, "modality", "text") or "text"
     energy_kwh = float(getattr(energy, "energy_kwh", 0.0)) if energy is not None else 0.0
     co2_kg = float(getattr(energy, "co2_kg", 0.0)) if energy is not None else 0.0
-    train_path = str(getattr(cfg.data, "train", "") or "")
+    raw_train = getattr(cfg.data, "train", "") or ""
+    # #443 — pass the raw str|list through so top-domain extraction
+    # aggregates across every interleaved dataset, instead of stringifying
+    # a list into a nonexistent path (pre-fix: `str(getattr(...) or "")`
+    # applied `or ""` to the getattr result BEFORE str(), so a non-empty
+    # list became its own Python repr string, e.g. "['a.jsonl', 'b.jsonl']"
+    # — neither a valid path nor useful doc text).
+    train_display = ", ".join(raw_train) if isinstance(raw_train, list) else str(raw_train)
     # #184 — best-effort extract the top crawled domains from the training data.
-    top_domains = load_top_domains_from_jsonl(train_path)
+    top_domains = load_top_domains_from_jsonl(raw_train)
     fmt = "pdf" if out_path.lower().endswith(".pdf") else "markdown"
     data = AnnexXIData(
         model_name=str(getattr(cfg, "output", run_id) or run_id),
         base_model=str(cfg.base),
         task=str(cfg.task),
-        dataset_summary=train_path,
+        dataset_summary=train_display,
         modalities=(modality,),
         train_compute_flops=0.0,
         train_energy_kwh=energy_kwh,
@@ -1991,6 +1998,17 @@ def _synth_lr_curve(n: int) -> list[float]:
     return out
 
 
+def _lr_finder_dataset_path(train) -> str:
+    """#443 — LR-finder samples one representative dataset; it already
+    bypasses load_dataset()/_finalize() for a lightweight sweep, so full
+    interleave fidelity is out of this issue's scope. Falls back to the
+    first dataset rather than crashing on a list. Extracted as its own
+    function so it can be exercised directly by
+    tests/test_issue443_interleave_wiring.py's enumerating test.
+    """
+    return train[0] if isinstance(train, list) else train
+
+
 def _live_lr_sweep_from_config(cfg, schedule: list[float]) -> list[float]:
     """Build a tiny in-process loop: load model + tokenizer + a slice of
     the train dataset, then call :func:`run_lr_sweep`."""
@@ -2016,13 +2034,7 @@ def _live_lr_sweep_from_config(cfg, schedule: list[float]) -> list[float]:
     ).to(device)
     model.train()
 
-    # #443 — LR-finder samples one representative dataset; it already
-    # bypasses load_dataset()/_finalize() for a lightweight sweep, so full
-    # interleave fidelity is out of this issue's scope. Fall back to the
-    # first dataset rather than crashing on a list.
-    lr_finder_train_path = (
-        cfg.data.train[0] if isinstance(cfg.data.train, list) else cfg.data.train
-    )
+    lr_finder_train_path = _lr_finder_dataset_path(cfg.data.train)
     dataset = load_raw_data(_Path(lr_finder_train_path))
     rows = list(dataset)[: max(2, len(schedule))]
     if not rows:

--- a/src/soup_cli/commands/train.py
+++ b/src/soup_cli/commands/train.py
@@ -2016,7 +2016,14 @@ def _live_lr_sweep_from_config(cfg, schedule: list[float]) -> list[float]:
     ).to(device)
     model.train()
 
-    dataset = load_raw_data(_Path(cfg.data.train))
+    # #443 — LR-finder samples one representative dataset; it already
+    # bypasses load_dataset()/_finalize() for a lightweight sweep, so full
+    # interleave fidelity is out of this issue's scope. Fall back to the
+    # first dataset rather than crashing on a list.
+    lr_finder_train_path = (
+        cfg.data.train[0] if isinstance(cfg.data.train, list) else cfg.data.train
+    )
+    dataset = load_raw_data(_Path(lr_finder_train_path))
     rows = list(dataset)[: max(2, len(schedule))]
     if not rows:
         raise RuntimeError("training dataset is empty")

--- a/src/soup_cli/config/schema.py
+++ b/src/soup_cli/config/schema.py
@@ -242,7 +242,38 @@ class LoraConfig(BaseModel):
 
 
 class DataConfig(BaseModel):
-    train: str = Field(..., description="Path to training data or HF dataset name")
+    train: Union[str, List[str]] = Field(
+        ...,
+        description=(
+            "Path to training data or HF dataset name, or a list of >= 2 "
+            "local file paths to combine via data.interleave. (#443)"
+        ),
+    )
+
+    @field_validator("train", mode="before")
+    @classmethod
+    def _validate_train_shape(cls, v):
+        if isinstance(v, str):
+            return v
+        if isinstance(v, list):
+            if len(v) == 0:
+                raise ValueError("data.train list must not be empty")
+            if len(v) == 1:
+                raise ValueError(
+                    "data.train list must have >= 2 entries for "
+                    "data.interleave — use a single string path for one "
+                    "dataset"
+                )
+            for i, entry in enumerate(v):
+                if not isinstance(entry, str) or not entry.strip():
+                    raise ValueError(
+                        f"data.train[{i}] must be a non-empty string"
+                    )
+            return v
+        raise ValueError(
+            "data.train must be a string or a list of strings "
+            f"(got {type(v).__name__})"
+        )
     format: Literal[
         "alpaca", "sharegpt", "chatml", "dpo", "kto", "llava", "sharegpt4v",
         "plaintext", "embedding", "audio", "tool-calling", "auto",
@@ -669,10 +700,13 @@ class DataConfig(BaseModel):
     @field_validator("interleave")
     @classmethod
     def _validate_interleave_v042(cls, value):
-        # Shape validation only — full ``parse_interleave`` requires
-        # ``num_datasets`` which the trainer supplies at runtime. We accept
-        # None / str / dict here and reject obvious type errors so a YAML
-        # like ``data.interleave: 99`` fails loudly at config load.
+        # Shape validation only, independent of `train`. We accept None /
+        # str / dict here and reject obvious type errors so a YAML like
+        # ``data.interleave: 99`` fails loudly at config load. The full
+        # parse (which needs num_datasets = len(data.train)) now happens
+        # in SoupConfig._validate_interleave_compat below — num_datasets is
+        # a parse-time constant since #443 widened data.train to accept a
+        # list.
         if value is None:
             return None
         if isinstance(value, str):
@@ -5299,6 +5333,74 @@ class SoupConfig(BaseModel):
         elif replay_knobs_set:
             raise ValueError(
                 "data.replay_ratio / data.replay_seed require data.replay"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_interleave_compat(self) -> "SoupConfig":
+        """#443 — data.interleave requires data.train to be a list of local
+        file paths, and is fully parsed here rather than in the field
+        validator: num_datasets = len(data.train) is a parse-time constant
+        now that train can be list-shaped.
+
+        packing / multipack concatenate rows into fixed-length blocks, so a
+        per-source mixture ratio stops being meaningful at block
+        boundaries — reject rather than silently mis-mix. Mirrors
+        _validate_replay_compat's identical reasoning for the same
+        packing/multipack conflict, one validator up.
+
+        streaming and HF-hub dataset names are follow-up work (#459,
+        blocked on #443) — v1 refuses them at parse time with a message
+        naming the limitation, rather than silently only mixing the
+        local-file subset.
+        """
+        from pathlib import Path
+
+        from soup_cli.utils.data_pipeline import is_remote_uri, parse_interleave
+
+        data = self.data
+        train_is_list = isinstance(data.train, list)
+
+        if data.interleave is not None:
+            if not train_is_list:
+                raise ValueError(
+                    "data.interleave requires data.train to be a list of "
+                    ">= 2 local file paths"
+                )
+            # Full parse now that num_datasets is a parse-time constant —
+            # validates strategy/probs shape against the actual dataset
+            # count (parse_interleave is otherwise unmodified by #443).
+            parse_interleave(data.interleave, num_datasets=len(data.train))
+
+            if self.training.packing:
+                raise ValueError(
+                    "data.interleave is incompatible with training.packing "
+                    "(packing concatenates rows into fixed blocks, so a "
+                    "per-source mixture ratio stops being meaningful)"
+                )
+            if self.training.multipack:
+                raise ValueError(
+                    "data.interleave is incompatible with "
+                    "training.multipack (bin-packing breaks the "
+                    "per-source mixture ratio)"
+                )
+            if data.streaming:
+                raise ValueError(
+                    "data.interleave does not support data.streaming=true "
+                    "(follow-up: #459) — disable streaming or drop "
+                    "interleave"
+                )
+            for entry in data.train:
+                if is_remote_uri(entry) or not Path(entry).suffix:
+                    raise ValueError(
+                        f"data.interleave only supports local file paths; "
+                        f"{entry!r} looks like a remote URI or an HF-hub "
+                        "dataset name (follow-up: #459)"
+                    )
+        elif train_is_list:
+            raise ValueError(
+                "data.train as a list requires data.interleave to be set "
+                "— otherwise the mixture strategy is undefined"
             )
         return self
 

--- a/src/soup_cli/data/loader.py
+++ b/src/soup_cli/data/loader.py
@@ -213,8 +213,15 @@ def load_dataset(data_config: DataConfig) -> dict:
     - Local files (.jsonl, .json, .csv, .parquet, .txt)
     - HuggingFace dataset names (auto-detected if no file extension)
     - Remote fsspec URIs (s3://, gs://, gcs://, az://, abfs://, abfss://, oci://) — v0.53.8 #85
+    - A list of >= 2 local files combined via data.interleave — #443. Schema
+      validation (SoupConfig._validate_interleave_compat) already guarantees
+      data.interleave is set and every entry is a local file path whenever
+      data.train is a list, so this branch never has to re-check that.
     """
     train_path = data_config.train
+
+    if isinstance(train_path, list):
+        return _load_interleaved_local_datasets(train_path, data_config)
 
     # v0.53.8 #85 — fsspec live remote loader. Schema accepts these URIs
     # since v0.42.0; live loader lands here. Lazy-imports fsspec + the
@@ -254,6 +261,128 @@ def load_dataset(data_config: DataConfig) -> dict:
 
     # Split into train/val, then mix replay into train (v0.71.36).
     return _finalize(formatted, data_config)
+
+
+def _load_one_local_dataset(train_path: str, data_config: DataConfig) -> list[dict]:
+    """Load + format one local file — the same per-file pipeline the
+    single-path branch of load_dataset() runs above, factored out so
+    #443's interleave path (below) reuses it rather than re-deriving it.
+    The single-path branch itself is left inline and untouched, so its
+    output stays byte-identical by construction rather than by
+    refactor-equivalence.
+    """
+    path = Path(train_path)
+    raw_data = load_raw_data(path)
+
+    fmt = data_config.format
+    if fmt == "auto":
+        fmt = detect_format(raw_data)
+        console.print(f"[dim]Auto-detected format ({train_path}): {fmt}[/]")
+
+    formatted = [format_to_messages(row, fmt) for row in raw_data]
+    formatted = [r for r in formatted if r is not None]
+
+    if is_vision_format(fmt):
+        image_dir = Path(data_config.image_dir) if data_config.image_dir else path.parent
+        formatted = _validate_vision_images(formatted, image_dir)
+    if is_audio_format(fmt):
+        audio_dir = Path(data_config.audio_dir) if data_config.audio_dir else path.parent
+        formatted = _validate_audio_files(formatted, audio_dir)
+    return formatted
+
+
+def _cycle_to(rows: list[dict], target: int) -> list[dict]:
+    """Deterministically repeat/truncate ``rows`` to exactly ``target`` rows
+    via round-robin cycling. No RNG, no new seed knob — #443's scope does
+    not authorize one, and the downstream HF Trainer's default sampler
+    already shuffles every epoch, so row ORDER out of this function is not
+    load-bearing; only per-source row COUNT is.
+    """
+    if target <= len(rows):
+        return rows[:target]
+    out = list(rows)
+    i = 0
+    while len(out) < target:
+        out.append(rows[i % len(rows)])
+        i += 1
+    return out
+
+
+def _apportion(probs: tuple[float, ...], total: int) -> list[int]:
+    """Largest-remainder apportionment: integer per-dataset quotas summing
+    to exactly ``total``, as close as possible to ``probs[i] * total``.
+    Deterministic; ties break by dataset index.
+    """
+    raw = [p * total for p in probs]
+    base = [int(x) for x in raw]
+    remainder = total - sum(base)
+    order = sorted(range(len(probs)), key=lambda i: (raw[i] - base[i]), reverse=True)
+    for i in order[:remainder]:
+        base[i] += 1
+    return base
+
+
+def _combine_interleaved(per_dataset_rows: list[list[dict]], spec) -> list[dict]:
+    """Combine per-dataset row lists per an InterleaveSpec (#443).
+
+    ``concat`` / ``under`` / ``over`` / ``probs`` control per-source row
+    COUNT, not order — see _cycle_to's docstring for why order doesn't
+    matter here.
+    """
+    sizes = [len(rows) for rows in per_dataset_rows]
+    if any(n == 0 for n in sizes):
+        raise ValueError(
+            "data.interleave: every dataset in data.train must have "
+            ">= 1 row after formatting"
+        )
+    if spec.strategy == "concat":
+        combined: list[dict] = []
+        for rows in per_dataset_rows:
+            combined.extend(rows)
+        return combined
+    if spec.strategy == "under":
+        target = min(sizes)
+        combined = []
+        for rows in per_dataset_rows:
+            combined.extend(rows[:target])
+        return combined
+    if spec.strategy == "over":
+        target = max(sizes)
+        combined = []
+        for rows in per_dataset_rows:
+            combined.extend(_cycle_to(rows, target))
+        return combined
+    if spec.strategy == "probs":
+        quotas = _apportion(spec.probs, sum(sizes))
+        combined = []
+        for rows, quota in zip(per_dataset_rows, quotas):
+            combined.extend(_cycle_to(rows, quota))
+        return combined
+    raise AssertionError(f"unreachable interleave strategy {spec.strategy!r}")
+
+
+def _load_interleaved_local_datasets(train_paths: list[str], data_config: DataConfig) -> dict:
+    """#443 — load + combine every local dataset in a list-shaped
+    data.train per data.interleave, then hand the combined rows to the
+    existing, unmodified _finalize() — same seam every other loader uses.
+    """
+    from soup_cli.utils.data_pipeline import parse_interleave
+
+    spec = parse_interleave(data_config.interleave, num_datasets=len(train_paths))
+    if spec is None:
+        # Defence-in-depth only: SoupConfig._validate_interleave_compat
+        # already requires data.interleave whenever data.train is a list,
+        # so a caller only reaches here via a hand-built DataConfig that
+        # skipped SoupConfig validation.
+        raise ValueError("data.train is a list but data.interleave is not set")
+
+    per_dataset_rows = [_load_one_local_dataset(p, data_config) for p in train_paths]
+    combined = _combine_interleaved(per_dataset_rows, spec)
+    console.print(
+        f"[dim]Interleaved {len(train_paths)} datasets "
+        f"(strategy={spec.strategy}) -> {len(combined)} rows[/]"
+    )
+    return _finalize(combined, data_config)
 
 
 def _validate_vision_images(data: list[dict], image_dir: Path) -> list[dict]:

--- a/src/soup_cli/mcp_server/registry.py
+++ b/src/soup_cli/mcp_server/registry.py
@@ -606,7 +606,7 @@ _MUTATING_NOTE = (
 def _collect_external_protected_inputs(cfg: SoupConfig) -> list[ProtectedFile]:
     """Collect and digest external paths (datasets, models) referenced by cfg."""
     protected: list[ProtectedFile] = []
-    candidate_paths: list[tuple[str, str | None]] = [
+    candidate_paths: list[tuple[str, str | list[str] | None]] = [
         ("data.train", getattr(cfg.data, "train", None)),
         ("data.eval", getattr(cfg.data, "eval", None)),
         ("data.replay", getattr(cfg.data, "replay", None)),
@@ -619,8 +619,16 @@ def _collect_external_protected_inputs(cfg: SoupConfig) -> list[ProtectedFile]:
         candidate_paths.append(("training.eval_gate.suite", cfg.training.eval_gate.suite))
 
     for field, path in candidate_paths:
-        if isinstance(path, str) and path and is_under_cwd(path) and os.path.exists(path):
-            protected.append(digest_file(path, field))
+        # #443 — data.interleave lets data.train be a list of local paths.
+        # Digest each entry independently (one ProtectedFile per file) so
+        # every interleaved file is re-validated before execution, instead
+        # of the list silently contributing zero entries (isinstance(path,
+        # str) used to fail before os.path.exists even ran).
+        entries = path if isinstance(path, list) else [path]
+        for i, entry in enumerate(entries):
+            entry_field = f"{field}[{i}]" if isinstance(path, list) else field
+            if isinstance(entry, str) and entry and is_under_cwd(entry) and os.path.exists(entry):
+                protected.append(digest_file(entry, entry_field))
     return protected
 
 

--- a/src/soup_cli/utils/annex_xi.py
+++ b/src/soup_cli/utils/annex_xi.py
@@ -416,40 +416,63 @@ def extract_top_domains(
 def load_top_domains_from_jsonl(
     path: object, *, top_n: int = 10
 ) -> Tuple[Tuple[str, float], ...]:
-    """Best-effort domain extraction from a cwd-contained JSONL file.
+    """Best-effort domain extraction from cwd-contained JSONL file(s).
 
-    Returns ``()`` on any failure (missing file, outside cwd, symlink,
+    ``path`` may be a single path or a list of paths (#443 — data.interleave
+    lets data.train be list-shaped; Annex XI/XII's "top domains" section
+    must aggregate across every constituent file, not just go blank or
+    report only the first). ``extract_top_domains`` runs ONCE on the
+    concatenated row stream so top-N selection is global across the whole
+    interleaved corpus, not biased per-file.
+
+    Returns ``()`` on total failure (missing file(s), outside cwd, symlink,
     unreadable, oversize) — an Annex doc must never fail because the corpus
-    is unavailable. cwd-contained + symlink-rejected via the shared helper.
+    is unavailable. Each entry is cwd-contained + symlink-rejected via the
+    shared helper independently; an invalid entry is skipped (best-effort),
+    matching this function's existing single-path contract.
     """
-    if not isinstance(path, str) or not path:
+    if isinstance(path, str):
+        candidates = [path] if path else []
+    elif isinstance(path, list):
+        candidates = [p for p in path if isinstance(p, str) and p]
+    else:
         return ()
-    try:
-        realpath = enforce_under_cwd_and_no_symlink(path, "data.train")
-    except (ValueError, OSError) as exc:
-        _LOG.debug("load_top_domains_from_jsonl: rejected %r: %s", path, exc)
+    if not candidates:
         return ()
-    try:
-        if not os.path.isfile(realpath):
-            return ()
-        if os.path.getsize(realpath) > _MAX_JSONL_BYTES:
-            return ()
-    except OSError:
+
+    realpaths: list[str] = []
+    for p in candidates:
+        try:
+            real = enforce_under_cwd_and_no_symlink(p, "data.train")
+        except (ValueError, OSError) as exc:
+            _LOG.debug("load_top_domains_from_jsonl: rejected %r: %s", p, exc)
+            continue
+        try:
+            if not os.path.isfile(real):
+                continue
+            if os.path.getsize(real) > _MAX_JSONL_BYTES:
+                continue
+        except OSError:
+            continue
+        realpaths.append(real)
+    if not realpaths:
         return ()
 
     def _row_iter():
-        try:
-            with open(realpath, encoding="utf-8") as fh:
-                for line in fh:
-                    raw = line.strip()
-                    if not raw:
-                        continue
-                    try:
-                        yield json.loads(raw)
-                    except (ValueError, TypeError):
-                        continue
-        except OSError as exc:
-            _LOG.debug("load_top_domains_from_jsonl: read failed: %s", exc)
+        for real in realpaths:
+            try:
+                with open(real, encoding="utf-8") as fh:
+                    for line in fh:
+                        raw = line.strip()
+                        if not raw:
+                            continue
+                        try:
+                            yield json.loads(raw)
+                        except (ValueError, TypeError):
+                            continue
+            except OSError as exc:
+                _LOG.debug("load_top_domains_from_jsonl: read failed: %s", exc)
+                continue
 
     try:
         return extract_top_domains(_row_iter(), top_n=top_n)

--- a/src/soup_cli/utils/data_mix.py
+++ b/src/soup_cli/utils/data_mix.py
@@ -599,15 +599,13 @@ def render_mix_recipe_yaml(report: MixOptimizationReport) -> str:
     null bytes in dataset paths (mirrors v0.46.0 Part A
     ``render_recipe_yaml``).
 
-    ``data.train`` renders as a single string — the highest-weighted dataset
-    from the search — because ``DataConfig.train`` is typed ``str`` and
-    ``soup train`` has no reader for a weighted multi-dataset mixture
-    (``data.interleave`` is validated at config-load time but never consumed
-    by ``load_dataset()``). Emitting the full dataset list there produced a
-    recipe ``soup train`` itself could not load (#330). The full ranked
-    weight/path breakdown is kept in a comment so the human-review value
-    isn't lost by collapsing to one path. ``data.interleave`` is left as-is
-    below — it already round-trips through the schema fine.
+    ``data.train`` renders as the full dataset list, index-aligned with
+    ``data.interleave.probs`` — #443 wired ``data.interleave`` into
+    ``load_dataset()``, so ``soup train`` can now consume the real
+    N-dataset mixture this search found, rather than the
+    single-highest-weighted-dataset collapse #330 used as a stopgap while
+    there was no training-time reader. The full ranked weight/path
+    breakdown is still kept in a comment for quick human review.
     """
     if not isinstance(report, MixOptimizationReport):
         raise TypeError(
@@ -641,24 +639,6 @@ def render_mix_recipe_yaml(report: MixOptimizationReport) -> str:
             f"({len(report.best_weights)}) must match report.datasets length "
             f"({len(report.datasets)})."
         )
-    best_idx = max(
-        range(len(report.best_weights)), key=lambda i: report.best_weights[i]
-    )
-    best_path = report.datasets[best_idx]
-    lines.append("#")
-    lines.append(
-        "# soup train does not yet consume a weighted multi-dataset mixture"
-    )
-    lines.append(
-        "# (data.interleave has no training-time reader) — data.train below"
-    )
-    lines.append(
-        "# is the single best-performing dataset from this search. To train"
-    )
-    lines.append(
-        "# on a real combination of all N datasets, merge them first with"
-    )
-    lines.append("# `soup data merge`, then point data.train at the merged file.")
     lines.append("#")
     lines.append("# Full ranked result:")
     ranked = sorted(
@@ -667,12 +647,22 @@ def render_mix_recipe_yaml(report: MixOptimizationReport) -> str:
     for path, w in ranked:
         lines.append(f"#   {w:.6f}  {path}")
     lines.append("data:")
-    lines.append("  interleave:")
-    lines.append("    strategy: probs")
-    lines.append("    probs:")
-    for w in report.best_weights:
-        lines.append(f"      - {w:.6f}")
-    lines.append(f"  train: {json.dumps(best_path)}")
+    if len(report.datasets) >= 2:
+        # #443 — soup train now consumes a real N-dataset mixture, so
+        # data.train renders every searched dataset, index-aligned with
+        # data.interleave.probs below (build_optimization_plan already
+        # requires >= 2 datasets, so the single-dataset branch is a
+        # defensive fallback, not a reachable optimizer output).
+        lines.append("  interleave:")
+        lines.append("    strategy: probs")
+        lines.append("    probs:")
+        for w in report.best_weights:
+            lines.append(f"      - {w:.6f}")
+        lines.append("  train:")
+        for path in report.datasets:
+            lines.append(f"    - {json.dumps(path)}")
+    else:
+        lines.append(f"  train: {json.dumps(report.datasets[0])}")
     return "\n".join(lines) + "\n"
 
 

--- a/src/soup_cli/utils/mix_proxy.py
+++ b/src/soup_cli/utils/mix_proxy.py
@@ -174,15 +174,12 @@ def _render_overlay_yaml(
     accidental key collisions; weights + datasets are sanitised above so the
     output cannot inject keys (the renderer emits scalars only).
 
-    ``data.train`` renders as a single string — the highest-weighted dataset
-    in *this* candidate — because ``DataConfig.train`` is typed ``str`` and
-    ``soup train`` has no reader for a weighted multi-dataset mixture
-    (``data.interleave`` is validated at config-load time but never consumed
-    by ``load_dataset()``). Emitting the full dataset list here produced a
-    proxy-run config ``soup train`` itself could not load (#330's defect in
-    this module's own renderer — #442). ``data.interleave`` is still written
-    below so the searched mixture isn't lost, with a comment noting which
-    dataset was picked and why.
+    ``data.train`` renders as the full dataset list, index-aligned with
+    ``data.interleave.probs`` — #443 wired ``data.interleave`` into
+    ``load_dataset()``, so ``soup train`` can now consume the real
+    N-dataset mixture this candidate searched, rather than the
+    single-highest-weighted-dataset collapse #330/#442 used as a stopgap
+    while there was no training-time reader.
     """
     import yaml  # noqa: PLC0415
 
@@ -193,8 +190,7 @@ def _render_overlay_yaml(
     if not isinstance(data_block, dict):
         data_block = {}
         raw["data"] = data_block
-    best_idx = max(range(len(weights)), key=lambda i: weights[i])
-    data_block["train"] = datasets[best_idx]
+    data_block["train"] = list(datasets)
     data_block["interleave"] = {
         "strategy": "probs",
         "probs": [float(w) for w in weights],
@@ -203,7 +199,10 @@ def _render_overlay_yaml(
 
     # Insert an explanatory comment directly above the `train:` line inside
     # the `data:` block — a targeted line insert, not a value edit, so it
-    # can't touch anything the schema will parse.
+    # can't touch anything the schema will parse. The comment names the
+    # exact list `data.train` renders as, so an anti-drift test can tie the
+    # comment's claim to the actual emitted value rather than to a
+    # separately-tracked variable (the #442 lesson).
     lines = dumped.split("\n")
     data_idx = next((i for i, ln in enumerate(lines) if ln == "data:"), -1)
     if data_idx >= 0:
@@ -212,12 +211,11 @@ def _render_overlay_yaml(
             if ln and not ln.startswith(" "):
                 break  # left the data: block
             if ln.startswith("  train:"):
+                rounded_probs = [round(float(w), 6) for w in weights]
                 lines.insert(
                     i,
-                    f"  # picked {datasets[best_idx]!r} (weight "
-                    f"{weights[best_idx]:.6f}, highest in this candidate) — "
-                    "soup train has no reader for a weighted multi-dataset "
-                    "mixture, see #330/#442/#443",
+                    f"  # data.interleave=probs {rounded_probs} over "
+                    f"{list(datasets)!r} — see #443",
                 )
                 break
         dumped = "\n".join(lines)

--- a/src/soup_cli/utils/terraform_plan.py
+++ b/src/soup_cli/utils/terraform_plan.py
@@ -262,11 +262,30 @@ def build_plan(config: Mapping[str, Any]) -> TrainingPlan:
 
     data_cfg = config.get("data", {}) if isinstance(config.get("data"), Mapping) else {}
     train_path = data_cfg.get("train", "") if isinstance(data_cfg, Mapping) else ""
-    if not isinstance(train_path, str):
-        train_path = ""
 
     config_sha = compute_config_sha(config)
-    dataset_sha = compute_dataset_sha(train_path)
+
+    if isinstance(train_path, list):
+        # #443 — data.interleave: combine a per-entry SHA-256 per list
+        # entry into one dataset_sha, order-preserved (NOT sorted) —
+        # reordering the list is a real semantic change, it realigns
+        # data.interleave.probs to a different file. Mirrors ship.py's
+        # _compute_provenance combination pattern.
+        zero = "0" * _SHA_REGEX_LEN
+        entry_shas = [compute_dataset_sha(p) for p in train_path if isinstance(p, str)]
+        if entry_shas and any(sha != zero for sha in entry_shas):
+            dataset_sha = hashlib.sha256("\x1e".join(entry_shas).encode()).hexdigest()
+        else:
+            # Every entry missing/out-of-cwd (or no valid string entries)
+            # — keep the single all-zero "no dataset yet" sentinel rather
+            # than hashing together N zero-sentinels, which would be a
+            # non-zero SHA that falsely reads as "dataset present".
+            dataset_sha = zero
+    else:
+        if not isinstance(train_path, str):
+            train_path = ""
+        dataset_sha = compute_dataset_sha(train_path)
+
     minutes = _estimate_runtime_minutes(config)
     cost = _estimate_cost(minutes, _DEFAULT_SPOT_PRICE)
     return TrainingPlan(

--- a/tests/test_issue330_mix_recipe_train_loadable.py
+++ b/tests/test_issue330_mix_recipe_train_loadable.py
@@ -1,11 +1,17 @@
 """`soup data mix --optimize` writes a recipe `soup train` cannot load (issue #330).
 
 `render_mix_recipe_yaml` emitted `data.train` as a YAML list, but `DataConfig.train`
-is typed `str` — so the recipe it writes for a human to splice into `soup.yaml`
+was typed `str` — so the recipe it writes for a human to splice into `soup.yaml`
 failed `load_config_from_string` with `data -> train: Input should be a valid
-string`. `data.train` now renders as the single highest-weighted dataset from the
-search; `data.interleave` is unchanged (it already round-trips fine — the bug was
-only ever `train`).
+string`. #330's fix collapsed `data.train` to the single highest-weighted dataset
+from the search, since there was no training-time reader for a real mixture yet.
+
+#443 wired `data.interleave` into `load_dataset()` and widened `DataConfig.train`
+to accept a list, so this module's renderer went back to emitting the full
+dataset list (the shape #330 originally had to move away from) — it is now a
+config `soup train` can actually load. The tests below were updated in place
+(renamed where the assertion itself flipped) rather than deleted, since the
+schema-loadability guarantee they pin still matters, just against the new shape.
 """
 
 from __future__ import annotations
@@ -41,17 +47,27 @@ def test_rendered_recipe_loads_through_config_schema(tmp_path):
     # spliced into a real soup.yaml, matching how a human would use it.
     data_block = text[text.index("data:"):]
     cfg = load_config_from_string(_splice_into_config(data_block))
-    assert cfg.data.train == str(tmp_path / "a.jsonl")
+    assert cfg.data.train == [str(tmp_path / "a.jsonl"), str(tmp_path / "b.jsonl")]
 
 
-def test_train_is_the_highest_weighted_dataset(tmp_path):
+def test_train_contains_all_datasets_in_report_order(tmp_path):
+    # #443 superseded #330/#442's single-best-dataset collapse now that the
+    # trainer can consume a real mixture — this test's old name/assertion
+    # ("highest weighted dataset only") is intentionally reversed, not
+    # deleted: the full dataset list must survive, in report.datasets order,
+    # index-aligned with data.interleave.probs.
     report = _report(
         ["a.jsonl", "b.jsonl", "c.jsonl"], [0.2, 0.55, 0.25], tmp_path
     )
     text = render_mix_recipe_yaml(report)
     data_block = text[text.index("data:"):]
     cfg = load_config_from_string(_splice_into_config(data_block))
-    assert cfg.data.train == str(tmp_path / "b.jsonl")
+    assert cfg.data.train == [
+        str(tmp_path / "a.jsonl"),
+        str(tmp_path / "b.jsonl"),
+        str(tmp_path / "c.jsonl"),
+    ]
+    assert cfg.data.interleave == {"strategy": "probs", "probs": [0.2, 0.55, 0.25]}
 
 
 def test_full_ranked_breakdown_still_in_comments(tmp_path):
@@ -65,14 +81,20 @@ def test_full_ranked_breakdown_still_in_comments(tmp_path):
     assert str(tmp_path / "b.jsonl") in text
 
 
-def test_apply_cli_prints_new_string_shape_recipe(tmp_path, monkeypatch):
+def test_apply_cli_prints_dataset_list_shape_recipe(tmp_path, monkeypatch):
+    # #443 flipped the canonical `--optimize` output shape: `train:` is now
+    # followed by a YAML list ("-" markers), not a single quoted string —
+    # the reverse of what this test asserted pre-#443.
     _make_files(tmp_path, ["a.jsonl", "b.jsonl"])
     monkeypatch.chdir(tmp_path)
     from typer.testing import CliRunner
 
     from soup_cli.cli import app
 
-    runner = CliRunner()
+    # Force a wide terminal — the datasets resolve to absolute paths under
+    # tmp_path, long enough that Rich's default wrapping would otherwise
+    # break a path across the 200-char window this test inspects.
+    runner = CliRunner(env={"COLUMNS": "300"})
     result = runner.invoke(
         app,
         [
@@ -88,13 +110,14 @@ def test_apply_cli_prints_new_string_shape_recipe(tmp_path, monkeypatch):
     result = runner.invoke(app, ["data", "mix", "--apply", "rec.yaml"])
     assert result.exit_code == 0, (result.output, repr(result.exception))
     # Rich wraps long lines to the console width, so compare with whitespace
-    # collapsed rather than by exact line — "train:" must be followed
-    # directly by the path, not by a "-" list marker (the old shape).
+    # collapsed rather than by exact line — "train:" must be followed by a
+    # "-" list marker (the new shape), not directly by a path.
     compact = "".join(result.output.split())
     assert "train:" in compact, result.output
     after = compact[compact.index("train:") + len("train:"):]
-    assert not after.startswith("-"), result.output
-    assert "a.jsonl" in after[:200], result.output
+    assert after.startswith("-"), result.output
+    assert "a.jsonl" in after[:400], result.output
+    assert "b.jsonl" in after[:400], result.output
 
 
 def test_render_recipe_rejects_empty_weights(tmp_path):
@@ -120,7 +143,10 @@ def test_render_recipe_rejects_mismatched_weights_length(tmp_path):
 def test_apply_cli_quotes_path_needing_quoting(tmp_path, monkeypatch):
     # Maintainer's repro: an unquoted `train: odd: name.jsonl` line is not
     # valid YAML when pasted back — the --apply echo must quote it the same
-    # way the renderer does.
+    # way the renderer does. Exercises the legacy single-string on-disk
+    # shape (pre-#443, or a search over exactly one dataset) — #443's
+    # renderer no longer emits single-string form for >= 2 datasets, but
+    # --apply must still round-trip old recipe files correctly.
     import yaml
 
     monkeypatch.chdir(tmp_path)
@@ -145,9 +171,13 @@ def test_apply_cli_quotes_path_needing_quoting(tmp_path, monkeypatch):
 
 
 def test_apply_handles_pre_fix_list_shaped_recipe(tmp_path, monkeypatch):
-    # A recipe written by the pre-fix code (data.train as a YAML list) must
-    # still print via --apply rather than crash — old files on disk survive
-    # the fix.
+    # A recipe written by the pre-#330-fix code (data.train as a YAML list,
+    # by accident — there was no training-time reader yet) must still print
+    # via --apply rather than crash. This happens to be byte-identical to
+    # #443's new intentional list shape from the CLI's point of view (both
+    # go through the "else" branch in commands/data_mix.py), but the two
+    # are conceptually distinct on-disk provenances, hence keeping this
+    # test separate from test_apply_handles_new_multi_dataset_recipe below.
     monkeypatch.chdir(tmp_path)
     (tmp_path / "old.yaml").write_text(
         "data:\n"
@@ -169,3 +199,45 @@ def test_apply_handles_pre_fix_list_shaped_recipe(tmp_path, monkeypatch):
     assert result.exit_code == 0, (result.output, repr(result.exception))
     assert "a.jsonl" in result.output
     assert "b.jsonl" in result.output
+
+
+def test_apply_handles_new_multi_dataset_recipe(tmp_path, monkeypatch):
+    # #443's canonical current shape: write a real recipe via --optimize
+    # (so it goes through render_mix_recipe_yaml, not a hand-written
+    # fixture), then confirm --apply round-trips data.train as a list and
+    # data.interleave.probs stays index-aligned with it.
+    _make_files(tmp_path, ["a.jsonl", "b.jsonl", "c.jsonl"])
+    monkeypatch.chdir(tmp_path)
+    from typer.testing import CliRunner
+
+    from soup_cli.cli import app
+
+    # Force a wide terminal — tmp_path is long enough on this OS that Rich's
+    # default-width line wrapping would otherwise break the path across
+    # lines mid-token, which yaml.safe_load below can't parse.
+    runner = CliRunner(env={"COLUMNS": "300"})
+    result = runner.invoke(
+        app,
+        [
+            "data", "mix",
+            "--optimize",
+            "--datasets", "a.jsonl,b.jsonl,c.jsonl",
+            "--budget", "60s",
+            "--num-probes", "2",
+            "--output", "rec3.yaml",
+        ],
+    )
+    assert result.exit_code == 0, (result.output, repr(result.exception))
+    result = runner.invoke(app, ["data", "mix", "--apply", "rec3.yaml"])
+    assert result.exit_code == 0, (result.output, repr(result.exception))
+    data_block = result.output[result.output.index("data:"):]
+    from pathlib import Path
+
+    import yaml
+
+    loaded = yaml.safe_load(data_block)
+    assert isinstance(loaded["data"]["train"], list)
+    # --optimize resolves --datasets to absolute paths under tmp_path.
+    basenames = {Path(p).name for p in loaded["data"]["train"]}
+    assert basenames == {"a.jsonl", "b.jsonl", "c.jsonl"}
+    assert len(loaded["data"]["interleave"]["probs"]) == 3

--- a/tests/test_issue443_interleave_wiring.py
+++ b/tests/test_issue443_interleave_wiring.py
@@ -1,0 +1,277 @@
+"""`data.interleave` is schema-validated but never consumed at training time (issue #443).
+
+`parse_interleave`/`InterleaveSpec` have been fully implemented and unit-tested since
+v0.42.0, and the schema has validated `data.interleave`'s shape since the same release
+— but `load_dataset()` never called `parse_interleave`, so every multi-dataset mixture
+request silently trained on nothing but `data.train`'s single path (the same gap #330
+and #442 papered over in their respective renderers, deliberately deferring the real
+fix to this issue).
+
+The maintainer's decision on #443 (Option A, scope fixed by him): `DataConfig.train`
+now accepts `str | list[str]`; a list requires `data.interleave`, applies to local file
+paths only, and is combined into one row set BEFORE the existing `val_split` line in
+`_finalize` runs (so a single path stays byte-identical). `packing` / `multipack` +
+`interleave`, and `data.streaming` / an HF-hub dataset name + `interleave`, are all
+rejected at parse time with a message naming the reason — streaming/hub-dataset
+interleaving is out of scope here, filed as follow-up #459.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from soup_cli.config.loader import load_config_from_string
+from soup_cli.config.schema import DataConfig, SoupConfig
+from soup_cli.data.loader import load_dataset
+
+
+def _write_jsonl(path: Path, texts: list[str]) -> None:
+    path.write_text(
+        "\n".join(f'{{"text": {t!r}}}' for t in texts).replace("'", '"') + "\n",
+        encoding="utf-8",
+    )
+
+
+def _cfg(tmp_path: Path, **data_overrides) -> SoupConfig:
+    data = {
+        "train": str(tmp_path / "a.jsonl"),
+        "format": "plaintext",
+        "val_split": 0.0,
+    }
+    data.update(data_overrides)
+    return SoupConfig.model_validate(
+        {
+            "base": "test-base",
+            "task": "sft",
+            "data": data,
+            "training": {"epochs": 1},
+            "output": str(tmp_path / "out"),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Loader-level: the actual acceptance criteria
+# ---------------------------------------------------------------------------
+
+
+def test_single_path_train_output_is_byte_identical_to_baseline(tmp_path):
+    # Golden test pinning the single-path branch — must not change AT ALL
+    # as a side effect of wiring interleave in. Any refactor that touches
+    # this branch's output shape fails here.
+    _write_jsonl(tmp_path / "a.jsonl", ["A-0", "A-1", "A-2"])
+    cfg = _cfg(tmp_path)
+    result = load_dataset(cfg.data)
+    assert result == {
+        "train": [
+            {"text": "A-0"},
+            {"text": "A-1"},
+            {"text": "A-2"},
+        ]
+    }
+
+
+def test_data_interleave_is_actually_consumed_not_just_parsed(tmp_path):
+    # The acceptance criterion in the maintainer's own words: a test that
+    # fails if data.interleave is ignored — asserting on the rows that
+    # reach the trainer, not on the parsed config. Before #443,
+    # load_dataset() never looked at data.interleave at all, so this would
+    # have silently returned only dataset A's rows (or crashed on a list
+    # train_path) — either way, this test fails on the pre-#443 code.
+    _write_jsonl(tmp_path / "a.jsonl", [f"A-{i}" for i in range(10)])
+    _write_jsonl(tmp_path / "b.jsonl", [f"B-{i}" for i in range(3)])
+    cfg = _cfg(
+        tmp_path,
+        train=[str(tmp_path / "a.jsonl"), str(tmp_path / "b.jsonl")],
+        interleave="under",
+    )
+    result = load_dataset(cfg.data)
+    texts = {row["text"] for row in result["train"]}
+    assert any(t.startswith("A-") for t in texts)
+    assert any(t.startswith("B-") for t in texts)
+
+
+def test_interleave_concat(tmp_path):
+    _write_jsonl(tmp_path / "a.jsonl", [f"A-{i}" for i in range(4)])
+    _write_jsonl(tmp_path / "b.jsonl", [f"B-{i}" for i in range(3)])
+    cfg = _cfg(
+        tmp_path,
+        train=[str(tmp_path / "a.jsonl"), str(tmp_path / "b.jsonl")],
+        interleave="concat",
+    )
+    result = load_dataset(cfg.data)
+    texts = [row["text"] for row in result["train"]]
+    assert len(texts) == 7
+    assert sum(t.startswith("A-") for t in texts) == 4
+    assert sum(t.startswith("B-") for t in texts) == 3
+
+
+def test_interleave_under_truncates_to_smallest(tmp_path):
+    _write_jsonl(tmp_path / "a.jsonl", [f"A-{i}" for i in range(10)])
+    _write_jsonl(tmp_path / "b.jsonl", [f"B-{i}" for i in range(3)])
+    cfg = _cfg(
+        tmp_path,
+        train=[str(tmp_path / "a.jsonl"), str(tmp_path / "b.jsonl")],
+        interleave="under",
+    )
+    result = load_dataset(cfg.data)
+    texts = [row["text"] for row in result["train"]]
+    assert len(texts) == 6
+    assert sum(t.startswith("A-") for t in texts) == 3
+    assert sum(t.startswith("B-") for t in texts) == 3
+
+
+def test_interleave_over_upsamples_to_largest(tmp_path):
+    _write_jsonl(tmp_path / "a.jsonl", [f"A-{i}" for i in range(10)])
+    _write_jsonl(tmp_path / "b.jsonl", [f"B-{i}" for i in range(3)])
+    cfg = _cfg(
+        tmp_path,
+        train=[str(tmp_path / "a.jsonl"), str(tmp_path / "b.jsonl")],
+        interleave="over",
+    )
+    result = load_dataset(cfg.data)
+    texts = [row["text"] for row in result["train"]]
+    assert len(texts) == 20
+    assert sum(t.startswith("A-") for t in texts) == 10
+    b_texts = [t for t in texts if t.startswith("B-")]
+    assert len(b_texts) == 10
+    # B only has 3 unique rows — over-sampling must repeat, not invent rows.
+    counts = Counter(b_texts)
+    assert set(counts) == {"B-0", "B-1", "B-2"}
+    assert sum(counts.values()) == 10
+
+
+def test_interleave_probs_matches_requested_ratio(tmp_path):
+    # 30 + 10 = 40 total, probs chosen to divide evenly so the expected
+    # counts are exact (no apportionment-rounding ambiguity).
+    _write_jsonl(tmp_path / "a.jsonl", [f"A-{i}" for i in range(30)])
+    _write_jsonl(tmp_path / "b.jsonl", [f"B-{i}" for i in range(10)])
+    cfg = _cfg(
+        tmp_path,
+        train=[str(tmp_path / "a.jsonl"), str(tmp_path / "b.jsonl")],
+        interleave={"strategy": "probs", "probs": [0.75, 0.25]},
+    )
+    result = load_dataset(cfg.data)
+    texts = [row["text"] for row in result["train"]]
+    assert len(texts) == 40
+    assert sum(t.startswith("A-") for t in texts) == 30
+    assert sum(t.startswith("B-") for t in texts) == 10
+
+
+def test_val_split_applied_once_after_mixing(tmp_path):
+    # Proves "one slice, the same line as today in _finalize": the split
+    # fraction must be computed off the COMBINED length, not per-source.
+    _write_jsonl(tmp_path / "a.jsonl", [f"A-{i}" for i in range(8)])
+    _write_jsonl(tmp_path / "b.jsonl", [f"B-{i}" for i in range(2)])
+    cfg = _cfg(
+        tmp_path,
+        train=[str(tmp_path / "a.jsonl"), str(tmp_path / "b.jsonl")],
+        interleave="concat",
+        val_split=0.2,
+    )
+    result = load_dataset(cfg.data)
+    combined_len = len(result["train"]) + len(result["val"])
+    assert combined_len == 10
+    assert len(result["val"]) == int(10 * 0.2)
+
+
+# ---------------------------------------------------------------------------
+# Schema-level: back-compat pin + the four parse-time refusals
+# ---------------------------------------------------------------------------
+
+
+def test_interleave_train_single_string_still_accepted_by_schema():
+    # Schema-level companion to the loader's byte-identical pin: a bare
+    # string data.train must keep validating exactly as before #443.
+    cfg = DataConfig(train="d.jsonl", format="auto")
+    assert cfg.train == "d.jsonl"
+    assert cfg.interleave is None
+
+
+def test_train_list_of_one_entry_rejected():
+    with pytest.raises(ValidationError, match=">= 2 entries"):
+        DataConfig(train=["only-one.jsonl"], interleave="concat")
+
+
+def test_train_list_without_interleave_rejected(tmp_path):
+    with pytest.raises(ValidationError, match="requires data.interleave"):
+        _cfg(tmp_path, train=["a.jsonl", "b.jsonl"])
+
+
+def test_interleave_with_packing_rejected_with_reason(tmp_path):
+    with pytest.raises(ValidationError, match="fixed blocks"):
+        SoupConfig.model_validate(
+            {
+                "base": "test-base",
+                "task": "sft",
+                "data": {
+                    "train": [str(tmp_path / "a.jsonl"), str(tmp_path / "b.jsonl")],
+                    "interleave": "concat",
+                    "format": "plaintext",
+                },
+                "training": {"epochs": 1, "packing": True},
+                "output": str(tmp_path / "out"),
+            }
+        )
+
+
+def test_interleave_with_multipack_rejected_with_reason(tmp_path):
+    with pytest.raises(ValidationError, match="mixture ratio"):
+        SoupConfig.model_validate(
+            {
+                "base": "test-base",
+                "task": "sft",
+                "data": {
+                    "train": [str(tmp_path / "a.jsonl"), str(tmp_path / "b.jsonl")],
+                    "interleave": "concat",
+                    "format": "plaintext",
+                },
+                "training": {"epochs": 1, "multipack": True},
+                "output": str(tmp_path / "out"),
+            }
+        )
+
+
+def test_interleave_with_streaming_rejected_with_reason(tmp_path):
+    with pytest.raises(ValidationError, match="#459"):
+        _cfg(
+            tmp_path,
+            train=[str(tmp_path / "a.jsonl"), str(tmp_path / "b.jsonl")],
+            interleave="concat",
+            streaming=True,
+        )
+
+
+def test_interleave_with_hub_dataset_name_rejected_with_reason(tmp_path):
+    with pytest.raises(ValidationError, match="#459"):
+        _cfg(
+            tmp_path,
+            train=[str(tmp_path / "a.jsonl"), "org/some-dataset"],
+            interleave="concat",
+        )
+
+
+def test_interleave_rendered_overlay_yaml_round_trips_through_loader(tmp_path):
+    # Belt-and-braces: a config assembled purely from YAML text (not
+    # Python dict kwargs) round-trips through the schema and the loader.
+    _write_jsonl(tmp_path / "a.jsonl", ["A-0", "A-1"])
+    _write_jsonl(tmp_path / "b.jsonl", ["B-0", "B-1"])
+    yaml_text = (
+        "base: test-base\n"
+        "task: sft\n"
+        "data:\n"
+        f"  train:\n    - {tmp_path / 'a.jsonl'}\n    - {tmp_path / 'b.jsonl'}\n"
+        "  interleave: concat\n"
+        "  format: plaintext\n"
+        "  val_split: 0.0\n"
+        "training:\n"
+        "  epochs: 1\n"
+        f"output: {tmp_path / 'out'}\n"
+    )
+    cfg = load_config_from_string(yaml_text)
+    result = load_dataset(cfg.data)
+    assert len(result["train"]) == 4

--- a/tests/test_issue443_interleave_wiring.py
+++ b/tests/test_issue443_interleave_wiring.py
@@ -237,7 +237,14 @@ def test_interleave_with_multipack_rejected_with_reason(tmp_path):
 
 
 def test_interleave_with_streaming_rejected_with_reason(tmp_path):
-    with pytest.raises(ValidationError, match="#459"):
+    # Maintainer's review: match="#459" alone survived a mutation swapping
+    # in a completely wrong reason while keeping the issue number — match
+    # on text unique to THIS reason instead. NOT match="streaming" alone:
+    # pydantic's ValidationError str embeds input_value={...}, which
+    # already contains the literal input dict's 'streaming': True — a bare
+    # "streaming" match would pass even against a wrong-reason mutation,
+    # for the same false-positive reason #459 did.
+    with pytest.raises(ValidationError, match="disable streaming or drop"):
         _cfg(
             tmp_path,
             train=[str(tmp_path / "a.jsonl"), str(tmp_path / "b.jsonl")],
@@ -247,7 +254,7 @@ def test_interleave_with_streaming_rejected_with_reason(tmp_path):
 
 
 def test_interleave_with_hub_dataset_name_rejected_with_reason(tmp_path):
-    with pytest.raises(ValidationError, match="#459"):
+    with pytest.raises(ValidationError, match="local file paths"):
         _cfg(
             tmp_path,
             train=[str(tmp_path / "a.jsonl"), "org/some-dataset"],
@@ -275,3 +282,138 @@ def test_interleave_rendered_overlay_yaml_round_trips_through_loader(tmp_path):
     cfg = load_config_from_string(yaml_text)
     result = load_dataset(cfg.data)
     assert len(result["train"]) == 4
+
+
+# ---------------------------------------------------------------------------
+# Enumerating test — every known consumer of cfg.data.train, one row each.
+#
+# Maintainer's review of PR #460: widening data.train to a list made three
+# OTHER consumers (mcp_server/registry.py, utils/terraform_plan.py,
+# utils/annex_xi.py) silently go blind — each filtered on
+# isinstance(path, str), so a list contributed nothing / coerced to the
+# same sentinel as "no dataset" / stringified into a bogus path. He asked
+# for one durable, enumerating test covering every known consumer (the 4
+# already fixed earlier in this PR + these 3), not a bespoke test per
+# site — so a future Nth consumer gets added to THIS table, not a new
+# test file.
+# ---------------------------------------------------------------------------
+
+
+def _write_url_jsonl(path: Path, count: int, domain: str) -> None:
+    lines = [f'{{"text": "row {i} https://{domain}/p{i}"}}' for i in range(count)]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _matched_fixture(tmp_path: Path):
+    """Two data shapes carrying the SAME effective dataset.
+
+    ``single``: one file, 8 example.com rows + 4 other.org rows (12 total).
+    ``as_list``: the identical 12 rows split into two files (8 + 4),
+    combined via interleave 'concat' — same total rows, same domain set.
+    """
+    single_path = tmp_path / "single.jsonl"
+    lines = [f'{{"text": "row {i} https://example.com/p{i}"}}' for i in range(8)]
+    lines += [f'{{"text": "row {i} https://other.org/p{i}"}}' for i in range(4)]
+    single_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    a_path = tmp_path / "a.jsonl"
+    b_path = tmp_path / "b.jsonl"
+    _write_url_jsonl(a_path, 8, "example.com")
+    _write_url_jsonl(b_path, 4, "other.org")
+
+    single_cfg = _cfg(tmp_path, train=str(single_path))
+    list_cfg = _cfg(
+        tmp_path, train=[str(a_path), str(b_path)], interleave="concat"
+    )
+    return single_cfg, list_cfg, single_path, a_path, b_path
+
+
+def test_every_data_train_consumer_handles_list_non_degenerately(tmp_path, monkeypatch):
+    """Enumerates ALL known consumers of cfg.data.train / data.train-derived
+    paths. Each row asserts the list-shaped result is non-degenerate (not
+    silently empty/zero/blind) compared to the equivalent single-path
+    result. A future consumer is added as a new row here, not a new test.
+    """
+    # registry._collect_external_protected_inputs and terraform_plan's
+    # compute_dataset_sha both gate on is_under_cwd(path), checked against
+    # the real process cwd — must actually chdir, not just pass tmp_path.
+    monkeypatch.chdir(tmp_path)
+
+    from soup_cli.commands.cost import _get_dataset_size
+    from soup_cli.commands.data import _cache_key_dataset_path
+    from soup_cli.commands.ship import _MAX_DATA_SHA_BYTES, _compute_provenance, _safe_hash_file
+    from soup_cli.commands.train import _lr_finder_dataset_path
+    from soup_cli.mcp_server.registry import _collect_external_protected_inputs
+    from soup_cli.utils.annex_xi import load_top_domains_from_jsonl
+    from soup_cli.utils.terraform_plan import build_plan, compute_dataset_sha
+
+    single_cfg, list_cfg, single_path, a_path, b_path = _matched_fixture(tmp_path)
+
+    # 1. cost._get_dataset_size(cfg) -> (row_count, is_estimated)
+    single_size, single_est = _get_dataset_size(single_cfg)
+    list_size, list_est = _get_dataset_size(list_cfg)
+    assert single_size == list_size == 12, "row counts must match — same total data"
+    assert single_est is False and list_est is False, (
+        "must actually read the files, not fall back to the default estimate"
+    )
+
+    # 2. data._cache_key_dataset_path(cfg) -> str fed to make_preprocess_cache_key
+    import json as _json
+
+    list_key_input = _cache_key_dataset_path(list_cfg)
+    assert list_key_input, "must not collapse to an empty/blind cache key input"
+    # JSON-parse rather than substring-search: json.dumps escapes backslashes
+    # in Windows paths, so a raw `str(a_path) in list_key_input` check would
+    # false-negative there.
+    parsed_key_input = _json.loads(list_key_input)
+    assert parsed_key_input["train"] == [str(a_path), str(b_path)], (
+        "list cache key input must name BOTH files, not just the first"
+    )
+
+    # 3. ship._compute_provenance(cfg) -> {"data_sha": <64-hex>, ...}
+    single_prov = _compute_provenance(single_cfg)
+    list_prov = _compute_provenance(list_cfg)
+    assert len(single_prov.get("data_sha", "")) == 64
+    assert len(list_prov.get("data_sha", "")) == 64
+    # must not silently equal a hash of only the first file — the pre-fix
+    # blind-to-a-single-file failure mode.
+    assert list_prov["data_sha"] != _safe_hash_file(str(a_path), _MAX_DATA_SHA_BYTES)
+
+    # 4. train._lr_finder_dataset_path(train) -> a real, existing file path
+    single_lr_path = _lr_finder_dataset_path(single_cfg.data.train)
+    list_lr_path = _lr_finder_dataset_path(list_cfg.data.train)
+    assert Path(single_lr_path).is_file() and Path(single_lr_path).stat().st_size > 0
+    assert Path(list_lr_path).is_file() and Path(list_lr_path).stat().st_size > 0
+
+    # 5. registry._collect_external_protected_inputs(cfg) -> list[ProtectedFile]
+    single_protected = _collect_external_protected_inputs(single_cfg)
+    list_protected = _collect_external_protected_inputs(list_cfg)
+    single_hits = [p for p in single_protected if p.path == str(single_path.resolve())]
+    list_hits = [
+        p for p in list_protected
+        if p.path in (str(a_path.resolve()), str(b_path.resolve()))
+    ]
+    assert len(single_hits) == 1, "single path contributes exactly one protected entry"
+    assert len(list_hits) == 2, "list must contribute one protected entry PER file, not zero"
+
+    # 6. terraform_plan.build_plan({...}) -> TrainingPlan.dataset_sha
+    zero = "0" * 64
+    single_plan = build_plan({"base": "b", "task": "sft", "data": {"train": str(single_path)}})
+    list_plan = build_plan(
+        {"base": "b", "task": "sft", "data": {"train": [str(a_path), str(b_path)]}}
+    )
+    assert single_plan.dataset_sha != zero
+    assert list_plan.dataset_sha != zero, (
+        "list must not silently produce the all-zero 'missing dataset' sentinel"
+    )
+    assert list_plan.dataset_sha != compute_dataset_sha(str(a_path)), (
+        "must not silently hash only the first file"
+    )
+
+    # 7. annex_xi.load_top_domains_from_jsonl(path) -> top domains, aggregated
+    single_domains = {d for d, _ in load_top_domains_from_jsonl(str(single_path))}
+    list_domains = {d for d, _ in load_top_domains_from_jsonl([str(a_path), str(b_path)])}
+    assert single_domains == list_domains == {"example.com", "other.org"}, (
+        "list must aggregate domains across every file, matching the "
+        "equivalent single-path corpus — not go blank or report only one file"
+    )

--- a/tests/test_v0420.py
+++ b/tests/test_v0420.py
@@ -698,7 +698,6 @@ data:
   streaming: true
   buffer_size: 1024
   shards: 4
-  interleave: concat
   mask_history: true
   train_on_prompt: false
   train_on_responses_only: true
@@ -726,7 +725,12 @@ output: ./out
         assert cfg.data.streaming is True
         assert cfg.data.buffer_size == 1024
         assert cfg.data.shards == 4
-        assert cfg.data.interleave == "concat"
+        # interleave is intentionally not in this kitchen-sink fixture: #443
+        # made data.interleave + data.streaming mutually exclusive at parse
+        # time (interleave now has a real training-time consumer, and it's
+        # local-files-only), so it can no longer sit alongside streaming:
+        # true here. interleave's own round-trip is covered by
+        # TestPartDInterleave below and by tests/test_issue443_interleave_wiring.py.
         assert cfg.data.mask_history is True
         assert cfg.data.image_resize_algorithm == "bicubic"
         assert cfg.data.video_fps == 24.0

--- a/tests/test_v0480_part_b.py
+++ b/tests/test_v0480_part_b.py
@@ -498,9 +498,14 @@ def test_render_recipe_shape(tmp_path):
     assert "0.600000" in text
     assert "0.400000" in text
     assert "a.jsonl" in text
-    # #330 — data.train is a single string (the highest-weighted dataset),
-    # not a list soup train's schema rejects.
-    assert f"train: {json.dumps(str(tmp_path / 'a.jsonl'))}" in text
+    # #330 introduced data.train as a single string (the highest-weighted
+    # dataset) because there was no training-time reader for a real
+    # mixture. #443 wired data.interleave into load_dataset() and restored
+    # the full-list shape for >= 2 datasets — train: is now a YAML list,
+    # index-aligned with interleave.probs.
+    assert "  train:" in text
+    assert f'- {json.dumps(str(tmp_path / "a.jsonl"))}' in text
+    assert f'- {json.dumps(str(tmp_path / "b.jsonl"))}' in text
 
 
 def test_render_recipe_rejects_non_report():

--- a/tests/test_v0535.py
+++ b/tests/test_v0535.py
@@ -498,14 +498,17 @@ def test_proxy_timeout_raises_runtimeerror(tmp_path, monkeypatch):
 def test_overlay_yaml_loads_through_config_schema(tmp_path):
     # #442 — same defect #330 fixed in the recipe writer, in the second
     # renderer: `_render_overlay_yaml` emitted `data.train` as a YAML list,
-    # but `DataConfig.train` is typed `str`, so every `--live` candidate got
-    # handed a config it could not load. Every other test in this section
-    # mocks `subprocess.run`, so this is the one that actually loads the
-    # *returned string* through the real schema — it fails if the renderer
-    # regresses to a list. (A fully unmocked `--live` run needs a real
-    # training subprocess/GPU and isn't practical in this suite; the
-    # remaining `--live` coverage below intentionally mocks `subprocess.run`
-    # and asserts orchestration instead.)
+    # but `DataConfig.train` was typed `str`, so every `--live` candidate
+    # got handed a config it could not load. #442's fix collapsed to a
+    # single dataset as a stopgap; #443 wired `data.interleave` into the
+    # loader and widened `data.train` back to a list, so the renderer now
+    # emits the full mixture again — this test pins that it still loads
+    # through the real schema. Every other test in this section mocks
+    # `subprocess.run`, so this is the one that actually loads the
+    # *returned string* through the real schema. (A fully unmocked `--live`
+    # run needs a real training subprocess/GPU and isn't practical in this
+    # suite; the remaining `--live` coverage below intentionally mocks
+    # `subprocess.run` and asserts orchestration instead.)
     from soup_cli.utils.mix_proxy import _render_overlay_yaml
 
     base_text = _make_base_yaml(tmp_path).read_text(encoding="utf-8")
@@ -513,17 +516,19 @@ def test_overlay_yaml_loads_through_config_schema(tmp_path):
         base_text, ("a.jsonl", "b.jsonl"), (0.3, 0.7)
     )
     cfg = load_config_from_string(overlay)
-    assert cfg.data.train == "b.jsonl"
+    assert cfg.data.train == ["a.jsonl", "b.jsonl"]
+    assert cfg.data.interleave == {"strategy": "probs", "probs": [0.3, 0.7]}
 
 
 def test_overlay_comment_does_not_drift_from_train_value(tmp_path):
     # Maintainer's review of #442: the comment spliced above `train:` names
     # which dataset was picked, but nothing tied that claim to the actual
     # value — it could vanish (mutation: delete the insertion block) or lie
-    # (mutation: comment names datasets[0] while train: keeps best_idx) and
-    # every other test still passes. Tying the assertion to the *parsed
-    # config's* value rather than the renderer's own variable is what makes
-    # the second mutation fail here.
+    # and every other test still passes. Tying the assertion to the
+    # *parsed config's* value rather than the renderer's own variable is
+    # what makes a lying comment fail here. #443 changed the renderer to
+    # emit the full dataset list rather than a single picked one, but the
+    # same anti-drift pattern applies against the list's repr.
     from soup_cli.utils.mix_proxy import _render_overlay_yaml
 
     base_text = _make_base_yaml(tmp_path).read_text(encoding="utf-8")
@@ -536,6 +541,46 @@ def test_overlay_comment_does_not_drift_from_train_value(tmp_path):
     comment = lines[idx - 1]
     assert comment.lstrip().startswith("#")  # fails if the block is deleted
     assert repr(cfg.data.train) in comment  # fails if the comment lies
+
+
+def test_overlay_yaml_rendered_config_actually_loads_via_load_dataset(tmp_path):
+    # #443 acceptance criterion: at least one test loads the rendered YAML
+    # through the real schema AND through load_dataset() — the #442 lesson
+    # (a config the tool could not load reading as a passing feature)
+    # extended one level deeper, to the loader that now actually consumes
+    # data.interleave rather than ignoring it.
+    from soup_cli.data.loader import load_dataset
+    from soup_cli.utils.mix_proxy import _render_overlay_yaml
+
+    (tmp_path / "a.jsonl").write_text(
+        "\n".join(f'{{"text": "A-{i}"}}' for i in range(5)) + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "b.jsonl").write_text(
+        "\n".join(f'{{"text": "B-{i}"}}' for i in range(5)) + "\n",
+        encoding="utf-8",
+    )
+    base_text = (
+        "base: test-base\n"
+        "task: sft\n"
+        "data:\n"
+        "  train: ./a.jsonl\n"
+        "  format: plaintext\n"
+        "  val_split: 0.0\n"
+        "training:\n"
+        "  epochs: 1\n"
+        "output: ./out\n"
+    )
+    overlay = _render_overlay_yaml(
+        base_text,
+        (str(tmp_path / "a.jsonl"), str(tmp_path / "b.jsonl")),
+        (0.5, 0.5),
+    )
+    cfg = load_config_from_string(overlay)
+    result = load_dataset(cfg.data)
+    texts = {row["text"] for row in result["train"]}
+    assert any(t.startswith("A-") for t in texts)
+    assert any(t.startswith("B-") for t in texts)
 
 
 def test_proxy_happy_path_reads_tracker(tmp_path, monkeypatch):

--- a/tests/test_v0713.py
+++ b/tests/test_v0713.py
@@ -276,6 +276,34 @@ class TestTopDomains:
         assert load_top_domains_from_jsonl(None) == ()
         assert load_top_domains_from_jsonl("") == ()
 
+    def test_load_from_jsonl_list_of_invalid_entries_returns_empty(self):
+        # #443 — data.interleave lets data.train be list-shaped; a list is
+        # now a legitimate input (see test_load_from_jsonl_list_aggregates
+        # below), but a list containing no valid string entries must still
+        # degrade to () same as the non-string single-path case above —
+        # not repurposing that test, since a list itself is no longer
+        # rejected.
+        from soup_cli.utils.annex_xi import load_top_domains_from_jsonl
+
+        assert load_top_domains_from_jsonl([None, 123, ""]) == ()
+        assert load_top_domains_from_jsonl([]) == ()
+
+    def test_load_from_jsonl_list_aggregates_across_files(self, tmp_path, monkeypatch):
+        # #443 — data.interleave: top-domain extraction must aggregate
+        # across every constituent file of a list-shaped data.train,
+        # globally (not per-file top-N), matching what the equivalent
+        # single merged file would report.
+        from soup_cli.utils.annex_xi import load_top_domains_from_jsonl
+
+        monkeypatch.chdir(tmp_path)
+        a = tmp_path / "a.jsonl"
+        a.write_text('{"text": "https://example.com/a"}\n', encoding="utf-8")
+        b = tmp_path / "b.jsonl"
+        b.write_text('{"text": "https://other.org/b"}\n', encoding="utf-8")
+        out = load_top_domains_from_jsonl(["a.jsonl", "b.jsonl"])
+        domains = {d for d, _ in out}
+        assert domains == {"example.com", "other.org"}
+
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics")
     def test_load_from_jsonl_symlink_returns_empty(self, tmp_path, monkeypatch):
         from soup_cli.utils.annex_xi import load_top_domains_from_jsonl


### PR DESCRIPTION
Closes #443.

## Scope contract (from your decision comment)

Implements exactly what you scoped, no more:

- `DataConfig.train: str | list[str]` — single path stays byte-identical (golden test),
  the interleave branch is new code that never touches the existing single-path branch.
- `data.interleave` applies to local file paths only, combined into one row set in the
  loader **before** the existing `val_split` line in `_finalize` runs — that function is
  unmodified.
- `training.packing` / `training.multipack` + `interleave`, and `data.streaming` / an
  HF-hub dataset name + `interleave`, are rejected at parse time with a message naming
  the reason — mirrors `_validate_replay_compat`'s existing packing/multipack precedent.
- Streaming/hub-dataset interleaving stays out of scope (#459).
- Both renderers (#330's recipe writer, #442's `--live` overlay) emit the real
  N-dataset mixture again instead of collapsing to one path.

## Combine algorithm

`concat` / `under` / `over` / `probs` control per-source row **count**, deterministically
(round-robin cycling, largest-remainder apportionment for `probs`) — no new seed field.
Reasoning: the HF `Trainer`'s default sampler already shuffles every epoch, so row order
out of the combine step isn't load-bearing, only composition is. Happy to add a seed knob
if you'd rather have one, but didn't want to add config surface you hadn't authorized.

## Acceptance criteria checklist

- [x] A test that fails if `data.interleave` is ignored — asserts on rows reaching the
  trainer (`test_data_interleave_is_actually_consumed_not_just_parsed`), not the parsed
  config.
- [x] Single-path back-compat pinned (`test_single_path_train_output_is_byte_identical_to_baseline`).
- [x] Each of the four parse-time refusals asserts its message names the reason — manually
  confirmed each test fails red without its guard clause before trusting it.
- [x] Both renderers emit the mixture shape; `test_overlay_yaml_rendered_config_actually_loads_via_load_dataset`
  loads the rendered YAML through the real schema *and* through `load_dataset()` (the #442
  lesson, extended one level deeper).

## Also touched

Five call sites that read `cfg.data.train` as a bare string (`cost.py`'s dataset-size
estimate, `data.py`'s preprocess cache key — folded `data.interleave` in so a strategy
change can't collide on a stale cache entry, `ship.py`'s provenance hash, `train.py`'s
LR-finder — falls back to the first dataset, out of this issue's scope).

Existing tests in `test_v0535.py`, `test_issue330_mix_recipe_train_loadable.py`, and one
fixture in `test_v0420.py` (which combined `interleave` + `streaming` in a kitchen-sink
round-trip, now mutually exclusive) updated in place — renamed where the assertion itself
flipped, never deleted silently.
