### PR TITLE
fix(replay): make max_points a hard cap on downsample output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,7 @@ reproducing 70+ versions of notes.
 ### Fixed
 
 - **`downsample` now returns at most `max_points` rows, which is what its
-  docstring has always promised (#473).** The stride was
+  docstring has always promised (#473 in #474).** The stride was
   `len(rows) // max_points` — a divisor, not a cap — so five rows with
   `max_points=2` came back with three, and the endpoint pin could add a
   fourth. Sample indices are now spread evenly across the series with both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,21 @@ reproducing 70+ versions of notes.
 
 ### Fixed
 
+- **`downsample` now returns at most `max_points` rows, which is what its
+  docstring has always promised (#473).** The stride was
+  `len(rows) // max_points` — a divisor, not a cap — so five rows with
+  `max_points=2` came back with three, and the endpoint pin could add a
+  fourth. Sample indices are now spread evenly across the series with both
+  endpoints included, so `soup runs replay` renders exactly
+  `min(len(rows), max_points)` points. Even spacing also avoids the cliff a
+  ceil-based stride would introduce: a series one row over the cap keeps
+  `max_points` points rather than roughly half of them. `max_points=1` is the
+  one shape where both endpoints cannot fit and returns the final row, which
+  is what the endpoint pin existed to guarantee. The off-by-one guard added
+  in #470 is kept, renamed to `test_last_index_lands_on_last_row_no_duplicate`
+  and re-pinned to the new arithmetic. Consequence of the old behaviour was a
+  chart with a few more points than intended, never a wrong number.
+
 - **`cut_ce.py` and `liger.py` now normalize path separators and match architecture
   keywords on the last path component only (#456 by @harshitthek in #458).**
   On Windows, `rsplit("/")` never split on backslashes, causing parent directory

--- a/src/soup_cli/utils/replay.py
+++ b/src/soup_cli/utils/replay.py
@@ -17,10 +17,6 @@ from typing import List, Optional, Sequence
 # even on long runs that logged tens of thousands of steps.
 MAX_PLOT_POINTS = 2000
 
-# Minimum step delta to keep when sub-sampling. Otherwise large stretches
-# can collapse into "step 100, 100, 100" duplicates after coarsening.
-_MIN_STEP_DELTA = 1
-
 
 @dataclass(frozen=True)
 class ReplaySummary:
@@ -65,18 +61,27 @@ def downsample(
     *,
     max_points: int = MAX_PLOT_POINTS,
 ) -> List[dict]:
-    """Return at most ``max_points`` rows preserving order + endpoints.
+    """Return exactly ``min(len(metrics), max_points)`` rows, order preserved.
 
-    Uses uniform stride sampling so chart shape is preserved.
+    ``max_points`` is a hard cap, not a stride divisor (#473). Both endpoints
+    are kept, so the first and final loss are always on the chart, and the
+    remaining slots are spread evenly between them to preserve chart shape.
+    Sampled indices are strictly increasing, so no row is emitted twice.
+
+    ``max_points=1`` is the one shape where both endpoints cannot fit: the
+    final row wins, since making the final loss visible is what the previous
+    endpoint pin existed to guarantee.
     """
     if max_points <= 0:
         raise ValueError("max_points must be positive")
     rows = list(metrics)
     if len(rows) <= max_points:
         return rows
-    stride = max(_MIN_STEP_DELTA, len(rows) // max_points)
-    sampled = rows[::stride]
-    # Always pin the last row so the final loss is visible.
-    if sampled[-1] is not rows[-1]:
-        sampled.append(rows[-1])
-    return sampled
+    if max_points == 1:
+        return [rows[-1]]
+    # Evenly spaced indices across [0, span] with both ends included. The
+    # `+ slots // 2` is integer round-half-up: floats would be exact at these
+    # sizes, but integer arithmetic keeps the endpoint landing provable.
+    span = len(rows) - 1
+    slots = max_points - 1
+    return [rows[(index * span + slots // 2) // slots] for index in range(max_points)]

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -69,23 +69,64 @@ class TestDownsample:
     def test_long_capped(self):
         rows = [_row(i, 2.0) for i in range(10_000)]
         out = downsample(rows, max_points=200)
-        assert len(out) <= 210  # MAX_POINTS + endpoint pin tolerance
+        assert len(out) == 200  # hard cap, no endpoint-pin overshoot (#473)
         assert out[0] == rows[0]
         assert out[-1] == rows[-1]
 
     def test_default_cap(self):
         rows = [_row(i, 2.0) for i in range(MAX_PLOT_POINTS * 4)]
         out = downsample(rows)
-        assert len(out) <= MAX_PLOT_POINTS + 5
+        assert len(out) == MAX_PLOT_POINTS
 
-    def test_stride_lands_on_last_row_no_duplicate_pin(self):
-        # 5 rows, max_points=2 -> stride = 5 // 2 = 2, so rows[::2] already
-        # ends on index 4 (the last row); the endpoint pin must not append a
-        # second copy (branch 80->82 in replay.py).
+    def test_last_index_lands_on_last_row_no_duplicate(self):
+        # 5 rows, max_points=3 -> evenly spaced indices 0, 2, 4, so the final
+        # sample IS the last row and appears exactly once. Renamed from
+        # test_stride_lands_on_last_row_no_duplicate_pin (#470): the endpoint
+        # pin is gone, but this is still the only guard against an off-by-one
+        # in the index arithmetic.
         rows = [_row(i, 2.0) for i in range(5)]
-        out = downsample(rows, max_points=2)
+        out = downsample(rows, max_points=3)
         assert out == [rows[0], rows[2], rows[4]]
         assert out[-1] is rows[-1]
+
+    @pytest.mark.parametrize("total", [3, 5, 8, 13, 101, 1000])
+    @pytest.mark.parametrize("max_points", [1, 2, 3, 7, 50])
+    def test_never_returns_more_than_max_points(self, total, max_points):
+        # The docstring promises "at most max_points"; before #473 a 5-row
+        # series with max_points=2 came back with 3 rows.
+        rows = [_row(i, 2.0) for i in range(total)]
+        out = downsample(rows, max_points=max_points)
+        assert len(out) <= max_points
+
+    def test_one_row_over_the_cap_drops_exactly_one_row(self):
+        # A ceil-based stride would halve a series sitting a single row over
+        # the cap (101 rows, cap 100 -> 51 points). Even spacing keeps 100.
+        rows = [_row(i, 2.0) for i in range(101)]
+        out = downsample(rows, max_points=100)
+        assert len(out) == 100
+        assert out[0] is rows[0]
+        assert out[-1] is rows[-1]
+
+    def test_endpoints_survive_every_shape(self):
+        for total in range(3, 40):
+            for max_points in range(2, total):
+                rows = [_row(i, 2.0) for i in range(total)]
+                out = downsample(rows, max_points=max_points)
+                assert out[0]["step"] == 0, (total, max_points)
+                assert out[-1]["step"] == total - 1, (total, max_points)
+
+    def test_order_preserved_without_duplicates(self):
+        rows = [_row(i, 2.0) for i in range(97)]
+        out = downsample(rows, max_points=13)
+        steps = [row["step"] for row in out]
+        assert steps == sorted(steps)
+        assert len(set(steps)) == len(steps)
+
+    def test_max_points_one_keeps_the_final_row(self):
+        # Both endpoints cannot fit in a single slot; the final loss wins,
+        # which is exactly what the old endpoint pin existed to guarantee.
+        rows = [_row(i, 2.0) for i in range(5)]
+        assert downsample(rows, max_points=1) == [rows[-1]]
 
     def test_zero_max_rejected(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
## What does this PR do?

Closes #473.

`downsample` promised "at most `max_points` rows" and did not deliver: the stride was
`len(rows) // max_points`, which is a **divisor, not a cap**. Five rows with `max_points=2`
gave a stride of 2, so `rows[::2]` returned three rows, and in other shapes the endpoint pin
appended a fourth.

**The contract I picked is the hard cap**, not a docstring softening. `MAX_PLOT_POINTS` exists
so `soup runs replay` never hands the terminal renderer more points than it can draw; a bound
that the function is free to exceed is not a bound.

## How

Not a ceil-based stride. That caps correctly but has a cliff: a series one row over the cap
(2001 rows, cap 2000) collapses to 1001 points, because `ceil(2000/1999) = 2` — a 2x fidelity
loss for being one row too long.

Instead, `max_points` evenly spaced indices across `[0, len(rows) - 1]`, both ends included:

```python
span = len(rows) - 1
slots = max_points - 1
return [rows[(index * span + slots // 2) // slots] for index in range(max_points)]
```

- returns exactly `min(len(rows), max_points)` rows — the cap is now also the target
- both endpoints always present, so first and final loss stay on the chart
- indices are strictly increasing (`span > slots` when `len(rows) > max_points`), so the
  endpoint-pin branch is not "made to fit under the cap" — it is deleted, along with
  `_MIN_STEP_DELTA`, which the new arithmetic makes structurally unreachable
- integer round-half-up rather than floats, so "the last index lands exactly on `span`" is
  provable rather than a floating-point courtesy

`max_points=1` is the one shape where both endpoints cannot fit. It returns the final row —
making the final loss visible is exactly what the old pin existed for. Documented in the
docstring.

## On the #470 guard

`test_stride_lands_on_last_row_no_duplicate_pin` is **kept, not deleted**, per the issue. It
survives almost verbatim: at `max_points=3` over 5 rows the new arithmetic lands on 0, 2, 4, so
`out == [rows[0], rows[2], rows[4]]` still holds and still fails on an off-by-one in the index
formula. Renamed to `test_last_index_lands_on_last_row_no_duplicate`, since there is no stride
and no pin left for the old name to describe.

Two existing tests were tightened from tolerances that encoded the old sloppiness:
`test_long_capped` `<= 210` -> `== 200`, and `test_default_cap` `<= MAX_PLOT_POINTS + 5` ->
`== MAX_PLOT_POINTS`.

## New tests

- `test_never_returns_more_than_max_points` — 30-case sweep over shapes x caps; this is the
  bug from the issue, and it failed at `assert 3 <= 2` before the fix
- `test_one_row_over_the_cap_drops_exactly_one_row` — 101 rows / cap 100 stays at 100; this is
  the test that a ceil-based stride would fail (it returns 51)
- `test_endpoints_survive_every_shape` — every `(total, max_points)` pair for totals 3..39
- `test_order_preserved_without_duplicates` — strictly increasing, no repeats
- `test_max_points_one_keeps_the_final_row` — pins the degenerate case

Beyond the suite, the contract was verified by brute force over every `(n, k)` in
`1..259 x 1..259`: `len(out) == min(n, k)`, indices strictly increasing, last row always
present.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Tests

## Checklist

- [x] `ruff check src/soup_cli/ tests/` passes
- [x] `pytest tests/ -v` passes — 18048 passed, 377 skipped, coverage 81% (gate 77%)
- [x] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed — no
      docs page documents the plot-point cap; `CHANGELOG.md` has the entry
