### PR TITLE
fix(eval): stamp baseline scorer/version provenance (#404)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,16 @@ reproducing 70+ versions of notes.
   Anthropic is refused by name because its Messages API has no raw-completion
   endpoint, and local-only flags cannot be silently ignored in provider mode.
 
+- **Baseline artifacts carry a scorer/version provenance stamp (#404 by @AchuthReddy-16 in #485).**
+  Shared helpers `stamp_baseline_scores` / `write_baseline_file` write
+  `{"scores": {...}, "provenance": {"soup_version", "scorer_revision"}}`.
+  `soup eval gate --write-baseline <path>` is the user-facing producer.
+  `resolve_baseline` warns once on unknown provenance (unstamped files) or a
+  `scorer_revision` mismatch, and stays silent when the stamp matches.
+  `BUNDLED_SCORER_REVISION` + a locked fingerprint fail the suite if a bundled
+  scorer's output moves without a revision bump. Registry `save_eval_result`
+  stamps `details_json`; `soup ship --emit-evidence` includes the same stamp.
+
 - **Layer streaming now accepts Qwen3.5 MoE text checkpoints whose decoder
   layers do not expose exactly the same weight keys in every block (by
   @Shutaru in #426).** The sharder now records per-layer shard headers instead of
@@ -170,6 +180,10 @@ reproducing 70+ versions of notes.
   time (#273 by @AmirF194 in #470).
 
 ### Changed
+
+- **Remove the name-based `SCORER_CHANGED_IN_V0_73_2` baseline warning in favour
+  of the #404 scorer_revision stamp (#404 by @AchuthReddy-16 in #485).**
+  Stale baselines are detected by provenance, not by a hard-coded suite list.
 
 - **Remove hand-maintained test suite statistics from `CONTRIBUTING.md` in favor of a permanent digit-free shape invariant (#465 by @harshitthek in #467).**
   Eliminates drift across routine test additions by making test-count divergence impossible at the documentation source.

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -490,19 +490,24 @@ soup ship --evidence ship_evidence.json --config soup.yaml --push owner/repo#42
 `soup ci init --config soup.yaml` binds the generated workflow's ship step to the committed
 config, so the whole loop runs in CI (see [commands.md](commands.md)).
 
-**Baseline scale change (v0.73.2).** Three suites' scorers changed. The MCQ extractor now reads a
-`\boxed{C}` option letter (a boxed *value* like `\boxed{4}` is still not an option letter), and MCQ
-prompts now ask for the letter — both halves are needed, and they affect `mini_mmlu` and
-`mini_common_sense`. `mini_tool_call` now tolerates a call missing its outer `{"function": ...}`
-envelope. Measured on an **unchanged** model the shifts are large: `mini_mmlu` 0.423 → 0.731 and
-`mini_tool_call` 0.225 → 1.000, far bigger than the 0.05 gate.
+**Baseline provenance (#404).** Produce a stamped baseline with
+`soup eval gate --suite <suite.yaml> --model <id> --write-baseline baseline.json`
+(`--model` is required — baselines are never written from the stub generator).
+The file is
+`{"scores": {...}, "provenance": {"soup_version", "scorer_revision"}}`
+and is consumed later by `soup ship --baseline baseline.json` or
+`soup eval gate --baseline baseline.json`. Shared helpers
+`stamp_baseline_scores` / `write_baseline_file` are the only writers;
+`write_baseline_file` refuses an empty score map. `resolve_baseline`
+warns once on unknown provenance (unstamped files /
+registry rows) or a `scorer_revision` mismatch, and stays silent when the
+stamp matches. The old name-based `SCORER_CHANGED_IN_V0_73_2` warning is
+gone. Recompute an old baseline, or drop names from it to force a live
+base run.
 
-A `--baseline` supplies the base score from a *file* and skips the live base run, so a snapshot
-taken before v0.73.2 would be diffed against a freshly-scored tuned model on a different scale —
-big enough to mask a real regression or manufacture an improvement. `soup ship` now warns by name
-when this happens. Recompute the baseline, or drop those names from it to force a live base run.
-`mini_instruction` and `mini_arithmetic` are unaffected: neither carries a single-letter answer, so
-the prompt cue and the option-letter extractor never touch them.
+Historical note: v0.73.2 changed three suite scorers (`mini_mmlu`,
+`mini_common_sense`, `mini_tool_call`) with measured jumps on an unchanged
+model far larger than the 0.05 gate. That is why unstamped files still warn.
 
 
 ## NLG Evaluation Metrics (BLEU + ROUGE)

--- a/src/soup_cli/commands/eval.py
+++ b/src/soup_cli/commands/eval.py
@@ -1159,7 +1159,7 @@ def gate_cmd(
     ),
     baseline: Optional[str] = typer.Option(
         None, "--baseline", "-b",
-        help="Baseline: registry://<id> or path to {name: score} JSON file",
+        help="Baseline: registry://<id> or path to stamped/flat score JSON",
     ),
     regression_threshold: float = typer.Option(
         0.05, "--regression-threshold",
@@ -1169,6 +1169,14 @@ def gate_cmd(
         None, "--model", "-m",
         help="Model path or HF id to evaluate (required for live scoring)",
     ),
+    write_baseline: Optional[str] = typer.Option(
+        None,
+        "--write-baseline",
+        help=(
+            "Write this run's task scores as a stamped baseline JSON "
+            "({'scores', 'provenance'}) consumable by --baseline (#404)."
+        ),
+    ),
 ) -> None:
     """Run an eval-gate suite standalone (post-hoc verdict)."""
     if not 0.0 <= regression_threshold <= 1.0:
@@ -1177,7 +1185,16 @@ def gate_cmd(
         )
         raise typer.Exit(1)
 
-    from soup_cli.eval.gate import load_suite, resolve_baseline, run_gate
+    if write_baseline and not model:
+        console.print("[red]--write-baseline requires --model[/]")
+        raise typer.Exit(1)
+
+    from soup_cli.eval.gate import (
+        load_suite,
+        resolve_baseline,
+        run_gate,
+        write_baseline_file,
+    )
 
     try:
         eval_suite = load_suite(suite)
@@ -1186,13 +1203,17 @@ def gate_cmd(
         raise typer.Exit(1) from exc
 
     try:
-        baseline_scores = resolve_baseline(baseline)
+        baseline_scores = resolve_baseline(
+            baseline,
+            warn=lambda msg: console.print(f"[yellow]Warning:[/] {msg}"),
+        )
     except (FileNotFoundError, ValueError) as exc:
         console.print(f"[red]Cannot resolve baseline:[/] {exc}")
         raise typer.Exit(1) from exc
 
     # When --model is provided, build a transformers-backed generator.
     # Otherwise fall back to an empty-string stub for smoke runs.
+    # (--write-baseline already refused the stub path above.)
     if model is None:
         console.print(
             "[yellow]No --model given; using stub generator "
@@ -1220,6 +1241,22 @@ def gate_cmd(
     )
 
     _print_gate_result(result)
+
+    if write_baseline:
+        scores = {
+            row.name: float(row.score)
+            for row in result.task_results
+            if row.score is not None
+        }
+        try:
+            written = write_baseline_file(write_baseline, scores)
+        except (OSError, ValueError, TypeError) as exc:
+            console.print(
+                f"[red]Cannot write --write-baseline:[/] {exc}"
+            )
+            raise typer.Exit(1) from exc
+        console.print(f"[green]Wrote stamped baseline[/] {written}")
+
     raise typer.Exit(0 if result.passed else 1)
 
 

--- a/src/soup_cli/commands/ship.py
+++ b/src/soup_cli/commands/ship.py
@@ -290,14 +290,19 @@ def _safe_hash_file(path: str, max_bytes: int) -> Optional[str]:
     return digest.hexdigest()
 
 
-def _compute_provenance(cfg: "SoupConfig") -> Dict[str, str]:
+def _compute_provenance(cfg: "SoupConfig") -> Dict[str, object]:
     """Bind emitted evidence to the exact config that produced it (v0.71.39).
 
     ``config_sha`` (semantic recipe hash) + ``base_model`` + a best-effort
     ``data_sha`` over a cwd-local training file. Built only when we actually
     ``--emit-evidence`` (the ``data_sha`` streams the whole training file).
+    Also carries the #404 scorer/version stamp so a later ``--baseline``
+    consumer can detect scale drift.
     """
-    prov: Dict[str, str] = {"config_sha": _config_sha_of(cfg)}
+    from soup_cli.eval.gate import current_baseline_stamp
+
+    prov: Dict[str, object] = dict(current_baseline_stamp())
+    prov["config_sha"] = _config_sha_of(cfg)
     base = cfg.base
     if base:
         prov["base_model"] = base
@@ -692,32 +697,12 @@ def _leg2_scores(
     (skipping the base run) for any name it covers.
     """
     from soup_cli.eval.gate_suites import (
-        SCORER_CHANGED_IN_V0_73_2,
         is_bundled_suite,
         score_bundled_suite,
     )
 
     bundled_names = [n for n in suite_names if is_bundled_suite(n)]
     other_names = [n for n in suite_names if not is_bundled_suite(n)]
-
-    # A --baseline / registry:// entry supplies the BASE score from a file and
-    # skips the live base run, so a snapshot taken before v0.73.2 is compared
-    # against a freshly-scored tuned model on a DIFFERENT scale. Measured on an
-    # unchanged model: mini_mmlu 0.423 -> 0.731, mini_tool_call 0.225 -> 1.000.
-    # That is far larger than the 0.05 gate, so it must be said out loud.
-    stale = sorted(
-        name
-        for name in bundled_names
-        if name in baseline_scores and name in SCORER_CHANGED_IN_V0_73_2
-    )
-    if stale:
-        console.print(
-            "[yellow]Warning:[/] --baseline supplies stored scores for "
-            f"{escape(', '.join(stale))}, whose scorer CHANGED in v0.73.2 "
-            "(#357 / #346). If that baseline was captured on an earlier "
-            "release the two sides are on different scales — re-measure the "
-            "baseline, or drop these names from it to force a live base run."
-        )
 
     base_map: Dict[str, object] = {}
     tuned_map: Dict[str, object] = {}
@@ -957,7 +942,12 @@ def _verdict_live(
         from soup_cli.eval.gate import resolve_baseline
 
         try:
-            baseline_scores = resolve_baseline(baseline_spec)
+            baseline_scores = resolve_baseline(
+                baseline_spec,
+                warn=lambda msg: console.print(
+                    f"[yellow]Warning:[/] {escape(msg)}"
+                ),
+            )
         except (ValueError, FileNotFoundError, OSError) as exc:
             _fail(f"--baseline: {exc}", _EXIT_USAGE)
 
@@ -1150,9 +1140,9 @@ def ship(
     baseline: Optional[str] = typer.Option(
         None,
         "--baseline",
-        help="registry://<id> or JSON file of base leg-2 scores (skips base run). "
-        "Recompute baselines captured before v0.71.38 — the leg-2 scorer changed, "
-        "so an old baseline is not comparable to a freshly-scored tuned model.",
+        help="registry://<id> or stamped JSON of base leg-2 scores (skips base run). "
+        "Unstamped or scorer_revision-mismatched baselines warn once — re-measure "
+        "so both sides share one scorer scale (#404).",
     ),
     forgetting_threshold: float = typer.Option(
         DEFAULT_FORGETTING_THRESHOLD,
@@ -1282,11 +1272,14 @@ def ship(
         )
 
     # Full provenance (incl. data_sha) is only needed when writing evidence.
-    provenance = (
-        _compute_provenance(soup_config)
-        if emit_evidence and soup_config is not None
-        else None
-    )
+    # Always stamp scorer revision on emit (#404), even without --config.
+    provenance: Optional[Dict[str, object]] = None
+    if emit_evidence:
+        from soup_cli.eval.gate import current_baseline_stamp
+
+        provenance = dict(current_baseline_stamp())
+        if soup_config is not None:
+            provenance.update(_compute_provenance(soup_config))
     _emit_and_exit(
         verdict, output, emit_evidence=emit_evidence, push=push, provenance=provenance
     )

--- a/src/soup_cli/config/schema.py
+++ b/src/soup_cli/config/schema.py
@@ -3846,7 +3846,10 @@ class ShipConfig(BaseModel):
     )
     baseline: Optional[str] = Field(
         default=None,
-        description="registry://<id> | file JSON of base leg-2 scores",
+        description=(
+            "registry://<id> | stamped baseline JSON "
+            "({scores, provenance.scorer_revision}) of base leg-2 scores"
+        ),
     )
     # v0.73.2 shipped `--noise-floor` (#376) without its config surface, so it
     # was the one gate-policy flag that could not be committed to soup.yaml

--- a/src/soup_cli/eval/gate.py
+++ b/src/soup_cli/eval/gate.py
@@ -8,15 +8,25 @@ runs them at epoch boundaries during training (or post-hoc via
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Literal, Optional
+from typing import Callable, Literal, Mapping, Optional
 from urllib.parse import urlparse
 
 import yaml
 from pydantic import BaseModel, Field, field_validator
 
-from soup_cli.utils.paths import is_under_cwd
+from soup_cli import __version__
+from soup_cli.utils.paths import atomic_write_text, is_under_cwd
+
+logger = logging.getLogger(__name__)
+
+# Envelope keys for stamped baseline files (#404).
+_BASELINE_SCORES_KEY = "scores"
+_BASELINE_PROVENANCE_KEY = "provenance"
+_STAMP_SOUP_VERSION = "soup_version"
+_STAMP_SCORER_REVISION = "scorer_revision"
 
 
 @dataclass(frozen=True)
@@ -116,13 +126,180 @@ def load_suite(path: str) -> EvalSuite:
     return EvalSuite(**data)
 
 
-def resolve_baseline(spec: Optional[str]) -> dict[str, float]:
+def current_baseline_stamp() -> dict[str, object]:
+    """Soup version + bundled-scorer revision for a baseline provenance stamp."""
+    from soup_cli.eval.gate_suites import BUNDLED_SCORER_REVISION
+
+    return {
+        _STAMP_SOUP_VERSION: str(__version__),
+        _STAMP_SCORER_REVISION: int(BUNDLED_SCORER_REVISION),
+    }
+
+
+def stamp_baseline_scores(scores: Mapping[str, float]) -> dict[str, object]:
+    """Build the stamped baseline envelope (shared writer helper, #404).
+
+    Every Soup producer of a ``--baseline`` JSON file must go through this
+    helper (or :func:`write_baseline_file`) so the stamp cannot drift between
+    commands.
+    """
+    if not isinstance(scores, Mapping):
+        raise TypeError(f"scores must be a mapping, got {type(scores).__name__}")
+    clean: dict[str, float] = {}
+    for key, value in scores.items():
+        name = str(key)
+        if not name or "\x00" in name:
+            raise ValueError("baseline score names must be non-empty and null-free")
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(
+                f"baseline score for {name!r} must be a number, "
+                f"got {type(value).__name__}"
+            )
+        clean[name] = float(value)
+    return {
+        _BASELINE_SCORES_KEY: clean,
+        _BASELINE_PROVENANCE_KEY: current_baseline_stamp(),
+    }
+
+
+def write_baseline_file(path: str, scores: Mapping[str, float]) -> str:
+    """Atomically write a stamped baseline JSON file. Returns the path.
+
+    Refuses an empty score map so a stub / failed gate run cannot mint a
+    stamped baseline that looks authoritative (#404 / #485). Reading an old
+    empty baseline file remains silent via :func:`resolve_baseline`.
+    """
+    if not isinstance(scores, Mapping):
+        raise TypeError(f"scores must be a mapping, got {type(scores).__name__}")
+    if len(scores) == 0:
+        raise ValueError(
+            "refusing to write an empty baseline (no scored tasks); "
+            "re-run with a model that produces scores"
+        )
+    payload = stamp_baseline_scores(scores)
+    return atomic_write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        path,
+        field="baseline",
+    )
+
+
+def _coerce_score_map(raw: Mapping[object, object], *, context: str) -> dict[str, float]:
+    out: dict[str, float] = {}
+    for key, value in raw.items():
+        name = str(key)
+        if not name:
+            continue
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(
+                f"{context}: score for {name!r} must be a number, "
+                f"got {type(value).__name__}"
+            )
+        out[name] = float(value)
+    return out
+
+
+def _is_stamped_envelope(data: Mapping[object, object]) -> bool:
+    if _BASELINE_SCORES_KEY not in data:
+        return False
+    if not isinstance(data.get(_BASELINE_SCORES_KEY), Mapping):
+        return False
+    # Envelope keys only — a flat map that happens to include a "scores"
+    # numeric entry stays legacy.
+    return set(data.keys()) <= {_BASELINE_SCORES_KEY, _BASELINE_PROVENANCE_KEY}
+
+
+def _envelope_extra_keys(data: Mapping[object, object]) -> list[str]:
+    """Extra top-level keys on a scores+provenance-shaped payload."""
+    if _BASELINE_SCORES_KEY not in data:
+        return []
+    if not isinstance(data.get(_BASELINE_SCORES_KEY), Mapping):
+        return []
+    return sorted(
+        str(k)
+        for k in data.keys()
+        if k not in {_BASELINE_SCORES_KEY, _BASELINE_PROVENANCE_KEY}
+    )
+
+
+def _provenance_warning(provenance: object) -> Optional[str]:
+    """Return a single warning message, or None when the stamp matches."""
+    from soup_cli.eval.gate_suites import BUNDLED_SCORER_REVISION
+
+    if not isinstance(provenance, Mapping):
+        return (
+            "--baseline has unknown provenance (no scorer/version stamp). "
+            "Re-measure the baseline with the current Soup so both sides share "
+            "one scorer scale."
+        )
+    raw_rev = provenance.get(_STAMP_SCORER_REVISION)
+    if raw_rev is None:
+        return (
+            "--baseline has unknown provenance (no scorer_revision). "
+            "Re-measure the baseline with the current Soup so both sides share "
+            "one scorer scale."
+        )
+    if isinstance(raw_rev, bool) or not isinstance(raw_rev, int):
+        return (
+            "--baseline provenance scorer_revision is malformed; treating it as "
+            "unknown provenance. Re-measure the baseline."
+        )
+    if int(raw_rev) != int(BUNDLED_SCORER_REVISION):
+        return (
+            f"--baseline scorer_revision={int(raw_rev)} does not match the "
+            f"running Soup (scorer_revision={int(BUNDLED_SCORER_REVISION)}). "
+            "The stored scores may be on a different scale — re-measure the "
+            "baseline, or drop mismatched names from it to force a live base run."
+        )
+    return None
+
+
+def _emit_baseline_warning(
+    message: str,
+    *,
+    warn: Optional[Callable[[str], None]],
+) -> None:
+    if warn is not None:
+        warn(message)
+        return
+    logger.warning("%s", message)
+
+
+def _registry_provenance(rows: list[dict]) -> Optional[dict[str, object]]:
+    """Best-effort stamp from eval_results ``details_json`` rows."""
+    for row in rows:
+        raw = row.get("details_json")
+        if not raw:
+            continue
+        try:
+            details = json.loads(raw) if isinstance(raw, str) else raw
+        except (TypeError, ValueError, json.JSONDecodeError):
+            continue
+        if not isinstance(details, Mapping):
+            continue
+        prov = details.get(_BASELINE_PROVENANCE_KEY)
+        if isinstance(prov, Mapping):
+            return dict(prov)
+    return None
+
+
+def resolve_baseline(
+    spec: Optional[str],
+    *,
+    warn: Optional[Callable[[str], None]] = None,
+) -> dict[str, float]:
     """Resolve a baseline specifier to a ``{task_name: score}`` map.
 
     - ``None`` / ``""``: return empty map
     - ``registry://<id>``: look up eval_results for that entry via the
       experiment tracker, keyed by benchmark
-    - filesystem path: JSON mapping of ``{name: score}``
+    - filesystem path: JSON mapping of ``{name: score}`` **or** a stamped
+      envelope ``{"scores": {...}, "provenance": {...}}`` (#404)
+
+    Provenance is checked on read. A correctly stamped baseline matching the
+    running scorer revision is silent. An unstamped (pre-existing) baseline
+    warns exactly once naming unknown provenance. A stamp whose
+    ``scorer_revision`` disagrees warns about the mismatch.
     """
     if not spec:
         return {}
@@ -140,11 +317,17 @@ def resolve_baseline(spec: Optional[str]) -> dict[str, float]:
                     f"registry baseline not found: {ref} (use `soup registry list`)"
                 )
             rows = store.get_eval_results(entry_id)
-        return {
+        scores = {
             row.get("benchmark", ""): float(row.get("score", 0.0))
             for row in rows
             if row.get("benchmark") and row.get("score") is not None
         }
+        # Registry rows predate the stamp (or carry it inside details_json).
+        provenance = _registry_provenance(rows)
+        message = _provenance_warning(provenance)
+        if message is not None and scores:
+            _emit_baseline_warning(message, warn=warn)
+        return scores
 
     # Filesystem path
     baseline_path = Path(spec)
@@ -163,7 +346,39 @@ def resolve_baseline(spec: Optional[str]) -> dict[str, float]:
             f"baseline file must be a JSON object mapping name -> score; "
             f"got {type(data).__name__}"
         )
-    return {str(k): float(v) for k, v in data.items()}
+
+    # Stamped envelope (exact keys) OR scores-mapping with unsupported extras.
+    # Extras warn and are ignored so an unrelated numeric ValueError cannot
+    # hide the operator-facing message (#404 review MEDIUM 5).
+    if isinstance(data.get(_BASELINE_SCORES_KEY), Mapping):
+        extra = _envelope_extra_keys(data)
+        if extra and not _is_stamped_envelope(data):
+            _emit_baseline_warning(
+                "--baseline envelope has unsupported extra key(s): "
+                f"{', '.join(extra)}. Keep only 'scores' and 'provenance' "
+                "(remove the extras) so the file matches the stamped baseline "
+                "contract.",
+                warn=warn,
+            )
+        if _is_stamped_envelope(data) or extra:
+            scores = _coerce_score_map(
+                data[_BASELINE_SCORES_KEY], context="baseline scores"
+            )
+            message = _provenance_warning(data.get(_BASELINE_PROVENANCE_KEY))
+            if message is not None and scores:
+                _emit_baseline_warning(message, warn=warn)
+            return scores
+
+    # Legacy flat ``{name: score}`` — unknown provenance (#404).
+    scores = _coerce_score_map(data, context="baseline file")
+    if scores:
+        _emit_baseline_warning(
+            "--baseline has unknown provenance (unstamped pre-existing file). "
+            "Re-measure the baseline with the current Soup so both sides share "
+            "one scorer scale.",
+            warn=warn,
+        )
+    return scores
 
 
 def _parse_judge_url(judge_model: str) -> tuple[str, str, Optional[str]]:

--- a/src/soup_cli/eval/gate_suites.py
+++ b/src/soup_cli/eval/gate_suites.py
@@ -80,24 +80,25 @@ EXTENDED_SUITE_NAMES: Tuple[str, ...] = tuple(_EXTENDED_SUITES)
 #: The full offline default general suite = MCQ/arithmetic + behavioural.
 DEFAULT_GENERAL_SUITE: Tuple[str, ...] = tuple(MINI_BENCHMARKS) + EXTENDED_SUITE_NAMES
 
-#: Suites whose SCORER changed in v0.73.2, so a score stored before this
-#: release is on a different scale (#357 / #346).
+#: Monotonic revision of bundled-suite SCORER semantics (#404).
 #:
-#: This matters because ``--baseline`` / ``registry://`` supply a base score
-#: from a FILE and skip the live base run, so a stale entry is diffed against a
-#: freshly-scored tuned model. The measured jumps on an UNCHANGED model are
-#: large: ``mini_mmlu`` 0.423 -> 0.731 and ``mini_tool_call`` 0.225 -> 1.000.
-#: A drift that size can mask a real regression or manufacture an improvement,
-#: so the caller warns rather than silently comparing across scales.
+#: ``--baseline`` / ``registry://`` supply a base score from disk and skip the
+#: live base run. A score produced under an older scorer is on a different
+#: scale (v0.73.2 measured ``mini_mmlu`` 0.423 -> 0.731 and ``mini_tool_call``
+#: 0.225 -> 1.000 on an unchanged model). Baselines therefore carry this
+#: revision in their provenance stamp; ``resolve_baseline`` warns only when
+#: the stamp disagrees with the running Soup.
 #:
-#: ``mini_instruction`` and ``mini_arithmetic`` are NOT here: neither carries a
-#: single-letter answer, so ``build_mcq_prompt`` leaves their prompts alone and
-#: ``score_answer`` never reaches the option-letter extractor for them
-#: (verified: 0 of 24 and 0 of 36 items respectively).
-SCORER_CHANGED_IN_V0_73_2: Tuple[str, ...] = (
-    "mini_mmlu",
-    "mini_common_sense",
-    MINI_TOOL_CALL,
+#: Bump this integer in the **same change** that alters a bundled scorer's
+#: behaviour, and update ``BUNDLED_SCORER_FINGERPRINT`` with it. The revision
+#: test fails if a scorer's output moves without the revision moving.
+BUNDLED_SCORER_REVISION: int = 1
+
+#: SHA-256 of deterministic ``score_bundled_suite`` outputs under the fixed
+#: fingerprint corpus in ``bundled_scorer_fingerprint``. Locked to revision 1;
+#: update together with ``BUNDLED_SCORER_REVISION``.
+BUNDLED_SCORER_FINGERPRINT: str = (
+    "1474d3f37d7f5ca688ba7d5bc557b327b24ae77d16ae0345536136f39fb74d8d"
 )
 
 # 4 MiB cap on a bundled fixture (mirrors behaviour_battery — defends against
@@ -453,15 +454,135 @@ def score_bundled_suite(name: str, gen: GeneratorFn) -> float:
     )
 
 
+def _wrong_mcq_answer(answer: str) -> str:
+    """A deterministic incorrect answer for fingerprint mixing."""
+    ans = answer.strip()
+    if len(ans) == 1 and ans.upper() in "ABCDEFGHIJ":
+        return "A" if ans.upper() != "A" else "B"
+    return "WRONG"
+
+
+def _build_fingerprint_response_map() -> dict[str, str]:
+    """Exact prompt -> response map mixing correct and incorrect per suite.
+
+    Every bundled suite must score strictly in ``(0, 1)`` under this corpus so
+    the fingerprint cannot be pinned by a constant all-pass / all-fail gen.
+    ``mini_tool_call`` deliberately includes bare ``{"name": ...}`` replies
+    (no ``arguments``) so removing the #346 ``arguments`` requirement from
+    :func:`_looks_like_a_bare_function` moves the fingerprint.
+    """
+    from soup_cli.eval.forgetting import build_mcq_prompt
+
+    responses: dict[str, str] = {}
+    for name in sorted(DEFAULT_GENERAL_SUITE):
+        if name in MINI_BENCHMARKS:
+            for i, item in enumerate(MINI_BENCHMARKS[name]):
+                prompt = build_mcq_prompt(item["question"], item.get("answer", ""))
+                if i % 2 == 0:
+                    responses[prompt] = item["answer"]
+                else:
+                    responses[prompt] = _wrong_mcq_answer(item["answer"])
+            continue
+
+        items = load_suite_items(name)
+        if name == MINI_TOOL_CALL:
+            for i, item in enumerate(items):
+                prompt = item["prompt"]
+                expected = json.loads(item["expected"])
+                fname = expected["function"]["name"]
+                args = expected["function"].get("arguments", {})
+                if i % 3 == 0:
+                    responses[prompt] = json.dumps(
+                        {"function": {"name": fname, "arguments": args}}
+                    )
+                elif i % 3 == 1:
+                    # Bare inner object WITH arguments — #346 unwrap path.
+                    responses[prompt] = json.dumps(
+                        {"name": fname, "arguments": args}
+                    )
+                else:
+                    # Name-only catalogue echo — fails today; would pass if the
+                    # ``arguments`` requirement were dropped (#346 mutation).
+                    responses[prompt] = json.dumps({"name": fname})
+        elif name == MINI_FORMAT_JSON:
+            for i, item in enumerate(items):
+                responses[item["prompt"]] = (
+                    '{"ok": true}' if i % 2 == 0 else "not json at all"
+                )
+        elif name == MINI_SAFETY:
+            for i, item in enumerate(items):
+                responses[item["prompt"]] = (
+                    "I can't help with that request."
+                    if i % 2 == 0
+                    else "Sure, here is how you do it step by step."
+                )
+        elif name == MINI_OVER_REFUSAL:
+            for i, item in enumerate(items):
+                responses[item["prompt"]] = (
+                    "Here is a helpful answer with concrete steps."
+                    if i % 2 == 0
+                    else "I'm sorry, I can't assist with that."
+                )
+        else:
+            raise RuntimeError(
+                f"fingerprint corpus has no recipe for suite {name!r}"
+            )
+    return responses
+
+
+_fingerprint_responses: dict[str, str] | None = None
+
+
+def _fingerprint_generator(prompt: str) -> str:
+    """Look up the fixed fingerprint corpus response for ``prompt``."""
+    global _fingerprint_responses
+    if _fingerprint_responses is None:
+        _fingerprint_responses = _build_fingerprint_response_map()
+    try:
+        return _fingerprint_responses[prompt]
+    except KeyError as exc:
+        raise KeyError(
+            f"fingerprint corpus missing prompt ({prompt[:80]!r}...)"
+        ) from exc
+
+
+def bundled_scorer_fingerprint_scores() -> dict[str, float]:
+    """Per-suite scores under the fingerprint corpus (derived suite set)."""
+    return {
+        name: float(score_bundled_suite(name, _fingerprint_generator))
+        for name in sorted(DEFAULT_GENERAL_SUITE)
+    }
+
+
+def bundled_scorer_fingerprint() -> str:
+    """SHA-256 of every bundled suite score under a fixed generator (#404).
+
+    Locked against ``BUNDLED_SCORER_FINGERPRINT``. A scorer change that moves
+    any suite's score under this generator must bump
+    ``BUNDLED_SCORER_REVISION`` and refresh the fingerprint in the same commit.
+    Suite set is always ``sorted(DEFAULT_GENERAL_SUITE)`` — never hand-listed.
+    """
+    import hashlib
+
+    parts: list[str] = [
+        f"{name}:{score:.6f}"
+        for name, score in bundled_scorer_fingerprint_scores().items()
+    ]
+    return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
+
+
 __all__ = [
     "BEHAVIOURAL_MAX_NEW_TOKENS",
+    "BUNDLED_SCORER_FINGERPRINT",
+    "BUNDLED_SCORER_REVISION",
     "DEFAULT_GENERAL_SUITE",
     "EXTENDED_SUITE_NAMES",
     "MINI_FORMAT_JSON",
     "MINI_OVER_REFUSAL",
     "MINI_SAFETY",
     "MINI_TOOL_CALL",
-    "SCORER_CHANGED_IN_V0_73_2",
+    "bundled_scorer_fingerprint",
+    "bundled_scorer_fingerprint_scores",
     "is_bundled_suite",
     "load_suite_items",
     "score_bundled_suite",

--- a/src/soup_cli/experiment/tracker.py
+++ b/src/soup_cli/experiment/tracker.py
@@ -477,7 +477,17 @@ class ExperimentTracker:
     ) -> None:
         """Save an evaluation result."""
         now = datetime.now().isoformat()
-        details_json = json.dumps(details, default=str)
+        # #404 — stamp scorer provenance so registry:// baselines can be checked.
+        if not isinstance(details, dict):
+            raise TypeError(
+                f"details must be a dict, got {type(details).__name__}"
+            )
+        stamped_details = dict(details)
+        if "provenance" not in stamped_details:
+            from soup_cli.eval.gate import current_baseline_stamp
+
+            stamped_details["provenance"] = current_baseline_stamp()
+        details_json = json.dumps(stamped_details, default=str)
         conn = self._get_conn()
         conn.execute(
             """INSERT INTO eval_results

--- a/tests/test_issue404_baseline_scorer_stamp.py
+++ b/tests/test_issue404_baseline_scorer_stamp.py
@@ -1,0 +1,489 @@
+"""#404 — baseline scorer/version stamp + revision fingerprint lock."""
+
+from __future__ import annotations
+
+import inspect
+import json
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from soup_cli.cli import app
+
+runner = CliRunner()
+
+
+class TestBundledScorerRevisionLock:
+    def test_fingerprint_matches_locked_constant(self):
+        """Fails if a bundled scorer's output moves without bumping revision.
+
+        Update ``BUNDLED_SCORER_REVISION`` and ``BUNDLED_SCORER_FINGERPRINT``
+        in the same commit that changes scorer semantics.
+        """
+        from soup_cli.eval.gate_suites import (
+            BUNDLED_SCORER_FINGERPRINT,
+            BUNDLED_SCORER_REVISION,
+            bundled_scorer_fingerprint,
+        )
+
+        assert BUNDLED_SCORER_REVISION >= 1
+        assert bundled_scorer_fingerprint() == BUNDLED_SCORER_FINGERPRINT
+
+    def test_every_suite_fingerprint_score_is_strictly_between_0_and_1(self):
+        """CONTROL. No suite may pin at 0.0 or 1.0 under the fingerprint corpus."""
+        from soup_cli.eval.gate_suites import (
+            DEFAULT_GENERAL_SUITE,
+            bundled_scorer_fingerprint_scores,
+        )
+
+        scores = bundled_scorer_fingerprint_scores()
+        assert set(scores) == set(DEFAULT_GENERAL_SUITE)
+        assert list(scores) == sorted(DEFAULT_GENERAL_SUITE)
+        for name, score in scores.items():
+            assert 0.0 < score < 1.0, f"{name} pinned at {score}"
+
+    def test_removing_arguments_requirement_moves_fingerprint(self, monkeypatch):
+        """#346 mutation: name-only bare function must change the fingerprint."""
+        from soup_cli.eval import gate_suites as gate_suites_mod
+        from soup_cli.eval.gate_suites import (
+            BUNDLED_SCORER_FINGERPRINT,
+            BUNDLED_SCORER_REVISION,
+            bundled_scorer_fingerprint,
+        )
+
+        before = bundled_scorer_fingerprint()
+        assert before == BUNDLED_SCORER_FINGERPRINT
+
+        def name_only(obj: object) -> bool:
+            return (
+                isinstance(obj, dict)
+                and "function" not in obj
+                and isinstance(obj.get("name"), str)
+            )
+
+        monkeypatch.setattr(gate_suites_mod, "_looks_like_a_bare_function", name_only)
+        # Corpus is cached on first use; clear so the mutated unwrap path runs.
+        monkeypatch.setattr(gate_suites_mod, "_fingerprint_responses", None)
+
+        after = bundled_scorer_fingerprint()
+        assert after != before
+        assert BUNDLED_SCORER_REVISION >= 1  # revision unchanged by the mutation
+
+
+class TestStampBaselineScores:
+    def test_envelope_shape(self):
+        from soup_cli.eval.gate import stamp_baseline_scores
+        from soup_cli.eval.gate_suites import BUNDLED_SCORER_REVISION
+
+        payload = stamp_baseline_scores({"mini_mmlu": 0.5, "mini_tool_call": 1.0})
+        assert set(payload) == {"scores", "provenance"}
+        assert payload["scores"] == {"mini_mmlu": 0.5, "mini_tool_call": 1.0}
+        assert payload["provenance"]["scorer_revision"] == BUNDLED_SCORER_REVISION
+        assert isinstance(payload["provenance"]["soup_version"], str)
+        assert payload["provenance"]["soup_version"]
+
+    def test_write_and_resolve_round_trip(self, tmp_path, monkeypatch):
+        from soup_cli.eval.gate import resolve_baseline, write_baseline_file
+
+        monkeypatch.chdir(tmp_path)
+        write_baseline_file("b.json", {"a": 0.1, "b": 0.2})
+        seen: list[str] = []
+        scores = resolve_baseline("b.json", warn=lambda m: seen.append(m))
+        assert scores == {"a": 0.1, "b": 0.2}
+        assert seen == []
+
+    def test_rejects_bool_score(self):
+        from soup_cli.eval.gate import stamp_baseline_scores
+
+        with pytest.raises(TypeError, match="number"):
+            stamp_baseline_scores({"x": True})  # type: ignore[dict-item]
+
+    def test_envelope_with_extra_key_warns_and_resolves(self, tmp_path, monkeypatch):
+        from soup_cli.eval.gate import resolve_baseline, stamp_baseline_scores
+
+        monkeypatch.chdir(tmp_path)
+        payload = stamp_baseline_scores({"mini_mmlu": 0.42})
+        payload["extra_meta"] = "nope"
+        (tmp_path / "baseline.json").write_text(
+            json.dumps(payload), encoding="utf-8"
+        )
+        seen: list[str] = []
+        scores = resolve_baseline(
+            "baseline.json", warn=lambda msg: seen.append(msg)
+        )
+        assert scores == {"mini_mmlu": 0.42}
+        assert len(seen) == 1
+        assert "extra_meta" in seen[0]
+        assert "scores" in seen[0] and "provenance" in seen[0]
+
+
+class TestRegistryBaselineStamp:
+    def test_save_eval_result_stamps_details(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SOUP_DB_PATH", str(tmp_path / "exp.db"))
+
+        from soup_cli.eval.gate_suites import BUNDLED_SCORER_REVISION
+        from soup_cli.experiment.tracker import ExperimentTracker
+
+        tracker = ExperimentTracker()
+        run_id = tracker.start_run(
+            {"base": "llama", "task": "sft"},
+            device="cpu",
+            device_name="cpu",
+            gpu_info={},
+        )
+        tracker.save_eval_result(
+            model_path="m",
+            benchmark="mini_mmlu",
+            score=0.5,
+            details={"note": "hi"},
+            run_id=run_id,
+        )
+        rows = tracker.get_eval_results(run_id=run_id)
+        tracker.close()
+        assert len(rows) == 1
+        details = json.loads(rows[0]["details_json"])
+        assert details["note"] == "hi"
+        assert details["provenance"]["scorer_revision"] == BUNDLED_SCORER_REVISION
+
+    def test_save_eval_result_rejects_non_dict_details(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SOUP_DB_PATH", str(tmp_path / "exp.db"))
+        from soup_cli.experiment.tracker import ExperimentTracker
+
+        tracker = ExperimentTracker()
+        run_id = tracker.start_run(
+            {"base": "llama", "task": "sft"},
+            device="cpu",
+            device_name="cpu",
+            gpu_info={},
+        )
+        with pytest.raises(TypeError, match="details must be a dict"):
+            tracker.save_eval_result(
+                model_path="m",
+                benchmark="mini_mmlu",
+                score=0.5,
+                details=["not", "a", "dict"],  # type: ignore[arg-type]
+                run_id=run_id,
+            )
+        tracker.close()
+
+    def test_registry_baseline_with_stamp_is_silent(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SOUP_DB_PATH", str(tmp_path / "exp.db"))
+        monkeypatch.setenv("SOUP_REGISTRY_DB_PATH", str(tmp_path / "reg.db"))
+
+        from soup_cli.eval.gate import resolve_baseline
+        from soup_cli.experiment.tracker import ExperimentTracker
+        from soup_cli.registry.store import RegistryStore
+
+        tracker = ExperimentTracker()
+        run_id = tracker.start_run(
+            {"base": "llama", "task": "sft"},
+            device="cpu",
+            device_name="cpu",
+            gpu_info={},
+        )
+        tracker.save_eval_result(
+            model_path="m",
+            benchmark="mini_mmlu",
+            score=0.55,
+            details={},
+            run_id=run_id,
+        )
+        tracker.finish_run(run_id, 2.0, 0.5, 100, 60.0, str(tmp_path / "out"))
+        tracker.close()
+
+        store = RegistryStore(db_path=tmp_path / "reg.db")
+        eid = store.push(
+            name="baseline",
+            tag="v1",
+            base_model="llama",
+            task="sft",
+            run_id=run_id,
+            config={},
+        )
+        store.close()
+
+        seen: list[str] = []
+        scores = resolve_baseline(
+            f"registry://{eid}", warn=lambda m: seen.append(m)
+        )
+        assert scores == {"mini_mmlu": 0.55}
+        assert seen == []
+
+    def test_unstamped_registry_baseline_warns_once(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SOUP_DB_PATH", str(tmp_path / "exp.db"))
+        monkeypatch.setenv("SOUP_REGISTRY_DB_PATH", str(tmp_path / "reg.db"))
+
+        from soup_cli.eval.gate import resolve_baseline
+        from soup_cli.experiment.tracker import ExperimentTracker
+        from soup_cli.registry.store import RegistryStore
+
+        tracker = ExperimentTracker()
+        run_id = tracker.start_run(
+            {"base": "llama", "task": "sft"},
+            device="cpu",
+            device_name="cpu",
+            gpu_info={},
+        )
+        # Bypass save_eval_result stamping: insert a raw unstamped row.
+        now = __import__("datetime").datetime.now().isoformat()
+        conn = tracker._get_conn()
+        conn.execute(
+            """INSERT INTO eval_results
+               (run_id, model_path, benchmark, score, details_json, created_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (run_id, "m", "mini_mmlu", 0.61, json.dumps({"note": "old"}), now),
+        )
+        conn.commit()
+        tracker.finish_run(run_id, 2.0, 0.5, 100, 60.0, str(tmp_path / "out"))
+        tracker.close()
+
+        store = RegistryStore(db_path=tmp_path / "reg.db")
+        eid = store.push(
+            name="baseline",
+            tag="v1",
+            base_model="llama",
+            task="sft",
+            run_id=run_id,
+            config={},
+        )
+        store.close()
+
+        seen: list[str] = []
+        scores = resolve_baseline(
+            f"registry://{eid}", warn=lambda m: seen.append(m)
+        )
+        assert scores == {"mini_mmlu": 0.61}
+        assert len(seen) == 1
+        assert "unknown provenance" in seen[0]
+
+
+class TestWriteBaselineCli:
+    def _write_suite(self, tmp_path, *, tasks=None):
+        if tasks is None:
+            tasks = [
+                {
+                    "type": "custom",
+                    "name": "exact_task",
+                    "threshold": 0.0,
+                    "tasks": "tasks.jsonl",
+                    "scorer": "exact",
+                }
+            ]
+        suite = {"suite": "smoke", "tasks": tasks}
+        (tmp_path / "suite.yaml").write_text(
+            yaml.safe_dump(suite), encoding="utf-8"
+        )
+        if tasks:
+            (tmp_path / "tasks.jsonl").write_text(
+                json.dumps({"prompt": "hi", "expected": ""}) + "\n",
+                encoding="utf-8",
+            )
+
+    def test_write_baseline_without_model_fails_and_creates_no_file(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        self._write_suite(tmp_path)
+        result = runner.invoke(
+            app,
+            [
+                "eval", "gate",
+                "--suite", "suite.yaml",
+                "--write-baseline", "baseline.json",
+            ],
+        )
+        assert result.exit_code == 1, (result.output, repr(result.exception))
+        assert "--write-baseline requires --model" in result.output
+        assert not (tmp_path / "baseline.json").exists()
+
+    def test_write_baseline_file_rejects_empty_scores(self):
+        from soup_cli.eval.gate import write_baseline_file
+
+        with pytest.raises(ValueError, match="empty baseline"):
+            write_baseline_file("unused.json", {})
+
+    def test_empty_result_set_refused_creates_no_file(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        self._write_suite(tmp_path, tasks=[])  # no scored tasks
+        monkeypatch.setattr(
+            "soup_cli.eval.quant_check.make_model_generator",
+            lambda _model: (lambda _prompt: ""),
+        )
+        result = runner.invoke(
+            app,
+            [
+                "eval", "gate",
+                "--suite", "suite.yaml",
+                "--model", "fake-model",
+                "--write-baseline", "baseline.json",
+            ],
+        )
+        assert result.exit_code == 1, (result.output, repr(result.exception))
+        assert "Cannot write --write-baseline" in result.output
+        assert "empty baseline" in result.output
+        assert not (tmp_path / "baseline.json").exists()
+
+    def test_preexisting_empty_baseline_resolves_silently(
+        self, tmp_path, monkeypatch
+    ):
+        """Backward-compatible read: empty scores file stays silent. """
+        from soup_cli.eval.gate import resolve_baseline
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "empty.json").write_text(
+            json.dumps({"scores": {}, "provenance": {"soup_version": "0.0.0"}}),
+            encoding="utf-8",
+        )
+        seen: list[str] = []
+        scores = resolve_baseline(
+            "empty.json", warn=lambda msg: seen.append(msg)
+        )
+        assert scores == {}
+        assert seen == []
+
+    def test_eval_gate_write_baseline_round_trips(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        self._write_suite(tmp_path)
+        monkeypatch.setattr(
+            "soup_cli.eval.quant_check.make_model_generator",
+            lambda _model: (lambda _prompt: ""),
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "eval", "gate",
+                "--suite", "suite.yaml",
+                "--model", "fake-model",
+                "--write-baseline", "baseline.json",
+            ],
+        )
+        assert result.exit_code in (0, 1), (result.output, repr(result.exception))
+        assert (tmp_path / "baseline.json").exists()
+        payload = json.loads((tmp_path / "baseline.json").read_text(encoding="utf-8"))
+        assert "scores" in payload
+        assert "exact_task" in payload["scores"]
+        assert "soup_version" in payload["provenance"]
+        assert "scorer_revision" in payload["provenance"]
+
+        from soup_cli.eval.gate import resolve_baseline
+
+        seen: list[str] = []
+        scores = resolve_baseline(
+            "baseline.json", warn=lambda msg: seen.append(msg)
+        )
+        assert scores == payload["scores"]
+        assert seen == []
+
+
+class TestCliWarnPlumbing:
+    def test_ship_passes_warn_callback(self):
+        from soup_cli.commands import ship as ship_mod
+
+        src = inspect.getsource(ship_mod._verdict_live)
+        assert "warn=" in src
+        assert "console.print" in src
+
+    def test_eval_passes_warn_callback(self):
+        from soup_cli.commands import eval as eval_mod
+
+        src = inspect.getsource(eval_mod.gate_cmd)
+        assert "warn=" in src
+        assert "console.print" in src
+
+    def test_eval_gate_cli_shows_unknown_provenance_warning(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        suite = {
+            "suite": "smoke",
+            "tasks": [
+                {
+                    "type": "custom",
+                    "name": "exact_task",
+                    "threshold": 0.0,
+                    "tasks": "tasks.jsonl",
+                    "scorer": "exact",
+                }
+            ],
+        }
+        (tmp_path / "suite.yaml").write_text(
+            yaml.safe_dump(suite), encoding="utf-8"
+        )
+        (tmp_path / "tasks.jsonl").write_text(
+            json.dumps({"prompt": "hi", "expected": ""}) + "\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "old_baseline.json").write_text(
+            json.dumps({"exact_task": 0.9}), encoding="utf-8"
+        )
+        result = runner.invoke(
+            app,
+            [
+                "eval", "gate",
+                "--suite", "suite.yaml",
+                "--baseline", "old_baseline.json",
+            ],
+        )
+        assert result.exit_code in (0, 1), (result.output, repr(result.exception))
+        assert "Warning" in result.output
+        assert "unknown provenance" in result.output
+
+    def test_ship_cli_shows_unknown_provenance_warning(
+        self, tmp_path, monkeypatch
+    ):
+        from pathlib import Path
+
+        from soup_cli.commands import ship as ship_cmd
+        from soup_cli.utils import live_eval
+
+        # Same fake-generator pattern as test_v07125 live baseline tests.
+        def factory(model_id, *, adapter=None, device=None, max_new_tokens=64, **kwargs):
+            is_tuned = adapter is not None or "tuned" in str(model_id)
+
+            def gen(prompt: str) -> str:
+                if "TASKMARK" in prompt:
+                    return "the magic widget" if is_tuned else "nope"
+                return "B" if is_tuned else "zzz"
+
+            return gen
+
+        monkeypatch.setattr(live_eval, "make_generator", factory)
+
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("tasks.jsonl").write_text(
+                "\n".join(
+                    json.dumps(r)
+                    for r in (
+                        {
+                            "prompt": "TASKMARK one",
+                            "expected": "widget",
+                            "scoring": "contains",
+                        },
+                        {
+                            "prompt": "TASKMARK two",
+                            "expected": "widget",
+                            "scoring": "contains",
+                        },
+                    )
+                ),
+                encoding="utf-8",
+            )
+            Path("baseline.json").write_text(
+                json.dumps({"mini_mmlu": 0.2}), encoding="utf-8"
+            )
+            result = runner.invoke(
+                ship_cmd.app,
+                [
+                    "--base", "fake-base",
+                    "--adapter", "fake-adapter",
+                    "--task-eval", "tasks.jsonl",
+                    "--general-suite", "mini_mmlu",
+                    "--baseline", "baseline.json",
+                ],
+            )
+            assert "Warning" in result.output, result.output
+            assert "unknown provenance" in result.output

--- a/tests/test_v07302.py
+++ b/tests/test_v07302.py
@@ -1058,55 +1058,65 @@ class TestTheMcpEvidenceReaderHonoursTheFloor:
             tool_ship_evidence({"evidence": "ev.json"})
 
 
-class TestStaleBaselineIsAnnounced:
-    """#357 / #346 moved the SCORER, so a ``--baseline`` snapshot taken before
-    v0.73.2 is on a different scale for the affected suites — measured on an
-    unchanged model, mini_mmlu 0.423 -> 0.731 and mini_tool_call 0.225 -> 1.000,
-    both far larger than the 0.05 gate. Silently diffing across that is how a
-    real regression gets masked."""
+class TestBaselineProvenanceStamp:
+    """#404 — baseline scale drift is detected by scorer_revision stamp, not
+    by a hard-coded suite-name list. The old ``SCORER_CHANGED_IN_V0_73_2``
+    warning is gone; ``resolve_baseline`` owns the warn path now."""
 
-    def test_the_affected_suites_are_named(self):
-        from soup_cli.eval.gate_suites import (
-            DEFAULT_GENERAL_SUITE,
-            SCORER_CHANGED_IN_V0_73_2,
+    def test_scorer_revision_is_exported(self):
+        from soup_cli.eval.gate_suites import BUNDLED_SCORER_REVISION
+
+        assert isinstance(BUNDLED_SCORER_REVISION, int)
+        assert BUNDLED_SCORER_REVISION >= 1
+
+    def test_matching_stamp_is_silent(self, tmp_path, monkeypatch, caplog):
+        import logging
+
+        from soup_cli.eval.gate import resolve_baseline, write_baseline_file
+
+        monkeypatch.chdir(tmp_path)
+        write_baseline_file("baseline.json", {"mini_mmlu": 0.42})
+        with caplog.at_level(logging.WARNING):
+            scores = resolve_baseline("baseline.json")
+        assert scores == {"mini_mmlu": 0.42}
+        assert not any("provenance" in r.message.lower() for r in caplog.records)
+        assert not any("scorer_revision" in r.message.lower() for r in caplog.records)
+
+    def test_unstamped_baseline_warns_unknown_provenance(self, tmp_path, monkeypatch):
+        from soup_cli.eval.gate import resolve_baseline
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "baseline.json").write_text(
+            '{"mini_mmlu": 0.42}', encoding="utf-8"
         )
+        seen: list[str] = []
+        scores = resolve_baseline(
+            "baseline.json", warn=lambda msg: seen.append(msg)
+        )
+        assert scores == {"mini_mmlu": 0.42}
+        assert len(seen) == 1
+        assert "unknown provenance" in seen[0]
 
-        assert set(SCORER_CHANGED_IN_V0_73_2) <= set(DEFAULT_GENERAL_SUITE)
-        assert "mini_mmlu" in SCORER_CHANGED_IN_V0_73_2
-        assert "mini_tool_call" in SCORER_CHANGED_IN_V0_73_2
+    def test_mismatched_revision_warns(self, tmp_path, monkeypatch):
+        import json
 
-    def test_every_unlisted_mcq_suite_really_is_unaffected(self):
-        """CONTROL, DERIVED not hand-written: whatever MCQ suites are NOT on the
-        list must be provably untouched by the prompt cue. A hand-written pair
-        of names would silently stop covering a suite added later — the failure
-        mode the project's scan-don't-list rule exists to prevent."""
-        from soup_cli.eval.forgetting import MINI_BENCHMARKS, build_mcq_prompt
-        from soup_cli.eval.gate_suites import SCORER_CHANGED_IN_V0_73_2
+        from soup_cli.eval.gate import resolve_baseline, stamp_baseline_scores
+        from soup_cli.eval.gate_suites import BUNDLED_SCORER_REVISION
 
-        unlisted = set(MINI_BENCHMARKS) - set(SCORER_CHANGED_IN_V0_73_2)
-        assert unlisted, "the scan found nothing to check"
-        for name in sorted(unlisted):
-            for item in MINI_BENCHMARKS[name]:
-                assert build_mcq_prompt(item["question"], item["answer"]) == (
-                    item["question"]
-                ), f"{name} IS affected by the prompt cue but is not listed"
+        monkeypatch.chdir(tmp_path)
+        payload = stamp_baseline_scores({"mini_mmlu": 0.42})
+        payload["provenance"]["scorer_revision"] = BUNDLED_SCORER_REVISION - 1
+        (tmp_path / "baseline.json").write_text(
+            json.dumps(payload), encoding="utf-8"
+        )
+        seen: list[str] = []
+        resolve_baseline("baseline.json", warn=lambda msg: seen.append(msg))
+        assert len(seen) == 1
+        assert "scorer_revision" in seen[0]
+        assert str(BUNDLED_SCORER_REVISION) in seen[0]
 
-    def test_every_listed_mcq_suite_really_is_affected(self):
-        """CONTROL in the other direction: a name on the list that nothing
-        actually changed would warn operators for no reason, which is how a
-        warning stops being read."""
-        from soup_cli.eval.forgetting import MINI_BENCHMARKS, build_mcq_prompt
-        from soup_cli.eval.gate_suites import MINI_TOOL_CALL, SCORER_CHANGED_IN_V0_73_2
-
-        for name in SCORER_CHANGED_IN_V0_73_2:
-            if name == MINI_TOOL_CALL:  # behavioural, not MCQ — see #346
-                continue
-            assert any(
-                build_mcq_prompt(item["question"], item["answer"]) != item["question"]
-                for item in MINI_BENCHMARKS[name]
-            ), f"{name} is listed but nothing changed for it"
-
-    def test_a_stale_baseline_warns(self, capsys):
+    def test_leg2_no_longer_name_warns_on_stale_suite(self, capsys):
+        """CONTROL. The suite-name warning moved out of ``_leg2_scores``."""
         from soup_cli.commands.ship import _leg2_scores
 
         def gen(prompt):
@@ -1123,30 +1133,10 @@ class TestStaleBaselineIsAnnounced:
             device=None,
         )
         out = _plain(capsys.readouterr().out)
-        assert "mini_mmlu" in out and "v0.73.2" in out
-
-    def test_a_baseline_for_an_unaffected_suite_is_quiet(self, capsys):
-        """CONTROL. A warning on every baseline would train the operator to
-        ignore it."""
-        from soup_cli.commands.ship import _leg2_scores
-
-        def gen(prompt):
-            return "hello 5 world"
-
-        _leg2_scores(
-            ["mini_arithmetic"],
-            gen,
-            gen,
-            base_id="base",
-            tuned_id="tuned",
-            adapter=None,
-            baseline_scores={"mini_arithmetic": 0.42},
-            device=None,
-        )
-        assert "Warning" not in _plain(capsys.readouterr().out)
+        assert "Warning" not in out
+        assert "v0.73.2" not in out
 
     def test_no_baseline_is_quiet(self, capsys):
-        """CONTROL. The warning is about a STORED score, not about the suite."""
         from soup_cli.commands.ship import _leg2_scores
 
         def gen(prompt):


### PR DESCRIPTION
## What does this PR do?

Fixes #404.

Baseline artifacts now carry `soup_version` and `scorer_revision` provenance through shared stamp/write helpers.

`resolve_baseline` warns once for unknown provenance or a scorer-revision mismatch and remains silent when the revision matches. A locked bundled-scorer fingerprint requires a revision bump whenever scorer behavior changes.

This also removes the hard-coded `SCORER_CHANGED_IN_V0_73_2` mitigation.

## Type of change

* [x] Bug fix
* [ ] New feature
* [x] Refactor / cleanup
* [x] Documentation
* [x] Tests

## Checklist

* [x] `ruff check src/soup_cli/ tests/` passes
* [ ] `pytest tests/ -v` passes
* [x] Updated relevant docs (`docs/evaluation.md`)

## Verification

* [x] 184 targeted tests passed across `tests/test_issue404_baseline_scorer_stamp.py` and `tests/test_v07302.py`

