### PR TITLE
ci: exercise Transformers compatibility floor (#478)

### DIFF
--- a/.github/constraints/transformers-floor.txt
+++ b/.github/constraints/transformers-floor.txt
@@ -1,0 +1,23 @@
+# #478 — Transformers pin for the dedicated floor-compat CI job.
+#
+# Declared train floor in pyproject.toml remains:
+#   transformers>=4.36.0,<5.0.0
+#
+# transformers==4.36.0 is not resolvable with the declared trl range
+# (trl>=0.14.0,<0.29): even trl 0.14.0 requires transformers>=4.46.0, and
+# newer trl releases require >=4.56.1 / >=4.56.2. Raising Soup's declared
+# transformers floor in pyproject.toml needs an explicit maintainer
+# dependency-policy decision. Do NOT treat 4.55.4 (the last pre-dtype=
+# release) as the declared floor.
+#
+# This file pins:
+#   transformers==4.46.1 — lowest non-yanked resolvable Transformers version
+#     tested with the lowest declared TRL version
+#   trl==0.14.0 — lowest version in Soup's declared trl range
+#
+# These pins are for the floor CI cell only so pip cannot silently upgrade
+# that job. Do not describe pip's preferred/latest compatible TRL as the
+# floor. Runtime dtype= regressions are caught by the static guard in
+# tests/test_transformers_floor_compat.py (dtype= is >=4.56-only).
+transformers==4.46.1
+trl==0.14.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,47 @@ jobs:
       - name: Run one-step MLX SFT through the real CLI
         run: pytest -o addopts= -m smoke -k mlx_sft_smoke -q tests/test_smoke_train.py
 
+  # #478: declared transformers floor (4.36.0) cannot resolve against declared
+  # trl>=0.14,<0.29 — see .github/constraints/transformers-floor.txt. Do not
+  # raise Soup's pin without a dependency-policy decision. This job installs
+  # under an explicit transformers(+trl) constraint so pip cannot silently
+  # upgrade the cell, asserts the pinned versions, and runs the static dtype=
+  # guard (the accepted fallback when a true floor runtime cell is impractical).
+  transformers-floor:
+    runs-on: ubuntu-latest
+    env:
+      PYTHONUTF8: "1"
+      PYTHONIOENCODING: "utf-8"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install with Transformers floor constraints
+        run: pip install -e ".[dev]" -c .github/constraints/transformers-floor.txt
+      - name: Verify constrained dependency graph
+        run: python -m pip check
+      - name: Assert constrained Transformers and TRL versions
+        run: |
+          python - <<'PY'
+          import importlib.metadata as md
+
+          expected = {"transformers": "4.46.1", "trl": "0.14.0"}
+          for name, want in expected.items():
+              got = md.version(name)
+              assert got == want, (
+                  f"floor job expected {name}=={want} from "
+                  f".github/constraints/transformers-floor.txt, got {got} — "
+                  f"pip silently upgraded, ignored -c, or constraints drifted"
+              )
+              print(f"{name}={got} (matches constraints)")
+          PY
+      - name: Run Transformers floor compatibility guard
+        run: >
+          pytest -o addopts= --no-cov -q
+          tests/test_transformers_floor_compat.py
+          tests/test_bugfixes.py::TestDiffModelLoading
+
   test:
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,22 @@ reproducing 70+ versions of notes.
   with a pageable CPU source and MPS layer buffers; CUDA pinning behaviour is
   unchanged.
 
+- **CI and production load sites no longer assume Transformers ``dtype=``
+  (#478).** ``dtype=`` on ``AutoModel*.from_pretrained`` / ``from_config`` is the
+  >=4.56 rename of ``torch_dtype=``. Soup still declares
+  ``transformers>=4.36.0,<5.0.0``, but the 12-cell matrix only ever installed the
+  newest 4.x, so a >=4.56-only kwarg stayed green. Call sites in chat / diff /
+  infer / export / merge / serve / mole routing / layer-stream runtime now pass
+  ``torch_dtype=`` (still accepted on current 4.57.x). A static AST guard fails
+  if a production ``AutoModel*`` load/config site reintroduces ``dtype=``. A new
+  Ubuntu/3.11 ``transformers-floor`` job installs under
+  ``.github/constraints/transformers-floor.txt`` using the lowest non-yanked
+  resolvable Transformers version ``4.46.1`` with the lowest version in the
+  declared TRL range ``0.14.0`` (``transformers==4.36.0`` is ResolutionImpossible
+  against declared ``trl`` — the declared Transformers floor in
+  ``pyproject.toml`` remains unchanged), runs ``pip check``, asserts both pins,
+  and runs the guard. The existing 12-cell matrix is untouched.
+
 - **`downsample` now returns at most `max_points` rows, which is what its
   docstring has always promised (#473 in #474).** The stride was
   `len(rows) // max_points` — a divisor, not a cap — so five rows with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -458,6 +458,13 @@ Great areas for first contributions:
 GitHub Actions runs on every push and PR:
 - **ruff** linting on Python 3.11 (must pass)
 - **pytest** on Python 3.10, 3.11, 3.12 across Ubuntu, Windows, macOS (must pass)
+- **transformers-floor** on Ubuntu / Python 3.11 (#478): installs
+  `.[dev]` under `.github/constraints/transformers-floor.txt`, asserts the
+  pinned `transformers` version, and runs the static `dtype=` / `torch_dtype=`
+  load-site guard. The declared `[train]` floor remains
+  `transformers>=4.36.0,<5.0.0` in `pyproject.toml`; `transformers==4.36.0`
+  cannot resolve against the declared `trl` range, so this job does not rewrite
+  that pin.
 
 See `.github/workflows/ci.yml`.
 

--- a/src/soup_cli/commands/chat.py
+++ b/src/soup_cli/commands/chat.py
@@ -234,7 +234,7 @@ def _load_model(
             base_model,
             trust_remote_code=trust_remote_code,
             device_map="auto",
-            dtype=torch.float16,
+            torch_dtype=torch.float16,
         )
         console.print(f"[dim]Loading LoRA adapter: {model_path}...[/]")
         model_obj = PeftModel.from_pretrained(base, model_path)
@@ -244,7 +244,7 @@ def _load_model(
             model_path,
             trust_remote_code=trust_remote_code,
             device_map="auto",
-            dtype=torch.float16,
+            torch_dtype=torch.float16,
         )
 
     model_obj.eval()

--- a/src/soup_cli/commands/diff.py
+++ b/src/soup_cli/commands/diff.py
@@ -262,7 +262,7 @@ def _load_model(
             base_model,
             trust_remote_code=trc,
             device_map="auto",
-            dtype=torch.float16,
+            torch_dtype=torch.float16,
         )
         model_obj = PeftModel.from_pretrained(base, model_path)
     else:
@@ -270,7 +270,7 @@ def _load_model(
             model_path,
             trust_remote_code=trc,
             device_map="auto",
-            dtype=torch.float16,
+            torch_dtype=torch.float16,
         )
 
     model_obj.eval()

--- a/src/soup_cli/commands/export.py
+++ b/src/soup_cli/commands/export.py
@@ -401,7 +401,7 @@ def _merge_adapter(
     console.print(f"[dim]Loading base model: {base_model}...[/]")
     model = AutoModelForCausalLM.from_pretrained(
         base_model,
-        dtype=torch.float16,
+        torch_dtype=torch.float16,
         trust_remote_code=trc,
         device_map="cpu",
     )

--- a/src/soup_cli/commands/infer.py
+++ b/src/soup_cli/commands/infer.py
@@ -696,7 +696,7 @@ def _load_model(
             base_model,
             trust_remote_code=trc,
             device_map="auto",
-            dtype=torch.float16,
+            torch_dtype=torch.float16,
         )
         model_obj = PeftModel.from_pretrained(base_obj, model_path)
     else:
@@ -704,7 +704,7 @@ def _load_model(
             model_path,
             trust_remote_code=trc,
             device_map="auto",
-            dtype=torch.float16,
+            torch_dtype=torch.float16,
         )
 
     model_obj.eval()

--- a/src/soup_cli/commands/merge.py
+++ b/src/soup_cli/commands/merge.py
@@ -175,7 +175,7 @@ def merge(
         console.print(f"[dim]Loading base model: {base}...[/]")
         model = AutoModelForCausalLM.from_pretrained(
             base,
-            dtype=model_dtype,
+            torch_dtype=model_dtype,
             trust_remote_code=trc,
             device_map="cpu",
         )

--- a/src/soup_cli/commands/serve.py
+++ b/src/soup_cli/commands/serve.py
@@ -1335,7 +1335,7 @@ def _load_model(
             base_model,
             trust_remote_code=trust_remote_code,
             device_map="auto",
-            dtype=load_dtype,
+            torch_dtype=load_dtype,
         )
         console.print(f"[dim]Loading LoRA adapter: {model_path}...[/]")
         model_obj = PeftModel.from_pretrained(base, model_path)
@@ -1345,7 +1345,7 @@ def _load_model(
             model_path,
             trust_remote_code=trust_remote_code,
             device_map="auto",
-            dtype=load_dtype,
+            torch_dtype=load_dtype,
         )
 
     model_obj.eval()
@@ -1443,7 +1443,7 @@ def _load_draft_model(speculative_model: str, device: str):
     draft = AutoModelForCausalLM.from_pretrained(
         speculative_model,
         device_map="auto" if device != "cpu" else "cpu",
-        dtype=torch.float16 if device != "cpu" else torch.float32,
+        torch_dtype=torch.float16 if device != "cpu" else torch.float32,
     )
     draft.eval()
     return draft

--- a/src/soup_cli/utils/layer_stream_runtime.py
+++ b/src/soup_cli/utils/layer_stream_runtime.py
@@ -1340,14 +1340,12 @@ def build_meta_skeleton(
     if quant == QUANT_NF4:
         quant_config = build_nf4_config(dtype, double_quant=double_quant)
     with init_empty_weights():
-        try:
-            model = AutoModelForCausalLM.from_config(
-                config, dtype=torch_dtype, trust_remote_code=trust_remote_code
-            )
-        except TypeError:
-            model = AutoModelForCausalLM.from_config(
-                config, torch_dtype=torch_dtype, trust_remote_code=trust_remote_code
-            )
+        # torch_dtype= is the spelling that works across Soup's declared
+        # transformers range (>=4.36,<5). dtype= is the >=4.56 rename only
+        # (#478 / #471); using it here would TypeError on older installs.
+        model = AutoModelForCausalLM.from_config(
+            config, torch_dtype=torch_dtype, trust_remote_code=trust_remote_code
+        )
         if quant_config is not None:
             from transformers.integrations.bitsandbytes import replace_with_bnb_linear
 

--- a/src/soup_cli/utils/mole_routing.py
+++ b/src/soup_cli/utils/mole_routing.py
@@ -788,7 +788,7 @@ def load_mole_for_serve(
         resolved_base,
         trust_remote_code=trust_remote_code,
         device_map="auto" if device == "cuda" else None,
-        dtype=load_dtype,
+        torch_dtype=load_dtype,
     )
     # The gate is a Linear(hidden_dim, N); a base whose hidden size differs from
     # the manifest would shape-mismatch deep in decode. Fail loud at load

--- a/tests/test_bugfixes.py
+++ b/tests/test_bugfixes.py
@@ -129,21 +129,29 @@ class TestComputeDtype:
             assert dtype == torch.float16
 
 
-# --- BUG-005: diff dtype -> torch_dtype ---
+# --- BUG-005: diff load dtype spelling (#478) ---
 
 
 class TestDiffModelLoading:
-    """Test diff command uses correct parameter names."""
+    """Test diff command uses Transformers kwargs compatible with the floor."""
 
-    def test_load_model_uses_dtype(self):
-        """_load_model should pass dtype= (not the old torch_dtype=)."""
+    def test_load_model_uses_torch_dtype(self):
+        """_load_model must pass torch_dtype= (not the >=4.56-only dtype=).
+
+        dtype= is the rename of torch_dtype= at transformers>=4.56. Soup declares
+        transformers>=4.36.0,<5.0.0; using dtype= TypeErrors on older installs
+        inside that range (#478 / #471). torch_dtype= remains accepted (with a
+        deprecation warning) on current 4.57.x.
+        """
         import inspect
 
         from soup_cli.commands.diff import _load_model
 
         source = inspect.getsource(_load_model)
-        assert "dtype=torch.float16" in source
-        assert "torch_dtype=" not in source
+        assert "torch_dtype=torch.float16" in source
+        # Substring-safe: torch_dtype=... contains the letters dtype=
+        bare = source.replace("torch_dtype=", "")
+        assert "dtype=" not in bare
 
 
 # --- BUG-006: wandb version pin ---

--- a/tests/test_speculative_decoding.py
+++ b/tests/test_speculative_decoding.py
@@ -111,7 +111,8 @@ class TestDraftModelLoading:
             _load_draft_model("small-model", "cuda")
             call_kwargs = mock_load.call_args[1]
             assert call_kwargs["device_map"] == "auto"
-            assert call_kwargs["dtype"] == torch.float16
+            assert call_kwargs["torch_dtype"] == torch.float16
+            assert "dtype" not in call_kwargs
 
     def test_load_draft_model_no_trust_remote_code(self):
         """_load_draft_model should NOT pass trust_remote_code."""

--- a/tests/test_transformers_floor_compat.py
+++ b/tests/test_transformers_floor_compat.py
@@ -1,0 +1,172 @@
+"""#478 — Transformers load kwargs must stay compatible with the declared floor.
+
+``pyproject.toml`` declares ``transformers>=4.36.0,<5.0.0``, but CI's normal
+``pip install -e ".[dev]"`` resolves to the newest 4.x. A kwarg that only exists
+on >=4.56 (``dtype=`` on ``from_pretrained`` / ``from_config``, the rename of
+``torch_dtype=``) therefore passes the 12-cell matrix and TypeErrors on older
+installs inside the declared range — exactly what #471 nearly shipped.
+
+``transformers==4.36.0`` cannot resolve against Soup's declared ``trl`` range
+(even ``trl==0.14.0`` requires ``transformers>=4.46.0``; see the floor CI job
+comments and ``.github/constraints/transformers-floor.txt``). Raising Soup's
+declared floor is a dependency-policy call, not something this suite does.
+Until that decision lands, the accepted #478 fallback is a static guard: no
+production ``AutoModel*.from_pretrained`` / ``from_config`` call site may pass
+``dtype=``.
+
+Unsloth's ``FastLanguageModel.from_pretrained(..., dtype=)`` and Soup wrapper
+kwargs that are not Transformers load APIs are out of scope.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_ROOT = REPO_ROOT / "src" / "soup_cli"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+CONSTRAINTS = REPO_ROOT / ".github" / "constraints" / "transformers-floor.txt"
+
+_LOAD_METHODS = frozenset({"from_pretrained", "from_config"})
+
+
+def _attr_parts(node: ast.AST) -> list[str]:
+    parts: list[str] = []
+    cur: ast.AST | None = node
+    while isinstance(cur, ast.Attribute):
+        parts.append(cur.attr)
+        cur = cur.value
+    if isinstance(cur, ast.Name):
+        parts.append(cur.id)
+    return list(reversed(parts))
+
+
+def _is_auto_model_load(call: ast.Call) -> bool:
+    """True for ``AutoModel*.from_pretrained`` / ``from_config`` (any prefix)."""
+    parts = _attr_parts(call.func)
+    if len(parts) < 2:
+        return False
+    if parts[-1] not in _LOAD_METHODS:
+        return False
+    return any(part.startswith("AutoModel") for part in parts[:-1])
+
+
+def find_post_floor_dtype_kwargs(source: str, *, filename: str = "<string>") -> list[str]:
+    """Return ``file:line`` hits for ``dtype=`` on AutoModel load/config calls."""
+    tree = ast.parse(source, filename=filename)
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not _is_auto_model_load(node):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "dtype":
+                hits.append(f"{filename}:{node.lineno}")
+    return hits
+
+
+def iter_production_hits() -> list[str]:
+    hits: list[str] = []
+    for path in sorted(SRC_ROOT.rglob("*.py")):
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        hits.extend(
+            find_post_floor_dtype_kwargs(
+                path.read_text(encoding="utf-8"),
+                filename=rel,
+            )
+        )
+    return hits
+
+
+def _transformers_floor_job_block(text: str) -> str:
+    """Return the ``transformers-floor:`` job body through the next top-level job."""
+    start = text.find("\n  transformers-floor:")
+    assert start != -1, "ci.yml missing transformers-floor job"
+    rest = text[start + 1 :]
+    # Next job at the same indent is a line starting with two spaces + name + ':'
+    # after the transformers-floor block; find "\n  test:" which follows.
+    end_rel = rest.find("\n  test:")
+    assert end_rel != -1, "ci.yml transformers-floor job not followed by test job"
+    return rest[:end_rel]
+
+
+class TestTransformersFloorDtypeGuard:
+    def test_no_production_auto_model_load_uses_dtype_kwarg(self):
+        hits = iter_production_hits()
+        assert hits == [], (
+            "AutoModel*.from_pretrained / from_config must use torch_dtype= "
+            "(works across transformers>=4.36,<5). dtype= is the >=4.56-only "
+            "rename and TypeErrors on older installs inside our declared range "
+            f"(#478). Offending sites: {hits}"
+        )
+
+    def test_scanner_flags_a_deliberate_dtype_mutation(self):
+        """CONTROL: a broken scanner that always returns [] would greenwash #478."""
+        bad = (
+            "from transformers import AutoModelForCausalLM\n"
+            "AutoModelForCausalLM.from_pretrained('x', dtype='auto')\n"
+        )
+        hits = find_post_floor_dtype_kwargs(bad, filename="mutation.py")
+        assert hits == ["mutation.py:2"]
+
+    def test_scanner_allows_torch_dtype(self):
+        good = (
+            "from transformers import AutoModelForCausalLM\n"
+            "AutoModelForCausalLM.from_pretrained('x', torch_dtype='auto')\n"
+        )
+        assert find_post_floor_dtype_kwargs(good, filename="ok.py") == []
+
+    def test_scanner_ignores_unsloth_and_non_auto_model_apis(self):
+        noise = (
+            "FastLanguageModel.from_pretrained('x', dtype=None)\n"
+            "PeftModel.from_pretrained(base, 'adapter', dtype=None)\n"
+            "torch.zeros(3, dtype=torch.float16)\n"
+            "load_model_and_tokenizer('x', dtype='auto')\n"
+        )
+        assert find_post_floor_dtype_kwargs(noise, filename="noise.py") == []
+
+    def test_scanner_sees_from_config_and_qualified_names(self):
+        src = (
+            "import transformers\n"
+            "transformers.AutoModelForCausalLM.from_config(cfg, dtype=x)\n"
+            "AutoModelForSequenceClassification.from_pretrained('m', dtype=y)\n"
+        )
+        hits = find_post_floor_dtype_kwargs(src, filename="q.py")
+        assert hits == ["q.py:2", "q.py:3"]
+
+
+class TestFloorConstraintAndWorkflowPins:
+    def test_constraints_pin_lowest_resolvable_pair(self):
+        """4.36.0 is documented as unresolvable; pins are 4.46.1 + trl 0.14.0."""
+        text = CONSTRAINTS.read_text(encoding="utf-8")
+        assert "4.36.0" in text and "not resolvable" in text.lower()
+        assert "transformers==4.46.1" in text
+        assert "trl==0.14.0" in text
+        assert "trl==0.17.0" not in text
+        # Never claim 4.55.4 (or any pre-dtype probe) is the declared floor.
+        assert "declared" in text.lower() and "floor" in text.lower()
+
+    def test_workflow_runs_pip_check_and_asserts_both_exact_versions(self):
+        job = _transformers_floor_job_block(CI_WORKFLOW.read_text(encoding="utf-8"))
+        assert "python -m pip check" in job
+        assert 'transformers": "4.46.1"' in job or "transformers': '4.46.1'" in job
+        # Hard-coded exact pins in the assertion step (not a soft parse-only check).
+        assert '"4.46.1"' in job and '"0.14.0"' in job
+        assert "trl" in job
+        assert "-c .github/constraints/transformers-floor.txt" in job
+
+
+@pytest.mark.parametrize(
+    "snippet,expect_hit",
+    [
+        ("AutoModel.from_pretrained(m, dtype=t)", True),
+        ("AutoModelForVision2Seq.from_pretrained(m, dtype=t)", True),
+        ("AutoModelForCausalLM.from_config(c, dtype=t)", True),
+        ("AutoModelForCausalLM.from_pretrained(m, torch_dtype=t)", False),
+    ],
+)
+def test_scanner_parametrized_shapes(snippet: str, expect_hit: bool):
+    hits = find_post_floor_dtype_kwargs(snippet + "\n", filename="p.py")
+    assert bool(hits) is expect_hit


### PR DESCRIPTION
## What does this PR do?

Fixes #478.

The 12 existing test cells install the newest Transformers 4.x, so they cannot detect code that accidentally depends on a newer API. That happened with `dtype=`: it works on Transformers 4.56+, while Soup still declares support from 4.36.

I reproduced the dependency boundary before choosing the CI pin. The declared `transformers==4.36.0` floor cannot resolve with `trl>=0.14,<0.29`, because even TRL 0.14.0 requires Transformers 4.46+. The new floor job therefore uses the lowest combination that resolves under the current declarations:

- `transformers==4.46.1`, the lowest non-yanked resolvable Transformers release
- `trl==0.14.0`, the lowest declared TRL release

The job installs with explicit constraints, runs `pip check`, and asserts both installed versions so pip cannot silently move the cell upward.

Production `AutoModel*` calls now use `torch_dtype=`, which works at this effective floor and on current Transformers. A source-derived AST test scans the production tree for `dtype=` on `from_pretrained` and `from_config`; deliberately changing one call back to `dtype=` makes the test fail with the file and line number.

The existing 12-cell matrix and the declared dependency range are unchanged. Changing the declared 4.36 floor is left as a separate dependency-policy decision.

## Verification

- `ruff check src/soup_cli/ tests/`
- 26 focused compatibility and model-loading tests passed
- Constrained install resolved at Transformers 4.46.1 / TRL 0.14.0
- `pip check` passed
- Production scan found zero incompatible `dtype=` calls