### PR TITLE
fix(stream): keep Apple Silicon host store on CPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,7 +121,8 @@ reproducing 70+ versions of notes.
 
 ### Fixed
 
-- **Layer streaming now keeps its host store on CPU on Apple Silicon (#434).**
+- **Layer streaming now keeps its host store on CPU on Apple Silicon
+  (#434 by @Amix29 in #480).**
   PyTorch 2.7+ can return an MPS tensor for
   `torch.empty(device="cpu", pin_memory=True)`, while `is_pinned()` remains
   false. Direct runtime callers could therefore place the whole frozen base in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,18 @@ reproducing 70+ versions of notes.
 
 ### Fixed
 
+- **Layer streaming now keeps its host store on CPU on Apple Silicon (#434).**
+  PyTorch 2.7+ can return an MPS tensor for
+  `torch.empty(device="cpu", pin_memory=True)`, while `is_pinned()` remains
+  false. Direct runtime callers could therefore place the whole frozen base in
+  the MPS allocator and still report a pinned RAM store, even though the normal
+  `soup train` setup already disabled pinning outside CUDA. The runtime now
+  disables both optional and required pinning when the target is MPS, and
+  `RamSource` independently refuses any allocation that is not genuinely CPU
+  memory (or claims pinning without being pinned). MPS proceeds experimentally
+  with a pageable CPU source and MPS layer buffers; CUDA pinning behaviour is
+  unchanged.
+
 - **`downsample` now returns at most `max_points` rows, which is what its
   docstring has always promised (#473 in #474).** The stride was
   `len(rows) // max_points` — a divisor, not a cap — so five rows with

--- a/docs/performance-and-quantization.md
+++ b/docs/performance-and-quantization.md
@@ -248,6 +248,17 @@ soup train --config soup.yaml
 
 **How it works.** LoRA adapters + their gradients + optimizer state stay resident in VRAM (they are small). The frozen base lives in CPU RAM, page-locked when the machine allows it, and is streamed: each decoder layer is copied into one of two pre-allocated VRAM buffers on a dedicated CUDA stream while the previous layer is still computing, so the load overlaps the compute. Each layer is read **twice** per step — once in the forward pass and once when the backward pass recomputes it — because `dL/dx = Wᵀ · dL/dy` needs the weights to reach the layers below. That is physics, not an implementation detail, and it is why streaming costs time.
 
+**Apple Silicon is experimental.** With `backend: transformers`, MPS uses a pageable CPU
+source and MPS layer buffers; host pinning is disabled. PyTorch 2.7+ may otherwise turn
+`torch.empty(device="cpu", pin_memory=True)` into an MPS tensor, charging the entire base
+to the MPS allocator while `is_pinned()` is still false (#434). Soup refuses that state at
+the source boundary and also disables pinning before allocation. Apple Silicon has unified
+physical memory, so the CUDA capacity and throughput numbers below do not transfer: only
+the MPS allocator's streamed weights are bounded by the buffer pool, while the CPU source
+still consumes unified memory. No claim is made yet that streaming fits a larger model or
+runs faster than resident MPS training. `backend: mlx` remains a separate, incompatible
+model-loading path and is rejected with `stream_layers`.
+
 The tradeoff: **1.43× slower than resident training**, measured at 0.5B — the only apples-to-apples comparison available on the reference box, because 1.5B and above cannot run resident there at all.
 
 ### NF4 streaming (`quantization: 4bit`)
@@ -314,11 +325,12 @@ refusing:
 |---|---|
 | RAM tier on CUDA | pins, or **refuses** naming the store size |
 | Disk tier (base does not fit in RAM, weights stream from NVMe) | announces that pinning does not apply, proceeds |
-| CPU (no CUDA device) | announces that page-locking is a host-to-device optimization, proceeds |
+| Non-CUDA target (CPU or MPS) | announces that CUDA host pinning does not apply, proceeds with a pageable CPU source |
 
 Refusing on those two would brick the large-model runs the disk tier exists for, and
 would make `stream_pin: true` uncommittable to a `soup.yaml` shared between a GPU box and
-a CPU box. The RAM tier is where the flag has real semantics, and there it still refuses.
+a non-CUDA box. The CUDA RAM tier is where the flag has real semantics, and there it still
+refuses.
 
 Set while `stream_layers: false` the key is rejected as a footgun, like the other
 `stream_*` keys.

--- a/src/soup_cli/config/schema.py
+++ b/src/soup_cli/config/schema.py
@@ -3107,11 +3107,10 @@ class TrainingConfig(BaseModel):
             "is worth up to 6.56x measured throughput, so a silent fallback "
             "spends the whole margin the feature exists to provide. On the disk "
             "tier (the base does not fit in RAM, so there is no RAM store to "
-            "page-lock) and on CPU (page-locking is a host-to-device transfer "
-            "optimization and there is no device) pinning is INAPPLICABLE rather "
-            "than unsatisfiable: 'true' is announced and the run proceeds "
-            "without it, so the key stays committable to a config shared between "
-            "a GPU box and a CPU box."
+            "page-lock) and on non-CUDA targets (CPU or MPS) pinning is "
+            "INAPPLICABLE rather than unsatisfiable: 'true' is announced and the "
+            "run proceeds with a pageable CPU source, so the key stays committable "
+            "to a config shared between CUDA and non-CUDA boxes."
         ),
     )
 

--- a/src/soup_cli/trainer/stream_setup.py
+++ b/src/soup_cli/trainer/stream_setup.py
@@ -472,14 +472,15 @@ class StreamingSetupMixin:
             use_rslora=tcfg.lora.use_rslora,
         )
 
-        # #366 review — on CPU there is no CUDA device, so page-locking (a
-        # host->device transfer optimization) is inapplicable. An explicit
-        # stream_pin=true is honoured by saying so, not by dropping it silently.
+        # #366 / #434 — CUDA host pinning is inapplicable on every non-CUDA
+        # target. An explicit stream_pin=true is honoured by saying so, not by
+        # dropping it silently. On MPS the pageable CPU source is also what keeps
+        # the frozen base out of the accelerator allocator.
         if tcfg.stream_pin is True and not on_cuda:
             console.print(
                 "[yellow]training.stream_pin=true, but no CUDA device is present: "
-                "page-locking is a host-to-device transfer optimization and does "
-                "not apply on CPU. Proceeding without it.[/]"
+                "CUDA host pinning does not apply to this target. Proceeding with "
+                "a pageable CPU source.[/]"
             )
 
         model, runtime = build_streamed_model(
@@ -494,8 +495,8 @@ class StreamingSetupMixin:
             # #366: on the RAM tier stream_pin=true refuses rather than silently
             # falling back to a pageable store; on the disk tier the runtime
             # announces that pinning is inapplicable (no RAM store to lock); on
-            # CPU the notice above covers it. require_pin only carries the RAM
-            # refusal, so it is gated on a real CUDA device.
+            # non-CUDA targets the notice above covers it. require_pin only carries
+            # the CUDA RAM-tier refusal, so it is gated on a real CUDA device.
             require_pin=(tcfg.stream_pin is True) and on_cuda,
             seed=tcfg.seed if getattr(tcfg, "seed", None) is not None else 0,
             trust_remote_code=self._trust_remote_code,

--- a/src/soup_cli/utils/layer_stream_runtime.py
+++ b/src/soup_cli/utils/layer_stream_runtime.py
@@ -330,6 +330,21 @@ class RamSource:
                         device="cpu",
                         pin_memory=self.pinned,
                     )
+                    # PyTorch 2.7+ on Apple Silicon may return an MPS tensor for
+                    # ``device="cpu", pin_memory=True``.  Accepting that would put
+                    # the entire supposed host store in the accelerator allocator
+                    # while reporting it as pinned CPU RAM (#434).
+                    if dst.device.type != "cpu":
+                        raise RuntimeError(
+                            "layer streaming's RAM source requested a CPU tensor, "
+                            f"but torch returned {dst.device}. Pinned host memory is "
+                            "CUDA-only here; retry with pin=False."
+                        )
+                    if self.pinned and not dst.is_pinned():
+                        raise RuntimeError(
+                            "layer streaming requested pinned CPU RAM, but torch "
+                            "returned pageable memory; retry with pin=False."
+                        )
                     src = handle.get_tensor(name)
                     dst.copy_(src)
                     del src
@@ -1591,6 +1606,16 @@ def install_streaming(
     import torch
 
     from soup_cli.utils.layer_shard import QUANT_NF4
+
+    # PyTorch 2.7+ on Apple Silicon can turn
+    # ``device="cpu", pin_memory=True`` into an MPS allocation, placing the
+    # whole base in the accelerator allocator and defeating the host-store
+    # invariant (#434). Keep this MPS-specific guard at the runtime boundary as
+    # well as in stream_setup so direct callers are safe. CPU retains its
+    # existing try/fallback semantics, including the require_pin wiring tests.
+    if str(device).startswith("mps"):
+        pin = False
+        require_pin = False
 
     # Validate the index BEFORE touching the model: an index whose `quant` and
     # `quant_specs` disagree passes the cache key (which reads `quant`) and

--- a/src/soup_cli/utils/layer_stream_runtime.py
+++ b/src/soup_cli/utils/layer_stream_runtime.py
@@ -1614,6 +1614,16 @@ def install_streaming(
     # well as in stream_setup so direct callers are safe. CPU retains its
     # existing try/fallback semantics, including the require_pin wiring tests.
     if str(device).startswith("mps"):
+        if require_pin:
+            message = (
+                "layer streaming was called with require_pin=True, but the target "
+                "is MPS. Pinned CPU host memory is CUDA-only here; proceeding "
+                "with a pageable CPU source."
+            )
+            if console is not None:
+                console.print(f"[yellow]{message}[/]")
+            else:
+                logger.warning(message)
         pin = False
         require_pin = False
 

--- a/tests/test_qwen35_streaming.py
+++ b/tests/test_qwen35_streaming.py
@@ -497,7 +497,30 @@ class TestQwen35StreamingRuntime:
             for tensor in layer.values()
         )
 
-    def test_ram_source_refuses_a_non_cpu_allocation(self, tmp_path, monkeypatch):
+    @pytest.mark.parametrize("device_type", ["meta", "mps"])
+    def test_ram_source_refuses_a_non_cpu_allocation(
+        self, tmp_path, monkeypatch, device_type
+    ):
+        from soup_cli.utils.layer_shard import shard_checkpoint
+        from soup_cli.utils.layer_stream_runtime import RamSource
+
+        weights = _heterogeneous_weights_dir(tmp_path)
+        out = str(tmp_path / "shards")
+        index = shard_checkpoint(weights, out, dtype="float32", arch="qwen3")
+        layer_specs = RamSource.layer_specs_from_shards(out, index.n_layers)
+        def _misplaced_empty(*args, **kwargs):
+            del args
+            if kwargs.get("pin_memory"):
+                return types.SimpleNamespace(device=torch.device(device_type))
+            raise AssertionError("RamSource allocations should request pin_memory")
+
+        monkeypatch.setattr(torch, "empty", _misplaced_empty)
+        with pytest.raises(RuntimeError, match=rf"requested a CPU tensor.*{device_type}"):
+            RamSource(out, index.n_layers, layer_specs, pin=True)
+
+    def test_ram_source_refuses_pageable_memory_when_pinning_was_requested(
+        self, tmp_path, monkeypatch
+    ):
         from soup_cli.utils.layer_shard import shard_checkpoint
         from soup_cli.utils.layer_stream_runtime import RamSource
 
@@ -507,14 +530,55 @@ class TestQwen35StreamingRuntime:
         layer_specs = RamSource.layer_specs_from_shards(out, index.n_layers)
         real_empty = torch.empty
 
-        def _misplaced_empty(*args, **kwargs):
-            if kwargs.get("pin_memory"):
-                return real_empty(*args, dtype=kwargs.get("dtype"), device="meta")
-            return real_empty(*args, **kwargs)
+        def _pageable_empty(*args, **kwargs):
+            allocation = dict(kwargs)
+            allocation["pin_memory"] = False
+            return real_empty(*args, **allocation)
 
-        monkeypatch.setattr(torch, "empty", _misplaced_empty)
-        with pytest.raises(RuntimeError, match="requested a CPU tensor.*meta"):
+        monkeypatch.setattr(torch, "empty", _pageable_empty)
+        with pytest.raises(RuntimeError, match="returned pageable memory"):
             RamSource(out, index.n_layers, layer_specs, pin=True)
+
+    def test_mps_gate_disables_pinning_for_direct_callers(
+        self, tmp_path, monkeypatch
+    ):
+        import soup_cli.utils.layer_stream_runtime as runtime_module
+        from soup_cli.utils.layer_shard import shard_checkpoint
+
+        class _SourceCapturedError(Exception):
+            pass
+
+        captured = {}
+        messages = []
+
+        class _RecordingConsole:
+            def print(self, *args, **_kwargs):
+                messages.append(" ".join(str(arg) for arg in args))
+
+        def _capture_source(*args, **kwargs):
+            captured["pin"] = args[3]
+            captured["require_pin"] = kwargs["require_pin"]
+            raise _SourceCapturedError
+
+        weights = _heterogeneous_weights_dir(tmp_path)
+        out = str(tmp_path / "shards")
+        index = shard_checkpoint(weights, out, dtype="float32", arch="qwen3")
+        monkeypatch.setattr(runtime_module, "_build_source", _capture_source)
+
+        with pytest.raises(_SourceCapturedError):
+            runtime_module.install_streaming(
+                _heterogeneous_meta_model(),
+                shard_dir=out,
+                index=index,
+                device="mps",
+                pin=True,
+                require_pin=True,
+                console=_RecordingConsole(),
+            )
+
+        assert captured == {"pin": False, "require_pin": False}
+        assert any("require_pin=True" in message for message in messages)
+        assert any("pageable CPU source" in message for message in messages)
 
     @pytest.mark.skipif(
         not (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()),

--- a/tests/test_qwen35_streaming.py
+++ b/tests/test_qwen35_streaming.py
@@ -497,6 +497,63 @@ class TestQwen35StreamingRuntime:
             for tensor in layer.values()
         )
 
+    def test_ram_source_refuses_a_non_cpu_allocation(self, tmp_path, monkeypatch):
+        from soup_cli.utils.layer_shard import shard_checkpoint
+        from soup_cli.utils.layer_stream_runtime import RamSource
+
+        weights = _heterogeneous_weights_dir(tmp_path)
+        out = str(tmp_path / "shards")
+        index = shard_checkpoint(weights, out, dtype="float32", arch="qwen3")
+        layer_specs = RamSource.layer_specs_from_shards(out, index.n_layers)
+        real_empty = torch.empty
+
+        def _misplaced_empty(*args, **kwargs):
+            if kwargs.get("pin_memory"):
+                return real_empty(*args, dtype=kwargs.get("dtype"), device="meta")
+            return real_empty(*args, **kwargs)
+
+        monkeypatch.setattr(torch, "empty", _misplaced_empty)
+        with pytest.raises(RuntimeError, match="requested a CPU tensor.*meta"):
+            RamSource(out, index.n_layers, layer_specs, pin=True)
+
+    @pytest.mark.skipif(
+        not (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()),
+        reason="needs Apple Silicon MPS",
+    )
+    def test_mps_target_keeps_the_host_store_on_cpu(self, tmp_path):
+        from soup_cli.utils.layer_shard import shard_checkpoint
+        from soup_cli.utils.layer_stream_runtime import install_streaming
+
+        weights = _heterogeneous_weights_dir(tmp_path)
+        out = str(tmp_path / "shards")
+        index = shard_checkpoint(weights, out, dtype="float32", arch="qwen3")
+        runtime = install_streaming(
+            _heterogeneous_meta_model(),
+            shard_dir=out,
+            index=index,
+            device="mps",
+            pin=True,
+            require_pin=True,
+        )
+        try:
+            assert runtime.pinned is False
+            assert all(
+                tensor.device.type == "cpu"
+                for layer in runtime.source.store
+                for tensor in layer.values()
+            )
+            assert all(
+                tensor.device.type == "mps"
+                for slot in runtime.pool.buffers
+                for tensor in slot.values()
+            )
+            runtime.pool.load_async(0, runtime.source)
+            copied = runtime.pool.wait(0)["self_attn.q_proj.weight"].cpu()
+            source = runtime.source.get(0, "self_attn.q_proj.weight")
+            assert torch.equal(copied, source)
+        finally:
+            runtime.close()
+
     def test_install_streaming_accepts_heterogeneous_layer_sets(self, tmp_path):
         from soup_cli.utils.layer_shard import shard_checkpoint
         from soup_cli.utils.layer_stream_runtime import install_streaming


### PR DESCRIPTION
## Summary

- disable optional and required host pinning at the runtime boundary for MPS targets, including direct callers
- make `RamSource` reject storage that is not genuinely on CPU, or a requested pinned allocation that is not pinned
- document the experimental Apple Silicon path and update non-CUDA `stream_pin` messaging

Fixes #434.

## Reproduction and scope

Measured on a MacBook Pro M4 Max with 128 GB unified memory:

- tested PyTorch 2.0.1 through 2.6.0 samples raise when asked for pinned CPU memory without CUDA
- tested PyTorch 2.7.0 through 2.12.1 samples, plus an unreleased 2.13.0 development build, return an `mps:0` tensor for `torch.empty(device="cpu", pin_memory=True)`, while `is_pinned()` is false
- a 256 MiB reproduction increased `torch.mps.current_allocated_memory()` by exactly 256 MiB
- with this patch, the source tensors remain on CPU, the two layer buffers live on MPS, `runtime.pinned` is false, and the CPU-to-MPS copy is exact

The regular `soup train` setup already gated pinning on CUDA. The unsafe case was the lower-level runtime default/direct-call path, plus the lack of a postcondition at the source boundary.

Apple Silicon support remains explicitly experimental. Unified physical memory means the CUDA capacity and throughput figures do not transfer, and this PR does not claim that streaming fits a larger model or runs faster than resident MPS training.

## Additional hardware checks

- toy Qwen3.5 LoRA streamed vs resident MPS: forward output, loss, and all 4 LoRA gradients matched exactly
- toy Qwen3.5 NF4 with bitsandbytes 0.50.1: forward output, loss, and all 8 LoRA gradients matched exactly

These checks support correctness of the small reproduction only; they are not a broad production-support claim.

## Validation

- `486 passed, 42 skipped` across the full layer-streaming test set
- `ruff check src/soup_cli/ tests/`
- `git diff --check`

## Contributor identity

I changed my GitHub account from `Sir-Lysander` to `Amix29`; this PR and its commit are submitted from the new account.

