### PR TITLE
test: guard cross-tokenizer boundary merge bias (#462)

### DIFF
--- a/docs/serving-and-export.md
+++ b/docs/serving-and-export.md
@@ -347,6 +347,8 @@ Higher is better; roughly, ≥70% is where speculative decoding starts paying fo
 forward pass on realistic hardware. `--min-acceptance 0.6` exits **2** below the floor, so CI can
 gate on it (exit 0 = ok, 2 = below floor, 1 = error).
 
+*Note: For cross-tokenizer drafts, the measured acceptance rate is a strict lower bound. A token boundary merge between the prompt and the first generated token can cause the score to read up to `1/n_gen` lower than its true value, but it will never over-report.*
+
 `distill` runs logit KD through the existing `task: distill` trainer and emits a **dense** model
 (a PEFT adapter directory cannot be loaded as an `assistant_model`). When draft and target share a
 tokenizer, standard distillation is used. When tokenizers or vocabularies differ, `soup draft distill`

--- a/src/soup_cli/utils/draft.py
+++ b/src/soup_cli/utils/draft.py
@@ -528,6 +528,11 @@ def measure_acceptance(
     allowing speculative evaluation across different vocabularies and tokenization
     boundaries.
 
+    Note: Cross-tokenizer acceptance is a **lower bound**. A boundary merge (where
+    the draft tokenizer merges the last prompt character with the first generated
+    character) drops the straddling token, shortening the score by up to ``1/n_gen``.
+    The bias is always downward.
+
     Returns ``(accepted, total)`` summed over prompts.
     """
     import torch

--- a/tests/test_issue304_cross_tokenizer.py
+++ b/tests/test_issue304_cross_tokenizer.py
@@ -150,6 +150,22 @@ class TestCrossTokenizerAcceptanceKernel:
         assert count_accepted_spans(draft, target) == 4
         assert compute_acceptance_spans(draft, target) == 1.0
 
+    def test_boundary_merge_bias_is_pinned(self):
+        """Regression test for #462: a merged prompt/generation boundary token
+        costs exactly 1/n_gen, always downward."""
+        from soup_cli.utils.draft import compute_acceptance_spans, count_accepted_spans
+
+        target = ["b", "c"]
+        # control: clean boundary
+        draft_clean = ["b", "c"]
+        assert count_accepted_spans(draft_clean, target) == 2
+        assert compute_acceptance_spans(draft_clean, target) == 1.0
+
+        # merged boundary (b + c -> 'bc')
+        draft_merged = ["bc"]
+        assert count_accepted_spans(draft_merged, target) == 1
+        assert compute_acceptance_spans(draft_merged, target) == 0.5
+
     def test_repeated_substrings_and_interrupted_spans(self):
         """Verify repeated words and interrupted spans do not produce false positives."""
         from soup_cli.utils.draft import compute_acceptance_spans, count_accepted_spans

--- a/tests/test_issue304_cross_tokenizer.py
+++ b/tests/test_issue304_cross_tokenizer.py
@@ -155,16 +155,17 @@ class TestCrossTokenizerAcceptanceKernel:
         costs exactly 1/n_gen, always downward."""
         from soup_cli.utils.draft import compute_acceptance_spans, count_accepted_spans
 
-        target = ["b", "c"]
+        target = ["c", "d", "e", "f"]
         # control: clean boundary
-        draft_clean = ["b", "c"]
-        assert count_accepted_spans(draft_clean, target) == 2
+        draft_clean = ["c", "d", "e", "f"]
+        assert count_accepted_spans(draft_clean, target) == 4
         assert compute_acceptance_spans(draft_clean, target) == 1.0
 
-        # merged boundary (b + c -> 'bc')
-        draft_merged = ["bc"]
-        assert count_accepted_spans(draft_merged, target) == 1
-        assert compute_acceptance_spans(draft_merged, target) == 0.5
+        # merged boundary: the first generated character merges with the prompt tail
+        # and is excluded from the draft's proposal list.
+        draft_merged = ["d", "e", "f"]
+        assert count_accepted_spans(draft_merged, target) == 3
+        assert compute_acceptance_spans(draft_merged, target) == 0.75
 
     def test_repeated_substrings_and_interrupted_spans(self):
         """Verify repeated words and interrupted spans do not produce false positives."""


### PR DESCRIPTION
Closes #462.

**Note:** This PR is built on top of the cross-tokenizer draft feature from #417 (`CODING-DARSH:feat/draft-cross-tokenizer`) since the issue explicitly addresses a behavior introduced there. 

It includes:
- The docstring note on the cross-tokenizer branch of `measure_acceptance` stating that alpha is a lower bound.
- The fixture as a regression test pinning the downward bias when a boundary token is merged.
- A note in `docs/serving-and-export.md` next to the acceptance-rate explanation.