### PR TITLE
fix(export): GPTQ requires calibration data, standard shard name, real ImportError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,21 @@ reproducing 70+ versions of notes.
   un-run one — `pending` is what a report keeps when the process dies mid-arm
   and no handler runs, which is the case the incremental write exists for.
 
+- **`soup export --format gptq` crashed with no calibration data and, when it
+  did run, wrote a shard name the standard loader can't find
+  (#338 by @MakazhanAlpamys in #PLACEHOLDER).** With no `--calibration-data`,
+  `_export_gptq` called `model.quantize(tokenizer)`; auto-gptq's `quantize()`
+  expects tokenized examples, not a bare tokenizer, so this failed with
+  "object is not iterable". GPTQ export now requires `--calibration-data`
+  up front and rejects a file with zero usable samples, since auto-gptq has
+  no built-in fallback dataset (unlike AWQ). Separately, `save_quantized`
+  writes its own `gptq_model-<bits>bit-<group>g.safetensors` shard, which
+  `AutoModelForCausalLM.from_pretrained` does not look for; the exported
+  directory now also carries a standard `model.safetensors`. The shared
+  `except ImportError` blocks on both the AWQ and GPTQ paths also stopped
+  reporting a fixed "not installed" string when the package itself imports
+  fine but a transitive import inside it fails for an unrelated reason.
+
 ## [0.73.3] - 2026-08-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,7 +189,7 @@ reproducing 70+ versions of notes.
 
 - **`soup export --format gptq` crashed with no calibration data and, when it
   did run, wrote a shard name the standard loader can't find
-  (#338 by @MakazhanAlpamys in #PLACEHOLDER).** With no `--calibration-data`,
+  (#338 by @MakazhanAlpamys in #475).** With no `--calibration-data`,
   `_export_gptq` called `model.quantize(tokenizer)`; auto-gptq's `quantize()`
   expects tokenized examples, not a bare tokenizer, so this failed with
   "object is not iterable". GPTQ export now requires `--calibration-data`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,7 +189,7 @@ reproducing 70+ versions of notes.
 
 - **`soup export --format gptq` crashed with no calibration data and, when it
   did run, wrote a shard name the standard loader can't find
-  (#338 by @MakazhanAlpamys in #475).** With no `--calibration-data`,
+  (#338 by @AmirF194 in #475).** With no `--calibration-data`,
   `_export_gptq` called `model.quantize(tokenizer)`; auto-gptq's `quantize()`
   expects tokenized examples, not a bare tokenizer, so this failed with
   "object is not iterable". GPTQ export now requires `--calibration-data`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -40,7 +40,7 @@ soup export --model ./output --deploy ollama  Export GGUF + auto-deploy to Ollam
 soup export --model ./output --format onnx    Export to ONNX
 soup export --model ./output --format tensorrt Export to TensorRT-LLM
 soup export --model ./output --format awq     Export to AWQ (4-bit)
-soup export --model ./output --format gptq    Export to GPTQ (4-bit)
+soup export --model ./output --format gptq --calibration-data cal.jsonl  Export to GPTQ (4-bit)
 soup deploy ollama --model m.gguf --name x    Deploy GGUF to Ollama
 soup deploy ollama --list                     List Soup-deployed models
 soup deploy ollama --remove <name>            Remove model from Ollama

--- a/src/soup_cli/commands/export.py
+++ b/src/soup_cli/commands/export.py
@@ -96,7 +96,7 @@ def export(
     calibration_data: Optional[str] = typer.Option(
         None,
         "--calibration-data",
-        help="Path to calibration JSONL for AWQ/GPTQ (default: use built-in sample)",
+        help="Path to calibration JSONL. Required for GPTQ; optional for AWQ.",
     ),
     calibration_samples: int = typer.Option(
         128,
@@ -867,6 +867,16 @@ def _load_calibration_texts(cal_path: Optional[Path], max_samples: int = 128) ->
     return texts
 
 
+def _standardize_gptq_shard_name(output_path: Path, bits: int, group_size: int) -> None:
+    """auto_gptq's save_quantized names its shard gptq_model-<bits>bit-<group>g.safetensors,
+    a name AutoModelForCausalLM.from_pretrained does not look for; rename it to the
+    standard model.safetensors so the exported directory reloads."""
+    shard = output_path / f"gptq_model-{bits}bit-{group_size}g.safetensors"
+    standard = output_path / "model.safetensors"
+    if shard.exists() and not standard.exists():
+        shard.rename(standard)
+
+
 def _export_awq(
     model_path: Path,
     output: Optional[str],
@@ -894,7 +904,10 @@ def _export_awq(
 
     try:
         from awq import AutoAWQForCausalLM
-    except ImportError:
+    except ImportError as exc:
+        if exc.name != "awq":
+            console.print(f"[red]autoawq import failed:[/] {exc}")
+            raise typer.Exit(1)
         console.print(
             "[red]autoawq not installed.[/]\n"
             "Install with: [bold]pip install \"soup-cli\\[awq]\"[/]\n"
@@ -1023,10 +1036,24 @@ def _export_gptq(
 
     # Validate calibration path (security: path traversal protection)
     cal_path = _validate_calibration_path(calibration_data)
+    if cal_path is None:
+        console.print(
+            "[red]GPTQ export requires --calibration-data.[/]\n"
+            "Unlike --format awq, auto-gptq has no built-in fallback dataset: "
+            "pass a calibration JSONL, e.g. [bold]--calibration-data path/to/data.jsonl[/]."
+        )
+        raise typer.Exit(1)
+    calib_texts = _load_calibration_texts(cal_path, max_samples=calibration_samples)
+    if not calib_texts:
+        console.print(f"[red]No usable calibration samples found in {cal_path}.[/]")
+        raise typer.Exit(1)
 
     try:
         from auto_gptq import AutoGPTQForCausalLM, BaseQuantizeConfig
-    except ImportError:
+    except ImportError as exc:
+        if exc.name != "auto_gptq":
+            console.print(f"[red]auto-gptq import failed:[/] {exc}")
+            raise typer.Exit(1)
         console.print(
             "[red]auto-gptq not installed.[/]\n"
             "Install with: [bold]pip install \"soup-cli\\[gptq]\"[/]\n"
@@ -1100,23 +1127,15 @@ def _export_gptq(
         )
         tokenizer = AutoTokenizer.from_pretrained(str(source_path), trust_remote_code=trc_tok)
 
-        # Load calibration data if provided
-        calib_data = None
-        if cal_path:
-            texts = _load_calibration_texts(
-                cal_path, max_samples=calibration_samples,
-            )
-            calib_data = [tokenizer(t, return_tensors="pt") for t in texts]
+        calib_data = [tokenizer(t, return_tensors="pt") for t in calib_texts]
 
         console.print(f"[dim]Quantizing to GPTQ {bits}-bit (group_size={group_size})...[/]")
-        if calib_data:
-            model.quantize(calib_data)
-        else:
-            model.quantize(tokenizer)
+        model.quantize(calib_data)
 
         console.print("[dim]Saving quantized model...[/]")
         model.save_quantized(str(output_path))
         tokenizer.save_pretrained(str(output_path))
+        _standardize_gptq_shard_name(output_path, bits, group_size)
 
     except Exception as exc:
         console.print(f"[red]GPTQ export failed:[/] {exc}")

--- a/tests/test_awq_gptq_export.py
+++ b/tests/test_awq_gptq_export.py
@@ -282,6 +282,15 @@ class TestGptqExportFunction:
         cal_file = tmp_path / "cal.jsonl"
         cal_file.write_text('{"text": "sample"}\n', encoding="utf-8")
 
+        real_import = builtins.__import__
+
+        def custom_import(name, *args, **kwargs):
+            if name == "auto_gptq":
+                raise ModuleNotFoundError("No module named 'auto_gptq'", name="auto_gptq")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", custom_import)
+
         runner = CliRunner()
         result = runner.invoke(
             app,
@@ -293,7 +302,7 @@ class TestGptqExportFunction:
         assert result.exit_code != 0
         assert "auto-gptq" in result.output.lower() or "not installed" in result.output.lower()
 
-    def test_export_gptq_no_calibration_data_raises(self, tmp_path):
+    def test_export_gptq_no_calibration_data_raises(self, tmp_path, capsys):
         """GPTQ has no built-in fallback dataset: no --calibration-data must raise,
         never fall through to model.quantize(tokenizer) (auto-gptq expects examples,
         not a tokenizer, and rejects one with 'object is not iterable')."""
@@ -316,6 +325,7 @@ class TestGptqExportFunction:
                     calibration_data=None,
                 )
         mock_gptq_class.from_pretrained.assert_not_called()
+        assert "--calibration-data" in capsys.readouterr().out
 
     def test_export_gptq_empty_calibration_file_raises(self, tmp_path):
         """A --calibration-data file that yields zero usable samples (empty,
@@ -612,17 +622,25 @@ class TestAwqGptqImportErrorSurfacesRealCause:
         cal_file = tmp_path / "cal.jsonl"
         cal_file.write_text('{"text": "sample"}\n', encoding="utf-8")
 
+        real_import = builtins.__import__
+
+        def custom_import(name, *args, **kwargs):
+            if name == "auto_gptq":
+                raise ModuleNotFoundError("No module named 'auto_gptq'", name="auto_gptq")
+            return real_import(name, *args, **kwargs)
+
         import soup_cli.commands.export as export_mod
 
-        with mock_patch(
-            "soup_cli.commands.export._validate_calibration_path",
-            return_value=cal_file,
-        ):
-            with pytest.raises(ClickExit):
-                export_mod._export_gptq(
-                    model_dir, None, None, bits=4, group_size=128,
-                    calibration_data=str(cal_file),
-                )
+        with mock_patch.object(builtins, "__import__", side_effect=custom_import):
+            with mock_patch(
+                "soup_cli.commands.export._validate_calibration_path",
+                return_value=cal_file,
+            ):
+                with pytest.raises(ClickExit):
+                    export_mod._export_gptq(
+                        model_dir, None, None, bits=4, group_size=128,
+                        calibration_data=str(cal_file),
+                    )
         output = capsys.readouterr().out
         assert "not installed" in output.lower()
 

--- a/tests/test_awq_gptq_export.py
+++ b/tests/test_awq_gptq_export.py
@@ -270,26 +270,89 @@ class TestAwqExportFunction:
 class TestGptqExportFunction:
     """Test _export_gptq logic."""
 
-    def test_export_gptq_import_error(self, tmp_path):
+    def test_export_gptq_import_error(self, tmp_path, monkeypatch):
         """GPTQ export should print friendly error when auto-gptq not installed."""
         from typer.testing import CliRunner
 
         from soup_cli.cli import app
 
+        monkeypatch.chdir(tmp_path)
         model_dir = tmp_path / "model"
         model_dir.mkdir()
+        cal_file = tmp_path / "cal.jsonl"
+        cal_file.write_text('{"text": "sample"}\n', encoding="utf-8")
 
         runner = CliRunner()
         result = runner.invoke(
-            app, ["export", "--model", str(model_dir), "--format", "gptq"]
+            app,
+            [
+                "export", "--model", str(model_dir), "--format", "gptq",
+                "--calibration-data", str(cal_file),
+            ],
         )
         assert result.exit_code != 0
         assert "auto-gptq" in result.output.lower() or "not installed" in result.output.lower()
+
+    def test_export_gptq_no_calibration_data_raises(self, tmp_path):
+        """GPTQ has no built-in fallback dataset: no --calibration-data must raise,
+        never fall through to model.quantize(tokenizer) (auto-gptq expects examples,
+        not a tokenizer, and rejects one with 'object is not iterable')."""
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+
+        mock_gptq_class = MagicMock()
+        gptq_mod = MagicMock()
+        gptq_mod.AutoGPTQForCausalLM = mock_gptq_class
+        gptq_mod.BaseQuantizeConfig = MagicMock
+
+        import soup_cli.commands.export as export_mod
+
+        with mock_patch.object(
+            builtins, "__import__", side_effect=_mock_import(gptq_mock=gptq_mod)
+        ):
+            with pytest.raises(ClickExit):
+                export_mod._export_gptq(
+                    model_dir, None, None, bits=4, group_size=128,
+                    calibration_data=None,
+                )
+        mock_gptq_class.from_pretrained.assert_not_called()
+
+    def test_export_gptq_empty_calibration_file_raises(self, tmp_path):
+        """A --calibration-data file that yields zero usable samples (empty,
+        or only malformed JSON lines) must raise the same way as no file at
+        all, before the model is ever loaded."""
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        cal_file = tmp_path / "cal.jsonl"
+        cal_file.write_text("\n\nnot json\n", encoding="utf-8")
+
+        mock_gptq_class = MagicMock()
+        gptq_mod = MagicMock()
+        gptq_mod.AutoGPTQForCausalLM = mock_gptq_class
+        gptq_mod.BaseQuantizeConfig = MagicMock
+
+        import soup_cli.commands.export as export_mod
+
+        with mock_patch.object(
+            builtins, "__import__", side_effect=_mock_import(gptq_mock=gptq_mod)
+        ):
+            with mock_patch(
+                "soup_cli.commands.export._validate_calibration_path",
+                return_value=cal_file,
+            ):
+                with pytest.raises(ClickExit):
+                    export_mod._export_gptq(
+                        model_dir, None, None, bits=4, group_size=128,
+                        calibration_data=str(cal_file),
+                    )
+        mock_gptq_class.from_pretrained.assert_not_called()
 
     def test_export_gptq_calls_quantize(self, tmp_path):
         """GPTQ export should call AutoGPTQForCausalLM methods."""
         model_dir = tmp_path / "model"
         model_dir.mkdir()
+        cal_file = tmp_path / "cal.jsonl"
+        cal_file.write_text('{"text": "sample"}\n', encoding="utf-8")
 
         mock_model = MagicMock()
         mock_gptq_class = MagicMock()
@@ -303,6 +366,7 @@ class TestGptqExportFunction:
         import soup_cli.commands.export as export_mod
 
         out_path = tmp_path / "out"
+        out_path.mkdir()
         with mock_patch.object(
             builtins, "__import__", side_effect=_mock_import(gptq_mock=gptq_mod)
         ):
@@ -314,18 +378,24 @@ class TestGptqExportFunction:
                     "soup_cli.commands.export._validate_output_path",
                     return_value=out_path,
                 ):
-                    export_mod._export_gptq(
-                        model_dir, str(out_path), None,
-                        bits=4, group_size=128, calibration_data=None,
-                    )
-                    mock_gptq_class.from_pretrained.assert_called_once()
-                    mock_model.quantize.assert_called_once()
-                    mock_model.save_quantized.assert_called_once()
+                    with mock_patch(
+                        "soup_cli.commands.export._validate_calibration_path",
+                        return_value=cal_file,
+                    ):
+                        export_mod._export_gptq(
+                            model_dir, str(out_path), None,
+                            bits=4, group_size=128, calibration_data=str(cal_file),
+                        )
+                        mock_gptq_class.from_pretrained.assert_called_once()
+                        mock_model.quantize.assert_called_once()
+                        mock_model.save_quantized.assert_called_once()
 
     def test_export_gptq_default_output_path(self, tmp_path):
         """Default GPTQ output path should be model_name + _gptq suffix."""
         model_dir = tmp_path / "my_model"
         model_dir.mkdir()
+        cal_file = tmp_path / "cal.jsonl"
+        cal_file.write_text('{"text": "sample"}\n', encoding="utf-8")
 
         mock_model = MagicMock()
         mock_gptq_class = MagicMock()
@@ -345,13 +415,17 @@ class TestGptqExportFunction:
                 "transformers.AutoTokenizer.from_pretrained",
                 return_value=mock_tokenizer,
             ):
-                export_mod._export_gptq(
-                    model_dir, None, None, bits=4, group_size=128,
-                    calibration_data=None,
-                )
-                save_call = mock_model.save_quantized.call_args
-                output_path = save_call[0][0]
-                assert "my_model_gptq" in output_path
+                with mock_patch(
+                    "soup_cli.commands.export._validate_calibration_path",
+                    return_value=cal_file,
+                ):
+                    export_mod._export_gptq(
+                        model_dir, None, None, bits=4, group_size=128,
+                        calibration_data=str(cal_file),
+                    )
+                    save_call = mock_model.save_quantized.call_args
+                    output_path = save_call[0][0]
+                    assert "my_model_gptq" in output_path
 
     def test_export_gptq_invalid_bits(self, tmp_path):
         """Invalid bits value should raise ClickExit."""
@@ -378,6 +452,179 @@ class TestGptqExportFunction:
                 model_dir, None, None, bits=4, group_size=128,
                 calibration_data=str(Path("C:/Windows/System32/drivers/etc/hosts")),
             )
+
+
+# ─── GPTQ Shard Name Regression (issue #338, P2) ─────────────────────────
+
+
+class TestGptqStandardShardName:
+    """auto_gptq's save_quantized names its shard gptq_model-<bits>bit-<group>g.safetensors,
+    which AutoModelForCausalLM.from_pretrained does not look for."""
+
+    def test_standardize_renames_shard_to_model_safetensors(self, tmp_path):
+        from soup_cli.commands.export import _standardize_gptq_shard_name
+
+        out = tmp_path / "out"
+        out.mkdir()
+        (out / "gptq_model-4bit-128g.safetensors").write_bytes(b"weights")
+
+        _standardize_gptq_shard_name(out, bits=4, group_size=128)
+
+        assert (out / "model.safetensors").exists()
+        assert not (out / "gptq_model-4bit-128g.safetensors").exists()
+
+    def test_standardize_does_not_overwrite_existing_standard_name(self, tmp_path):
+        from soup_cli.commands.export import _standardize_gptq_shard_name
+
+        out = tmp_path / "out"
+        out.mkdir()
+        (out / "model.safetensors").write_bytes(b"already-standard")
+        (out / "gptq_model-4bit-128g.safetensors").write_bytes(b"weights")
+
+        _standardize_gptq_shard_name(out, bits=4, group_size=128)
+
+        assert (out / "model.safetensors").read_bytes() == b"already-standard"
+
+    def test_standardize_no_op_when_shard_absent(self, tmp_path):
+        from soup_cli.commands.export import _standardize_gptq_shard_name
+
+        out = tmp_path / "out"
+        out.mkdir()
+
+        _standardize_gptq_shard_name(out, bits=4, group_size=128)
+
+        assert not (out / "model.safetensors").exists()
+
+    def test_export_gptq_end_to_end_leaves_standard_name(self, tmp_path):
+        """Full _export_gptq run: save_quantized's mock writes the real auto_gptq
+        shard name, and the standard model.safetensors must exist afterward."""
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        cal_file = tmp_path / "cal.jsonl"
+        cal_file.write_text('{"text": "sample"}\n', encoding="utf-8")
+        out_path = tmp_path / "out"
+        out_path.mkdir()
+
+        def fake_save_quantized(path):
+            Path(path, "gptq_model-4bit-128g.safetensors").write_bytes(b"weights")
+
+        mock_model = MagicMock()
+        mock_model.save_quantized.side_effect = fake_save_quantized
+        mock_gptq_class = MagicMock()
+        mock_gptq_class.from_pretrained = MagicMock(return_value=mock_model)
+        mock_tokenizer = MagicMock()
+
+        gptq_mod = MagicMock()
+        gptq_mod.AutoGPTQForCausalLM = mock_gptq_class
+        gptq_mod.BaseQuantizeConfig = MagicMock
+
+        import soup_cli.commands.export as export_mod
+
+        with mock_patch.object(
+            builtins, "__import__", side_effect=_mock_import(gptq_mock=gptq_mod)
+        ):
+            with mock_patch(
+                "transformers.AutoTokenizer.from_pretrained",
+                return_value=mock_tokenizer,
+            ):
+                with mock_patch(
+                    "soup_cli.commands.export._validate_output_path",
+                    return_value=out_path,
+                ):
+                    with mock_patch(
+                        "soup_cli.commands.export._validate_calibration_path",
+                        return_value=cal_file,
+                    ):
+                        export_mod._export_gptq(
+                            model_dir, str(out_path), None,
+                            bits=4, group_size=128, calibration_data=str(cal_file),
+                        )
+
+        assert (out_path / "model.safetensors").exists()
+        assert not (out_path / "gptq_model-4bit-128g.safetensors").exists()
+
+
+# ─── Import-Error Masking Regression (issue #338, ImportError swallowing) ──
+
+
+class TestAwqGptqImportErrorSurfacesRealCause:
+    """except ImportError must not print a fixed 'not installed' string when the
+    package itself imports but a transitive import inside it fails for an
+    unrelated reason, which used to discard the real exception."""
+
+    def test_gptq_transitive_import_failure_message(self, tmp_path, capsys):
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        cal_file = tmp_path / "cal.jsonl"
+        cal_file.write_text('{"text": "sample"}\n', encoding="utf-8")
+
+        real_import = builtins.__import__
+
+        def custom_import(name, *args, **kwargs):
+            if name == "auto_gptq":
+                raise ImportError("libfoo.so: cannot open shared object file", name="libfoo")
+            return real_import(name, *args, **kwargs)
+
+        import soup_cli.commands.export as export_mod
+
+        with mock_patch.object(builtins, "__import__", side_effect=custom_import):
+            with mock_patch(
+                "soup_cli.commands.export._validate_calibration_path",
+                return_value=cal_file,
+            ):
+                with pytest.raises(ClickExit):
+                    export_mod._export_gptq(
+                        model_dir, None, None, bits=4, group_size=128,
+                        calibration_data=str(cal_file),
+                    )
+        output = capsys.readouterr().out
+        assert "libfoo.so" in output
+        assert "not installed" not in output.lower()
+
+    def test_awq_transitive_import_failure_message(self, tmp_path, capsys):
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+
+        real_import = builtins.__import__
+
+        def custom_import(name, *args, **kwargs):
+            if name == "awq":
+                raise ImportError("libbar.so: cannot open shared object file", name="libbar")
+            return real_import(name, *args, **kwargs)
+
+        import soup_cli.commands.export as export_mod
+
+        with mock_patch.object(builtins, "__import__", side_effect=custom_import):
+            with pytest.raises(ClickExit):
+                export_mod._export_awq(
+                    model_dir, None, None, bits=4, group_size=128,
+                    calibration_data=None,
+                )
+        output = capsys.readouterr().out
+        assert "libbar.so" in output
+        assert "not installed" not in output.lower()
+
+    def test_gptq_real_missing_package_still_shows_install_hint(self, tmp_path, capsys):
+        """When auto-gptq is genuinely absent (exc.name == 'auto_gptq'), the
+        friendly install hint must still show; this must not regress."""
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        cal_file = tmp_path / "cal.jsonl"
+        cal_file.write_text('{"text": "sample"}\n', encoding="utf-8")
+
+        import soup_cli.commands.export as export_mod
+
+        with mock_patch(
+            "soup_cli.commands.export._validate_calibration_path",
+            return_value=cal_file,
+        ):
+            with pytest.raises(ClickExit):
+                export_mod._export_gptq(
+                    model_dir, None, None, bits=4, group_size=128,
+                    calibration_data=str(cal_file),
+                )
+        output = capsys.readouterr().out
+        assert "not installed" in output.lower()
 
 
 # ─── CLI Integration Tests ───────────────────────────────────────────────


### PR DESCRIPTION
Refs #338. Covers the two GPTQ code bugs (P1, P2) plus the shared except-ImportError fix; whether `soup-cli[train,awq]` can ever resolve together is a packaging policy call and is left open, per the issue's own acceptance criteria.

## Root cause

- **P1:** with no `--calibration-data`, `_export_gptq` called `model.quantize(tokenizer)`. auto-gptq's `quantize()` expects tokenized examples (`List[Dict[str, torch.LongTensor]]`), not a bare tokenizer, and rejects one with `'Qwen2TokenizerFast' object is not iterable` (the issue's own traceback). Unlike `--format awq`, auto-gptq has no built-in fallback dataset, so GPTQ export now requires `--calibration-data` up front and rejects a file that yields zero usable samples.
- **P2:** `save_quantized` writes its own `gptq_model-<bits>bit-<group>g.safetensors` shard name, which `AutoModelForCausalLM.from_pretrained` does not look for. The exported directory now also carries a standard `model.safetensors` (a rename, since the weights themselves are fine per the issue).
- Both the AWQ and GPTQ `except ImportError` blocks printed a fixed "not installed" string even when the package imports but a transitive import inside it raised `ImportError` for an unrelated reason, discarding the real exception. They now check `exc.name` and surface the real cause when it does not match the package itself.

## Verification

- No auto-gptq/autoawq wheel installs on this box (matches the issue's own finding), so the fix is verified with a synthetic `auto_gptq`/`awq` module injected via `builtins.__import__`, mirroring this repo's own established pattern in `test_awq_gptq_export.py` (`_mock_import`). 8 new/updated tests; each pinned regression fails on `main` and passes on this branch (checked directly, stashing just the source change).
- Every changed line in `export.py` is covered (`--cov=soup_cli.commands.export --cov-report=term-missing`).
- Full file suite (49 tests) plus `ruff check` run clean on Python 3.10, 3.11 and 3.12 (the whole CI matrix), each in a fresh `python:X-slim` container with `pip install -e .` + `transformers` (no `torch`, since nothing here touches the GPTQ/AWQ model classes themselves).
- Not verified: an actual GPTQ quantization run (no installable auto-gptq here, same constraint the issue reports), and the `[train]`+`[awq]` pip conflict.
