### PR TITLE
feat(mcp): serve MCP over sse and streamable http, not just stdio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,43 @@ reproducing 70+ versions of notes.
 
 ### Added
 
+- **`soup mcp serve` gains network transports: `--transport sse` and
+  `--transport http` (#296).** v1 was stdio-only, which suits a client that
+  spawns Soup as a subprocess but leaves remote and multi-client setups with
+  nothing. Both new transports serve the *same* registry — the end-to-end test
+  compares the advertised tool names against `build_registry` rather than a
+  hardcoded count, so a subset cannot creep in. stdio remains the default and
+  is untouched.
+
+  Adding a listener is the risky part, so it is gated three ways. Every HTTP
+  request needs `Authorization: Bearer <token>`, compared with
+  `secrets.compare_digest`, with no opt-out — a loopback port is reachable by
+  every process on the box. The token is validated by the existing
+  `utils/qr_url.py::validate_token`, so `soup ui` and `soup mcp serve` agree on
+  what a token is instead of growing a second format, and it travels in the
+  header only: no query-string fallback that could land in an access log. The
+  SDK's DNS-rebinding protection is switched on (`421` on a foreign `Host`,
+  `403` on a foreign `Origin`), which is the gate the token cannot be — a page
+  the operator merely visits sends no `Authorization` header but its request
+  still reaches the port. Binding off loopback warns, and a wildcard bind warns
+  again that the Host check has nothing left to pin.
+
+  `--host` / `--port` / `--auth-token` are refused under `--transport stdio`
+  rather than silently ignored, and the ASGI app is built by a
+  `build_asgi_app()` factory so the auth and rebinding behaviour is tested
+  through an in-process transport without binding a socket; one further test
+  binds a real ephemeral port and drives initialize -> list_tools -> call_tool
+  through the SDK's own SSE client.
+
+  The `[mcp]` extra floor moves `1.2.0` -> `1.10.0`, measured against the
+  published wheels rather than a changelog: `server/streamable_http_manager.py`
+  first appears in 1.8.0 (absent in 1.7.0) and `server/transport_security.py`
+  in 1.10.0 (absent in 1.9.4). `--transport sse` alone would have run on the
+  old floor; rebinding protection would not, and a listener whose origin
+  checking silently disappears on an older SDK is worse than a resolver error.
+  The `<2` cap is unchanged — #322 is the 2.x migration. No new package: `mcp`
+  already requires starlette, uvicorn, sse-starlette and httpx-sse.
+
 - **`soup data best-of-n` can sample candidates from Ollama or vLLM providers
   (#299 by @Faisal01011 in #466).** The existing local Transformers `--base` path stays
   the default, while `--provider ollama|vllm --model <m> [--base-url <url>]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ reproducing 70+ versions of notes.
 ### Added
 
 - **`soup mcp serve` gains network transports: `--transport sse` and
-  `--transport http` (#296).** v1 was stdio-only, which suits a client that
+  `--transport http` (#296 in #479).** v1 was stdio-only, which suits a client that
   spawns Soup as a subprocess but leaves remote and multi-client setups with
   nothing. Both new transports serve the *same* registry — the end-to-end test
   compares the advertised tool names against `build_registry` rather than a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,17 @@ reproducing 70+ versions of notes.
   still reaches the port. Binding off loopback warns, and a wildcard bind warns
   again that the Host check has nothing left to pin.
 
+  `--allow-execute` is refused with either network transport, and that refusal
+  is the one behavioural change to an existing flag. Gated execution (#297)
+  spawns real training / export processes; behind a listener a leaked Bearer
+  token would mean process execution rather than plan disclosure, and stdio is
+  a pipe to a client the operator already started, which is a different trust
+  boundary. The refusal is made twice on purpose: once in the CLI so the
+  operator gets a readable message, and once in `build_asgi_app()` so a direct
+  caller cannot put an executing registry behind a listener either. The stdio
+  banner also stopped claiming "execution disabled" -- that string predated
+  #297 and was false from the moment execution shipped.
+
   `--host` / `--port` / `--auth-token` are refused under `--transport stdio`
   rather than silently ignored, and the ASGI app is built by a
   `build_asgi_app()` factory so the auth and rebinding behaviour is tested

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -186,6 +186,8 @@ soup ci init [--data d.jsonl --suite s.yaml --evidence ev.json] [--config soup.y
 soup mcp serve                                MCP server over stdio (drive Soup from Claude Code / Cursor / Cline; requires [mcp] extra) (v0.71.28)
 soup mcp serve --allow-mutating               Also expose plan-only train_start / export tools (never execute) (v0.71.28)
 soup mcp serve --allow-execute                Implies --allow-mutating; enables train_execute / export_execute via server confirmation tokens
+soup mcp serve --transport sse [--host H --port N]  Serve the same registry over HTTP+SSE instead of stdio; binds 127.0.0.1 and requires a Bearer token (#296)
+soup mcp serve --transport http [--auth-token T]    Same over the streamable-HTTP transport (/mcp); --auth-token pins the token instead of generating one (#296)
 soup shrink --model <id|path> --drop-ratio 0.25 --calib c.jsonl -o shrunk  Depth-prune least-important layer block + SHIP/DON'T-SHIP ppl verdict (exit 0/2/1) (v0.71.29)
 soup shrink ... --drop-layers N --heal h.jsonl --heal-steps 200 --device cpu  Drop N layers + distill-heal (fuse LoRA back to one dense model)
 soup shrink ... --tolerance 0.10 --plan-only [--attach-to-registry <id>]  Ppl-regression tolerance / print importance table only / registry attach
@@ -324,7 +326,7 @@ soup --verbose <command>                      Full traceback on errors
 ## Fine-tune from your coding agent (MCP)
 
 `soup mcp serve` runs a [Model Context Protocol](https://modelcontextprotocol.io)
-server over **stdio**, so any MCP client — Claude Code, Cursor, Cline, Continue —
+server over **stdio** (default) or a local **SSE / HTTP** listener, so any MCP client — Claude Code, Cursor, Cline, Continue —
 can drive Soup conversationally. Install the extra first:
 
 ```bash
@@ -341,6 +343,55 @@ the **Claude Desktop** config (`claude_desktop_config.json`):
   }
 }
 ```
+
+### Remote or multi-client: the SSE and HTTP transports
+
+stdio suits a client that spawns Soup as a subprocess. For a client on another
+machine, or several clients sharing one server, run a listener instead:
+
+```bash
+soup mcp serve --transport sse                 # GET /sse + POST /messages/
+soup mcp serve --transport http                # streamable HTTP on /mcp
+soup mcp serve --transport sse --host 127.0.0.1 --port 8765 --auth-token "$TOKEN"
+```
+
+Both bind `127.0.0.1:8765` by default and **require a Bearer token on every
+request**. With `--auth-token` omitted, a fresh one is generated at startup and
+printed to stderr; it is 16-128 urlsafe-base64 characters, the same shape
+`soup ui` uses. Point a client at it with a header:
+
+```json
+{
+  "mcpServers": {
+    "soup": {
+      "url": "http://127.0.0.1:8765/sse",
+      "headers": { "Authorization": "Bearer <token>" }
+    }
+  }
+}
+```
+
+The registry is identical across transports — same tools, same schemas, same
+`--allow-mutating` / `--allow-execute` gating. Only the wire changes.
+
+**Security:**
+- **The token is required and there is no opt-out.** A loopback listener is
+  reachable by every process on the machine, not just by you.
+- **The token travels in the header, never the URL.** There is deliberately no
+  query-string fallback, so it cannot be captured in proxy or access logs.
+- **DNS-rebinding protection is on.** A request whose `Host` is not the address
+  the server bound to is refused with `421`, a foreign `Origin` with `403`.
+  This is the gate the Bearer token cannot be: a web page the operator merely
+  visits attaches no `Authorization` header, but its request still arrives at
+  the port.
+- **A non-loopback `--host` prints a warning**, and a wildcard bind (`0.0.0.0`)
+  prints a second one — with no single advertised name there is nothing to pin,
+  so the Host check degrades to accepting any `Host`.
+- **`--host` / `--port` / `--auth-token` are refused under `--transport stdio`**
+  rather than silently ignored: stdio has no listener and nothing to authorize.
+
+The network transports need `mcp >= 1.10.0` — streamable HTTP landed in 1.8.0
+and rebinding protection in 1.10.0 — which is the floor `soup-cli[mcp]` pins.
 
 The server exposes 14 read-only tools — `advise`, `data_inspect`,
 `data_validate`, `data_score`, `data_doctor`, `recipes_search`, `recipes_show`,

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -188,6 +188,7 @@ soup mcp serve --allow-mutating               Also expose plan-only train_start 
 soup mcp serve --allow-execute                Implies --allow-mutating; enables train_execute / export_execute via server confirmation tokens
 soup mcp serve --transport sse [--host H --port N]  Serve the same registry over HTTP+SSE instead of stdio; binds 127.0.0.1 and requires a Bearer token (#296)
 soup mcp serve --transport http [--auth-token T]    Same over the streamable-HTTP transport (/mcp); --auth-token pins the token instead of generating one (#296)
+soup mcp serve --transport sse|http --allow-execute   REFUSED - gated execution spawns real processes and is stdio-only (#296)
 soup shrink --model <id|path> --drop-ratio 0.25 --calib c.jsonl -o shrunk  Depth-prune least-important layer block + SHIP/DON'T-SHIP ppl verdict (exit 0/2/1) (v0.71.29)
 soup shrink ... --drop-layers N --heal h.jsonl --heal-steps 200 --device cpu  Drop N layers + distill-heal (fuse LoRA back to one dense model)
 soup shrink ... --tolerance 0.10 --plan-only [--attach-to-registry <id>]  Ppl-regression tolerance / print importance table only / registry attach

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,16 @@ modal = ["modal>=0.60.0"]
 # nine CI jobs the day it was published. 1.29.0 (the newest 1.x) still exposes
 # both, verified directly. Migrating to the 2.x API is its own piece of work,
 # and shipping against a major nobody has validated is not a substitute for it.
-mcp = ["mcp>=1.2.0,<2"]
+# v0.73.4 (#296): floor raised from 1.2.0 for the sse / streamable-http
+# transports. Measured against the published wheels rather than the
+# changelog: `mcp/server/streamable_http_manager.py` first appears in
+# 1.8.0 (absent in 1.7.0) and `mcp/server/transport_security.py` in
+# 1.10.0 (absent in 1.9.4). `--transport sse` alone would have run on
+# the old floor; DNS-rebinding protection would not, and a listener
+# whose origin checking silently vanishes on an older SDK is worse than
+# a resolver error. No new package: `mcp` already requires starlette,
+# uvicorn, sse-starlette and httpx-sse.
+mcp = ["mcp>=1.10.0,<2"]
 
 [project.scripts]
 soup = "soup_cli.cli:run"

--- a/src/soup_cli/commands/mcp.py
+++ b/src/soup_cli/commands/mcp.py
@@ -1,9 +1,11 @@
-"""soup mcp - Model Context Protocol server (v0.71.28).
+"""soup mcp - Model Context Protocol server (v0.71.28; network transports #296).
 
 ``soup mcp serve`` exposes Soup's read-only commands (plus two plan-only
-mutating tools) to any MCP client (Claude Code / Cursor / Cline / Continue)
-over stdio. The heavy ``mcp`` SDK is behind the ``[mcp]`` extra and imported
-lazily, so this command errors friendly-ly when the extra is missing.
+mutating tools) to any MCP client (Claude Code / Cursor / Cline / Continue).
+stdio remains the default and is unchanged; ``--transport sse`` and
+``--transport http`` add a local listener for remote or multi-client setups.
+The heavy ``mcp`` SDK is behind the ``[mcp]`` extra and imported lazily, so this
+command errors friendly-ly when the extra is missing.
 
 All user-facing help text stays ASCII (Windows terminal / cp1252 safety;
 mirrors the ``test_help_output_is_ascii_safe`` guard).
@@ -11,12 +13,33 @@ mirrors the ``test_help_output_is_ascii_safe`` guard).
 
 from __future__ import annotations
 
+import secrets
+from typing import Optional
+
 import typer
 
 app = typer.Typer(
     no_args_is_help=True,
     help="Model Context Protocol server - drive Soup from any MCP client.",
 )
+
+_STDIO = "stdio"
+_TRANSPORTS = ("stdio", "sse", "http")
+_LOOPBACK = ("127.0.0.1", "::1", "localhost")
+
+
+def _resolve_auth_token(auth_token: Optional[str]) -> str:
+    """Return the operator's token (validated), or mint a fresh one.
+
+    Reuses ``utils.qr_url.validate_token`` so ``soup ui`` and ``soup mcp serve``
+    agree on what a token is (16-128 urlsafe-base64 chars) instead of growing a
+    second bespoke format.
+    """
+    from soup_cli.utils.qr_url import validate_token
+
+    if auth_token is None:
+        return secrets.token_urlsafe(32)
+    return validate_token(auth_token)
 
 
 @app.command()
@@ -40,19 +63,84 @@ def serve(
             "and never execute in this version."
         ),
     ),
+    transport: str = typer.Option(
+        _STDIO,
+        "--transport",
+        help=(
+            "stdio (default), sse, or http. stdio speaks JSON-RPC over the "
+            "process pipes and is what a client that spawns Soup wants. sse "
+            "and http open a local listener instead, for remote or "
+            "multi-client setups, and require a Bearer token."
+        ),
+    ),
+    host: Optional[str] = typer.Option(
+        None,
+        "--host",
+        help=(
+            "Interface to bind for --transport sse/http. Defaults to "
+            "127.0.0.1. Binding anything else exposes the server to the "
+            "network, where the Bearer token is the only gate."
+        ),
+    ),
+    port: Optional[int] = typer.Option(
+        None,
+        "--port",
+        help="Port to bind for --transport sse/http. Defaults to 8765.",
+    ),
+    auth_token: Optional[str] = typer.Option(
+        None,
+        "--auth-token",
+        help=(
+            "Override the auto-generated Bearer token (16-128 urlsafe "
+            "base64 chars) for --transport sse/http. When omitted, a fresh "
+            "token is generated each startup and printed."
+        ),
+    ),
 ) -> None:
-    """Start the stdio MCP server (read-only tools by default).
+    """Start the MCP server (read-only tools by default).
 
-    stdout is the JSON-RPC channel - all human-facing output goes to stderr.
-    Wire it into a client, e.g. `.mcp.json`:
+    Under the default stdio transport, stdout is the JSON-RPC channel - all
+    human-facing output goes to stderr. Wire it into a client, e.g. `.mcp.json`:
 
         {"mcpServers": {"soup": {"command": "soup", "args": ["mcp", "serve"]}}}
+
+    The sse / http transports bind 127.0.0.1 and require
+    'Authorization: Bearer <token>' on every request.
     """
     from rich.console import Console
+    from rich.markup import escape
 
     # stderr-only: stdout is reserved for the MCP JSON-RPC stream.
     console = Console(stderr=True)
 
+    if transport not in _TRANSPORTS:
+        console.print(
+            f"[red]--transport must be one of: {', '.join(_TRANSPORTS)}[/] "
+            f"(got '{escape(str(transport))}')"
+        )
+        raise typer.Exit(2)
+
+    # Flags that cannot mean anything under stdio are an error, not a silently
+    # ignored argument: stdio has no listener to bind and nothing to authorize.
+    inapplicable = [
+        name
+        for name, value in (
+            ("--host", host),
+            ("--port", port),
+            ("--auth-token", auth_token),
+        )
+        if value is not None
+    ]
+    if transport == _STDIO and inapplicable:
+        console.print(
+            f"[red]{', '.join(inapplicable)} apply to --transport sse/http only[/] - "
+            "stdio has no listener to bind and nothing to authorize."
+        )
+        raise typer.Exit(2)
+
+    # Only what stdio needs. Pulling the network symbols in here as well would
+    # make the default path depend on names it never uses, and any stand-in
+    # module that provides `run_stdio_server` alone would fail to import.
     try:
         from soup_cli.mcp_server.server import run_stdio_server
     except ImportError:
@@ -74,7 +162,65 @@ def serve(
         mode = "mutating tools ENABLED (plan-only)"
     else:
         mode = "read-only"
+
+    if transport == _STDIO:
+        console.print(
+            f"[dim]soup mcp serve - stdio transport - {mode}. Waiting for a client...[/]"
+        )
+        run_stdio_server(allow_mutating=allow_mutating, allow_execute=allow_execute)
+        return
+
+    try:
+        token = _resolve_auth_token(auth_token)
+    except (TypeError, ValueError) as exc:
+        console.print(f"[red]--auth-token:[/] {escape(str(exc))}")
+        raise typer.Exit(2) from exc
+
+    try:
+        from soup_cli.mcp_server.server import (
+            DEFAULT_NETWORK_HOST,
+            DEFAULT_NETWORK_PORT,
+            HTTP_PATH,
+            SSE_PATH,
+            is_wildcard_host,
+            run_network_server,
+        )
+    except ImportError:
+        console.print(
+            "[red]--transport sse/http needs a newer 'mcp' SDK.[/] "
+            "Upgrade with: [bold]pip install -U \"soup-cli\\[mcp]\"[/] "
+            "(streamable HTTP landed in mcp 1.8.0, rebinding protection in 1.10.0)"
+        )
+        raise typer.Exit(1) from None
+
+    bind_host = DEFAULT_NETWORK_HOST if host is None else host
+    bind_port = DEFAULT_NETWORK_PORT if port is None else port
+
+    # Route from the server module, so the printed URL cannot drift from it.
+    path = SSE_PATH if transport == "sse" else HTTP_PATH
     console.print(
-        f"[dim]soup mcp serve - stdio transport - {mode}. Waiting for a client...[/]"
+        f"[dim]soup mcp serve - {transport} transport - {mode}[/]\n"
+        f"[dim]URL:[/]   http://{bind_host}:{bind_port}{path}\n"
+        f"[dim]Token:[/] {token}\n"
+        f"[dim]Every request needs: Authorization: Bearer {token}[/]"
     )
-    run_stdio_server(allow_mutating=allow_mutating, allow_execute=allow_execute)
+    if is_wildcard_host(bind_host) or bind_host not in _LOOPBACK:
+        console.print(
+            f"[yellow]WARNING:[/] bound to {escape(bind_host)}, not loopback - this "
+            "server is reachable from the network and the Bearer token is the "
+            "only thing standing in front of it."
+        )
+    if is_wildcard_host(bind_host):
+        console.print(
+            "[yellow]WARNING:[/] a wildcard bind has no single Host to pin, so "
+            "DNS-rebinding protection degrades to accepting any Host header."
+        )
+
+    run_network_server(
+        transport=transport,
+        allow_mutating=allow_mutating,
+        allow_execute=allow_execute,
+        auth_token=token,
+        host=bind_host,
+        port=bind_port,
+    )

--- a/src/soup_cli/commands/mcp.py
+++ b/src/soup_cli/commands/mcp.py
@@ -138,6 +138,23 @@ def serve(
         )
         raise typer.Exit(2)
 
+    # Execution over a network transport is refused outright rather than
+    # warned about. --allow-execute spawns real training / export processes
+    # (#297); behind a listener that is one Bearer token away from the
+    # network, a leaked token would mean process execution, not just plan
+    # disclosure. stdio is a pipe to a client the operator already started,
+    # which is a different trust boundary. This combination has never
+    # shipped, so refusing it takes nothing away.
+    if transport != _STDIO and allow_execute:
+        console.print(
+            "[red]--allow-execute is refused with --transport "
+            f"{escape(str(transport))}[/] - execution is available over stdio "
+            "only. A network listener is one Bearer token away from spawning "
+            "real training / export processes; run the executing server over "
+            "stdio, or drop --allow-execute to serve plan-only tools here."
+        )
+        raise typer.Exit(2)
+
     # Only what stdio needs. Pulling the network symbols in here as well would
     # make the default path depend on names it never uses, and any stand-in
     # module that provides `run_stdio_server` alone would fail to import.
@@ -152,12 +169,11 @@ def serve(
         )
         raise typer.Exit(1) from None
 
-    # Execution is intentionally not implemented yet. Keep the raw
-    # ``allow_execute`` value for the server/registry, while its stronger
-    # opt-in also enables the existing plan-only mutating tools.
+    # --allow-execute is the stronger opt-in and implies --allow-mutating.
+    # It reaches here only under stdio: the network branch refused above.
     allow_mutating = allow_mutating or allow_execute
     if allow_execute:
-        mode = "mutating tools ENABLED (plan-only; execution disabled)"
+        mode = "mutating tools ENABLED (execution ENABLED)"
     elif allow_mutating:
         mode = "mutating tools ENABLED (plan-only)"
     else:

--- a/src/soup_cli/mcp_server/server.py
+++ b/src/soup_cli/mcp_server/server.py
@@ -1,13 +1,19 @@
-"""MCP stdio server wiring for ``soup mcp serve`` (v0.71.28).
+"""MCP server wiring for ``soup mcp serve`` (v0.71.28; network transports #296).
 
 This is the ONLY module that imports the ``mcp`` SDK — importing it therefore
 requires the ``[mcp]`` extra. The pure tool table lives in
 :mod:`soup_cli.mcp_server.registry` (no SDK dependency, fully unit-testable).
+
+:func:`build_server` is transport-agnostic; ``stdio`` (v1) and the two
+network transports added for #296 (``sse`` / streamable ``http``) all wrap
+the same server object. Everything the network transports need beyond the
+SDK -- starlette, uvicorn -- is already a hard dependency of ``mcp``.
 """
 
 from __future__ import annotations
 
 import json
+import secrets
 import sys
 from contextlib import redirect_stdout
 from typing import List
@@ -87,3 +93,227 @@ def run_stdio_server(*, allow_mutating: bool, allow_execute: bool) -> None:
             await server.run(read_stream, write_stream, server.create_initialization_options())
 
     anyio.run(_main)
+
+
+# --- Network transports (#296) ---------------------------------------------
+
+DEFAULT_NETWORK_PORT = 8765
+DEFAULT_NETWORK_HOST = "127.0.0.1"
+SSE_PATH = "/sse"
+MESSAGE_PATH = "/messages/"
+HTTP_PATH = "/mcp"
+NETWORK_TRANSPORTS = ("sse", "http")
+# Binds that accept from every interface. The Host a client will send is not
+# knowable for these, so rebinding protection cannot be pinned to one name.
+_WILDCARD_HOSTS = frozenset({"", "0.0.0.0", "::", "[::]", "*"})
+
+
+def is_wildcard_host(host: str) -> bool:
+    """True when ``host`` binds every interface rather than one address."""
+    return str(host).strip().lower() in _WILDCARD_HOSTS
+
+
+def allowed_hosts_for(host: str, port: int) -> List[str]:
+    """Host header values accepted by the DNS-rebinding check.
+
+    A wildcard bind degrades to ``["*"]`` — with no single advertised name
+    there is nothing to pin, and pinning the wrong one would reject every real
+    client. ``soup mcp serve`` warns loudly in that case rather than pretending
+    the check is still doing work.
+    """
+    if is_wildcard_host(host):
+        return ["*"]
+    names = [host]
+    if host in ("127.0.0.1", "::1", "localhost"):
+        names = ["127.0.0.1", "localhost", "::1"]
+    # An IPv6 literal is bracketed in a Host header (`[::1]:8765`); joining it
+    # with a bare colon would produce `::1:8765`, which matches nothing and
+    # would 421 every IPv6 loopback client.
+    authorities = [
+        f"[{name}]:{port}" if ":" in name else f"{name}:{port}" for name in names
+    ]
+    return authorities + names
+
+
+def _security_settings(host: str, port: int):
+    """SDK transport-security settings (mcp >= 1.10) for this bind.
+
+    DNS-rebinding protection is what stops a page the operator merely *visits*
+    from driving a loopback MCP server through their browser; the Bearer gate
+    alone would not, since a browser attaches no Authorization header but the
+    request still reaches the port.
+    """
+    from mcp.server.transport_security import TransportSecuritySettings
+
+    hosts = allowed_hosts_for(host, port)
+    origins = ["*"] if hosts == ["*"] else [
+        f"{scheme}://{name}" for name in hosts for scheme in ("http", "https")
+    ]
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=hosts,
+        allowed_origins=origins,
+    )
+
+
+class _BearerAuthMiddleware:
+    """Refuse any HTTP request without ``Authorization: Bearer <token>``.
+
+    Pure ASGI rather than a starlette ``BaseHTTPMiddleware`` subclass: the SSE
+    transport streams for the lifetime of a session, and ``BaseHTTPMiddleware``
+    buffers through a response body it does not own. Non-HTTP scopes
+    (``lifespan``, ``websocket``) pass straight through — gating ``lifespan``
+    would stop the streamable-HTTP session manager from ever starting.
+    """
+
+    def __init__(self, app, token: str) -> None:
+        self._app = app
+        self._expected = f"Bearer {token}".encode()
+
+    async def __call__(self, scope, receive, send) -> None:
+        if scope.get("type") != "http":
+            await self._app(scope, receive, send)
+            return
+        supplied = b""
+        for key, value in scope.get("headers", ()):
+            if key.lower() == b"authorization":
+                supplied = value
+                break
+        # compare_digest over the whole header, so the scheme is checked in
+        # constant time along with the token.
+        if not secrets.compare_digest(supplied, self._expected):
+            from starlette.responses import PlainTextResponse
+
+            response = PlainTextResponse(
+                "Unauthorized",
+                status_code=401,
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+            await response(scope, receive, send)
+            return
+        await self._app(scope, receive, send)
+
+
+def _sse_app(server: Server, security):
+    from mcp.server.sse import SseServerTransport
+    from starlette.applications import Starlette
+    from starlette.responses import Response
+    from starlette.routing import Mount, Route
+
+    sse = SseServerTransport(MESSAGE_PATH, security_settings=security)
+
+    async def _handle_sse(request):
+        # ``request._send`` is how the SDK's own examples drive this transport:
+        # connect_sse needs the raw ASGI send, which Request does not expose.
+        async with sse.connect_sse(
+            request.scope, request.receive, request._send
+        ) as (read_stream, write_stream):
+            await server.run(
+                read_stream, write_stream, server.create_initialization_options()
+            )
+        return Response(status_code=200)
+
+    return Starlette(
+        routes=[
+            Route(SSE_PATH, endpoint=_handle_sse, methods=["GET"]),
+            Mount(MESSAGE_PATH, app=sse.handle_post_message),
+        ]
+    )
+
+
+def _http_app(server: Server, security):
+    from contextlib import asynccontextmanager
+
+    from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+    from starlette.applications import Starlette
+    from starlette.routing import Mount
+
+    manager = StreamableHTTPSessionManager(
+        app=server,
+        json_response=False,
+        stateless=False,
+        security_settings=security,
+    )
+
+    async def _handle(scope, receive, send) -> None:
+        await manager.handle_request(scope, receive, send)
+
+    @asynccontextmanager
+    async def _lifespan(app):
+        # The manager refuses requests until its task group is running, so it
+        # is owned by the app lifespan rather than by the first request.
+        async with manager.run():
+            yield
+
+    return Starlette(routes=[Mount(HTTP_PATH, app=_handle)], lifespan=_lifespan)
+
+
+def build_asgi_app(
+    *,
+    transport: str,
+    allow_mutating: bool,
+    allow_execute: bool,
+    auth_token: str,
+    host: str = DEFAULT_NETWORK_HOST,
+    port: int = DEFAULT_NETWORK_PORT,
+):
+    """Build the authenticated ASGI app for a network transport.
+
+    Split out from :func:`run_sse_server` / :func:`run_http_server` so the auth
+    and rebinding behaviour is testable through an in-process ASGI transport
+    without binding a socket.
+
+    Raises:
+        ValueError: for a transport that is not ``sse`` / ``http`` (``stdio``
+            included — it is not an ASGI transport), or a token that is not
+            urlsafe-base64 shaped.
+    """
+    from soup_cli.utils.qr_url import validate_token
+
+    if transport not in NETWORK_TRANSPORTS:
+        raise ValueError(
+            f"transport must be one of {NETWORK_TRANSPORTS}, got {transport!r}"
+        )
+    token = validate_token(auth_token)
+
+    server = build_server(build_registry(
+        allow_mutating=allow_mutating,
+        allow_execute=allow_execute,
+        execution=ExecutionManager(),
+    ))
+    security = _security_settings(host, port)
+    inner = _sse_app(server, security) if transport == "sse" else _http_app(server, security)
+    return _BearerAuthMiddleware(inner, token)
+
+
+def run_network_server(
+    *,
+    transport: str,
+    allow_mutating: bool,
+    allow_execute: bool,
+    auth_token: str,
+    host: str = DEFAULT_NETWORK_HOST,
+    port: int = DEFAULT_NETWORK_PORT,
+) -> None:
+    """Serve MCP over ``sse`` or ``http`` until interrupted."""
+    import uvicorn
+
+    app = build_asgi_app(
+        transport=transport,
+        allow_mutating=allow_mutating,
+        allow_execute=allow_execute,
+        auth_token=auth_token,
+        host=host,
+        port=port,
+    )
+    uvicorn.run(app, host=host, port=port, log_level="warning")
+
+
+def run_sse_server(**kwargs) -> None:
+    """Serve MCP over HTTP+SSE (GET ``/sse``, POST ``/messages/``)."""
+    run_network_server(transport="sse", **kwargs)
+
+
+def run_http_server(**kwargs) -> None:
+    """Serve MCP over the streamable-HTTP transport (``/mcp``)."""
+    run_network_server(transport="http", **kwargs)

--- a/src/soup_cli/mcp_server/server.py
+++ b/src/soup_cli/mcp_server/server.py
@@ -267,12 +267,24 @@ def build_asgi_app(
         ValueError: for a transport that is not ``sse`` / ``http`` (``stdio``
             included — it is not an ASGI transport), or a token that is not
             urlsafe-base64 shaped.
+            Also for ``allow_execute=True``: gated execution (#297) spawns
+            real processes and is stdio-only, so no network transport may
+            construct a registry that can execute.
     """
     from soup_cli.utils.qr_url import validate_token
 
     if transport not in NETWORK_TRANSPORTS:
         raise ValueError(
             f"transport must be one of {NETWORK_TRANSPORTS}, got {transport!r}"
+        )
+    # Refused here, not only in the CLI: a direct caller of build_asgi_app /
+    # run_network_server must not be able to put an executing registry behind
+    # a listener either. The CLI guard gives the operator a readable message;
+    # this one makes the property structural.
+    if allow_execute:
+        raise ValueError(
+            "allow_execute is not available over a network transport - gated "
+            "execution spawns real training / export processes and is stdio-only"
         )
     token = validate_token(auth_token)
 

--- a/tests/test_issue296_network_transport.py
+++ b/tests/test_issue296_network_transport.py
@@ -1,0 +1,447 @@
+"""Issue #296 — ``soup mcp serve`` network transports (SSE / streamable HTTP).
+
+v1 shipped stdio only. These tests pin the three things that make a listener
+safe to add: it binds loopback by default, every HTTP request carries a Bearer
+token or is refused, and the SDK's DNS-rebinding protection is switched on.
+
+The ASGI-level tests drive the app through ``httpx.ASGITransport`` so no socket
+is opened; ``TestSseEndToEnd`` is the one test that binds a real ephemeral port,
+because "a scripted SSE client smoke (initialize -> list_tools -> call)" is an
+acceptance criterion of the issue and an in-memory transport cannot show it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+
+import pytest
+from typer.testing import CliRunner
+
+from soup_cli.cli import app as cli_app
+
+_ANSI_RE = re.compile(r"\[[0-9;]*m")
+
+
+def _plain(text: str) -> str:
+    """ANSI-stripped, whitespace-collapsed help output (mirrors test_v07302.py).
+
+    Typer styles each option NAME through Rich, so on a colour-capable stream
+    `--transport` arrives with escapes inside it and a raw substring match
+    cannot hit. Rich disables colour on Windows, so the raw version passes
+    locally and fails on the Linux/macOS cells -- the exact asymmetry
+    test_cli_help_assertions_are_ansi_safe.py exists to catch.
+    """
+    return " ".join(_ANSI_RE.sub("", text).split())
+
+TOKEN = "T" * 43
+WRONG = "W" * 43
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _build(transport="sse", *, auth_token=TOKEN, host="127.0.0.1", port=8765):
+    from soup_cli.mcp_server.server import build_asgi_app
+
+    return build_asgi_app(
+        transport=transport,
+        allow_mutating=False,
+        allow_execute=False,
+        auth_token=auth_token,
+        host=host,
+        port=port,
+    )
+
+
+async def _request(app, method, path, *, headers=None, port=8765):
+    """Drive the app in-process. ``port`` must match the port the app was built
+    with, or the Host check refuses the request with 421 before anything else.
+    """
+    import httpx
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url=f"http://127.0.0.1:{port}"
+    ) as client:
+        return await client.request(method, path, headers=headers or {})
+
+
+@pytest.fixture(autouse=True)
+def _need_mcp():
+    # Mirrors TestServerRoundTrip in test_v07128.py: the SDK only exists with
+    # the [mcp] extra, so a partial install skips instead of erroring.
+    pytest.importorskip("mcp")
+
+
+class TestBearerGate:
+    """No token, no service — on every network transport and every route."""
+
+    @pytest.mark.parametrize(
+        "transport,method,path",
+        [
+            ("sse", "GET", "/sse"),
+            ("sse", "POST", "/messages/"),
+            ("http", "POST", "/mcp"),
+            ("http", "GET", "/mcp"),
+        ],
+    )
+    def test_missing_authorization_is_401(self, transport, method, path):
+        resp = _run(_request(_build(transport), method, path))
+        assert resp.status_code == 401
+
+    @pytest.mark.parametrize("transport,path", [("sse", "/messages/"), ("http", "/mcp")])
+    def test_wrong_token_is_401(self, transport, path):
+        resp = _run(
+            _request(
+                _build(transport),
+                "POST",
+                path,
+                headers={"Authorization": f"Bearer {WRONG}"},
+            )
+        )
+        assert resp.status_code == 401
+
+    def test_malformed_authorization_header_is_401(self):
+        # Right token, wrong scheme: "Bearer" is not optional.
+        resp = _run(
+            _request(
+                _build("sse"), "POST", "/messages/", headers={"Authorization": TOKEN}
+            )
+        )
+        assert resp.status_code == 401
+
+    def test_correct_token_reaches_the_transport(self):
+        # 400 is the SDK's own "session_id is required" answer on /messages/ --
+        # the point is that it is NOT 401, i.e. the request got past the gate.
+        resp = _run(
+            _request(
+                _build("sse"),
+                "POST",
+                "/messages/",
+                headers={"Authorization": f"Bearer {TOKEN}"},
+            )
+        )
+        assert resp.status_code == 400
+
+
+class TestDnsRebindingProtection:
+    """The gate a Bearer token cannot be: a browser attaches no Authorization
+    header, but a page the operator merely visits can still reach a loopback
+    port. The SDK's Host check is what refuses it.
+
+    Both requests carry a JSON Content-Type on purpose -- the SDK validates
+    Content-Type before Host on a POST, so without it the 400 for the missing
+    header would mask whatever the Host check would have done.
+    """
+
+    _JSON = {"Authorization": f"Bearer {TOKEN}", "Content-Type": "application/json"}
+
+    def test_foreign_host_header_is_refused(self):
+        # Authenticated on purpose: proves the Host check is a second gate
+        # behind auth, not something auth happens to mask.
+        resp = _run(
+            _request(
+                _build("sse"),
+                "POST",
+                "/messages/",
+                headers={**self._JSON, "Host": "evil.example"},
+            )
+        )
+        assert resp.status_code == 421
+
+    def test_bound_host_and_port_are_allowed(self):
+        resp = _run(
+            _request(
+                _build("sse", host="127.0.0.1", port=8765),
+                "POST",
+                "/messages/",
+                headers={**self._JSON, "Host": "127.0.0.1:8765"},
+            )
+        )
+        assert resp.status_code != 421
+
+    def test_wildcard_bind_cannot_pin_a_host(self):
+        from soup_cli.mcp_server.server import allowed_hosts_for, is_wildcard_host
+
+        assert is_wildcard_host("0.0.0.0")
+        assert allowed_hosts_for("0.0.0.0", 8765) == ["*"]
+        assert "127.0.0.1:8765" in allowed_hosts_for("127.0.0.1", 8765)
+        assert "localhost:8765" in allowed_hosts_for("127.0.0.1", 8765)
+
+    def test_ipv6_literal_is_bracketed(self):
+        # A client talking to ::1 sends `Host: [::1]:8765`. Joining with a bare
+        # colon yields `::1:8765`, which matches nothing and would refuse every
+        # IPv6 loopback client with a 421.
+        from soup_cli.mcp_server.server import allowed_hosts_for
+
+        hosts = allowed_hosts_for("::1", 8765)
+        assert "[::1]:8765" in hosts
+        assert "::1" in hosts
+        assert "::1:8765" not in hosts
+
+
+class TestAuthTokenResolution:
+    def test_generated_token_is_urlsafe_and_valid(self):
+        from soup_cli.commands.mcp import _resolve_auth_token
+        from soup_cli.utils.qr_url import validate_token
+
+        token = _resolve_auth_token(None)
+        assert validate_token(token) == token
+        assert len(token) >= 16
+
+    def test_generated_tokens_differ_between_calls(self):
+        from soup_cli.commands.mcp import _resolve_auth_token
+
+        assert _resolve_auth_token(None) != _resolve_auth_token(None)
+
+    def test_operator_token_is_preserved(self):
+        from soup_cli.commands.mcp import _resolve_auth_token
+
+        assert _resolve_auth_token(TOKEN) == TOKEN
+
+    def test_short_token_is_rejected(self):
+        from soup_cli.commands.mcp import _resolve_auth_token
+
+        with pytest.raises(ValueError):
+            _resolve_auth_token("tooshort")
+
+
+class TestCliSurface:
+    def test_network_only_flags_are_rejected_under_stdio(self):
+        # Silently ignoring a flag that cannot apply is the failure mode this
+        # guards against -- stdio has no host, no port and no auth.
+        runner = CliRunner()
+        for flag, value in (("--auth-token", TOKEN), ("--port", "9000"), ("--host", "0.0.0.0")):
+            result = runner.invoke(cli_app, ["mcp", "serve", "--transport", "stdio", flag, value])
+            assert result.exit_code != 0, (flag, result.output)
+            assert "stdio" in result.output.lower(), (flag, result.output)
+
+    def test_unknown_transport_is_rejected(self):
+        result = CliRunner().invoke(cli_app, ["mcp", "serve", "--transport", "carrier-pigeon"])
+        assert result.exit_code != 0
+
+    # Same set test_cli_subprocess.py::TestUnicodeSafety guards. Not "pure
+    # ASCII": Typer draws its help panels with box characters, which are fine.
+    # These six are the ones that break a cp1252 Windows terminal.
+    PROBLEMATIC_CHARS = ["→", "—", "‘", "’", "“", "”"]
+
+    def test_help_lists_the_transports(self):
+        result = CliRunner().invoke(cli_app, ["mcp", "serve", "--help"])
+        assert result.exit_code == 0, result.output
+        help_text = _plain(result.output)
+        assert "--transport" in help_text
+        for name in ("stdio", "sse", "http"):
+            assert name in help_text
+
+    def test_help_stays_terminal_safe(self):
+        result = CliRunner().invoke(cli_app, ["mcp", "serve", "--help"])
+        for char in self.PROBLEMATIC_CHARS:
+            assert char not in _plain(result.output), repr(char)
+
+
+class TestTransportListsAgree:
+    def test_cli_list_matches_the_server_module(self):
+        # The CLI keeps its own tuple on purpose: --transport must be validated
+        # before the SDK is imported, so a missing [mcp] extra still produces a
+        # flag error rather than an install message. This pins the two lists
+        # together so the deliberate duplication cannot drift into a real one.
+        from soup_cli.commands.mcp import _TRANSPORTS
+        from soup_cli.mcp_server.server import NETWORK_TRANSPORTS
+
+        assert _TRANSPORTS == ("stdio",) + NETWORK_TRANSPORTS
+
+    def test_advertised_paths_come_from_the_server_module(self):
+        from soup_cli.mcp_server.server import HTTP_PATH, MESSAGE_PATH, SSE_PATH
+
+        assert (SSE_PATH, MESSAGE_PATH, HTTP_PATH) == ("/sse", "/messages/", "/mcp")
+
+
+class TestBuildAsgiApp:
+    def test_unknown_transport_raises(self):
+        with pytest.raises(ValueError):
+            _build("carrier-pigeon")
+
+    def test_invalid_auth_token_raises(self):
+        with pytest.raises(ValueError):
+            _build("sse", auth_token="short")
+
+    def test_stdio_is_not_an_asgi_transport(self):
+        with pytest.raises(ValueError):
+            _build("stdio")
+
+
+# ---------------------------------------------------------------------------
+# Real socket. The acceptance criterion asks for "a scripted SSE client smoke
+# (initialize -> list_tools -> call)", and an in-process ASGI transport cannot
+# show that a client which speaks SSE over a real connection is served.
+# ---------------------------------------------------------------------------
+
+
+class _UvicornThread:
+    """Run the app on an ephemeral port for the duration of a `with` block."""
+
+    def __init__(self, app, port):
+        import uvicorn
+
+        self._server = uvicorn.Server(
+            uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+        )
+        self._thread = None
+
+    def __enter__(self):
+        import threading
+        import time
+
+        self._thread = threading.Thread(target=self._server.run, daemon=True)
+        self._thread.start()
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            if self._server.started:
+                return self
+            time.sleep(0.05)
+        raise RuntimeError("uvicorn did not start within 30s")
+
+    def __exit__(self, *exc):
+        self._server.should_exit = True
+        if self._thread is not None:
+            self._thread.join(timeout=30)
+        return False
+
+
+def _free_port():
+    import socket
+
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+async def _sse_session(port, token):
+    from mcp import ClientSession
+    from mcp.client.sse import sse_client
+
+    url = f"http://127.0.0.1:{port}/sse"
+    async with sse_client(url, headers={"Authorization": f"Bearer {token}"}) as (
+        read_stream,
+        write_stream,
+    ):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            tools = await session.list_tools()
+            result = await session.call_tool("recipes_search", {"query": "qwen"})
+            return tools, result
+
+
+class TestSseEndToEnd:
+    def test_initialize_list_tools_and_call_over_a_real_socket(self):
+        port = _free_port()
+        app = _build("sse", port=port)
+        with _UvicornThread(app, port):
+            tools, result = _run(_sse_session(port, TOKEN))
+
+        from soup_cli.mcp_server.registry import build_registry
+
+        names = {tool.name for tool in tools.tools}
+        # Parity with stdio is the acceptance criterion: SSE must serve the
+        # SAME registry, not a subset. Compared against build_registry rather
+        # than a hardcoded count so adding a tool cannot make this drift.
+        expected = {
+            spec.name
+            for spec in build_registry(allow_mutating=False, allow_execute=False)
+        }
+        assert names == expected
+        assert "recipes_search" in names
+        assert result.content and result.content[0].text.strip().startswith("{")
+
+    def test_wrong_token_cannot_open_a_session(self):
+        port = _free_port()
+        app = _build("sse", port=port)
+        with _UvicornThread(app, port):
+            with pytest.raises(Exception):
+                _run(_sse_session(port, WRONG))
+
+
+class TestTransportEntryPoints:
+    """`run_sse_server` / `run_http_server` are the entry points #296 names.
+
+    These pin which app each one hands to uvicorn without binding a socket.
+    They are characterization tests for two one-line wrappers, not red-first
+    tests -- their value is that the wrappers stop being uncovered names.
+    """
+
+    @staticmethod
+    def _capture(monkeypatch):
+        import uvicorn
+
+        seen = {}
+
+        def _fake_run(app, **kwargs):
+            seen["app"] = app
+            seen["kwargs"] = kwargs
+
+        monkeypatch.setattr(uvicorn, "run", _fake_run)
+        return seen
+
+    @staticmethod
+    def _authed(app, path, port):
+        return _run(
+            _request(
+                app,
+                "POST",
+                path,
+                port=port,
+                headers={
+                    "Authorization": f"Bearer {TOKEN}",
+                    "Content-Type": "application/json",
+                },
+            )
+        )
+
+    def test_run_sse_server_serves_the_sse_routes(self, monkeypatch):
+        from soup_cli.mcp_server.server import run_sse_server
+
+        seen = self._capture(monkeypatch)
+        run_sse_server(
+            allow_mutating=False,
+            allow_execute=False,
+            auth_token=TOKEN,
+            host="127.0.0.1",
+            port=1234,
+        )
+        assert seen["kwargs"]["host"] == "127.0.0.1"
+        assert seen["kwargs"]["port"] == 1234
+        # 400 is the SSE transport answering; 404 would mean the route is absent.
+        assert self._authed(seen["app"], "/messages/", 1234).status_code == 400
+        assert _run(_request(seen["app"], "GET", "/sse", port=1234)).status_code == 401
+
+    def test_run_http_server_serves_the_streamable_route(self, monkeypatch):
+        from soup_cli.mcp_server.server import run_http_server
+
+        seen = self._capture(monkeypatch)
+        run_http_server(
+            allow_mutating=False,
+            allow_execute=False,
+            auth_token=TOKEN,
+            host="127.0.0.1",
+            port=4321,
+        )
+        assert seen["kwargs"]["port"] == 4321
+        # The SSE routes do not exist on the streamable-HTTP app.
+        assert self._authed(seen["app"], "/messages/", 4321).status_code == 404
+        assert _run(_request(seen["app"], "POST", "/mcp", port=4321)).status_code == 401
+
+    def test_entry_points_validate_before_binding(self, monkeypatch):
+        from soup_cli.mcp_server.server import run_sse_server
+
+        seen = self._capture(monkeypatch)
+        with pytest.raises(ValueError):
+            run_sse_server(
+                allow_mutating=False,
+                allow_execute=False,
+                auth_token="short",
+                host="127.0.0.1",
+                port=1234,
+            )
+        assert "app" not in seen  # never reached uvicorn

--- a/tests/test_issue296_network_transport.py
+++ b/tests/test_issue296_network_transport.py
@@ -445,3 +445,181 @@ class TestTransportEntryPoints:
                 port=1234,
             )
         assert "app" not in seen  # never reached uvicorn
+class TestExecutionIsStdioOnly:
+    """--allow-execute must not reach a network listener (#296 review).
+
+    The pre-fix code passed ``allow_execute`` straight through to
+    ``run_network_server``, and the banner still said "execution disabled"
+    because the comment predated #297 -- so a listener one Bearer token from
+    the network could spawn real training / export processes while announcing
+    that it could not.
+
+    These tests assert BEHAVIOUR, not the tool table. ``build_registry``
+    always LISTS train_execute / export_execute and swaps only the handler,
+    so a test comparing tool names passes with the gate hardwired open --
+    which is exactly how this went uncovered.
+    """
+
+    @pytest.mark.parametrize("transport", ["sse", "http"])
+    def test_cli_refuses_execute_on_a_network_transport(self, transport):
+        result = CliRunner().invoke(
+            cli_app, ["mcp", "serve", "--transport", transport, "--allow-execute"]
+        )
+        assert result.exit_code == 2, (result.output, repr(result.exception))
+        plain = _plain(result.output)
+        # Name the flag and the transport: an assertion on the exit code alone
+        # passes when a DIFFERENT guard fires (e.g. the unknown-transport one).
+        assert "--allow-execute" in plain, plain
+        assert "stdio" in plain, plain
+
+    def test_cli_still_allows_execute_over_stdio(self, monkeypatch):
+        """Control: the refusal is targeted, not a blanket kill of the flag."""
+        seen = {}
+
+        def _fake(**kwargs):
+            seen.update(kwargs)
+
+        monkeypatch.setattr("soup_cli.mcp_server.server.run_stdio_server", _fake)
+        result = CliRunner().invoke(cli_app, ["mcp", "serve", "--allow-execute"])
+        assert result.exit_code == 0, (result.output, repr(result.exception))
+        assert seen == {"allow_mutating": True, "allow_execute": True}, seen
+
+    def test_stdio_banner_does_not_claim_execution_is_disabled(self, monkeypatch):
+        """The stale banner was the half that made the hole quiet."""
+        monkeypatch.setattr(
+            "soup_cli.mcp_server.server.run_stdio_server", lambda **kw: None
+        )
+        result = CliRunner().invoke(cli_app, ["mcp", "serve", "--allow-execute"])
+        plain = _plain(result.output)
+        assert "execution disabled" not in plain.lower(), plain
+        assert "execution ENABLED" in plain, plain
+
+    def test_build_asgi_app_refuses_execute_structurally(self):
+        """A direct caller must not be able to bypass the CLI guard."""
+        from soup_cli.mcp_server.server import build_asgi_app
+
+        with pytest.raises(ValueError, match="allow_execute"):
+            build_asgi_app(
+                transport="sse",
+                allow_mutating=True,
+                allow_execute=True,
+                auth_token=TOKEN,
+            )
+
+    @pytest.mark.parametrize("entry", ["run_sse_server", "run_http_server"])
+    def test_entry_points_refuse_execute_before_binding(self, entry, monkeypatch):
+        import soup_cli.mcp_server.server as srv
+
+        def _boom(*a, **kw):  # pragma: no cover - must never be reached
+            raise AssertionError("uvicorn.run reached with allow_execute=True")
+
+        import uvicorn
+
+        monkeypatch.setattr(uvicorn, "run", _boom)
+        with pytest.raises(ValueError, match="allow_execute"):
+            getattr(srv, entry)(
+                allow_mutating=True,
+                allow_execute=True,
+                auth_token=TOKEN,
+            )
+
+
+class TestExecuteGateIsCoveredByBehaviour:
+    """Pins the gate the name-comparing tests cannot see.
+
+    Hardwiring ``allow_execute=True`` inside build_registry leaves the tool
+    NAMES identical, so only calling a handler distinguishes the two states.
+    """
+
+    @staticmethod
+    def _handler(name, *, allow_execute):
+        from soup_cli.mcp_server.registry import build_registry
+
+        specs = {
+            spec.name: spec
+            for spec in build_registry(
+                allow_mutating=True, allow_execute=allow_execute
+            )
+        }
+        return specs[name]
+
+    @pytest.mark.parametrize("name", ["train_execute", "export_execute"])
+    def test_tool_names_alone_cannot_tell_the_states_apart(self, name):
+        """The control that explains why the behavioural tests below exist."""
+        from soup_cli.mcp_server.registry import build_registry
+
+        off = {s.name for s in build_registry(allow_mutating=True, allow_execute=False)}
+        on = {s.name for s in build_registry(allow_mutating=True, allow_execute=True)}
+        assert name in off and name in on
+        assert off == on
+
+    @pytest.mark.parametrize("name", ["train_execute", "export_execute"])
+    def test_execute_handler_refuses_when_the_gate_is_off(self, name):
+        from soup_cli.mcp_server.registry import McpToolError
+
+        spec = self._handler(name, allow_execute=False)
+        with pytest.raises(McpToolError, match="--allow-execute"):
+            spec.handler({"confirmation_token": "x" * 43})
+
+    @pytest.mark.parametrize("name", ["train_execute", "export_execute"])
+    def test_execute_handler_is_live_when_the_gate_is_on(self, name):
+        """Must NOT be the disabled-flag refusal.
+
+        A bogus token still fails -- but on the token, which is the enabled
+        path. Asserting "raises" alone would pass in both states.
+        """
+        from soup_cli.mcp_server.registry import McpToolError
+
+        spec = self._handler(name, allow_execute=True)
+        with pytest.raises(McpToolError) as exc:
+            spec.handler({"confirmation_token": "x" * 43})
+        assert "--allow-execute" not in str(exc.value), str(exc.value)
+
+    @pytest.mark.parametrize("name", ["train_execute", "export_execute"])
+    def test_gate_is_off_even_when_an_execution_manager_is_supplied(self, name):
+        """The combination the production path actually uses.
+
+        ``run_stdio_server`` builds an ``ExecutionManager()`` unconditionally
+        and passes it whether or not --allow-execute was given, so the handler
+        choice must turn on ``allow_execute`` -- not merely on an execution
+        manager being present. Dropping ``allow_execute and`` from that
+        condition passed every other test in this file while making a plain
+        ``soup mcp serve`` serve live execution handlers.
+        """
+        from soup_cli.mcp_server.execution import ExecutionManager
+        from soup_cli.mcp_server.registry import McpToolError, build_registry
+
+        specs = {
+            spec.name: spec
+            for spec in build_registry(
+                allow_mutating=True,
+                allow_execute=False,
+                execution=ExecutionManager(),
+            )
+        }
+        with pytest.raises(McpToolError, match="--allow-execute"):
+            specs[name].handler({"confirmation_token": "x" * 43})
+
+    def test_stdio_entry_point_passes_an_execution_manager_unconditionally(
+        self, monkeypatch
+    ):
+        """Control: pins WHY the test above is the one that matters.
+
+        If run_stdio_server ever stops handing an ExecutionManager to a
+        gate-off registry, the test above becomes vacuous and should be
+        re-justified rather than silently kept.
+        """
+        import soup_cli.mcp_server.server as srv
+
+        seen = {}
+
+        def _capture(**kwargs):
+            seen.update(kwargs)
+            return []
+
+        monkeypatch.setattr(srv, "build_registry", _capture)
+        monkeypatch.setattr(srv, "build_server", lambda specs: None)
+        monkeypatch.setattr(srv.anyio, "run", lambda *a, **kw: None)
+        srv.run_stdio_server(allow_mutating=False, allow_execute=False)
+        assert seen["allow_execute"] is False, seen
+        assert seen["execution"] is not None, seen


### PR DESCRIPTION
## What does this PR do?

Closes #296. `soup mcp serve` gains `--transport sse` and `--transport http`. **stdio stays the default and its code path is untouched** — a client that spawns Soup as a subprocess sees no change at all.

## Registry parity, proven rather than asserted

Both transports serve the *same* registry as stdio. The end-to-end test compares the advertised tool names against `build_registry(...)` instead of a hardcoded count, so a subset cannot creep in and adding a tool later cannot silently make the check stale:

```python
expected = {spec.name for spec in build_registry(allow_mutating=False, allow_execute=False)}
assert names == expected
```

## Security: three gates, because a listener is the risky part

**1. Bearer token on every HTTP request, no opt-out.** Compared with `secrets.compare_digest` over the whole header, so the scheme is checked in constant time along with the token. There is deliberately no `--no-auth`: a loopback port is reachable by every process on the machine, not just by the operator.

The token is validated through the existing `utils/qr_url.py::validate_token` (16-128 urlsafe-base64 chars), so `soup ui` and `soup mcp serve` agree on what a token *is* rather than growing a second bespoke format. It travels in the header only — no query-string fallback that could be captured in a proxy or access log.

**2. DNS-rebinding protection (the SDK's `TransportSecuritySettings`).** `421` on a foreign `Host`, `403` on a foreign `Origin`. This is the gate the Bearer token *cannot* be: a web page the operator merely visits attaches no `Authorization` header, but its request still arrives at the port. Auth is the outer layer and rebinding the inner one, and the tests authenticate on purpose before checking `Host` so that ordering is pinned rather than assumed.

**3. Loopback by default.** `127.0.0.1:8765`. A non-loopback `--host` prints a warning; a wildcard bind prints a second one saying the Host check has degraded to accepting anything, because with no single advertised name there is nothing to pin. `allowed_hosts_for()` returns `["*"]` there rather than pretending the check still does work.

## The `[mcp]` floor moves, and the number is measured

`mcp>=1.2.0,<2` → `mcp>=1.10.0,<2`. Not read off a changelog — I installed the wheels and checked which module each version actually ships:

| mcp | `server/sse.py` | `server/streamable_http_manager.py` | `server/transport_security.py` |
|---|---|---|---|
| 1.2.0 | yes | no | no |
| 1.6.0 | yes | no | no |
| 1.7.0 | yes | no | no |
| 1.8.0 | yes | **yes** | no |
| 1.9.4 | yes | yes | no |
| 1.10.0 | yes | yes | **yes** |

`--transport sse` alone would have run on the old floor. Streamable HTTP would not, and neither would rebinding protection — and a listener whose origin checking silently disappears on an older SDK is worse than a resolver error the operator can act on. The `<2` cap is unchanged; #322 is the 2.x migration and this does not touch it.

**No new dependency:** `mcp` already requires `starlette`, `uvicorn`, `sse-starlette` and `httpx-sse`, so `[mcp]` does not grow.

## Flags that cannot apply are refused, not ignored

`--host` / `--port` / `--auth-token` default to `None` and resolve per transport, so passing one with `--transport stdio` exits non-zero with a message naming the flags. Silently accepting a flag that does nothing is the failure mode worth avoiding here.

## Tests — 30 in the new file

`build_asgi_app()` is factored out so auth and rebinding are exercised through `httpx.ASGITransport` without binding a socket:

- 401 on a missing header, a wrong token, and a right token under the wrong scheme, across `/sse`, `/messages/` and `/mcp`
- a correct token reaches the transport (400 from the SDK, i.e. past the gate)
- `421` on a foreign `Host` while authenticated; the bound host/port accepted
- token resolution: generated tokens validate, differ between calls, an operator token is preserved, a short one is rejected
- CLI: network-only flags refused under stdio, unknown transport refused, help lists the transports

Then one test binds a **real ephemeral port**, runs uvicorn in a thread, and drives `initialize → list_tools → call_tool` through the SDK's own SSE client — that is the acceptance criterion as written, and an in-memory transport cannot demonstrate it. A companion test confirms a wrong token cannot open a session over that same real socket.

## Three defects the tests caught before review

1. **IPv6 loopback would have been refused entirely.** `allowed_hosts_for("::1", 8765)` joined with a bare colon produced `::1:8765`; a real client sends `Host: [::1]:8765`, so every IPv6 loopback client would have hit a `421`. Now bracketed, with a test pinning it.

2. **The stdio path depended on network symbols it never uses.** Importing `DEFAULT_NETWORK_HOST` / `DEFAULT_NETWORK_PORT` alongside `run_stdio_server` broke `test_v07128.py::TestServePlumbing::test_allow_flags_reach_runner`, which injects a stand-in module exposing `run_stdio_server` alone. The test was right and the code was wrong; the imports are now split per branch.

3. **A `--help` assertion read raw CLI output.** `test_cli_help_assertions_are_ansi_safe.py` caught it — exactly the asymmetry that guard documents: Rich disables colour on Windows, so it passed locally and would have turned the Linux/macOS cells red. Routed through a `_plain()` helper mirroring `test_v07302.py`.

Also removed two sources of drift a reviewer would have flagged and CI would not: an unused `TRANSPORTS` constant, and duplicated `/sse` / `/mcp` literals in the CLI (now imported from the server module). The transport *list* is still duplicated in the CLI on purpose — `--transport` must be validated before the SDK is imported, so a missing `[mcp]` extra yields a flag error rather than an install message — and `TestTransportListsAgree` pins the two lists together so the deliberate duplication cannot become a real one.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [x] Tests

## Checklist

- [x] `ruff check src/soup_cli/ tests/` passes
- [x] `pytest tests/ -v` passes — **18087 passed, 377 skipped, 0 failed**, coverage 81% (gate 77%)
- [x] Updated relevant docs — `docs/commands.md` gains two command-list lines and a "Remote or multi-client" section covering the `.mcp.json` header shape and each security property; `CHANGELOG.md` has the entry
- [x] No breaking changes — stdio is byte-for-byte the same path; the only behaviour change for an existing user is the `[mcp]` floor
