### PR TITLE
test(replay): cover the stride-lands-on-last-row branch in downsample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,9 @@ reproducing 70+ versions of notes.
 - Branch coverage for `lr_groups.py`'s `build_optimizer_param_groups`: the case
   where every parameter matches a configured group, so no `base` optimizer
   group is appended (#273 by @AmirF194 in #469).
+- Branch coverage for `replay.py`'s `downsample`: the case where the stride
+  already lands on the last row, so the endpoint pin is not appended a second
+  time (#273 by @AmirF194 in #470).
 
 ### Changed
 

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -78,6 +78,15 @@ class TestDownsample:
         out = downsample(rows)
         assert len(out) <= MAX_PLOT_POINTS + 5
 
+    def test_stride_lands_on_last_row_no_duplicate_pin(self):
+        # 5 rows, max_points=2 -> stride = 5 // 2 = 2, so rows[::2] already
+        # ends on index 4 (the last row); the endpoint pin must not append a
+        # second copy (branch 80->82 in replay.py).
+        rows = [_row(i, 2.0) for i in range(5)]
+        out = downsample(rows, max_points=2)
+        assert out == [rows[0], rows[2], rows[4]]
+        assert out[-1] is rows[-1]
+
     def test_zero_max_rejected(self):
         with pytest.raises(ValueError):
             downsample([_row(0, 2.0)], max_points=0)


### PR DESCRIPTION
`downsample` in `replay.py` reported 98% branch coverage: `if sampled[-1] is not rows[-1]:` at line 80 always took the true branch in the existing tests, so the case where the stride already lands on the last row (the pin is redundant and must be skipped) went unexercised. A future regression there, appending a duplicate final row, would not be caught.

Adds `test_stride_lands_on_last_row_no_duplicate_pin`: 5 rows with `max_points=2` gives `stride = 5 // 2 = 2`, so `rows[::2]` already ends on index 4. Asserts the exact output (`[rows[0], rows[2], rows[4]]`) and that the last element is the same object as `rows[-1]`, not a duplicate. Also adds the CHANGELOG entry the repo's convention expects.

This is the `replay.py` follow-up to #469 (`lr_groups.py`), per the issue's "one module per PR" note. `log_level.py` needs nothing; it is already at 100% branch coverage on current `main`.

Verification:
- `pytest tests/test_replay.py --cov=soup_cli.utils.replay --cov-branch`: branch `80->82` shows `Missing` without this test, `100%` with it.
- `pytest tests/test_replay.py`: 15 passed.
- `ruff check src/soup_cli/utils/replay.py tests/test_replay.py`: clean.

Refs #273 (replay.py branch only; #469 covers lr_groups.py and is still open, so this does not close the issue).
