### PR TITLE
test(lr-groups): cover the all-matched branch in build_optimizer_param_groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ reproducing 70+ versions of notes.
 - **A repo-wide documentation ratchet to guarantee declared recipe counts stay synchronized with the catalog (#453 by @harshitthek in #457).**
   Derives the expected count dynamically from `len(RECIPES)` and scans all declared documentation sites, preventing silent Git auto-merge drift across sequential recipe additions.
 
+- Branch coverage for `lr_groups.py`'s `build_optimizer_param_groups`: the case
+  where every parameter matches a configured group, so no `base` optimizer
+  group is appended (#273).
+
 ### Changed
 
 - **Lazy callback builders now self-import their callback class names so runtime

--- a/tests/test_v0410_part_b.py
+++ b/tests/test_v0410_part_b.py
@@ -171,6 +171,24 @@ class TestBuildOptimizerParamGroups:
         assert len(out) == 1
         assert out[0]["name"] == "base"
 
+    def test_all_params_matched_no_base_group(self):
+        # Every param routes into a pattern group, so base_bucket stays empty
+        # and must not be appended (branch 229->235 in lr_groups.py).
+        groups = parse_lr_groups([
+            ("self_attn", 1e-4),
+            ("mlp", 2e-4),
+            ("lm_head", 3e-4),
+        ])
+        out = build_optimizer_param_groups(self._named_params(), 2e-5, groups)
+        names = [g["name"] for g in out]
+        assert names == ["lr_group:self_attn", "lr_group:mlp", "lr_group:lm_head"]
+        attn_bucket = next(g for g in out if g["name"] == "lr_group:self_attn")
+        assert sorted(attn_bucket["params"]) == ["T_q0", "T_v0"]
+        mlp_bucket = next(g for g in out if g["name"] == "lr_group:mlp")
+        assert mlp_bucket["params"] == ["T_g1"]
+        head_bucket = next(g for g in out if g["name"] == "lr_group:lm_head")
+        assert head_bucket["params"] == ["T_head"]
+
     def test_base_lr_bool_rejected(self):
         with pytest.raises(ValueError, match="must be a number"):
             build_optimizer_param_groups([], True, None)  # type: ignore[arg-type]


### PR DESCRIPTION
`build_optimizer_param_groups` in `lr_groups.py` reported 100% statement
coverage while one branch went unexercised: when every parameter name
matches a configured `lr_groups` pattern, `base_bucket` stays empty and the
`if base_bucket:` guard at line 229 skips appending the `base` group. No
test drove that path, so a future regression there (the optimizer silently
losing its base LR group) would not be caught.

Adds `test_all_params_matched_no_base_group`, which routes every parameter
into a pattern group and asserts the exact output: no `base` entry, and
each pattern bucket holds precisely the parameters it should. Also adds the
CHANGELOG entry the repo's convention expects for PR-authored changes.

This covers the `lr_groups.py` branch only, the one the issue calls out as
having real training consequences. `replay.py`'s branch is a separate,
smaller follow-up per the issue's own "one module per PR" guidance;
`log_level.py` is already at 100% branch coverage on current `main` and
needs nothing.

Verification:
- `pytest tests/test_v0410_part_b.py --cov=soup_cli.utils.lr_groups --cov-branch`: branch `229->235` shows `Missing` without this test, `100%` with it.
- `pytest tests/test_v0410_part_a.py tests/test_v0410_part_b.py tests/test_v0410_part_c.py`: 121 passed.
- `ruff check src/soup_cli/ tests/`: clean.

Refs #273 (lr_groups.py branch only; replay.py to follow in a separate PR).
