### PR TITLE
feat(data): add provider sampling to best-of-n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ reproducing 70+ versions of notes.
   --config`, the registry entry, or the adapter's `adapter_config.json`), per the issue's own
   Fix path; that plus `soup ship` reporting the numerics it judged with and a staleness gate
   on mismatched-numerics evidence are left open (issue acceptance criteria 2 and 4).
+
 - **`training.stream_pin` makes layer-streaming pinning configurable (#366 by @ousamabenyounes in #416).**
   Page-locking the RAM store is chosen automatically by `decide_pinning`, and
   until now nothing could override it — so while #331 was live, `pin=False` was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ reproducing 70+ versions of notes.
 
 ### Added
 
+- **`soup data best-of-n` can sample candidates from Ollama or vLLM providers
+  (#299 by @Faisal01011 in #466).** The existing local Transformers `--base` path stays
+  the default, while `--provider ollama|vllm --model <m> [--base-url <url>]`
+  draws each prompt's N candidates through the existing SSRF-validated raw-
+  completion seam. Provider and model are recorded in `_best_of_n` provenance;
+  Anthropic is refused by name because its Messages API has no raw-completion
+  endpoint, and local-only flags cannot be silently ignored in provider mode.
+
 - **Layer streaming now accepts Qwen3.5 MoE text checkpoints whose decoder
   layers do not expose exactly the same weight keys in every block (by
   @Shutaru in #426).** The sharder now records per-layer shard headers instead of
@@ -38,7 +46,6 @@ reproducing 70+ versions of notes.
   --config`, the registry entry, or the adapter's `adapter_config.json`), per the issue's own
   Fix path; that plus `soup ship` reporting the numerics it judged with and a staleness gate
   on mismatched-numerics evidence are left open (issue acceptance criteria 2 and 4).
-
 - **`training.stream_pin` makes layer-streaming pinning configurable (#366 by @ousamabenyounes in #416).**
   Page-locking the RAM store is chosen automatically by `decide_pinning`, and
   until now nothing could override it — so while #331 was live, `pin=False` was

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -297,7 +297,7 @@ soup local-rl train --db <path> --model <id> [--scheduler-dir <dir>] [--hour H] 
 soup build <manifest.yaml> [--dry-run] [--output-dir <dir>]  dbt-for-SFT DAG: validate + plan + live materialise (v0.69.0; live v0.71.6)
 soup expect <data.jsonl> <suite.yaml>         Expectations suite: PII / token-length / refusal / judge (v0.69.0)
 soup data gen-magpie --base <m> --provider ollama|vllm --target N --output <jsonl> [--base-url <url>] [--quality-filter]  Magpie synthetic generator — live (v0.69.0; live v0.71.6)
-soup data best-of-n --base <m> --prompts <jsonl> --n 8 --judge <url> -o <sft.jsonl> [--emit-pairs <dpo.jsonl>]  Best-of-N rejection sampling: sample N locally, judge picks winner -> SFT (+ DPO) rows (v0.71.31)
+soup data best-of-n (--base <m> | --provider ollama|vllm --model <m> [--base-url <url>]) --prompts <jsonl> --n 8 --judge <url> -o <sft.jsonl> [--emit-pairs <dpo.jsonl>]  Best-of-N rejection sampling: sample N locally (default) or through a raw-completion provider, then emit SFT (+ DPO) rows
 soup data evolve --input <seeds.jsonl> --provider ollama|vllm --model <m> --strategy depth|breadth --rounds N -o <jsonl>  Evol-Instruct (WizardLM) instruction evolution (v0.71.31)
 soup data persona-mix --prompts <jsonl> --n N --output <jsonl>  Persona-Hub diversity sampler (v0.69.0)
 soup data brain-rot <data.jsonl> [--strict]   Brain-rot detector — arXiv 2510.13928 (v0.69.0)

--- a/docs/data.md
+++ b/docs/data.md
@@ -185,17 +185,22 @@ soup data persona-mix --prompts prompts.jsonl --n 500 --output mixed.jsonl
 # Brain-rot detector (arXiv 2510.13928) — refuses to train on excessive slop
 soup data brain-rot data.jsonl --strict --max-major-fraction 0.10
 
-# Best-of-N rejection sampling (v0.71.31) — sample N locally, a judge picks the winner
+# Best-of-N rejection sampling — local sampling stays the default
 soup data best-of-n --base HuggingFaceTB/SmolLM2-135M-Instruct \
     --prompts prompts.jsonl --n 8 --judge ollama://llama3.1 \
     -o best_of_n.jsonl --emit-pairs pairs.jsonl
+
+# Or draw the N candidates from a running Ollama / vLLM raw-completion endpoint
+soup data best-of-n --provider ollama --model qwen2.5:7b \
+    --base-url http://localhost:11434 --prompts prompts.jsonl --n 8 \
+    --judge ollama://llama3.1 -o best_of_n.jsonl
 
 # Evol-Instruct (WizardLM depth/breadth, v0.71.31) — grow instruction diversity
 soup data evolve --input seeds.jsonl --provider ollama --model llama3.1 \
     --strategy depth --rounds 2 -o evolved.jsonl
 ```
 
-Every command applies the project-wide TOCTOU policy (`os.lstat + S_ISLNK` symlink rejection before any open) and cwd containment via the shared `paths.enforce_under_cwd_and_no_symlink` helper. All five are LIVE: `soup build` materialises with five built-in transforms (`identity` / `drop_empty` / `lowercase` / `strip` / `dedup_exact`) and SQLite-tracked incremental re-transform (v0.71.6); `soup data gen-magpie` harvests via raw completion against `--provider ollama|vllm` (loopback-only; `anthropic` rejected — no raw-completion endpoint, v0.71.6).
+Every command applies the project-wide TOCTOU policy (`os.lstat + S_ISLNK` symlink rejection before any open) and cwd containment via the shared `paths.enforce_under_cwd_and_no_symlink` helper. All five are LIVE: `soup build` materialises with five built-in transforms (`identity` / `drop_empty` / `lowercase` / `strip` / `dedup_exact`) and SQLite-tracked incremental re-transform (v0.71.6); `soup data gen-magpie` and provider-backed `best-of-n` harvest via raw completion against `--provider ollama|vllm` (SSRF-validated; `anthropic` rejected because the Messages API has no raw-completion endpoint). Provider-backed `best-of-n` records the sampler provider and model in each row's `_best_of_n` provenance; omit `--provider` to retain the local Transformers `--base` path.
 
 ### Custom Transforms
 

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -2896,9 +2896,10 @@ def gen_magpie(
         )
 
 
-# v0.71.31 — Best-of-N rejection sampling (local sampling + judge).
+# v0.71.31 — Best-of-N rejection sampling (local/provider sampling + judge).
 _BON_MAX_PROMPTS = 100_000
 _BON_MAX_JSONL_BYTES = 100 * 1024 * 1024  # 100 MiB
+_BON_PROVIDER_SAMPLERS = ("ollama", "vllm")
 
 
 def _load_bon_model(base: str, device: str, trust: bool):
@@ -2959,11 +2960,14 @@ def _bon_load_prompts(path: str) -> list:
 
 @app.command(name="best-of-n")
 def best_of_n(
-    base: str = typer.Option(..., "--base", help="Base model id/path to sample from"),
+    base: str = typer.Option("", "--base", help="Local base model id/path to sample from"),
     prompts: str = typer.Option(..., "--prompts", help="JSONL of {prompt|messages} rows"),
     judge: str = typer.Option(
         ..., "--judge", help="Judge URL (ollama://|https://|http://localhost)"
     ),
+    provider: str = typer.Option("", "--provider", help="Provider sampler: ollama | vllm"),
+    model: str = typer.Option("", "--model", help="Provider sampler model id"),
+    base_url: str = typer.Option("", "--base-url", help="Provider sampler base URL"),
     n: int = typer.Option(8, "--n", help="Candidates per prompt [2, 64]"),
     output: str = typer.Option(
         "", "--output", "-o", help="Output SFT JSONL (required unless --plan-only)"
@@ -2975,19 +2979,20 @@ def best_of_n(
     max_new_tokens: int = typer.Option(
         256, "--max-new-tokens", help="Max new tokens per candidate [1, 4096]"
     ),
-    device: str = typer.Option("", "--device", help="cuda | cpu"),
-    seed: int = typer.Option(0, "--seed", help="Sampling seed"),
+    device: str = typer.Option("", "--device", help="Local sampler device: cuda | cpu"),
+    seed: int = typer.Option(0, "--seed", help="Local sampling seed"),
     trust_remote_code: bool = typer.Option(
-        False, "--trust-remote-code", help="Allow custom model code on --base"
+        False, "--trust-remote-code", help="Allow custom model code on local --base"
     ),
     plan_only: bool = typer.Option(False, "--plan-only", help="Validate + print plan"),
 ) -> None:
     """Best-of-N rejection sampling: sample N per prompt, a judge picks the winner.
 
-    Samples ``--n`` candidates from ``--base`` locally (transformers), scores each
-    with ``--judge`` pointwise, and writes the winner as an SFT chat row (with
-    ``_best_of_n`` provenance). ``--emit-pairs`` additionally writes winner-vs-
-    loser DPO pairs. BOND-lite (Best-of-N distillation, v0.71.31).
+    Samples ``--n`` candidates from local ``--base`` (the default) or an Ollama /
+    vLLM raw-completion ``--provider``, scores each with ``--judge`` pointwise,
+    and writes the winner as an SFT chat row (with ``_best_of_n`` provenance).
+    ``--emit-pairs`` additionally writes winner-vs-loser DPO pairs. BOND-lite
+    (Best-of-N distillation, v0.71.31; provider sampling #299).
     """
     from rich.markup import escape as _escape
     from rich.panel import Panel
@@ -2995,6 +3000,7 @@ def best_of_n(
     from soup_cli.eval.gate import _parse_judge_url
     from soup_cli.eval.judge import JudgeEvaluator
     from soup_cli.utils import best_of_n as bon
+    from soup_cli.utils.magpie import make_magpie_generate_fn
     from soup_cli.utils.paths import atomic_write_text, enforce_under_cwd_and_no_symlink
     from soup_cli.utils.trust_remote import (
         model_requires_trust_remote_code,
@@ -3014,9 +3020,9 @@ def best_of_n(
 
     # --- Judge URL (SSRF via JudgeEvaluator construction) ---
     try:
-        provider, judge_model_id, api_base = _parse_judge_url(judge)
+        judge_provider, judge_model_id, api_base = _parse_judge_url(judge)
         evaluator = JudgeEvaluator(
-            provider=provider, model=judge_model_id, api_base=api_base
+            provider=judge_provider, model=judge_model_id, api_base=api_base
         )
     except (ValueError, TypeError) as exc:
         console.print(f"[red]Invalid --judge: {_escape(str(exc))}[/]")
@@ -3036,16 +3042,59 @@ def best_of_n(
         console.print("[red]--prompts produced no usable rows[/]")
         raise typer.Exit(2)
 
-    trust = resolve_trust_remote_code(
-        base,
-        requested=trust_remote_code,
-        console=console,
-        requires_remote_code=model_requires_trust_remote_code(base) or False,
-    )
+    # --- Sampler selection ---
+    generate_fn = None
+    sampling_provider = ""
+    trust = False
+    if provider:
+        if base:
+            console.print("[red]--base and --provider are mutually exclusive[/]")
+            raise typer.Exit(2)
+        if device or trust_remote_code or seed != 0:
+            console.print(
+                "[red]--device, --seed and --trust-remote-code apply only to local --base[/]"
+            )
+            raise typer.Exit(2)
+        sampling_provider = provider.strip().lower()
+        if sampling_provider == "anthropic":
+            console.print(
+                "[red]anthropic has no raw-completion endpoint; "
+                "--provider must be ollama or vllm[/]"
+            )
+            raise typer.Exit(2)
+        if sampling_provider not in _BON_PROVIDER_SAMPLERS:
+            console.print("[red]--provider must be ollama or vllm[/]")
+            raise typer.Exit(2)
+        try:
+            generate_fn = make_magpie_generate_fn(
+                sampling_provider,
+                model=model,
+                base_url=base_url or None,
+                temperature=temperature,
+                max_tokens=max_new_tokens,
+            )
+        except (TypeError, ValueError, ImportError) as exc:
+            console.print(f"[red]{_escape(str(exc))}[/]")
+            raise typer.Exit(2) from exc
+    else:
+        if not base:
+            console.print("[red]either local --base or --provider is required[/]")
+            raise typer.Exit(2)
+        if model or base_url:
+            console.print("[red]--model and --base-url require --provider[/]")
+            raise typer.Exit(2)
+        trust = resolve_trust_remote_code(
+            base,
+            requested=trust_remote_code,
+            console=console,
+            requires_remote_code=model_requires_trust_remote_code(base) or False,
+        )
+
+    sampler_label = f"{sampling_provider}:{model}" if generate_fn is not None else base
 
     console.print(
         Panel(
-            f"Base model:   [bold]{_escape(base)}[/]\n"
+            f"Sampler:      [bold]{_escape(sampler_label)}[/]\n"
             f"Prompts:      [bold]{len(prompt_list)}[/]\n"
             f"N candidates: [bold]{n}[/]\n"
             f"Judge:        [bold]{_escape(judge)}[/]",
@@ -3058,28 +3107,36 @@ def best_of_n(
         console.print("[red]--output is required unless --plan-only is set.[/]")
         raise typer.Exit(2)
 
-    import torch
+    local_model = None
+    tokenizer = None
+    if generate_fn is None:
+        import torch
 
-    torch.manual_seed(seed)
-    model, tokenizer = _load_bon_model(base, device, trust)
+        torch.manual_seed(seed)
+        local_model, tokenizer = _load_bon_model(base, device, trust)
 
     dev = device or None
     sft_lines: list = []
     pair_lines: list = []
     for prompt in prompt_list:
         candidates = bon.sample_candidates(
-            model,
+            local_model,
             tokenizer,
             prompt,
             n=n,
             temperature=temperature,
             max_new_tokens=max_new_tokens,
             device=dev,
+            generate_fn=generate_fn,
         )
         pick = bon.judge_pick_best(prompt, candidates, evaluator)
-        sft_lines.append(
-            json.dumps(bon.build_sft_row(prompt, pick, judge_model=judge), ensure_ascii=False)
-        )
+        row = bon.build_sft_row(prompt, pick, judge_model=judge)
+        if generate_fn is not None:
+            row["_best_of_n"]["sampler"] = {
+                "provider": sampling_provider,
+                "model": model,
+            }
+        sft_lines.append(json.dumps(row, ensure_ascii=False))
         if emit_pairs:
             pair = bon.build_dpo_pair(prompt, pick, candidates)
             if pair is not None:

--- a/src/soup_cli/utils/best_of_n.py
+++ b/src/soup_cli/utils/best_of_n.py
@@ -1,9 +1,10 @@
 """Best-of-N rejection sampling: sample N, a judge picks the winner (v0.71.31).
 
-Sampling loads a local ``transformers`` model (torch-lazy, inside
-``sample_candidates``); judging reuses the project's ``JudgeEvaluator``
-*pointwise* (score each candidate, argmax). The judge / build half is PURE (NO
-top-level torch) so it is CPU-unit-testable.
+Sampling either loads a local ``transformers`` model or calls an injected raw-
+completion provider (torch-lazy, inside ``sample_candidates``); judging reuses
+the project's ``JudgeEvaluator`` *pointwise* (score each candidate, argmax).
+The provider / judge / build path is PURE (NO top-level torch) so it is CPU-
+unit-testable.
 
 Output rows are SFT chat rows ``{"messages": [...], "_best_of_n": {...}}`` with
 provenance under the reserved ``_best_of_n`` key; ``build_dpo_pair`` optionally
@@ -11,7 +12,7 @@ emits a winner-vs-loser preference pair.
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Protocol
+from typing import TYPE_CHECKING, Callable, Optional, Protocol
 
 if TYPE_CHECKING:
     from transformers import PreTrainedModel, PreTrainedTokenizerBase
@@ -35,16 +36,23 @@ class BestOfNPick:
 
 
 def sample_candidates(
-    model: "PreTrainedModel",
-    tokenizer: "PreTrainedTokenizerBase",
+    model: "Optional[PreTrainedModel]",
+    tokenizer: "Optional[PreTrainedTokenizerBase]",
     prompt: str,
     *,
     n: int,
     temperature: float,
     max_new_tokens: int,
     device: Optional[str] = None,
+    generate_fn: Optional[Callable[[str], str]] = None,
 ) -> "list[str]":
-    """Sample ``n`` diverse continuations for ``prompt`` (do_sample)."""
+    """Sample ``n`` continuations locally or through a raw-completion provider."""
+    if generate_fn is not None:
+        return [generate_fn(prompt).strip() for _ in range(n)]
+
+    if model is None or tokenizer is None:
+        raise ValueError("local best-of-N sampling requires a model and tokenizer")
+
     import torch
 
     messages = [{"role": "user", "content": prompt}]

--- a/tests/test_v07131.py
+++ b/tests/test_v07131.py
@@ -850,6 +850,29 @@ class TestBestOfN:
 
 
 class TestBestOfNCli:
+    @staticmethod
+    def _invoke_guard(monkeypatch, tmp_path, *sampler_args):
+        from typer.testing import CliRunner
+
+        from soup_cli.commands.data import app
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("soup_cli.eval.judge.JudgeEvaluator", lambda **kw: _ScoreJudge())
+        prompts = tmp_path / "prompts.jsonl"
+        prompts.write_text('{"prompt": "question"}\n', encoding="utf-8")
+        return CliRunner().invoke(
+            app,
+            [
+                "best-of-n",
+                "--prompts",
+                str(prompts),
+                "--judge",
+                "ollama://judge",
+                "--plan-only",
+                *sampler_args,
+            ],
+        )
+
     def test_help(self):
         from typer.testing import CliRunner
 
@@ -862,6 +885,41 @@ class TestBestOfNCli:
         assert "--provider" in output
         assert "--model" in output
         assert "--base-url" in output
+
+    def test_rejects_local_base_with_provider(self, monkeypatch, tmp_path):
+        result = self._invoke_guard(
+            monkeypatch, tmp_path, "--base", "local-model", "--provider", "ollama"
+        )
+        assert result.exit_code == 2, (result.output, repr(result.exception))
+        assert "mutually exclusive" in _plain(result.output).lower()
+
+    def test_rejects_local_only_flags_with_provider(self, monkeypatch, tmp_path):
+        result = self._invoke_guard(
+            monkeypatch,
+            tmp_path,
+            "--provider",
+            "ollama",
+            "--model",
+            "sampler-model",
+            "--seed",
+            "42",
+        )
+        assert result.exit_code == 2, (result.output, repr(result.exception))
+        output = _plain(result.output).lower()
+        assert "--seed" in output
+        assert "only to local --base" in output
+
+    def test_rejects_provider_options_without_provider(self, monkeypatch, tmp_path):
+        result = self._invoke_guard(
+            monkeypatch, tmp_path, "--base", "local-model", "--model", "sampler-model"
+        )
+        assert result.exit_code == 2, (result.output, repr(result.exception))
+        assert "require --provider" in _plain(result.output).lower()
+
+    def test_requires_local_base_or_provider(self, monkeypatch, tmp_path):
+        result = self._invoke_guard(monkeypatch, tmp_path)
+        assert result.exit_code == 2, (result.output, repr(result.exception))
+        assert "either local --base or --provider" in _plain(result.output).lower()
 
     def test_provider_path_calls_sampler_and_records_provenance(self, monkeypatch):
         import json

--- a/tests/test_v07131.py
+++ b/tests/test_v07131.py
@@ -8,7 +8,16 @@ pairwise`` (#284), ``task='online_dpo'`` (schema + trainer + routing),
 
 from __future__ import annotations
 
+import re
+
 import pytest
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(text: str) -> str:
+    """Return ANSI-stripped, whitespace-collapsed CLI output."""
+    return " ".join(_ANSI_RE.sub("", text).split())
 
 # ---------------------------------------------------------------------------
 # Shared test doubles
@@ -731,6 +740,28 @@ class _ScoreJudge:
 
 
 class TestBestOfN:
+    def test_provider_generate_fn_is_called_n_times(self):
+        from soup_cli.utils.best_of_n import sample_candidates
+
+        calls = []
+
+        def generate(prompt):
+            calls.append(prompt)
+            return f"  answer {len(calls)}  "
+
+        candidates = sample_candidates(
+            None,
+            None,
+            "question",
+            n=3,
+            temperature=0.7,
+            max_new_tokens=64,
+            generate_fn=generate,
+        )
+
+        assert calls == ["question", "question", "question"]
+        assert candidates == ["answer 1", "answer 2", "answer 3"]
+
     def test_pick_best_argmax(self):
         from soup_cli.utils.best_of_n import judge_pick_best
 
@@ -826,7 +857,160 @@ class TestBestOfNCli:
 
         result = CliRunner().invoke(app, ["best-of-n", "--help"])
         assert result.exit_code == 0, (result.output, repr(result.exception))
-        assert "best-of-n" in result.output.lower() or "best of n" in result.output.lower()
+        output = _plain(result.output)
+        assert "best-of-n" in output.lower() or "best of n" in output.lower()
+        assert "--provider" in output
+        assert "--model" in output
+        assert "--base-url" in output
+
+    def test_provider_path_calls_sampler_and_records_provenance(self, monkeypatch):
+        import json
+        import os
+
+        from typer.testing import CliRunner
+
+        import soup_cli.commands.data as data_cmd
+        from soup_cli.commands.data import app
+
+        factory_calls = []
+        sample_calls = []
+
+        def fake_make(provider, **kwargs):
+            factory_calls.append((provider, kwargs))
+
+            def generate(prompt):
+                sample_calls.append(prompt)
+                return ("a", "longest", "mid")[len(sample_calls) - 1]
+
+            return generate
+
+        def fail_local_load(*_args, **_kwargs):
+            raise AssertionError("provider mode must not load the local model")
+
+        monkeypatch.setattr("soup_cli.utils.magpie.make_magpie_generate_fn", fake_make)
+        monkeypatch.setattr(data_cmd, "_load_bon_model", fail_local_load)
+        monkeypatch.setattr("soup_cli.eval.judge.JudgeEvaluator", lambda **kw: _ScoreJudge())
+
+        prompt_path = os.path.join(os.getcwd(), "_bon_provider_prompts.jsonl")
+        output_path = os.path.join(os.getcwd(), "_bon_provider_out.jsonl")
+        with open(prompt_path, "w", encoding="utf-8") as handle:
+            handle.write('{"prompt": "question"}\n')
+        try:
+            result = CliRunner().invoke(
+                app,
+                [
+                    "best-of-n",
+                    "--provider",
+                    "ollama",
+                    "--model",
+                    "sampler-model",
+                    "--base-url",
+                    "http://localhost:11434",
+                    "--prompts",
+                    prompt_path,
+                    "--n",
+                    "3",
+                    "--temperature",
+                    "0.7",
+                    "--max-new-tokens",
+                    "64",
+                    "--judge",
+                    "ollama://judge",
+                    "-o",
+                    output_path,
+                ],
+            )
+
+            assert result.exit_code == 0, (result.output, repr(result.exception))
+            assert factory_calls == [
+                (
+                    "ollama",
+                    {
+                        "model": "sampler-model",
+                        "base_url": "http://localhost:11434",
+                        "temperature": 0.7,
+                        "max_tokens": 64,
+                    },
+                )
+            ]
+            assert sample_calls == ["question", "question", "question"]
+            row = json.loads(open(output_path, encoding="utf-8").read())
+            assert row["messages"][1]["content"] == "longest"
+            assert row["_best_of_n"]["sampler"] == {
+                "provider": "ollama",
+                "model": "sampler-model",
+            }
+        finally:
+            for path in (prompt_path, output_path):
+                if os.path.exists(path):
+                    os.remove(path)
+
+    def test_provider_rejects_anthropic_by_name(self, monkeypatch):
+        import os
+
+        from typer.testing import CliRunner
+
+        from soup_cli.commands.data import app
+
+        monkeypatch.setattr("soup_cli.eval.judge.JudgeEvaluator", lambda **kw: _ScoreJudge())
+        path = os.path.join(os.getcwd(), "_bon_provider_anthropic.jsonl")
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write('{"prompt": "question"}\n')
+        try:
+            result = CliRunner().invoke(
+                app,
+                [
+                    "best-of-n",
+                    "--provider",
+                    "anthropic",
+                    "--model",
+                    "claude",
+                    "--prompts",
+                    path,
+                    "--judge",
+                    "ollama://judge",
+                    "--plan-only",
+                ],
+            )
+            assert result.exit_code == 2, (result.output, repr(result.exception))
+            assert "anthropic" in result.output.lower()
+            assert "ollama or vllm" in result.output.lower()
+        finally:
+            os.remove(path)
+
+    def test_provider_base_url_is_ssrf_validated(self, monkeypatch):
+        import os
+
+        from typer.testing import CliRunner
+
+        from soup_cli.commands.data import app
+
+        monkeypatch.setattr("soup_cli.eval.judge.JudgeEvaluator", lambda **kw: _ScoreJudge())
+        path = os.path.join(os.getcwd(), "_bon_provider_ssrf.jsonl")
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write('{"prompt": "question"}\n')
+        try:
+            result = CliRunner().invoke(
+                app,
+                [
+                    "best-of-n",
+                    "--provider",
+                    "ollama",
+                    "--model",
+                    "sampler-model",
+                    "--base-url",
+                    "http://evil.example.com:11434",
+                    "--prompts",
+                    path,
+                    "--judge",
+                    "ollama://judge",
+                    "--plan-only",
+                ],
+            )
+            assert result.exit_code == 2, (result.output, repr(result.exception))
+            assert "localhost" in result.output.lower()
+        finally:
+            os.remove(path)
 
     def test_reject_bad_n(self):
         import os
@@ -904,6 +1088,12 @@ class TestBestOfNCli:
             bon, "sample_candidates",
             lambda model, tok, prompt, **kw: ["a", "abcd", "xy"],
         )
+        monkeypatch.setattr(
+            "soup_cli.utils.magpie.make_magpie_generate_fn",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("local mode must not construct a provider sampler")
+            ),
+        )
         monkeypatch.setattr("soup_cli.eval.judge.JudgeEvaluator", lambda **kw: _ScoreJudge())
 
         ppath = os.path.join(os.getcwd(), "_bon_prompts_ok.jsonl")
@@ -922,6 +1112,12 @@ class TestBestOfNCli:
             assert len(rows) == 2
             assert rows[0]["messages"][1]["content"] == "abcd"  # longest wins
             assert rows[0]["_best_of_n"]["n"] == 3
+            assert set(rows[0]["_best_of_n"]) == {
+                "n",
+                "winner_idx",
+                "judge_model",
+                "scores",
+            }
             pairs = [json.loads(x) for x in open(dpath, encoding="utf-8") if x.strip()]
             assert pairs[0] == {"prompt": "q1", "chosen": "abcd", "rejected": "a"}
         finally:


### PR DESCRIPTION
## Summary
- add Ollama and vLLM sampling to `soup data best-of-n`
- preserve the existing local `--base` workflow
- validate provider URLs and record sampler provenance
- document provider usage and Anthropic's raw-completion limitation

## Tests
- `.venv/bin/python -m pytest -q --no-cov tests/test_cli_help_assertions_are_ansi_safe.py tests/test_v07131.py tests/test_v0716.py tests/test_cli_startup_is_light.py` (242 passed)
- `.venv/bin/ruff check src/soup_cli/ tests/`
- `git diff --check`

Closes #299