### PR TITLE
feat(monitor): support Apple Silicon via powermetrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ reproducing 70+ versions of notes.
 
 ### Added
 
+- **Native Apple Silicon telemetry for `soup monitor` (#99 by @Amix29).**
+  The monitor now reads bounded plist output from macOS `powermetrics` and
+  renders GPU utilization and power in the existing Rich table. It reuses an
+  explicitly cached sudo credential through non-interactive `sudo -n`, never
+  reads a password, and gives an actionable Activity Monitor fallback when
+  permission or telemetry is unavailable. NVIDIA-only VRAM, memory-utilization,
+  and temperature fields remain unavailable rather than being guessed.
+
 - **`soup data best-of-n` can sample candidates from Ollama or vLLM providers
   (#299 by @Faisal01011 in #466).** The existing local Transformers `--base` path stays
   the default, while `--provider ollama|vllm --model <m> [--base-url <url>]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ reproducing 70+ versions of notes.
 
 ### Added
 
-- **Native Apple Silicon telemetry for `soup monitor` (#99 by @Amix29).**
+- **Native Apple Silicon telemetry for `soup monitor` (#99 by @Amix29 in #481).**
   The monitor now reads bounded plist output from macOS `powermetrics` and
   renders GPU utilization and power in the existing Rich table. It reuses an
   explicitly cached sudo credential through non-interactive `sudo -n`, never

--- a/docs/backends-and-ops.md
+++ b/docs/backends-and-ops.md
@@ -636,7 +636,17 @@ soup monitor --refresh 0.5  # faster polling
 soup monitor --once         # single snapshot, no Live panel
 ```
 
-Calls `nvidia-smi` via list-args subprocess (no shell), 5s timeout, list of `GpuSample` rows rendered into a Rich table. Apple Silicon prints a yellow advisory pointing at Activity Monitor / `powermetrics`; native Apple Silicon support lands in v0.44.1.
+On NVIDIA systems, Soup calls `nvidia-smi` via a list-args subprocess (no shell)
+with a 5-second timeout. On Apple Silicon, it reads GPU utilization and power
+from `/usr/bin/powermetrics --samplers gpu_power --format plist`. Run `sudo -v`
+in a terminal before starting the monitor: Soup uses `sudo -n`, so it can reuse
+the cached credential without ever prompting for or reading a password. If the
+credential or utility is unavailable, the command exits with an Activity
+Monitor fallback rather than reporting an NVIDIA error.
+
+macOS does not expose NVIDIA-style dedicated VRAM, memory-utilization, or GPU
+temperature fields through this sampler. Those columns therefore remain `—`
+instead of guessing values from unified memory or unrelated thermal sensors.
 
 
 ## Soup Fetch — Bundled Examples

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -212,7 +212,7 @@ soup bench <model> --p50 --p95                Bench with tail-latency percentile
 soup bench <model> --backend auto             Auto-detect transformers/mlx backend (v0.53.9)
 soup serve --reasoning-parser deepseek-r1     Strip <think> blocks from responses (v0.53.9)
 soup doctor [--nccl] [--disk]                 Check environment (optionally check NCCL bandwidth, media type; --disk ~9s cold / ~2.4s warm)
-soup monitor                                  Live GPU monitor: util / temp / VRAM / power per GPU
+soup monitor                                  NVIDIA / Apple Silicon GPU monitor: util / temp / VRAM / power
 soup quickstart [--dry-run]                   Full demo
 soup plugins list|install|enable|disable      Manage Soup plugins
 soup llama cli|mtmd-cli|gguf-split|server ... Proxy to the llama.cpp binaries

--- a/src/soup_cli/commands/monitor.py
+++ b/src/soup_cli/commands/monitor.py
@@ -2,7 +2,7 @@
 
 Renders a Rich panel with one row per detected GPU: Util / Temp / VRAM /
 Power. Polls `nvidia-smi` (Linux/Windows/CUDA) at the configured refresh
-rate. Apple Silicon variant is a stub note in v0.44.0.
+rate, or `powermetrics` on Apple Silicon.
 """
 
 from __future__ import annotations
@@ -18,8 +18,10 @@ from rich.table import Table
 
 from soup_cli.utils.gpu_monitor import (
     GpuSample,
+    PowermetricsStatus,
     detect_apple_silicon,
     query_nvidia_smi,
+    query_powermetrics,
 )
 
 console = Console()
@@ -65,6 +67,60 @@ def _build_table(samples: list[GpuSample]) -> Table:
     return table
 
 
+def _powermetrics_error(status: PowermetricsStatus) -> str:
+    if status is PowermetricsStatus.PERMISSION_DENIED:
+        return (
+            "[yellow]Apple GPU metrics require permission to run "
+            "`/usr/bin/powermetrics`.[/]\n"
+            "Run [bold]sudo -v[/] in a terminal, then rerun `soup monitor`. "
+            "Soup uses `sudo -n`: it never prompts for or reads your password."
+        )
+    if status is PowermetricsStatus.UNAVAILABLE:
+        return (
+            "[yellow]`/usr/bin/powermetrics` is unavailable on this Mac. "
+            "Use Activity Monitor → Window → GPU History.[/]"
+        )
+    if status is PowermetricsStatus.INVALID_OUTPUT:
+        return (
+            "[yellow]`powermetrics` returned no usable Apple GPU sample. "
+            "Its plist schema may not expose `gpu_power` on this Mac.[/]"
+        )
+    return "[yellow]`powermetrics` failed or timed out while reading Apple GPU metrics.[/]"
+
+
+def _monitor_apple_silicon(refresh: float, once: bool) -> None:
+    title = "Soup GPU Monitor — Apple Silicon"
+    result = query_powermetrics(refresh)
+    if result.status is not PowermetricsStatus.OK:
+        console.print(_powermetrics_error(result.status))
+        raise typer.Exit(code=1)
+
+    samples = list(result.samples)
+    if once or not samples:
+        console.print(Panel(_build_table(samples), title=title))
+        return
+
+    with Live(
+        Panel(_build_table(samples), title=title),
+        refresh_per_second=max(1.0, 1.0 / refresh),
+        screen=False,
+        console=console,
+    ) as live:
+        try:
+            while True:
+                # powermetrics itself blocks for the requested sample window;
+                # sleeping here as well would double the refresh interval.
+                fresh = query_powermetrics(refresh)
+                if fresh.status is not PowermetricsStatus.OK:
+                    live.update(Panel(_powermetrics_error(fresh.status), title=title))
+                    # Failure paths can return immediately; avoid a busy loop.
+                    time.sleep(refresh)
+                    continue
+                live.update(Panel(_build_table(list(fresh.samples)), title=title))
+        except KeyboardInterrupt:
+            console.print("[dim]exit[/]")
+
+
 def monitor(
     refresh: float = typer.Option(
         2.0,
@@ -80,18 +136,14 @@ def monitor(
 ) -> None:
     """Live GPU monitor: Util / Temp / VRAM / Power per GPU.
 
-    Requires nvidia-smi on PATH. On Apple Silicon use Activity Monitor or
-    powermetrics — full Apple Silicon support lands in v0.44.1.
+    Uses nvidia-smi on NVIDIA systems and powermetrics on Apple Silicon.
     """
     if not (0.25 <= refresh <= 30.0):
         console.print("[red]--refresh must be in [0.25, 30][/]")
         raise typer.Exit(code=2)
     if detect_apple_silicon():
-        console.print(
-            "[yellow]Apple Silicon detected — `soup monitor` is "
-            "Apple-Silicon-aware in v0.44.1.[/]\n"
-            "Use Activity Monitor → Window → GPU History for now."
-        )
+        _monitor_apple_silicon(refresh, once)
+        return
     ok, samples = query_nvidia_smi()
     if not ok:
         console.print(

--- a/src/soup_cli/utils/gpu_monitor.py
+++ b/src/soup_cli/utils/gpu_monitor.py
@@ -6,19 +6,27 @@ Pure-Python helpers for parsing nvidia-smi CSV output and Apple Silicon
 
 from __future__ import annotations
 
+import math
+import os
+import plistlib
 import shutil
 import subprocess  # noqa: S404 — list-args invocation only
+from collections.abc import Mapping
 from dataclasses import dataclass
+from enum import Enum
 from typing import List, Optional, Tuple
 
 # Bounds (defence-in-depth)
 _NVIDIA_SMI_TIMEOUT_S = 5
 _MAX_GPUS = 128
+_MAX_POWERMETRICS_OUTPUT_BYTES = 1 * 1024 * 1024
+_POWERMETRICS_PATH = "/usr/bin/powermetrics"
+_SUDO_PATH = "/usr/bin/sudo"
 
 
 @dataclass(frozen=True)
 class GpuSample:
-    """One row of nvidia-smi output for a single GPU."""
+    """One row of GPU telemetry from NVIDIA or Apple tooling."""
 
     index: int
     name: str
@@ -28,6 +36,24 @@ class GpuSample:
     mem_total_mb: Optional[float]
     temp_c: Optional[float]
     power_w: Optional[float]
+
+
+class PowermetricsStatus(str, Enum):
+    """Closed outcomes for one non-interactive ``powermetrics`` query."""
+
+    OK = "ok"
+    UNAVAILABLE = "unavailable"
+    PERMISSION_DENIED = "permission_denied"
+    FAILED = "failed"
+    INVALID_OUTPUT = "invalid_output"
+
+
+@dataclass(frozen=True)
+class PowermetricsResult:
+    """Result of one bounded Apple Silicon telemetry query."""
+
+    status: PowermetricsStatus
+    samples: tuple[GpuSample, ...] = ()
 
 
 def _parse_float_or_none(text: str) -> Optional[float]:
@@ -108,6 +134,177 @@ def query_nvidia_smi() -> Tuple[bool, List[GpuSample]]:
     if result.returncode != 0:
         return False, []
     return True, parse_nvidia_smi_csv(result.stdout or "")
+
+
+def _finite_nonnegative(value: object) -> Optional[float]:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    number = float(value)
+    if not math.isfinite(number) or number < 0:
+        return None
+    return number
+
+
+def _powermetrics_power_w(
+    sample: Mapping[str, object],
+    gpu: Mapping[str, object],
+) -> Optional[float]:
+    processor_obj = sample.get("processor")
+    processor = processor_obj if isinstance(processor_obj, Mapping) else {}
+
+    # Current macOS plist output carries average power in mW. Prefer it to
+    # reconstructing power from the energy counter.
+    for source in (processor, gpu, sample):
+        power_mw = _finite_nonnegative(source.get("gpu_power"))
+        if power_mw is not None:
+            return power_mw / 1000.0
+
+    elapsed_ns = _finite_nonnegative(sample.get("elapsed_ns"))
+    if elapsed_ns is None or elapsed_ns <= 0:
+        return None
+    for source in (processor, gpu):
+        energy_mj = _finite_nonnegative(source.get("gpu_energy"))
+        if energy_mj is not None:
+            elapsed_seconds = elapsed_ns / 1_000_000_000.0
+            return energy_mj / elapsed_seconds / 1000.0
+    return None
+
+
+def _parse_powermetrics_sample(payload: bytes) -> Optional[GpuSample]:
+    try:
+        parsed = plistlib.loads(payload)
+    except (plistlib.InvalidFileException, ValueError, TypeError, OverflowError):
+        return None
+    if not isinstance(parsed, Mapping):
+        return None
+    gpu_obj = parsed.get("gpu")
+    if not isinstance(gpu_obj, Mapping):
+        return None
+
+    idle_ratio = _finite_nonnegative(gpu_obj.get("idle_ratio"))
+    util_gpu_pct = None
+    if idle_ratio is not None and idle_ratio <= 1.0:
+        util_gpu_pct = (1.0 - idle_ratio) * 100.0
+
+    hw_model = parsed.get("hw_model")
+    if (
+        isinstance(hw_model, str)
+        and hw_model
+        and "\x00" not in hw_model
+        and len(hw_model) <= 128
+    ):
+        name = f"Apple Silicon ({hw_model})"
+    else:
+        name = "Apple Silicon"
+
+    return GpuSample(
+        index=0,
+        name=name,
+        util_gpu_pct=util_gpu_pct,
+        util_mem_pct=None,
+        mem_used_mb=None,
+        mem_total_mb=None,
+        temp_c=None,
+        power_w=_powermetrics_power_w(parsed, gpu_obj),
+    )
+
+
+def parse_powermetrics_plist(payload: bytes) -> List[GpuSample]:
+    """Parse bounded, NUL-separated ``powermetrics --format plist`` output.
+
+    Apple emits one plist document per sample and prefixes later documents with
+    a NUL byte. Malformed documents are skipped; NVIDIA-only memory and
+    temperature fields remain unavailable instead of being guessed.
+    """
+    if not isinstance(payload, bytes):
+        raise TypeError("payload must be bytes")
+    if len(payload) > _MAX_POWERMETRICS_OUTPUT_BYTES:
+        return []
+
+    samples: List[GpuSample] = []
+    for document in payload.split(b"\x00"):
+        document = document.strip()
+        if not document:
+            continue
+        sample = _parse_powermetrics_sample(document)
+        if sample is not None:
+            samples.append(sample)
+    return samples
+
+
+def _effective_uid() -> int:
+    getter = getattr(os, "geteuid", None)
+    if getter is None:
+        return -1
+    return int(getter())
+
+
+def query_powermetrics(interval_seconds: float) -> PowermetricsResult:
+    """Collect one Apple GPU sample without prompting for credentials.
+
+    Non-root callers use ``sudo -n`` so a cached sudo ticket works while a
+    missing ticket fails immediately. The CLI can then tell the user to run
+    ``sudo -v`` explicitly; Soup never reads a password.
+    """
+    if isinstance(interval_seconds, bool) or not isinstance(
+        interval_seconds,
+        (int, float),
+    ):
+        raise TypeError("interval_seconds must be a number")
+    interval = float(interval_seconds)
+    if not math.isfinite(interval) or not (0.25 <= interval <= 30.0):
+        raise ValueError("interval_seconds must be finite and in [0.25, 30]")
+    if not os.path.isfile(_POWERMETRICS_PATH):
+        return PowermetricsResult(PowermetricsStatus.UNAVAILABLE)
+
+    sample_rate_ms = int(round(interval * 1000.0))
+    powermetrics_argv = [
+        _POWERMETRICS_PATH,
+        "--samplers",
+        "gpu_power",
+        "--sample-rate",
+        str(sample_rate_ms),
+        "--sample-count",
+        "1",
+        "--format",
+        "plist",
+        "--handle-invalid-values",
+    ]
+    if _effective_uid() == 0:
+        argv = powermetrics_argv
+    else:
+        if not os.path.isfile(_SUDO_PATH):
+            return PowermetricsResult(PowermetricsStatus.UNAVAILABLE)
+        argv = [_SUDO_PATH, "-n", *powermetrics_argv]
+
+    try:
+        result = subprocess.run(  # noqa: S603 — fixed absolute tools, list args, no shell
+            argv,
+            capture_output=True,
+            text=False,
+            timeout=interval + 5.0,
+            check=False,
+            shell=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return PowermetricsResult(PowermetricsStatus.FAILED)
+    if result.returncode != 0:
+        stderr = (result.stderr or b"").decode("utf-8", errors="replace").lower()
+        permission_markers = (
+            "password is required",
+            "a terminal is required",
+            "must be invoked as the superuser",
+            "not allowed to execute",
+            "permission denied",
+        )
+        if any(marker in stderr for marker in permission_markers):
+            return PowermetricsResult(PowermetricsStatus.PERMISSION_DENIED)
+        return PowermetricsResult(PowermetricsStatus.FAILED)
+
+    samples = parse_powermetrics_plist(result.stdout or b"")
+    if not samples:
+        return PowermetricsResult(PowermetricsStatus.INVALID_OUTPUT)
+    return PowermetricsResult(PowermetricsStatus.OK, tuple(samples[-1:]))
 
 
 def detect_apple_silicon() -> bool:

--- a/src/soup_cli/utils/gpu_monitor.py
+++ b/src/soup_cli/utils/gpu_monitor.py
@@ -280,6 +280,7 @@ def query_powermetrics(interval_seconds: float) -> PowermetricsResult:
     try:
         result = subprocess.run(  # noqa: S603 — fixed absolute tools, list args, no shell
             argv,
+            stdin=subprocess.DEVNULL,
             capture_output=True,
             text=False,
             timeout=interval + 5.0,

--- a/tests/test_issue99_apple_monitor.py
+++ b/tests/test_issue99_apple_monitor.py
@@ -1,0 +1,252 @@
+"""Issue #99 — native Apple Silicon metrics for ``soup monitor``."""
+
+from __future__ import annotations
+
+import io
+import math
+import plistlib
+import subprocess
+
+import pytest
+import typer
+from rich.console import Console
+
+from soup_cli.commands import monitor as monitor_command
+from soup_cli.utils import gpu_monitor
+from soup_cli.utils.gpu_monitor import (
+    GpuSample,
+    PowermetricsResult,
+    PowermetricsStatus,
+    parse_powermetrics_plist,
+    query_powermetrics,
+)
+
+
+def _plist_sample(
+    *,
+    idle_ratio: object = 0.25,
+    elapsed_ns: object = 2_000_000_000,
+    gpu_power_mw: object | None = 12_500.0,
+    gpu_energy_mj: object | None = 25_000,
+    hw_model: object = "Mac16,5",
+    gpu_sampler_energy_location: bool = False,
+) -> bytes:
+    gpu: dict[str, object] = {"idle_ratio": idle_ratio, "freq_hz": 1_500}
+    processor: dict[str, object] = {}
+    if gpu_power_mw is not None:
+        processor["gpu_power"] = gpu_power_mw
+    if gpu_energy_mj is not None:
+        destination = gpu if gpu_sampler_energy_location else processor
+        destination["gpu_energy"] = gpu_energy_mj
+    return plistlib.dumps(
+        {
+            "is_delta": True,
+            "elapsed_ns": elapsed_ns,
+            "hw_model": hw_model,
+            "gpu": gpu,
+            "processor": processor,
+        }
+    )
+
+
+def test_parse_powermetrics_uses_direct_power_and_active_ratio():
+    samples = parse_powermetrics_plist(_plist_sample())
+    assert samples == [
+        GpuSample(
+            index=0,
+            name="Apple Silicon (Mac16,5)",
+            util_gpu_pct=75.0,
+            util_mem_pct=None,
+            mem_used_mb=None,
+            mem_total_mb=None,
+            temp_c=None,
+            power_w=12.5,
+        )
+    ]
+
+
+def test_parse_powermetrics_derives_power_from_energy_and_elapsed_time():
+    payload = _plist_sample(gpu_power_mw=None, gpu_energy_mj=12_000)
+    sample = parse_powermetrics_plist(payload)[0]
+    assert sample.power_w == pytest.approx(6.0)
+
+
+def test_parse_powermetrics_accepts_gpu_sampler_energy_location():
+    payload = _plist_sample(
+        gpu_power_mw=None,
+        gpu_energy_mj=9_000,
+        gpu_sampler_energy_location=True,
+    )
+    sample = parse_powermetrics_plist(payload)[0]
+    assert sample.power_w == pytest.approx(4.5)
+
+
+def test_parse_powermetrics_handles_nul_separated_samples():
+    first = _plist_sample(idle_ratio=0.9, gpu_power_mw=1_000)
+    second = _plist_sample(idle_ratio=0.1, gpu_power_mw=2_000)
+    samples = parse_powermetrics_plist(first + b"\x00" + second)
+    assert [sample.util_gpu_pct for sample in samples] == pytest.approx([10.0, 90.0])
+    assert [sample.power_w for sample in samples] == pytest.approx([1.0, 2.0])
+
+
+@pytest.mark.parametrize("bad_ratio", [-0.1, 1.1, True, math.nan, math.inf, "busy"])
+def test_parse_powermetrics_rejects_invalid_idle_ratio(bad_ratio):
+    sample = parse_powermetrics_plist(_plist_sample(idle_ratio=bad_ratio))[0]
+    assert sample.util_gpu_pct is None
+
+
+@pytest.mark.parametrize("bad_power", [-1, True, math.nan, math.inf, "watts"])
+def test_parse_powermetrics_rejects_invalid_power(bad_power):
+    sample = parse_powermetrics_plist(
+        _plist_sample(gpu_power_mw=bad_power, gpu_energy_mj=None)
+    )[0]
+    assert sample.power_w is None
+
+
+def test_parse_powermetrics_rejects_invalid_model_name():
+    sample = parse_powermetrics_plist(_plist_sample(hw_model="x" * 129))[0]
+    assert sample.name == "Apple Silicon"
+
+
+def test_parse_powermetrics_skips_malformed_and_oversize_payloads():
+    assert parse_powermetrics_plist(b"not a plist") == []
+    assert parse_powermetrics_plist(b"x" * (gpu_monitor._MAX_POWERMETRICS_OUTPUT_BYTES + 1)) == []
+
+
+def test_parse_powermetrics_requires_bytes():
+    with pytest.raises(TypeError):
+        parse_powermetrics_plist("not bytes")  # type: ignore[arg-type]
+
+
+def _completed(*, stdout: bytes = b"", stderr: bytes = b"", returncode: int = 0):
+    return subprocess.CompletedProcess([], returncode, stdout=stdout, stderr=stderr)
+
+
+def test_query_powermetrics_root_uses_fixed_binary_without_shell(monkeypatch):
+    calls: list[tuple[list[str], dict[str, object]]] = []
+    monkeypatch.setattr(gpu_monitor.os.path, "isfile", lambda _path: True)
+    monkeypatch.setattr(gpu_monitor, "_effective_uid", lambda: 0)
+
+    def _run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return _completed(stdout=_plist_sample())
+
+    monkeypatch.setattr(gpu_monitor.subprocess, "run", _run)
+    result = query_powermetrics(0.25)
+
+    assert result.status is PowermetricsStatus.OK
+    assert len(result.samples) == 1
+    argv, kwargs = calls[0]
+    assert argv[0] == "/usr/bin/powermetrics"
+    assert "--samplers" in argv and "gpu_power" in argv
+    assert "--sample-rate" in argv and "250" in argv
+    assert "--sample-count" in argv and "1" in argv
+    assert "--format" in argv and "plist" in argv
+    assert "--handle-invalid-values" in argv
+    assert kwargs["shell"] is False
+    assert kwargs["text"] is False
+    assert kwargs["check"] is False
+
+
+def test_query_powermetrics_non_root_uses_non_interactive_sudo(monkeypatch):
+    calls: list[list[str]] = []
+    monkeypatch.setattr(gpu_monitor.os.path, "isfile", lambda _path: True)
+    monkeypatch.setattr(gpu_monitor, "_effective_uid", lambda: 501)
+
+    def _run(argv, **_kwargs):
+        calls.append(argv)
+        return _completed(stdout=_plist_sample())
+
+    monkeypatch.setattr(gpu_monitor.subprocess, "run", _run)
+    result = query_powermetrics(2.0)
+
+    assert result.status is PowermetricsStatus.OK
+    assert calls[0][:3] == ["/usr/bin/sudo", "-n", "/usr/bin/powermetrics"]
+
+
+def test_query_powermetrics_names_missing_sudo_ticket(monkeypatch):
+    monkeypatch.setattr(gpu_monitor.os.path, "isfile", lambda _path: True)
+    monkeypatch.setattr(gpu_monitor, "_effective_uid", lambda: 501)
+    monkeypatch.setattr(
+        gpu_monitor.subprocess,
+        "run",
+        lambda *_args, **_kwargs: _completed(
+            returncode=1,
+            stderr=b"sudo: a password is required\n",
+        ),
+    )
+    result = query_powermetrics(1.0)
+    assert result == PowermetricsResult(PowermetricsStatus.PERMISSION_DENIED)
+
+
+def test_query_powermetrics_reports_missing_binary(monkeypatch):
+    monkeypatch.setattr(gpu_monitor.os.path, "isfile", lambda _path: False)
+    assert query_powermetrics(1.0) == PowermetricsResult(PowermetricsStatus.UNAVAILABLE)
+
+
+def test_query_powermetrics_reports_timeout_and_invalid_output(monkeypatch):
+    monkeypatch.setattr(gpu_monitor.os.path, "isfile", lambda _path: True)
+    monkeypatch.setattr(gpu_monitor, "_effective_uid", lambda: 0)
+
+    def _timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(["powermetrics"], 1)
+
+    monkeypatch.setattr(gpu_monitor.subprocess, "run", _timeout)
+    assert query_powermetrics(1.0).status is PowermetricsStatus.FAILED
+
+    monkeypatch.setattr(
+        gpu_monitor.subprocess,
+        "run",
+        lambda *_args, **_kwargs: _completed(stdout=b"not plist"),
+    )
+    assert query_powermetrics(1.0).status is PowermetricsStatus.INVALID_OUTPUT
+
+
+@pytest.mark.parametrize("bad_interval", [True, 0.0, 0.24, 30.01, math.nan, math.inf])
+def test_query_powermetrics_validates_interval(bad_interval):
+    with pytest.raises((TypeError, ValueError)):
+        query_powermetrics(bad_interval)  # type: ignore[arg-type]
+
+
+def test_monitor_routes_apple_silicon_before_nvidia(monkeypatch):
+    output = io.StringIO()
+    sample = GpuSample(0, "Apple M4 Max", 87.0, None, None, None, None, 31.5)
+    monkeypatch.setattr(
+        monitor_command,
+        "console",
+        Console(file=output, color_system=None, width=160),
+    )
+    monkeypatch.setattr(monitor_command, "detect_apple_silicon", lambda: True)
+    monkeypatch.setattr(
+        monitor_command,
+        "query_powermetrics",
+        lambda _refresh: PowermetricsResult(PowermetricsStatus.OK, (sample,)),
+    )
+    monkeypatch.setattr(
+        monitor_command,
+        "query_nvidia_smi",
+        lambda: pytest.fail("Apple path must not query nvidia-smi"),
+    )
+
+    monitor_command.monitor(refresh=0.25, once=True)
+    rendered = output.getvalue()
+    assert "Apple M4 Max" in rendered
+    assert "87.0%" in rendered
+    assert "31.5 W" in rendered
+
+
+def test_monitor_apple_permission_error_is_actionable(monkeypatch):
+    output = io.StringIO()
+    monkeypatch.setattr(monitor_command, "console", Console(file=output, color_system=None))
+    monkeypatch.setattr(monitor_command, "detect_apple_silicon", lambda: True)
+    monkeypatch.setattr(
+        monitor_command,
+        "query_powermetrics",
+        lambda _refresh: PowermetricsResult(PowermetricsStatus.PERMISSION_DENIED),
+    )
+
+    with pytest.raises(typer.Exit) as exc:
+        monitor_command.monitor(refresh=0.25, once=True)
+    assert exc.value.exit_code == 1
+    assert "sudo -v" in output.getvalue()
+    assert "never prompts" in output.getvalue()

--- a/tests/test_issue99_apple_monitor.py
+++ b/tests/test_issue99_apple_monitor.py
@@ -30,6 +30,7 @@ def _plist_sample(
     gpu_energy_mj: object | None = 25_000,
     hw_model: object = "Mac16,5",
     gpu_sampler_energy_location: bool = False,
+    padding: str | None = None,
 ) -> bytes:
     gpu: dict[str, object] = {"idle_ratio": idle_ratio, "freq_hz": 1_500}
     processor: dict[str, object] = {}
@@ -38,15 +39,16 @@ def _plist_sample(
     if gpu_energy_mj is not None:
         destination = gpu if gpu_sampler_energy_location else processor
         destination["gpu_energy"] = gpu_energy_mj
-    return plistlib.dumps(
-        {
-            "is_delta": True,
-            "elapsed_ns": elapsed_ns,
-            "hw_model": hw_model,
-            "gpu": gpu,
-            "processor": processor,
-        }
-    )
+    payload: dict[str, object] = {
+        "is_delta": True,
+        "elapsed_ns": elapsed_ns,
+        "hw_model": hw_model,
+        "gpu": gpu,
+        "processor": processor,
+    }
+    if padding is not None:
+        payload["padding"] = padding
+    return plistlib.dumps(payload)
 
 
 def test_parse_powermetrics_uses_direct_power_and_active_ratio():
@@ -110,7 +112,12 @@ def test_parse_powermetrics_rejects_invalid_model_name():
 
 def test_parse_powermetrics_skips_malformed_and_oversize_payloads():
     assert parse_powermetrics_plist(b"not a plist") == []
-    assert parse_powermetrics_plist(b"x" * (gpu_monitor._MAX_POWERMETRICS_OUTPUT_BYTES + 1)) == []
+    oversized_plist = _plist_sample(
+        padding="x" * gpu_monitor._MAX_POWERMETRICS_OUTPUT_BYTES,
+    )
+    assert len(oversized_plist) > gpu_monitor._MAX_POWERMETRICS_OUTPUT_BYTES
+    assert plistlib.loads(oversized_plist)["gpu"]["idle_ratio"] == 0.25
+    assert parse_powermetrics_plist(oversized_plist) == []
 
 
 def test_parse_powermetrics_requires_bytes():
@@ -138,30 +145,35 @@ def test_query_powermetrics_root_uses_fixed_binary_without_shell(monkeypatch):
     assert len(result.samples) == 1
     argv, kwargs = calls[0]
     assert argv[0] == "/usr/bin/powermetrics"
-    assert "--samplers" in argv and "gpu_power" in argv
-    assert "--sample-rate" in argv and "250" in argv
-    assert "--sample-count" in argv and "1" in argv
-    assert "--format" in argv and "plist" in argv
+    assert argv[argv.index("--samplers") + 1] == "gpu_power"
+    assert argv[argv.index("--sample-rate") + 1] == "250"
+    assert argv[argv.index("--sample-count") + 1] == "1"
+    assert argv[argv.index("--format") + 1] == "plist"
     assert "--handle-invalid-values" in argv
+    assert kwargs["stdin"] is subprocess.DEVNULL
+    assert kwargs["timeout"] == pytest.approx(5.25)
     assert kwargs["shell"] is False
     assert kwargs["text"] is False
     assert kwargs["check"] is False
 
 
 def test_query_powermetrics_non_root_uses_non_interactive_sudo(monkeypatch):
-    calls: list[list[str]] = []
+    calls: list[tuple[list[str], dict[str, object]]] = []
     monkeypatch.setattr(gpu_monitor.os.path, "isfile", lambda _path: True)
     monkeypatch.setattr(gpu_monitor, "_effective_uid", lambda: 501)
 
-    def _run(argv, **_kwargs):
-        calls.append(argv)
+    def _run(argv, **kwargs):
+        calls.append((argv, kwargs))
         return _completed(stdout=_plist_sample())
 
     monkeypatch.setattr(gpu_monitor.subprocess, "run", _run)
     result = query_powermetrics(2.0)
 
     assert result.status is PowermetricsStatus.OK
-    assert calls[0][:3] == ["/usr/bin/sudo", "-n", "/usr/bin/powermetrics"]
+    argv, kwargs = calls[0]
+    assert argv[:3] == ["/usr/bin/sudo", "-n", "/usr/bin/powermetrics"]
+    assert kwargs["stdin"] is subprocess.DEVNULL
+    assert kwargs["timeout"] == pytest.approx(7.0)
 
 
 def test_query_powermetrics_names_missing_sudo_ticket(monkeypatch):
@@ -233,6 +245,28 @@ def test_monitor_routes_apple_silicon_before_nvidia(monkeypatch):
     assert "Apple M4 Max" in rendered
     assert "87.0%" in rendered
     assert "31.5 W" in rendered
+
+
+def test_monitor_non_apple_routes_to_nvidia(monkeypatch):
+    output = io.StringIO()
+    sample = GpuSample(0, "NVIDIA Test GPU", 42.0, 7.0, 512.0, 8192.0, 55.0, 75.0)
+    monkeypatch.setattr(
+        monitor_command,
+        "console",
+        Console(file=output, color_system=None, width=160),
+    )
+    monkeypatch.setattr(monitor_command, "detect_apple_silicon", lambda: False)
+    monkeypatch.setattr(
+        monitor_command,
+        "query_powermetrics",
+        lambda _refresh: pytest.fail("Non-Apple path must not query powermetrics"),
+    )
+    monkeypatch.setattr(monitor_command, "query_nvidia_smi", lambda: (True, [sample]))
+
+    monitor_command.monitor(refresh=0.25, once=True)
+    rendered = output.getvalue()
+    assert "NVIDIA Test GPU" in rendered
+    assert "42.0%" in rendered
 
 
 def test_monitor_apple_permission_error_is_actionable(monkeypatch):


### PR DESCRIPTION
## Summary

- detect Apple Silicon before entering the existing NVIDIA monitor path
- collect one bounded sample from the fixed `/usr/bin/powermetrics` binary and parse its NUL-separated plist output into the existing `GpuSample` table
- report GPU utilization and estimated power while leaving NVIDIA-only VRAM, memory-utilization, and temperature fields unavailable
- reuse an explicitly cached sudo credential through `sudo -n`, never prompt for or read a password, and provide an actionable Activity Monitor fallback
- preserve the NVIDIA implementation unchanged and document the Apple Silicon workflow

## Safety and compatibility

- fixed absolute executable paths, list arguments, and `shell=False`
- one sample per invocation, bounded parser input, finite/range checks, and malformed-output handling
- lazy behavior: no new dependency and no import-time hardware access
- Python 3.10, 3.11, and 3.12 targeted coverage

## Validation

- `ruff check src/soup_cli/ tests/`
- `mypy src/soup_cli/utils/gpu_monitor.py src/soup_cli/commands/monitor.py`
- `pytest tests/test_issue99_apple_monitor.py tests/test_v0440_part_a.py tests/test_v0440_review_followups.py -q -o addopts=`: 127 passed
- full non-smoke suite: 18,178 passed, 286 skipped, 6 deselected; 81.15% coverage
- the one deliberately excluded test was `test_find_quantize_binary_not_found`, because this development Mac genuinely has `/opt/homebrew/bin/llama-quantize` installed
- MacBook Pro M4 Max, 128 GB unified memory, 40-core GPU, macOS 26.5.2: Apple Silicon dispatch and the real no-sudo-ticket path were exercised; the installed Apple binary exposes the expected `gpu`, `idle_ratio`, `gpu_energy`, `processor.gpu_power`, `elapsed_ns`, and `hw_model` plist fields

A positive privileged snapshot was completed on the M4 Max after an interactive `sudo -v`: `soup monitor --once --refresh 0.25` rendered a live `Mac16,5` sample at 61.5% GPU utilization and 0.7 W, then exited normally. The end-to-end observation is recorded on #99. The implementation itself never attempts to automate or consume the administrator credential.

Closes #99.

Contributor continuity: I changed my GitHub account from `Sir-Lysander` to `Amix29`.

