### PR TITLE
fix(live-eval): thread quantization into load_model_and_tokenizer (#367)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,15 +27,17 @@ reproducing 70+ versions of notes.
   `moe_expert_quant`, which is applied only by the resident setup path and was
   otherwise silently ignored.
 
-- **`live_eval.load_model_and_tokenizer` accepts a `quantization` argument (#367 by @AmirF194).**
-  Every live evaluation path built on this helper (`soup ship` leg 1/2, `soup diagnose
-  --base-model`, `soup advise --probe-model`, `soup eval behavior`, `tunability --live`)
-  always loaded the base at full precision regardless of how the adapter was trained, so
-  an NF4-trained adapter was judged against a bf16 base it never saw. `quantization="4bit"`
-  now builds the same nf4 `BitsAndBytesConfig` every other 4-bit load path in this codebase
-  uses; `"8bit"` and the unset default are also supported. `soup ship` reporting the
-  numerics it judged with, and a staleness gate on evidence recorded under mismatched
-  numerics, are left open (issue acceptance criteria 2 and 4).
+- **`live_eval.load_model_and_tokenizer` gains a `quantization` parameter; no live evaluation
+  path sets it yet (#367 by @AmirF194 in #461).**
+  `quantization="4bit"` builds the same nf4 `BitsAndBytesConfig` every other 4-bit load path
+  in this codebase uses (`"8bit"` and the unset default are also supported), and the four
+  internal callers this helper has (`make_generator`, `make_multi_generator`, `lora_probe`,
+  `measure_logit_agreement`) still call it with no `quantization`, so today an NF4-trained
+  adapter is still judged against a bf16 base it never saw during training. The follow-up is
+  wiring those four callers to a default derived from the run's own configuration (`soup ship
+  --config`, the registry entry, or the adapter's `adapter_config.json`), per the issue's own
+  Fix path; that plus `soup ship` reporting the numerics it judged with and a staleness gate
+  on mismatched-numerics evidence are left open (issue acceptance criteria 2 and 4).
 
 - **`training.stream_pin` makes layer-streaming pinning configurable (#366 by @ousamabenyounes in #416).**
   Page-locking the RAM store is chosen automatically by `decide_pinning`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ reproducing 70+ versions of notes.
   `moe_expert_quant`, which is applied only by the resident setup path and was
   otherwise silently ignored.
 
+- **`live_eval.load_model_and_tokenizer` accepts a `quantization` argument (#367 by @AmirF194).**
+  Every live evaluation path built on this helper (`soup ship` leg 1/2, `soup diagnose
+  --base-model`, `soup advise --probe-model`, `soup eval behavior`, `tunability --live`)
+  always loaded the base at full precision regardless of how the adapter was trained, so
+  an NF4-trained adapter was judged against a bf16 base it never saw. `quantization="4bit"`
+  now builds the same nf4 `BitsAndBytesConfig` every other 4-bit load path in this codebase
+  uses; `"8bit"` and the unset default are also supported. `soup ship` reporting the
+  numerics it judged with, and a staleness gate on evidence recorded under mismatched
+  numerics, are left open (issue acceptance criteria 2 and 4).
+
 - **`training.stream_pin` makes layer-streaming pinning configurable (#366 by @ousamabenyounes in #416).**
   Page-locking the RAM store is chosen automatically by `decide_pinning`, and
   until now nothing could override it — so while #331 was live, `pin=False` was

--- a/src/soup_cli/utils/live_eval.py
+++ b/src/soup_cli/utils/live_eval.py
@@ -177,9 +177,13 @@ def load_model_and_tokenizer(
     if quant_config is not None:
         # A quantized load is pinned to a device at from_pretrained time
         # (BNB rejects a later .to() on an already-dispatched model), so
-        # device_map takes the place of the .to(dev) call below.
+        # device_map takes the place of the .to(dev) call below. A bare
+        # "cuda" has no index and later trips accelerate's device_map
+        # resolution (see _device_map_value's own docstring).
+        from soup_cli.utils.layer_stream_runtime import _device_map_value
+
         model_kwargs["quantization_config"] = quant_config
-        model_kwargs["device_map"] = dev
+        model_kwargs["device_map"] = _device_map_value(dev)
     model = AutoModelForCausalLM.from_pretrained(model_id, **model_kwargs)
     if adapter is not None:
         if not isinstance(adapter, str) or not adapter.strip():

--- a/src/soup_cli/utils/live_eval.py
+++ b/src/soup_cli/utils/live_eval.py
@@ -95,6 +95,34 @@ def resolve_device(device: Optional[str] = None) -> str:
         return "cpu"
 
 
+def _build_quantization_config(quantization: Optional[str]):
+    """``BitsAndBytesConfig`` for the two quant-menu formats live_eval needs,
+    or ``None`` to load the base at full precision (unchanged behavior).
+
+    Only ``"4bit"``/``"8bit"``/``None`` are supported here: the other
+    quant_menu formats (gptq/awq/hqq/aqlm/...) key off a full
+    ``TrainingConfig``, which live_eval callers don't have.
+    """
+    if quantization is None or quantization == "none":
+        return None
+    from transformers import BitsAndBytesConfig
+
+    if quantization == "8bit":
+        return BitsAndBytesConfig(load_in_8bit=True)
+    if quantization == "4bit":
+        from soup_cli.utils.gpu import get_compute_dtype
+
+        return BitsAndBytesConfig(
+            load_in_4bit=True,
+            bnb_4bit_quant_type="nf4",
+            bnb_4bit_compute_dtype=get_compute_dtype(),
+            bnb_4bit_use_double_quant=True,
+        )
+    raise ValueError(
+        f"live_eval quantization={quantization!r} not supported; use '4bit', '8bit', or None"
+    )
+
+
 def _apply_prompt_template(tokenizer: object, prompt: str) -> str:
     """Render a single user turn through the tokenizer's chat template.
 
@@ -120,6 +148,7 @@ def load_model_and_tokenizer(
     device: Optional[str] = None,
     trust_remote_code: bool = False,
     dtype: Optional[str] = None,
+    quantization: Optional[str] = None,
 ):
     """Load an ``AutoModelForCausalLM`` + tokenizer, optionally with a LoRA adapter.
 
@@ -128,6 +157,9 @@ def load_model_and_tokenizer(
     ``"auto"``) is forwarded as ``torch_dtype`` so a caller can preserve the
     checkpoint's native precision instead of upcasting to fp32 (``soup shrink``
     needs this so the shipped smaller model is not silently re-widened).
+    ``quantization`` (``"4bit"`` / ``"8bit"`` / ``None``) judges the base the
+    way it was trained instead of always upcasting to full precision; see
+    :func:`_build_quantization_config`.
     """
     if not isinstance(model_id, str) or not model_id.strip():
         raise ValueError("model_id must be a non-empty string")
@@ -141,6 +173,13 @@ def load_model_and_tokenizer(
     model_kwargs = {"trust_remote_code": trust_remote_code}
     if dtype is not None:
         model_kwargs["torch_dtype"] = dtype
+    quant_config = _build_quantization_config(quantization)
+    if quant_config is not None:
+        # A quantized load is pinned to a device at from_pretrained time
+        # (BNB rejects a later .to() on an already-dispatched model), so
+        # device_map takes the place of the .to(dev) call below.
+        model_kwargs["quantization_config"] = quant_config
+        model_kwargs["device_map"] = dev
     model = AutoModelForCausalLM.from_pretrained(model_id, **model_kwargs)
     if adapter is not None:
         if not isinstance(adapter, str) or not adapter.strip():
@@ -148,7 +187,8 @@ def load_model_and_tokenizer(
         from peft import PeftModel
 
         model = PeftModel.from_pretrained(model, adapter)
-    model = model.to(dev)
+    if quant_config is None:
+        model = model.to(dev)
     model.eval()
     return model, tokenizer, dev
 

--- a/tests/test_issue367_live_eval_quantization.py
+++ b/tests/test_issue367_live_eval_quantization.py
@@ -1,0 +1,144 @@
+"""#367 — live_eval.load_model_and_tokenizer took no quantization argument.
+
+Every live evaluation path built on this helper (``soup ship`` leg 1/2,
+``soup diagnose --base-model``, ``soup advise --probe-model``, ``soup eval
+behavior``, ``tunability --live``) always loaded the base at full precision,
+regardless of how the adapter was trained. An NF4-trained adapter was
+therefore judged on a bf16 base it never saw during training.
+
+Scoped to acceptance criteria 1 and 3 of the issue: threading the argument
+through and a test that the reported numerics match the requested ones (here,
+that ``from_pretrained`` actually receives the requested quantization_config).
+Acceptance criteria 2 and 4 (``soup ship`` reporting the numerics used, and a
+staleness gate on evidence recorded under mismatched numerics) are larger
+integration work into ``soup ship``'s evidence machinery and are left open,
+per the PR body.
+
+Tests mock at the ``from_pretrained`` boundary, matching every other test in
+this module's consumer chain (module docstring: "Tests mock at this
+boundary... so the orchestration logic... is exercised without a GPU").
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _fake_tokenizer():
+    tok = MagicMock()
+    tok.pad_token = "<pad>"
+    return tok
+
+
+class TestQuantizationReachesFromPretrained:
+    @patch("transformers.AutoTokenizer.from_pretrained")
+    @patch("transformers.AutoModelForCausalLM.from_pretrained")
+    def test_4bit_builds_an_nf4_config_and_pins_device_map(self, mock_model, mock_tok):
+        from soup_cli.utils.live_eval import load_model_and_tokenizer
+
+        mock_tok.return_value = _fake_tokenizer()
+        mock_model.return_value = MagicMock()
+
+        load_model_and_tokenizer("some/model", device="cpu", quantization="4bit")
+
+        _, kwargs = mock_model.call_args
+        quant_config = kwargs["quantization_config"]
+        assert quant_config.load_in_4bit is True
+        assert quant_config.bnb_4bit_quant_type == "nf4"
+        assert kwargs["device_map"] == "cpu"
+
+    @patch("transformers.AutoTokenizer.from_pretrained")
+    @patch("transformers.AutoModelForCausalLM.from_pretrained")
+    def test_8bit_builds_an_int8_config(self, mock_model, mock_tok):
+        from soup_cli.utils.live_eval import load_model_and_tokenizer
+
+        mock_tok.return_value = _fake_tokenizer()
+        mock_model.return_value = MagicMock()
+
+        load_model_and_tokenizer("some/model", device="cpu", quantization="8bit")
+
+        _, kwargs = mock_model.call_args
+        assert kwargs["quantization_config"].load_in_8bit is True
+        assert kwargs["device_map"] == "cpu"
+
+    @patch("transformers.AutoTokenizer.from_pretrained")
+    @patch("transformers.AutoModelForCausalLM.from_pretrained")
+    def test_unrecognised_quantization_is_rejected(self, mock_model, mock_tok):
+        """Fail closed: the quant_menu formats that need a full TrainingConfig
+        (gptq/awq/hqq/...) are explicitly out of scope here rather than
+        silently loading at full precision."""
+        from soup_cli.utils.live_eval import load_model_and_tokenizer
+
+        mock_tok.return_value = _fake_tokenizer()
+        with pytest.raises(ValueError, match="not supported"):
+            load_model_and_tokenizer("some/model", device="cpu", quantization="gptq")
+        assert mock_model.call_count == 0
+
+
+class TestBackwardsCompatibility:
+    """The 11 existing callers pass no ``quantization`` argument at all; none
+    of them may see a behavior change."""
+
+    @patch("transformers.AutoTokenizer.from_pretrained")
+    @patch("transformers.AutoModelForCausalLM.from_pretrained")
+    def test_unset_quantization_matches_the_pre_367_call_shape(self, mock_model, mock_tok):
+        from soup_cli.utils.live_eval import load_model_and_tokenizer
+
+        mock_tok.return_value = _fake_tokenizer()
+        fake_model = MagicMock()
+        mock_model.return_value = fake_model
+
+        load_model_and_tokenizer("some/model", device="cpu")
+
+        _, kwargs = mock_model.call_args
+        assert "quantization_config" not in kwargs
+        assert "device_map" not in kwargs
+        # Unquantized loads still move the model explicitly, as before #367.
+        fake_model.to.assert_called_once_with("cpu")
+
+    @patch("transformers.AutoTokenizer.from_pretrained")
+    @patch("transformers.AutoModelForCausalLM.from_pretrained")
+    def test_none_and_the_string_none_are_both_unquantized(self, mock_model, mock_tok):
+        from soup_cli.utils.live_eval import load_model_and_tokenizer
+
+        mock_tok.return_value = _fake_tokenizer()
+        for value in (None, "none"):
+            mock_model.reset_mock()
+            fake_model = MagicMock()
+            mock_model.return_value = fake_model
+            load_model_and_tokenizer("some/model", device="cpu", quantization=value)
+            assert "quantization_config" not in mock_model.call_args.kwargs
+
+
+class TestQuantizedLoadIsNotMovedAfterward:
+    """A quantized model is pinned to a device at ``from_pretrained`` time via
+    ``device_map``; calling ``.to()`` on it afterward is what BNB rejects.
+    This is the mechanism named in the fix's own comment, checked directly
+    rather than trusted."""
+
+    @patch("transformers.AutoTokenizer.from_pretrained")
+    @patch("transformers.AutoModelForCausalLM.from_pretrained")
+    def test_to_is_not_called_on_a_4bit_load(self, mock_model, mock_tok):
+        from soup_cli.utils.live_eval import load_model_and_tokenizer
+
+        mock_tok.return_value = _fake_tokenizer()
+        fake_model = MagicMock()
+        mock_model.return_value = fake_model
+
+        load_model_and_tokenizer("some/model", device="cpu", quantization="4bit")
+
+        fake_model.to.assert_not_called()
+
+
+class TestBuildQuantizationConfigHelper:
+    def test_none_and_literal_none_return_none(self):
+        from soup_cli.utils.live_eval import _build_quantization_config
+
+        assert _build_quantization_config(None) is None
+        assert _build_quantization_config("none") is None
+
+    def test_unsupported_value_raises_before_any_import(self):
+        from soup_cli.utils.live_eval import _build_quantization_config
+
+        with pytest.raises(ValueError, match="awq"):
+            _build_quantization_config("awq")

--- a/tests/test_issue367_live_eval_quantization.py
+++ b/tests/test_issue367_live_eval_quantization.py
@@ -45,7 +45,82 @@ class TestQuantizationReachesFromPretrained:
         quant_config = kwargs["quantization_config"]
         assert quant_config.load_in_4bit is True
         assert quant_config.bnb_4bit_quant_type == "nf4"
+        assert quant_config.bnb_4bit_use_double_quant is True
         assert kwargs["device_map"] == "cpu"
+
+    @patch("soup_cli.utils.gpu.get_compute_dtype")
+    @patch("transformers.AutoTokenizer.from_pretrained")
+    @patch("transformers.AutoModelForCausalLM.from_pretrained")
+    def test_4bit_compute_dtype_comes_from_get_compute_dtype(
+        self, mock_model, mock_tok, mock_get_dtype
+    ):
+        """The one wire connecting this fix to the #385/#387 T4 emulation-detect
+        fix: bnb_4bit_compute_dtype must actually come from get_compute_dtype(),
+        not a hardcoded value that happens to match on most hardware."""
+        import torch
+
+        from soup_cli.utils.live_eval import load_model_and_tokenizer
+
+        mock_tok.return_value = _fake_tokenizer()
+        mock_model.return_value = MagicMock()
+        # BitsAndBytesConfig validates this field is a torch.dtype (or a string
+        # naming one), so the sentinel has to be a real, distinctive dtype
+        # rather than an opaque object -- float16 is never get_compute_dtype's
+        # actual return value on any real hardware path, only bfloat16/float32.
+        mock_get_dtype.return_value = torch.float16
+
+        load_model_and_tokenizer("some/model", device="cpu", quantization="4bit")
+
+        mock_get_dtype.assert_called_once_with()
+        _, kwargs = mock_model.call_args
+        assert kwargs["quantization_config"].bnb_4bit_compute_dtype is torch.float16
+
+    @patch("transformers.AutoTokenizer.from_pretrained")
+    @patch("transformers.AutoModelForCausalLM.from_pretrained")
+    def test_4bit_on_a_bare_cuda_device_gets_an_indexed_device_map(
+        self, mock_model, mock_tok
+    ):
+        """A bare "cuda" has no index; accelerate's device_map resolution
+        does torch.device(value).index next and raises a TypeError naming
+        nothing the user could act on (the landmine layer_stream_runtime's
+        _device_map_value already exists to avoid, reused here)."""
+        from soup_cli.utils.live_eval import load_model_and_tokenizer
+
+        mock_tok.return_value = _fake_tokenizer()
+        mock_model.return_value = MagicMock()
+
+        with patch("torch.cuda.current_device", return_value=0):
+            load_model_and_tokenizer("some/model", device="cuda", quantization="4bit")
+
+        _, kwargs = mock_model.call_args
+        assert kwargs["device_map"] == 0
+
+    @patch("transformers.AutoTokenizer.from_pretrained")
+    @patch("transformers.AutoModelForCausalLM.from_pretrained")
+    @patch("peft.PeftModel.from_pretrained")
+    def test_4bit_with_an_adapter_attaches_to_the_quantized_base(
+        self, mock_peft, mock_model, mock_tok
+    ):
+        """Acceptance criterion 1: the base loads at the requested quantization
+        AND the adapter attaches to it, in the same call."""
+        from soup_cli.utils.live_eval import load_model_and_tokenizer
+
+        mock_tok.return_value = _fake_tokenizer()
+        base_model = MagicMock()
+        mock_model.return_value = base_model
+        adapted_model = MagicMock()
+        mock_peft.return_value = adapted_model
+
+        model, _, _ = load_model_and_tokenizer(
+            "some/model", adapter="some/adapter", device="cpu", quantization="4bit"
+        )
+
+        _, kwargs = mock_model.call_args
+        assert kwargs["quantization_config"].load_in_4bit is True
+        mock_peft.assert_called_once_with(base_model, "some/adapter")
+        assert model is adapted_model
+        adapted_model.to.assert_not_called()
+        base_model.to.assert_not_called()
 
     @patch("transformers.AutoTokenizer.from_pretrained")
     @patch("transformers.AutoModelForCausalLM.from_pretrained")


### PR DESCRIPTION
`live_eval.load_model_and_tokenizer` had no quantization parameter, so every live
evaluation path built on it (`soup ship` leg 1/2, `soup diagnose --base-model`, `soup
advise --probe-model`, `soup eval behavior`, `tunability --live`) always loaded the base
at full precision. An NF4-trained adapter was therefore judged on a bf16 base it never
saw during training, and a user comparing a `soup ship` score against `soup serve
--quantization 4bit` would see a discrepancy with no stated cause.

## Fix

Threads a `quantization: Optional[str] = None` parameter through
`load_model_and_tokenizer`, backward-compatible with all 11 existing call sites (none of
which pass it today). `_build_quantization_config` builds a `BitsAndBytesConfig` for
`"4bit"` (nf4, double-quant on, matching every other 4-bit load path in this codebase)
and `"8bit"`; unsupported values raise rather than silently loading at full precision.

A quantized model is pinned to a device via `device_map` at `from_pretrained` time
instead of the existing `.to(dev)` call, since BNB rejects moving an already-dispatched
model.

## Scope

This covers acceptance criteria 1 and 3 of #367 (threading the argument, and a test that
`from_pretrained` receives the requested config). Criteria 2 and 4, `soup ship` reporting
which numerics the judge used and a staleness gate on evidence recorded under mismatched
numerics, are larger integration work into `soup ship`'s evidence machinery and are left
open for a follow-up.

The other quant_menu formats (gptq/awq/hqq/aqlm/...) key off a full `TrainingConfig`,
which live_eval callers don't have; only `"4bit"`/`"8bit"`/`None` are supported here.

## Verification

- `tests/test_issue367_live_eval_quantization.py` (new): asserts `from_pretrained`
  receives the right `quantization_config` and `device_map` for `"4bit"`/`"8bit"`,
  that an unrecognised value raises before any model load, that the 11 existing callers'
  unset-quantization shape is unchanged (no `quantization_config`/`device_map` kwarg,
  `.to()` still called), and that `.to()` is never called on a quantized load.
- `ruff check` and `mypy` clean on the changed file.
- Did not run the full `soup ship`/`soup diagnose` CLI end to end (needs a real GPU and
  checkpoint); the new tests mock at the `from_pretrained` boundary, matching every other
  test in this module's consumer chain.
