### PR TITLE
feat(trainer): extend LISA to continued pre-training (#307)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,21 @@ reproducing 70+ versions of notes.
 
 ### Added
 
+- **LISA now accepts `task: pretrain`, not `sft` alone (#307 by @ousamabenyounes in #476).**
+  Continued pre-training is the same full-fine-tune-of-a-rotating-set-of-decoder-layers
+  mechanism LISA was built for, so the sft-only gate (inherited from Spectrum's
+  `unfrozen_parameters`) was arbitrary. The schema task gate now reads a
+  `_LISA_SUPPORTED_TASKS` allow-list (`sft`, `pretrain`) and its refusal names every
+  accepted task instead of only rejecting yours; `trainer/pretrain.py` replaces its LoRA
+  path with LISA and attaches `LisaCallback`, and reports its parameter summary as `LISA`
+  counted off the raw parameters, since a LISA run has no `PeftModel` wrapper to ask
+  `get_nb_trainable_parameters`. Both trainers route through one
+  `peft_wiring.apply_lisa_setup`, so they cannot drift on what "LISA is on" means. The
+  rest of the gate is unchanged: `transformers` + `text` + `quantization: none`, mutually
+  exclusive with the LoRA feature flags, `freeze_layers`/`freeze_ratio` and
+  `unfrozen_parameters`. The released `[0.71.34]` block below still says `task: sft`,
+  which is what 0.71.34 shipped.
+
 - **`soup eval aider` runs Aider's Polyglot code-editing benchmark through its
   official Docker harness (#91 by @Amix29 in #482).** The command preflights
   Docker, the daemon, and the locally built benchmark image; mounts a prepared
@@ -105,7 +120,6 @@ reproducing 70+ versions of notes.
   `BUNDLED_SCORER_REVISION` + a locked fingerprint fail the suite if a bundled
   scorer's output moves without a revision bump. Registry `save_eval_result`
   stamps `details_json`; `soup ship --emit-evidence` includes the same stamp.
-
 - **Layer streaming now accepts Qwen3.5 MoE text checkpoints whose decoder
   layers do not expose exactly the same weight keys in every block (by
   @Shutaru in #426).** The sharder now records per-layer shard headers instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,21 +25,6 @@ reproducing 70+ versions of notes.
 
 ### Added
 
-- **LISA now accepts `task: pretrain`, not `sft` alone (#307 by @ousamabenyounes in #476).**
-  Continued pre-training is the same full-fine-tune-of-a-rotating-set-of-decoder-layers
-  mechanism LISA was built for, so the sft-only gate (inherited from Spectrum's
-  `unfrozen_parameters`) was arbitrary. The schema task gate now reads a
-  `_LISA_SUPPORTED_TASKS` allow-list (`sft`, `pretrain`) and its refusal names every
-  accepted task instead of only rejecting yours; `trainer/pretrain.py` replaces its LoRA
-  path with LISA and attaches `LisaCallback`, and reports its parameter summary as `LISA`
-  counted off the raw parameters, since a LISA run has no `PeftModel` wrapper to ask
-  `get_nb_trainable_parameters`. Both trainers route through one
-  `peft_wiring.apply_lisa_setup`, so they cannot drift on what "LISA is on" means. The
-  rest of the gate is unchanged: `transformers` + `text` + `quantization: none`, mutually
-  exclusive with the LoRA feature flags, `freeze_layers`/`freeze_ratio` and
-  `unfrozen_parameters`. The released `[0.71.34]` block below still says `task: sft`,
-  which is what 0.71.34 shipped.
-
 - **`soup eval aider` runs Aider's Polyglot code-editing benchmark through its
   official Docker harness (#91 by @Amix29 in #482).** The command preflights
   Docker, the daemon, and the locally built benchmark image; mounts a prepared
@@ -120,6 +105,7 @@ reproducing 70+ versions of notes.
   `BUNDLED_SCORER_REVISION` + a locked fingerprint fail the suite if a bundled
   scorer's output moves without a revision bump. Registry `save_eval_result`
   stamps `details_json`; `soup ship --emit-evidence` includes the same stamp.
+
 - **Layer streaming now accepts Qwen3.5 MoE text checkpoints whose decoder
   layers do not expose exactly the same weight keys in every block (by
   @Shutaru in #426).** The sharder now records per-layer shard headers instead of

--- a/changelog.d/0.73.3/476.added.md
+++ b/changelog.d/0.73.3/476.added.md
@@ -1,0 +1,14 @@
+- **LISA now accepts `task: pretrain`, not `sft` alone (#307 by @ousamabenyounes in #476).**
+  Continued pre-training is the same full-fine-tune-of-a-rotating-set-of-decoder-layers
+  mechanism LISA was built for, so the sft-only gate (inherited from Spectrum's
+  `unfrozen_parameters`) was arbitrary. The schema task gate now reads a
+  `_LISA_SUPPORTED_TASKS` allow-list (`sft`, `pretrain`) and its refusal names every
+  accepted task instead of only rejecting yours; `trainer/pretrain.py` replaces its LoRA
+  path with LISA and attaches `LisaCallback`, and reports its parameter summary as `LISA`
+  counted off the raw parameters, since a LISA run has no `PeftModel` wrapper to ask
+  `get_nb_trainable_parameters`. Both trainers route through one
+  `peft_wiring.apply_lisa_setup`, so they cannot drift on what "LISA is on" means. The
+  rest of the gate is unchanged: `transformers` + `text` + `quantization: none`, mutually
+  exclusive with the LoRA feature flags, `freeze_layers`/`freeze_ratio` and
+  `unfrozen_parameters`. The released `[0.71.34]` block still says `task: sft`, which is
+  what 0.71.34 shipped.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -33,7 +33,7 @@ soup merge --adapter ./output --save-format 4bit --no-double-quant  Save a BNB-4
 soup merge-sharded-fsdp-weights ./shards -o merged.safetensors  Consolidate FSDP shards into one safetensors (v0.71.14; --plan-only previews)
 soup delinearize-llama4 ./src --target ./out [--num-experts N] [--plan-only]  Live Llama-4 fused-expert reshape [E*din,dout] -> [E,din,dout] + sidecar copy (v0.71.21)
 soup spectrum scan --model <id|path> --top-percent 50 [--modules mlp,attn] [-o patch.yaml]  Spectrum SNR scan (no model load) -> training.unfrozen_parameters YAML patch (v0.71.23)
-soup train --config sft.yaml  # training.lisa_enabled: true [lisa_num_layers lisa_interval_steps]  LISA layerwise importance sampling — full-FT quality at LoRA-like memory (sft/transformers/text/quantization=none) (v0.71.34)
+soup train --config sft.yaml  # training.lisa_enabled: true [lisa_num_layers lisa_interval_steps]  LISA layerwise importance sampling — full-FT quality at LoRA-like memory (sft or pretrain/transformers/text/quantization=none) (v0.71.34, pretrain #307)
 soup train --config sft.yaml  # training.stream_layers: true [stream_source stream_buffers]  BETA layer streaming — the frozen base streams from CPU RAM/NVMe one decoder layer at a time, so peak VRAM is bounded by ONE layer; quantization: 4bit streams it as NF4, ~4x smaller (sft/dpo/orpo/simpo/kto on transformers+text, 9 archs; grpo/ppo permanently excluded) (v0.72.0; NF4 v0.72.2; disk+batch+accum v0.72.3; preference losses v0.72.4)
 soup export --model ./output --format gguf    Export to GGUF (Ollama)
 soup export --model ./output --deploy ollama  Export GGUF + auto-deploy to Ollama

--- a/docs/peft-and-efficiency.md
+++ b/docs/peft-and-efficiency.md
@@ -391,7 +391,8 @@ Works with and without LoRA. When used with LoRA, LoRA is applied only to unfroz
 LISA (Layerwise Importance Sampled AdamW, [arXiv:2403.17919](https://arxiv.org/abs/2403.17919)) targets full-fine-tuning quality at LoRA-like memory. **Measured at 7B+, it delivers the first half and not the second** — see [what it actually costs](#what-lisa-actually-costs-measured-at-3b-and-8b) below before choosing it over LoRA. Instead of picking layers once (that's Spectrum's static `unfrozen_parameters`), LISA re-samples a small random set of decoder layers **every N steps** and freezes the rest; the input embeddings, the LM head, and the final norm stay trainable throughout.
 
 ```yaml
-task: sft
+task: sft                 # or `pretrain` — continued pre-training is the same
+                          # full-FT-of-active-layers mechanism (#307)
 backend: transformers
 modality: text
 training:
@@ -401,7 +402,7 @@ training:
   lisa_interval_steps: 20  # re-sample cadence, in global steps
 ```
 
-Because only a handful of layers train at any moment (and their optimizer state is cleared when they're re-frozen), peak optimizer memory is roughly `embeddings + head + lisa_num_layers` — far below a full fine-tune, while every layer still gets updated over the course of training. LISA is `sft` + `transformers` + `text` + `quantization: none` only, and is mutually exclusive with LoRA features, `freeze_layers`/`freeze_ratio`, and Spectrum's `unfrozen_parameters` (each independently decides what trains).
+Because only a handful of layers train at any moment (and their optimizer state is cleared when they're re-frozen), peak optimizer memory is roughly `embeddings + head + lisa_num_layers` — far below a full fine-tune, while every layer still gets updated over the course of training. LISA is `sft` or `pretrain` + `transformers` + `text` + `quantization: none` only, and is mutually exclusive with LoRA features, `freeze_layers`/`freeze_ratio`, and Spectrum's `unfrozen_parameters` (each independently decides what trains).
 
 ### What LISA actually costs, measured at 3B and 8B
 

--- a/src/soup_cli/config/schema.py
+++ b/src/soup_cli/config/schema.py
@@ -40,6 +40,13 @@ _MAX_UNFROZEN_PATTERN_LEN = 512
 # pattern *class* is rejected at parse time, not just compile failures.
 _UNFROZEN_REDOS_RE = re.compile(r"\([^)]*[+*][^)]*\)\s*[+*]")
 
+# v0.71.34 #267 / #307 — tasks whose transformers trainer wires LisaCallback.
+# LISA is full-FT of a rotating set of decoder layers, so a task only belongs
+# here once its trainer skips PEFT, keeps the model trainable, and calls
+# ``attach_lisa_callback``. Adding a task to this tuple without that wiring
+# would accept a config the trainer silently ignores.
+_LISA_SUPPORTED_TASKS = ("sft", "pretrain")
+
 
 class LoraConfig(BaseModel):
     # #340 — `r: 0` is the first-class full-fine-tuning switch: no
@@ -3017,9 +3024,9 @@ class TrainingConfig(BaseModel):
             "Enable LISA layerwise importance sampling (#267): every "
             "lisa_interval_steps, freeze all decoder layers except a random "
             "lisa_num_layers set (embeddings + head always trainable). Full "
-            "fine-tuning, LoRA off. sft + transformers + text + "
+            "fine-tuning, LoRA off. sft or pretrain + transformers + text + "
             "quantization=none only; mutually exclusive with LoRA features / "
-            "freeze_layers / unfrozen_parameters."
+            "freeze_layers / freeze_ratio / unfrozen_parameters."
         ),
     )
     lisa_num_layers: int = Field(
@@ -4799,9 +4806,13 @@ class SoupConfig(BaseModel):
         """v0.71.34 #267 — LISA compatibility gates.
 
         LISA is full-FT of a rotating set of decoder layers (LoRA off), so it
-        shares Spectrum's ``unfrozen_parameters`` gate: sft + transformers +
-        text + quantization=none, mutually exclusive with the LoRA feature
-        flags, the other freeze mechanisms, and ``unfrozen_parameters`` itself.
+        shares Spectrum's ``unfrozen_parameters`` gate: transformers + text +
+        quantization=none, mutually exclusive with the LoRA feature flags, the
+        other freeze mechanisms, and ``unfrozen_parameters`` itself.
+
+        #307 — the task gate is ``_LISA_SUPPORTED_TASKS`` rather than ``sft``
+        alone: continued pre-training is the same full-FT-of-active-layers
+        mechanism, and ``trainer/pretrain.py`` wires the callback the same way.
         """
         tcfg = self.training
         if not tcfg.lisa_enabled:
@@ -4817,10 +4828,12 @@ class SoupConfig(BaseModel):
                     "lisa_enabled=true to use LISA layer sampling."
                 )
             return self
-        if self.task != "sft":
+        if self.task not in _LISA_SUPPORTED_TASKS:
             raise ValueError(
                 f"training.lisa_enabled (LISA layerwise sampling) requires "
-                f"task='sft'; got task={self.task!r}"
+                f"task in "
+                f"{', '.join(repr(t) for t in _LISA_SUPPORTED_TASKS)}; "
+                f"got task={self.task!r}"
             )
         if self.backend != "transformers":
             raise ValueError(
@@ -4830,7 +4843,7 @@ class SoupConfig(BaseModel):
         if self.modality != "text":
             raise ValueError(
                 f"training.lisa_enabled requires modality='text' (the LISA "
-                f"callback is wired in the text SFT trainer); "
+                f"callback is wired in the text SFT and pretrain trainers); "
                 f"got modality={self.modality!r}"
             )
         if tcfg.quantization != "none":

--- a/src/soup_cli/trainer/pretrain.py
+++ b/src/soup_cli/trainer/pretrain.py
@@ -85,10 +85,24 @@ class PretrainTrainerWrapper:
         else:
             self._setup_transformers(cfg, tcfg)
 
-        trainable, total = self.model.get_nb_trainable_parameters()
+        # #307 — a LISA run has no PEFT wrapper, so `get_nb_trainable_parameters`
+        # (a PeftModel method) is absent and the count comes straight off the
+        # parameters. The label follows the same split: reporting "LoRA applied"
+        # for a run that applied no adapter is the docs-contradict-code defect.
+        if tcfg.lisa_enabled:
+            trainable = sum(
+                param.numel()
+                for param in self.model.parameters()
+                if param.requires_grad
+            )
+            total = sum(param.numel() for param in self.model.parameters())
+            label = "LISA"
+        else:
+            trainable, total = self.model.get_nb_trainable_parameters()
+            label = "LoRA applied"
         pct = 100 * trainable / total
         console.print(
-            f"[green]LoRA applied:[/] {trainable:,} trainable"
+            f"[green]{label}:[/] {trainable:,} trainable"
             f" / {total:,} total ({pct:.2f}%)"
         )
 
@@ -249,10 +263,13 @@ class PretrainTrainerWrapper:
         # v0.40.6 #67 — ReLoRA callback (magnitude-prune LoRA every N steps).
         from soup_cli.utils.peft_wiring import (
             attach_curriculum_callback,
+            attach_lisa_callback,
             attach_plugin_callback,
             attach_relora_callback,
         )
         attach_relora_callback(self.trainer, tcfg)
+        # #307 — LISA layerwise importance sampling (v0.71.34 #267 for sft).
+        attach_lisa_callback(self.trainer, tcfg)
         # v0.53.5 #114/#115 — dynamic curriculum live callback.
         attach_curriculum_callback(self.trainer, tcfg, str(output_dir), console)
         # v0.53.6 #101 — Soup plugin TrainerCallback.
@@ -314,37 +331,42 @@ class PretrainTrainerWrapper:
 
         apply_block_expansion_if_configured(self.model, tcfg, console)
 
-        # LoRA — with MoE-aware target modules if moe_lora is enabled
-        from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+        # #307 — LISA layerwise importance sampling. Full-FT of a rotating set
+        # of decoder layers, so it fully replaces the LoRA path below (the
+        # schema cross-validator guarantees no LoRA-feature / freeze flag is
+        # combined). Shared with the SFT trainer so the two cannot drift.
+        from soup_cli.utils.peft_wiring import apply_lisa_setup, resolve_lora_target_modules
 
-        target_modules = resolve_lora_target_modules(self.model, tcfg.lora.target_modules)
+        if not apply_lisa_setup(self.model, tcfg, console):
+            # LoRA — with MoE-aware target modules if moe_lora is enabled
+            target_modules = resolve_lora_target_modules(self.model, tcfg.lora.target_modules)
 
-        if tcfg.moe_lora and is_moe:
-            moe_targets = get_moe_target_modules(self.model)
-            if moe_targets:
-                target_modules = moe_targets
-                console.print(
-                    f"[green]ScatterMoE LoRA:[/] targeting {len(moe_targets)} module patterns"
-                )
+            if tcfg.moe_lora and is_moe:
+                moe_targets = get_moe_target_modules(self.model)
+                if moe_targets:
+                    target_modules = moe_targets
+                    console.print(
+                        f"[green]ScatterMoE LoRA:[/] targeting {len(moe_targets)} module patterns"
+                    )
 
-        lora_config = LoraConfig(
-            r=tcfg.lora.r,
-            lora_alpha=tcfg.lora.alpha,
-            lora_dropout=tcfg.lora.dropout,
-            target_modules=target_modules,
-            task_type=TaskType.CAUSAL_LM,
-            bias="none",
-            use_dora=tcfg.lora.use_dora,
-            use_rslora=tcfg.lora.use_rslora,
-        )
-        # v0.40.6 #67 — surgical PEFT patches.
-        from soup_cli.utils.peft_wiring import (
-            apply_post_lora_patches,
-            apply_pre_lora_patches,
-        )
-        apply_pre_lora_patches(self.model, cfg.base)
-        self.model = get_peft_model(self.model, lora_config)
-        apply_post_lora_patches(self.model)
+            lora_config = LoraConfig(
+                r=tcfg.lora.r,
+                lora_alpha=tcfg.lora.alpha,
+                lora_dropout=tcfg.lora.dropout,
+                target_modules=target_modules,
+                task_type=TaskType.CAUSAL_LM,
+                bias="none",
+                use_dora=tcfg.lora.use_dora,
+                use_rslora=tcfg.lora.use_rslora,
+            )
+            # v0.40.6 #67 — surgical PEFT patches.
+            from soup_cli.utils.peft_wiring import (
+                apply_post_lora_patches,
+                apply_pre_lora_patches,
+            )
+            apply_pre_lora_patches(self.model, cfg.base)
+            self.model = get_peft_model(self.model, lora_config)
+            apply_post_lora_patches(self.model)
 
         # v0.71.12 #84 — Mixture-of-Depths selective-token routing (applied
         # after get_peft_model so the routers are trainable).

--- a/src/soup_cli/trainer/pretrain.py
+++ b/src/soup_cli/trainer/pretrain.py
@@ -12,8 +12,8 @@ from soup_cli.utils.gpu import (
     bf16_fp16_flags,
     estimate_batch_size,
     model_size_from_name,
+    resolve_base_load_dtype,
     resolve_device_map,
-    resolve_frozen_base_load_dtype,
 )
 from soup_cli.utils.mixed_precision import align_trainable_dtype_for_fp16
 from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
@@ -303,7 +303,9 @@ class PretrainTrainerWrapper:
         dev_map = resolve_device_map(self.device)
         model_kwargs = {
             "trust_remote_code": self._trust_remote_code, "device_map": dev_map,
-            "torch_dtype": resolve_frozen_base_load_dtype(self.device),
+            "torch_dtype": resolve_base_load_dtype(
+                self.device, full_finetune=tcfg.lisa_enabled
+            ),
         }
         if quant_config_obj is not None:
             model_kwargs["quantization_config"] = quant_config_obj

--- a/src/soup_cli/trainer/sft.py
+++ b/src/soup_cli/trainer/sft.py
@@ -15,8 +15,8 @@ from soup_cli.utils.gpu import (
     bf16_fp16_flags,
     estimate_batch_size,
     model_size_from_name,
+    resolve_base_load_dtype,
     resolve_device_map,
-    resolve_frozen_base_load_dtype,
 )
 from soup_cli.utils.mixed_precision import align_trainable_dtype_for_fp16
 from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
@@ -1113,8 +1113,8 @@ class SFTTrainerWrapper(StreamingSetupMixin):
           default this issue exists to remove — the parameters an optimizer
           actually steps stay fp32 master weights rather than silently
           inheriting whatever the checkpoint happened to be stored in. This
-          half is genuinely SFT's own — the shared helper below has no
-          full-fine-tuning branch.
+          branch is centralized in ``resolve_base_load_dtype`` so SFT and
+          pretraining LISA cannot drift.
         - Frozen base (LoRA / QLoRA — the base never receives an optimizer
           step): delegate to ``resolve_frozen_base_load_dtype`` (#492, added
           for the other twelve trainers) rather than re-deriving the same
@@ -1139,11 +1139,9 @@ class SFTTrainerWrapper(StreamingSetupMixin):
         4.46.1) — not a silent no-op, since transformers only forwards a
         kwarg into the config if the config already ``hasattr`` it.
         """
-        if is_full_finetune(tcfg):
-            import torch  # lazy — sft.py has no top-level torch import (house style)
-
-            return torch.float32
-        return resolve_frozen_base_load_dtype(self.device)
+        return resolve_base_load_dtype(
+            self.device, full_finetune=is_full_finetune(tcfg)
+        )
 
     @staticmethod
     def _as_sft_config(training_args, max_length):

--- a/src/soup_cli/trainer/sft.py
+++ b/src/soup_cli/trainer/sft.py
@@ -1340,19 +1340,12 @@ class SFTTrainerWrapper(StreamingSetupMixin):
             )
         elif tcfg.lisa_enabled:
             # v0.71.34 #267 — LISA layerwise importance sampling. Full-FT of a
-            # rotating set of decoder layers (LoRA off). The model stays FULLY
-            # trainable here so HF's create_optimizer (built before
-            # on_train_begin) includes every decoder param in its param groups;
-            # LisaCallback then flips requires_grad each interval — frozen
-            # params get grad=None and AdamW skips them. enable_input_require_grads
-            # keeps grad-checkpointing safe.
-            if hasattr(self.model, "enable_input_require_grads"):
-                self.model.enable_input_require_grads()
-            console.print(
-                f"[green]LISA:[/] layerwise importance sampling "
-                f"({tcfg.lisa_num_layers} layer(s) every "
-                f"{tcfg.lisa_interval_steps} steps, LoRA off)"
-            )
+            # rotating set of decoder layers (LoRA off). Centralised in
+            # ``peft_wiring.apply_lisa_setup`` so this trainer and the pretrain
+            # one (#307) cannot drift — same policy as block_expansion.
+            from soup_cli.utils.peft_wiring import apply_lisa_setup
+
+            apply_lisa_setup(self.model, tcfg, console)
         elif tcfg.lora.r == 0:
             # #340 — plain full fine-tuning. Until now the `else` below applied
             # LoRA unconditionally and the only way to train without an adapter

--- a/src/soup_cli/utils/gpu.py
+++ b/src/soup_cli/utils/gpu.py
@@ -470,6 +470,19 @@ def resolve_frozen_base_load_dtype(device: str):
     return "auto"
 
 
+def resolve_base_load_dtype(device: str, *, full_finetune: bool):
+    """Resolve model-load dtype without drifting between trainer wrappers.
+
+    An optimizer that steps the base needs explicit fp32 master weights. A
+    frozen LoRA base instead keeps the checkpoint/card-aware policy above.
+    """
+    if full_finetune:
+        import torch
+
+        return torch.float32
+    return resolve_frozen_base_load_dtype(device)
+
+
 def get_compute_dtype():
     """Return the best compute dtype for the current device.
 

--- a/src/soup_cli/utils/lisa.py
+++ b/src/soup_cli/utils/lisa.py
@@ -5,8 +5,9 @@ steps it freezes all decoder layers except a small randomly-sampled set
 (embeddings + language-model head always trainable). The dynamic cousin of
 Spectrum's static ``unfrozen_parameters`` selection.
 
-Correctness invariant (see also ``trainer/sft.py``): the SFT trainer leaves the
-model **fully trainable at prep time** so HF's ``create_optimizer`` (called
+Correctness invariant (see ``utils/peft_wiring.apply_lisa_setup``, shared by the
+SFT and pretrain trainers since #307): the trainer leaves the model **fully
+trainable at prep time** so HF's ``create_optimizer`` (called
 *before* ``on_train_begin``) includes every decoder parameter in its param
 groups. This callback then toggles ``requires_grad`` — frozen parameters produce
 ``grad=None`` and AdamW skips them, and their optimizer state is cleared on

--- a/src/soup_cli/utils/peft_wiring.py
+++ b/src/soup_cli/utils/peft_wiring.py
@@ -115,13 +115,45 @@ def attach_relora_callback(trainer: Any, tcfg: Any) -> bool:
     return True
 
 
+def apply_lisa_setup(model: Any, tcfg: Any, console: Any = None) -> bool:
+    """Prepare ``model`` for LISA full fine-tuning (v0.71.34 #267, #307).
+
+    Returns ``True`` when LISA is enabled (the caller must then SKIP its LoRA
+    path entirely), ``False`` otherwise.
+
+    The model is deliberately left FULLY trainable here: HF builds the
+    optimizer before the first callback fires, so every decoder parameter has
+    to be in a param group for :class:`~soup_cli.utils.lisa.LisaCallback` to be
+    able to re-activate it later. The callback then flips ``requires_grad``
+    each interval — frozen parameters produce no gradient and AdamW skips
+    them. ``enable_input_require_grads`` keeps gradient checkpointing working
+    without a LoRA adapter, exactly as the Spectrum branch does.
+
+    Centralised (rather than inlined per trainer) for the same reason
+    ``block_expansion.apply_block_expansion_if_configured`` is: the SFT and
+    pretrain trainers must not drift on what "LISA is on" means.
+    """
+    if not getattr(tcfg, "lisa_enabled", False):
+        return False
+    if hasattr(model, "enable_input_require_grads"):
+        model.enable_input_require_grads()
+    if console is not None:
+        console.print(
+            f"[green]LISA:[/] layerwise importance sampling "
+            f"({tcfg.lisa_num_layers} layer(s) every "
+            f"{tcfg.lisa_interval_steps} steps, LoRA off)"
+        )
+    return True
+
+
 def attach_lisa_callback(trainer: Any, tcfg: Any) -> bool:
     """Attach :class:`LisaCallback` when ``training.lisa_enabled`` is set.
 
     Returns ``True`` when a callback was attached, ``False`` otherwise. The
     schema-level cross-validator (``_validate_lisa_compat``) already enforces
-    the sft / transformers / text / quantization=none gate and mutual
-    exclusion, so this helper trusts the caller's task/backend (v0.71.34 #267).
+    the ``_LISA_SUPPORTED_TASKS`` / transformers / text / quantization=none
+    gate and mutual exclusion, so this helper trusts the caller's task/backend
+    (v0.71.34 #267; ``pretrain`` added in #307).
     """
     if not getattr(tcfg, "lisa_enabled", False):
         return False

--- a/tests/test_issue491_frozen_base_load_dtype.py
+++ b/tests/test_issue491_frozen_base_load_dtype.py
@@ -3,13 +3,11 @@
 
 PR #471 fixes ``SFTTrainerWrapper``: a frozen (LoRA) base keeps the
 checkpoint's own dtype instead of the HF default of upcasting every load to
-float32. The other twelve trainer wrappers build the identical
+float32. The other trainer wrappers build the identical
 ``model_kwargs`` shape (``trust_remote_code`` + ``device_map`` + optional
-``quantization_config``) with the same gap. None of them has a full
-fine-tuning branch: ``unfrozen_parameters``/``lisa_enabled`` are schema-gated
-to ``task='sft'`` and ``lora.r=0`` has no wired effect outside ``sft``, so
-``get_peft_model``/``peft_config`` runs unconditionally in every one of
-them and every load is a frozen LoRA base.
+``quantization_config``) with the same gap. Pretraining now has a LISA
+full-fine-tuning branch and therefore uses the full-FT-aware resolver; the
+remaining wrappers always load a frozen LoRA base.
 
 ``TestResolveFrozenBaseLoadDtype`` pins the shared helper in isolation.
 ``TestWrapperModelKwargsCarryDtype`` proves the wiring for real: each
@@ -165,9 +163,14 @@ class TestWrapperModelKwargsCarryDtype:
         # Patched in the wrapper module's own namespace (each trainer imports
         # the name directly), mirroring the real dtype-resolution call site.
         sentinel = object()
+        resolver_name = (
+            "resolve_base_load_dtype"
+            if class_name == "PretrainTrainerWrapper"
+            else "resolve_frozen_base_load_dtype"
+        )
         with patch("transformers.AutoTokenizer.from_pretrained", return_value=fake_tokenizer), \
              patch(f"transformers.{model_class_name}.from_pretrained", load_mock), \
-             patch(f"{module_path}.resolve_frozen_base_load_dtype", return_value=sentinel):
+             patch(f"{module_path}.{resolver_name}", return_value=sentinel):
             with pytest.raises(_StopAtLoadError):
                 wrapper._setup_transformers(cfg, cfg.training)
 

--- a/tests/test_v07134.py
+++ b/tests/test_v07134.py
@@ -6,7 +6,8 @@ Covers:
 * ``commands/adapters.py::arithmetic`` — ``soup adapters arithmetic``.
 * ``config/schema.py`` — LISA fields + ``_validate_lisa_compat``.
 * ``utils/lisa.py`` — ``LisaPolicy`` + ``LisaCallback`` (duck-typed).
-* ``utils/peft_wiring.py::attach_lisa_callback`` + SFT trainer wiring.
+* ``utils/peft_wiring.py::attach_lisa_callback`` / ``apply_lisa_setup``
+  + the SFT and (#307) pretrain trainer wiring.
 """
 
 from __future__ import annotations
@@ -14,6 +15,7 @@ from __future__ import annotations
 import ast
 import json
 import os
+import re
 from pathlib import Path
 
 import numpy as np
@@ -1039,3 +1041,455 @@ class TestSftRouting:
         src = Path(sft.__file__).read_text(encoding="utf-8")
         assert "tcfg.lisa_enabled" in src
         assert "attach_lisa_callback(" in src
+
+
+# ---------------------------------------------------------------------------
+# Task B4 — #307: LISA for continued pre-training (``task: pretrain``)
+#
+# LISA is full-FT of a rotating set of decoder layers, which is exactly what
+# continued pre-training does, so #307 widens the schema gate and wires the
+# callback into ``trainer/pretrain.py``. The tests below are behavioural on
+# purpose: a source-grep would pass on a branch that never runs.
+# ---------------------------------------------------------------------------
+_LISA_PRETRAIN = _LISA_BASE.replace("task: sft", "task: pretrain")
+
+# Text rows for the continued-pre-training path (plain documents, no chat
+# structure). Vocabulary restricted to the offline tiny tokenizer's words.
+_PRETRAIN_ROWS = [
+    {"text": "the cat sat on the mat"},
+    {"text": "the dog ran fast"},
+    {"text": "hello world one two"},
+    {"text": "red blue green"},
+]
+
+
+def _plain(text: str) -> str:
+    """Rich output as comparable text: ANSI stripped, runs of space collapsed.
+
+    Raw ``result.output`` phrase assertions have reddened this suite before;
+    route every rendered-output assertion through here even when it is green
+    today.
+    """
+    return re.sub(r"\s+", " ", re.sub(r"\x1b\[[0-9;]*m", "", text))
+
+
+def _requires_train_extra():
+    for mod in ("torch", "transformers", "peft", "trl", "datasets"):
+        pytest.importorskip(mod, reason=f"{mod} is only in the [train] extra")
+
+
+def _pretrain_wrapper(tmp_path, monkeypatch, *, n_layers=4, **training_over):
+    """A real ``PretrainTrainerWrapper`` over a real tiny offline checkpoint."""
+    import yaml
+
+    from soup_cli.config.loader import load_config_from_string
+    from soup_cli.trainer.pretrain import PretrainTrainerWrapper
+
+    # Reuse #341's fixture rather than a second copy of it: a real (tiny) Llama
+    # checkpoint plus an offline tokenizer, so nothing is downloaded and nothing
+    # is randomly initialised at load time.
+    from tests.test_issue341_seed_and_fullft import _tiny_llama_dir
+
+    base = _tiny_llama_dir(tmp_path, n_layers=n_layers)
+    monkeypatch.chdir(tmp_path)
+    training = {
+        "batch_size": 1,
+        "gradient_accumulation_steps": 1,
+        "quantization": "none",
+        "epochs": 1,
+        "lr": 1e-3,
+        "logging_steps": 100,
+        "save_steps": 10_000,
+        "lora": {"r": 4, "alpha": 8, "dropout": 0.0, "target_modules": ["q_proj"]},
+    }
+    training.update(training_over)
+    cfg = load_config_from_string(
+        yaml.safe_dump(
+            {
+                "base": base,
+                "task": "pretrain",
+                "backend": "transformers",
+                "modality": "text",
+                "data": {"train": "train.jsonl", "max_length": 64},
+                "training": training,
+                "output": str(tmp_path / "out"),
+            }
+        )
+    )
+    return PretrainTrainerWrapper(cfg, device="cpu"), {"train": list(_PRETRAIN_ROWS)}
+
+
+def _captured_console(monkeypatch):
+    """Patch the pretrain trainer's console with a REAL wide Rich console.
+
+    Real (not a recording double) because the summary line is Rich markup, and
+    wide because a narrow console wraps the parameter counts across a newline.
+    """
+    from io import StringIO
+
+    from rich.console import Console
+
+    import soup_cli.trainer.pretrain as pretrain_mod
+
+    buf = StringIO()
+    monkeypatch.setattr(pretrain_mod, "console", Console(file=buf, width=200))
+    return buf
+
+
+def _lisa_callbacks(trainer):
+    from soup_cli.utils.lisa import LisaCallback
+
+    return [
+        cb
+        for cb in trainer.callback_handler.callbacks
+        if isinstance(cb, LisaCallback)
+    ]
+
+
+class TestLisaPretrainSchema:
+    def test_pretrain_task_accepted(self):
+        cfg = _load(_LISA_PRETRAIN)
+        assert cfg.task == "pretrain"
+        assert cfg.training.lisa_enabled is True
+
+    @pytest.mark.parametrize("task", ["dpo", "grpo", "embedding"])
+    def test_other_tasks_refused_and_both_supported_tasks_named(self, task):
+        """The widened gate must still refuse everything else — and say what it
+        does accept. Asserting on the refused task alone would also pass for a
+        gate that had been widened to accept every task but this one."""
+        with pytest.raises(Exception) as excinfo:
+            _load(_LISA_BASE.replace("task: sft", f"task: {task}"))
+        message = str(excinfo.value)
+        assert "'sft'" in message
+        assert "'pretrain'" in message
+        assert task in message
+
+    def test_the_allow_list_is_exactly_sft_and_pretrain(self):
+        """Pins the membership of ``_LISA_SUPPORTED_TASKS`` itself.
+
+        The tests above prove the gate READS the tuple (emptying it, or
+        dropping either entry, reddens them), but not what is IN it: a tuple
+        widened to a task whose trainer never wires the callback — say
+        ``orpo`` — would accept the config and then silently ignore LISA, and
+        every other test here would still pass. This is the other half.
+        """
+        from soup_cli.config.schema import _LISA_SUPPORTED_TASKS
+
+        assert set(_LISA_SUPPORTED_TASKS) == {"sft", "pretrain"}
+
+
+class TestPretrainLisaWiring:
+    @pytest.mark.parametrize(
+        "num_layers,interval_steps", [(3, 15), (2, 7)]
+    )
+    def test_callback_carries_the_configured_policy(
+        self, tmp_path, monkeypatch, num_layers, interval_steps
+    ):
+        """Two distinct configurations: a callback built from hardcoded
+        constants would satisfy one of them and fail the other."""
+        _requires_train_extra()
+        _captured_console(monkeypatch)
+        wrapper, dataset = _pretrain_wrapper(
+            tmp_path,
+            monkeypatch,
+            lisa_enabled=True,
+            lisa_num_layers=num_layers,
+            lisa_interval_steps=interval_steps,
+        )
+        wrapper.setup(dataset)
+
+        callbacks = _lisa_callbacks(wrapper.trainer)
+        assert len(callbacks) == 1
+        assert callbacks[0].policy.num_layers == num_layers
+        assert callbacks[0].policy.interval_steps == interval_steps
+
+    def test_lisa_run_is_unwrapped_and_fully_trainable(self, tmp_path, monkeypatch):
+        _requires_train_extra()
+        from peft import PeftModel
+
+        _captured_console(monkeypatch)
+        wrapper, dataset = _pretrain_wrapper(
+            tmp_path, monkeypatch, lisa_enabled=True, lisa_num_layers=2
+        )
+        wrapper.setup(dataset)
+
+        assert not isinstance(wrapper.model, PeftModel)
+        # Fully trainable at setup time is the correctness invariant: HF builds
+        # the optimizer before on_train_begin, so a decoder parameter left out
+        # of the param groups can never be re-activated by the callback.
+        frozen = [
+            name
+            for name, param in wrapper.model.named_parameters()
+            if not param.requires_grad
+        ]
+        assert frozen == []
+
+    def test_lora_control_still_wraps_and_attaches_no_lisa_callback(
+        self, tmp_path, monkeypatch
+    ):
+        """The control: a plain pretrain config must be untouched by #307."""
+        _requires_train_extra()
+        from peft import PeftModel
+
+        _captured_console(monkeypatch)
+        wrapper, dataset = _pretrain_wrapper(tmp_path, monkeypatch)
+        wrapper.setup(dataset)
+
+        assert isinstance(wrapper.model, PeftModel)
+        assert _lisa_callbacks(wrapper.trainer) == []
+
+    @pytest.mark.parametrize("n_layers", [2, 4])
+    def test_summary_counts_every_parameter_and_says_lisa(
+        self, tmp_path, monkeypatch, n_layers
+    ):
+        """``get_nb_trainable_parameters`` is a PeftModel method and a LISA run
+        has no PeftModel, so the count comes off the parameters directly. Two
+        model depths, so a summary printing a constant fails one of them."""
+        _requires_train_extra()
+        buf = _captured_console(monkeypatch)
+        wrapper, dataset = _pretrain_wrapper(
+            tmp_path, monkeypatch, n_layers=n_layers, lisa_enabled=True
+        )
+        wrapper.setup(dataset)
+
+        expected = sum(param.numel() for param in wrapper.model.parameters())
+        out = _plain(buf.getvalue())
+        assert f"LISA: {expected:,} trainable / {expected:,} total (100.00%)" in out
+        assert "LoRA applied" not in out
+
+    def test_lora_control_summary_reports_the_adapter_count(
+        self, tmp_path, monkeypatch
+    ):
+        """Negative control for the label AND the number: without LISA the
+        summary must still name LoRA and report only the adapter as trainable,
+        which is strictly fewer parameters than the whole model."""
+        _requires_train_extra()
+        buf = _captured_console(monkeypatch)
+        wrapper, dataset = _pretrain_wrapper(tmp_path, monkeypatch)
+        wrapper.setup(dataset)
+
+        trainable, total = wrapper.model.get_nb_trainable_parameters()
+        out = _plain(buf.getvalue())
+        assert trainable < total
+        assert f"LoRA applied: {trainable:,} trainable / {total:,} total" in out
+        assert "LISA:" not in out
+
+
+class TestSharedLisaSetup:
+    """#307 — the SFT and pretrain trainers must not drift on what "LISA is on"
+    means, so both route through ``peft_wiring.apply_lisa_setup``.
+
+    Everything else about a LISA run (unwrapped model, every parameter
+    trainable) is produced by the surrounding ``elif`` skipping the LoRA path,
+    so it survives that call being deleted. The two behaviours the call itself
+    owns are pinned here: the ``enable_input_require_grads`` hand-off and the
+    fact that each trainer actually goes through the shared helper.
+    """
+
+    @staticmethod
+    def _tcfg(lisa_enabled):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            lisa_enabled=lisa_enabled, lisa_num_layers=2, lisa_interval_steps=20
+        )
+
+    @pytest.mark.parametrize("lisa_enabled,calls", [(True, 1), (False, 0)])
+    def test_input_require_grads_is_enabled_only_when_lisa_is_on(
+        self, lisa_enabled, calls
+    ):
+        """Without a LoRA adapter nothing else makes the embedding output
+        require grad, so gradient checkpointing dies with "None of the inputs
+        have requires_grad". Both directions, so a helper that unconditionally
+        enables it (or unconditionally returns a fixed verdict) fails one."""
+
+        class _Model:
+            def __init__(self):
+                self.enabled = 0
+
+            def enable_input_require_grads(self):
+                self.enabled += 1
+
+        from soup_cli.utils.peft_wiring import apply_lisa_setup
+
+        model = _Model()
+        assert apply_lisa_setup(model, self._tcfg(lisa_enabled)) is lisa_enabled
+        assert model.enabled == calls
+
+    def test_a_model_without_the_hook_is_still_accepted(self):
+        """The ``hasattr`` guard's own control: not every backend exposes
+        ``enable_input_require_grads``, and LISA must still turn on there."""
+        from soup_cli.utils.peft_wiring import apply_lisa_setup
+
+        assert apply_lisa_setup(object(), self._tcfg(True)) is True
+
+    @staticmethod
+    def _announce(tcfg):
+        """Drive the helper through a REAL wide Rich console.
+
+        Real because the banner is Rich markup and a recording double would
+        capture the object repr; wide because a narrow console wraps the
+        figures across a newline and the assertion then silently misses them.
+        """
+        from io import StringIO
+
+        from rich.console import Console
+
+        from soup_cli.utils.peft_wiring import apply_lisa_setup
+
+        buf = StringIO()
+        apply_lisa_setup(object(), tcfg, Console(file=buf, width=200))
+        return _plain(buf.getvalue())
+
+    @pytest.mark.parametrize("num_layers,interval_steps", [(3, 15), (2, 7)])
+    def test_the_announcement_carries_the_configured_policy(
+        self, num_layers, interval_steps
+    ):
+        """LISA replaces the LoRA path silently otherwise: the banner is the
+        only thing telling the user which policy is live. Two policies, with
+        the other one's figures asserted ABSENT, so a hardcoded banner passes
+        neither."""
+        tcfg = self._tcfg(True)
+        tcfg.lisa_num_layers = num_layers
+        tcfg.lisa_interval_steps = interval_steps
+
+        out = self._announce(tcfg)
+
+        assert (
+            f"LISA: layerwise importance sampling ({num_layers} layer(s) "
+            f"every {interval_steps} steps, LoRA off)"
+        ) in out
+        assert f"{5 - num_layers} layer(s)" not in out
+        assert f"every {22 - interval_steps} steps" not in out
+
+    def test_nothing_is_announced_when_lisa_is_off(self):
+        """The silent-case control: without it a helper that announces
+        unconditionally would print "LoRA off" on every plain LoRA run."""
+        assert self._announce(self._tcfg(False)) == ""
+
+    @pytest.mark.parametrize("lisa_enabled,expected_calls", [(True, 1), (False, 0)])
+    def test_the_sft_trainer_routes_lisa_through_the_shared_helper(
+        self, tmp_path, monkeypatch, lisa_enabled, expected_calls
+    ):
+        """Pins the #307 refactor: the SFT trainer's LISA branch must keep
+        delegating. Re-inlining it there (the drift this change exists to
+        prevent) leaves no call to observe."""
+        _requires_train_extra()
+        import soup_cli.utils.peft_wiring as peft_wiring
+        from tests.test_issue341_seed_and_fullft import _wrapper
+
+        seen = []
+        real = peft_wiring.apply_lisa_setup
+
+        def _spy(model, tcfg, console=None):
+            seen.append(model)
+            return real(model, tcfg, console)
+
+        monkeypatch.setattr(peft_wiring, "apply_lisa_setup", _spy)
+        over = (
+            {"lisa_enabled": True, "lisa_num_layers": 2} if lisa_enabled else {}
+        )
+        wrapper, dataset = _wrapper(tmp_path, monkeypatch, **over)
+        wrapper.setup(dataset)
+
+        assert len(seen) == expected_calls
+        if expected_calls:
+            assert seen[0] is wrapper.model
+
+    @pytest.mark.parametrize("lisa_enabled", [True, False])
+    def test_the_pretrain_trainer_routes_lisa_through_the_shared_helper(
+        self, tmp_path, monkeypatch, lisa_enabled
+    ):
+        """The pretrain half of the same pin, and the one the mutation needs:
+        this trainer asks the helper on EVERY run and lets its return value
+        decide whether the LoRA path runs, so the call is expected with LISA
+        both on and off. Rewriting the call site as ``if not
+        tcfg.lisa_enabled`` keeps every other test in this module green while
+        silently dropping ``enable_input_require_grads`` and the LISA
+        announcement here — that mutant dies on this test alone.
+        """
+        _requires_train_extra()
+        import soup_cli.utils.peft_wiring as peft_wiring
+
+        _captured_console(monkeypatch)
+        seen = []
+        real = peft_wiring.apply_lisa_setup
+
+        def _spy(model, tcfg, console=None):
+            seen.append(model)
+            return real(model, tcfg, console)
+
+        monkeypatch.setattr(peft_wiring, "apply_lisa_setup", _spy)
+        over = (
+            {"lisa_enabled": True, "lisa_num_layers": 2} if lisa_enabled else {}
+        )
+        wrapper, dataset = _pretrain_wrapper(tmp_path, monkeypatch, **over)
+        wrapper.setup(dataset)
+
+        assert len(seen) == 1
+        # ...and it is handed the trainer's own model, not some other object.
+        # With LISA on the model is left unwrapped, so it is still
+        # ``wrapper.model``; with LISA off ``get_peft_model`` wraps it right
+        # after, so it is that wrapper's base.
+        if lisa_enabled:
+            assert seen[0] is wrapper.model
+        else:
+            assert wrapper.model.get_base_model() is seen[0]
+
+
+class TestPretrainLisaEndToEnd:
+    def test_a_pretrain_lisa_run_moves_only_the_sampled_decoder_layers(
+        self, tmp_path, monkeypatch
+    ):
+        """The acceptance criterion, end to end: a real continued-pre-training
+        run with LISA moves the sampled decoder layer and no OTHER decoder
+        layer. Scoped to the decoder on purpose — the embeddings, the LM head
+        and the final norm stay trainable throughout by design (#267), so they
+        are expected to move and are not part of this claim.
+
+        A wiring test alone would pass on a callback that is attached and never
+        fires; this fails unless the sampling actually reaches the optimizer.
+        """
+        _requires_train_extra()
+        import torch
+
+        _captured_console(monkeypatch)
+        wrapper, dataset = _pretrain_wrapper(
+            tmp_path,
+            monkeypatch,
+            n_layers=4,
+            lisa_enabled=True,
+            lisa_num_layers=1,
+            # One sample at on_train_begin, none afterwards, so the active set
+            # is constant for the whole run and "what changed" is unambiguous.
+            lisa_interval_steps=1_000,
+        )
+        wrapper.setup(dataset)
+        before = {
+            name: param.detach().clone()
+            for name, param in wrapper.model.named_parameters()
+        }
+
+        wrapper.train()
+
+        from soup_cli.utils.lisa import _LAYER_RE
+
+        def _layers(names):
+            return {
+                int(_LAYER_RE.search(name).group(1))
+                for name in names
+                if _LAYER_RE.search(name)
+            }
+
+        active = _layers(
+            name
+            for name, param in wrapper.model.named_parameters()
+            if param.requires_grad
+        )
+        moved = _layers(
+            name
+            for name, param in wrapper.model.named_parameters()
+            if not torch.equal(param.detach(), before[name])
+        )
+        assert len(active) == 1, "one layer configured, one layer sampled"
+        assert moved == active

--- a/tests/test_v07134.py
+++ b/tests/test_v07134.py
@@ -1179,6 +1179,37 @@ class TestLisaPretrainSchema:
 
 
 class TestPretrainLisaWiring:
+    @pytest.mark.parametrize("lisa_enabled", [True, False])
+    def test_model_load_dtype_matches_whether_the_base_is_trainable(
+        self, tmp_path, monkeypatch, lisa_enabled
+    ):
+        """LISA steps the base weights, so it needs fp32 master weights.
+
+        The plain-LoRA control must keep the checkpoint-native dtype; otherwise
+        a repair that simply hardcodes fp32 for every pretrain run survives.
+        """
+        _requires_train_extra()
+        import torch
+        from transformers import AutoModelForCausalLM
+
+        _captured_console(monkeypatch)
+        captured_dtypes = []
+        real_from_pretrained = AutoModelForCausalLM.from_pretrained
+
+        def _capture_load_dtype(*args, **kwargs):
+            captured_dtypes.append(kwargs["torch_dtype"])
+            return real_from_pretrained(*args, **kwargs)
+
+        monkeypatch.setattr(
+            AutoModelForCausalLM, "from_pretrained", _capture_load_dtype
+        )
+        overrides = {"lisa_enabled": True} if lisa_enabled else {}
+        wrapper, dataset = _pretrain_wrapper(tmp_path, monkeypatch, **overrides)
+        wrapper.setup(dataset)
+
+        expected_dtype = torch.float32 if lisa_enabled else "auto"
+        assert captured_dtypes == [expected_dtype]
+
     @pytest.mark.parametrize(
         "num_layers,interval_steps", [(3, 15), (2, 7)]
     )
@@ -1489,7 +1520,7 @@ class TestPretrainLisaEndToEnd:
         moved = _layers(
             name
             for name, param in wrapper.model.named_parameters()
-            if not torch.equal(param.detach(), before[name])
+            if not torch.equal(param.detach().cpu(), before[name].cpu())
         )
         assert len(active) == 1, "one layer configured, one layer sampled"
         assert moved == active


### PR DESCRIPTION
Fixes #307

## What

LISA now supports `task: pretrain` as well as `task: sft`:

- the schema uses an explicit `_LISA_SUPPORTED_TASKS` allow-list;
- SFT and pretraining share `apply_lisa_setup()`, preventing their LISA wiring from drifting;
- pretraining skips PEFT for LISA, attaches `LisaCallback`, and reports the full model parameter count;
- LISA model loads use the shared full-fine-tuning-aware dtype resolver, preserving fp32 master weights, while ordinary pretraining LoRA loads retain the checkpoint-native frozen-base dtype;
- the end-to-end tensor comparison moves both operands to CPU, so the assertion is accelerator-neutral;
- release notes live in `changelog.d/0.73.3/476.added.md`; the released `CHANGELOG.md` is unchanged from `main`.

The command reference, PEFT/efficiency guide, schema description, and resolver documentation match the expanded task support.

## Acceptance criteria

- [x] `task: pretrain` + `lisa_enabled` is accepted by the schema
- [x] pretraining attaches `LisaCallback` and skips LoRA
- [x] a live tiny-Llama run changes only the sampled decoder layer
- [x] LISA loads fp32 master weights; plain LoRA retains `"auto"`
- [x] device-neutral end-to-end comparison
- [x] changelog fragment replaces the direct changelog edit

## Test verification (RED → GREEN)

The review regression test was run before the dtype fix:

```text
FAILED TestPretrainLisaWiring::test_model_load_dtype_matches_whether_the_base_is_trainable[True]
assert ['auto'] == [torch.float32]
1 failed, 1 passed
```

After routing both trainers through `resolve_base_load_dtype`:

```text
15 passed
```

The final focused replay, including existing SFT dtype coverage and the complete LISA module, passed:

```text
176 passed
```

Changelog fragment validation passed separately: `17 passed`.

## Full local CI replay

An isolated `upstream/main` baseline and the final branch were run under the same pinned environment:

```text
baseline: 1 failed, 18534 passed, 263 skipped, 5 deselected
final:    1 failed, 18559 passed, 263 skipped, 5 deselected
```

The sole failure is identical on both sides:
`tests/test_v07129.py::TestReviewFixes::test_fuse_adapter_produces_dense_model`
(`SamConfig` tokenizer mapping in the installed transformers environment).

- Ruff: pass
- Dependency check: pass
- Changed production-line coverage: 100% (40/40)
- Independent PR review: pass
- OCR peer review: pass

## Remote CI

All 14 checks passed on `66ac804`: Linux, macOS, and Windows on Python 3.10–3.12, MLX smoke, lint, type-check, recipe validation, and transformers-floor.
