### PR TITLE
chore(changelog): add conflict-free fragments

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,7 @@
 
 ## Checklist
 
-- [ ] `ruff check src/soup_cli/ tests/` passes
+- [ ] `ruff check src/soup_cli/ scripts/ tests/` passes
 - [ ] `pytest tests/ -v` passes
 - [ ] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed
+- [ ] Added a changelog fragment, or this change has no user-visible impact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           python-version: "3.11"
       - run: pip install ruff
-      - run: ruff check src/soup_cli/ tests/
+      - run: ruff check src/soup_cli/ scripts/ tests/
       - name: Lint the workflows themselves
         # `check-yaml` and a YAML parser both accept a workflow GitHub will
         # reject: 195d60b used the `runner` context in a job-level `env:` block,

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,5 +17,6 @@ jobs:
         with:
           python-version: "3.11"
       - run: pip install build
+      - run: python scripts/assemble_changelog.py --check-empty
       - run: python -m build
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ pytest tests/ -v --tb=short
 Run the linter:
 
 ```bash
-ruff check src/soup_cli/ tests/
+ruff check src/soup_cli/ scripts/ tests/
 ```
 
 If both pass — you're ready to contribute!
@@ -60,10 +60,10 @@ We use **ruff** for all code style and linting. Before committing, run:
 
 ```bash
 # Check for issues
-ruff check src/soup_cli/ tests/
+ruff check src/soup_cli/ scripts/ tests/
 
 # Auto-fix issues
-ruff check --fix src/soup_cli/ tests/
+ruff check --fix src/soup_cli/ scripts/ tests/
 ```
 
 ### Style Guidelines
@@ -337,13 +337,19 @@ git checkout -b fix/your-bug-fix
 - **Write tests first** (TDD) — then implement to pass them
 - Keep commits focused and logical
 
+For each user-visible pull request, add its entry to
+`changelog.d/<latest-release>/<number>.<category>.md` instead of editing `CHANGELOG.md`;
+use the newest released version in `CHANGELOG.md`, prefer the PR number rather than the
+issue it closes, and choose `added`, `changed`, `deprecated`, `removed`, `fixed`, or
+`security`.
+
 ### 3. Run Tests & Lint
 
 Before pushing, ensure everything passes:
 
 ```bash
 # Lint first
-ruff check --fix src/soup_cli/ tests/
+ruff check --fix src/soup_cli/ scripts/ tests/
 
 # Then run tests
 pytest tests/ -v --tb=short
@@ -378,7 +384,7 @@ Then open a pull request on GitHub with:
 
 When you open a PR, the GitHub template will show this checklist:
 
-- [ ] `ruff check src/soup_cli/ tests/` passes
+- [ ] `ruff check src/soup_cli/ scripts/ tests/` passes
 - [ ] `pytest tests/ -v` passes
 - [ ] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed
 - [ ] New tests added for new functionality
@@ -467,12 +473,14 @@ The project follows semantic versioning: `MAJOR.MINOR.PATCH`
 
 ### Version Bump Process
 
-1. Update version in `pyproject.toml` and `src/soup_cli/__init__.py`
-2. Run full test suite and linting
-3. Update `README.md`, the relevant page under `docs/`, `CHANGELOG.md`, and `SECURITY.md` (if security-related)
-4. Commit with message: `Release v0.X.0`
-5. Tag: `git tag v0.X.0 && git push --tags`
-6. GitHub Actions auto-publishes to PyPI on the `v*` tag (Trusted Publisher / OIDC)
+1. Run `python scripts/assemble_changelog.py` and review the assembled `CHANGELOG.md`
+2. Update version in `pyproject.toml` and `src/soup_cli/__init__.py`
+3. Run full test suite and linting
+4. Update `README.md`, the relevant page under `docs/`, and `SECURITY.md` (if security-related)
+5. Commit with message: `Release v0.X.0`
+6. Tag: `git tag v0.X.0 && git push --tags`
+7. GitHub Actions verifies that no fragment was left behind, then publishes to PyPI
+   on the `v*` tag (Trusted Publisher / OIDC)
 
 ## Recognition
 

--- a/changelog.d/0.73.3/490.changed.md
+++ b/changelog.d/0.73.3/490.changed.md
@@ -1,0 +1,6 @@
+- **User-visible changes now use per-PR changelog fragments (#487 by @Amix29 in #490).**
+  Contributors add a uniquely named, version-scoped Markdown file instead of editing the
+  shared `[Unreleased]` section. A standard-library assembler preserves long entries
+  verbatim, rejects stale or malformed fragments, and consumes them during release
+  preparation. A tag-time release gate refuses publication if any fragment remains, so
+  the conflict is removed without making changelog loss silent.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,33 @@
+# Changelog fragments
+
+User-visible pull requests add one Markdown fragment instead of editing the shared
+`CHANGELOG.md` file:
+
+```text
+changelog.d/<latest-release>/<number>.<category>.md
+```
+
+`<latest-release>` is the newest released version heading in `CHANGELOG.md`. `<number>`
+should be the pull-request number rather than the issue it closes; this keeps two pull
+requests for the same issue distinct and traceable. The validator rejects a second
+category with the same number. `<category>` is one of `added`, `changed`, `deprecated`,
+`removed`, `fixed`, or `security`.
+
+Write the complete changelog list item in the fragment and mention the same `#<number>` in
+its text. Long entries may contain paragraphs, tables, and fenced code blocks; assembly
+copies their Markdown verbatim. For example:
+
+```text
+changelog.d/0.73.3/490.changed.md
+```
+
+Before a release, run:
+
+```bash
+python scripts/assemble_changelog.py
+```
+
+The command validates every file, inserts entries under `[Unreleased]`, and consumes the
+fragments. A fragment based on an older release fails validation after a release, forcing
+its pull request to rebase and move the file. Tag publication independently refuses to
+continue while any fragment remains.

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository maintenance scripts."""

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Validate and assemble conflict-free changelog fragments."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+SECTIONS = ("added", "changed", "deprecated", "removed", "fixed", "security")
+SECTION_TITLES = {section: section.title() for section in SECTIONS}
+FRAGMENT_NAME = re.compile(
+    rf"^(?P<number>[1-9]\d*)\.(?P<section>{'|'.join(SECTIONS)})\.md$"
+)
+RELEASE_HEADING = re.compile(
+    r"^## \[(?P<version>\d+\.\d+\.\d+)\](?: - [^\r\n]*)?\r?$", re.MULTILINE
+)
+UNRELEASED_HEADING = re.compile(r"^## \[Unreleased\][^\r\n]*(?:\r?\n|$)", re.MULTILINE)
+SECTION_HEADING = re.compile(
+    r"^### (?P<title>[^\r\n]+?)[^\S\r\n]*(?:\r?\n|$)", re.MULTILINE
+)
+
+
+class ChangelogError(RuntimeError):
+    """A changelog fragment cannot be safely assembled."""
+
+
+@dataclass(frozen=True)
+class Fragment:
+    """A validated changelog fragment."""
+
+    path: Path
+    number: int
+    section: str
+    content: str
+
+
+def _read_utf8(path: Path) -> str:
+    try:
+        return path.read_bytes().decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ChangelogError(f"{path}: changelog files must be valid UTF-8") from exc
+
+
+def _latest_release(changelog: str, path: Path) -> str:
+    match = RELEASE_HEADING.search(changelog)
+    if match is None:
+        raise ChangelogError(f"{path}: no released version heading was found")
+    return match.group("version")
+
+
+def _fragment_files(fragment_root: Path) -> list[Path]:
+    if not fragment_root.exists():
+        return []
+    if not fragment_root.is_dir():
+        raise ChangelogError(f"{fragment_root}: expected a directory")
+
+    files: list[Path] = []
+    for path in sorted(fragment_root.rglob("*")):
+        if path.is_symlink():
+            raise ChangelogError(f"{path}: symlinks are not allowed in changelog.d")
+        if path.is_file():
+            files.append(path)
+    return files
+
+
+def validate_fragments(root: Path | str = ".") -> list[Fragment]:
+    """Return every fragment after validating layout, version, name, and content."""
+    root = Path(root)
+    changelog_path = root / "CHANGELOG.md"
+    if not changelog_path.is_file():
+        raise ChangelogError(f"{changelog_path}: file not found")
+
+    changelog = _read_utf8(changelog_path)
+    latest_release = _latest_release(changelog, changelog_path)
+    fragment_root = root / "changelog.d"
+    fragments: list[Fragment] = []
+
+    for path in _fragment_files(fragment_root):
+        relative = path.relative_to(fragment_root)
+        if relative == Path("README.md"):
+            continue
+        if len(relative.parts) == 1:
+            raise ChangelogError(
+                f"{path}: fragment must be inside a release-version directory"
+            )
+        if len(relative.parts) != 2:
+            raise ChangelogError(
+                f"{path}: fragment must be exactly one directory below changelog.d"
+            )
+
+        baseline = relative.parts[0]
+        if baseline != latest_release:
+            raise ChangelogError(
+                f"{path}: fragment baseline is {baseline}, but the latest release is "
+                f"{latest_release}; rebase and move the fragment before merging"
+            )
+
+        name_match = FRAGMENT_NAME.fullmatch(path.name)
+        if name_match is None:
+            allowed = "|".join(SECTIONS)
+            raise ChangelogError(
+                f"{path}: invalid fragment filename; expected "
+                f"<number>.({allowed}).md"
+            )
+
+        number = int(name_match.group("number"))
+        content = _read_utf8(path)
+        if not content:
+            raise ChangelogError(f"{path}: fragment must not be empty")
+        if not content.startswith("- "):
+            raise ChangelogError(f"{path}: fragment must start with a Markdown list item (`- `)")
+        if re.search(rf"(?<!\d)#{number}(?!\d)", content) is None:
+            raise ChangelogError(f"{path}: fragment must reference #{number}")
+
+        fragments.append(
+            Fragment(
+                path=path,
+                number=number,
+                section=name_match.group("section"),
+                content=content,
+            )
+        )
+
+    seen: dict[int, Path] = {}
+    for fragment in fragments:
+        previous = seen.setdefault(fragment.number, fragment.path)
+        if previous != fragment.path:
+            raise ChangelogError(
+                f"{fragment.path}: #{fragment.number} already has fragment {previous}; "
+                "use one fragment per issue or pull request"
+            )
+    return sorted(
+        fragments,
+        key=lambda fragment: (SECTIONS.index(fragment.section), fragment.number),
+    )
+
+
+def _unreleased_bounds(changelog: str) -> tuple[int, int]:
+    heading = UNRELEASED_HEADING.search(changelog)
+    if heading is None:
+        raise ChangelogError("CHANGELOG.md: missing `## [Unreleased]` heading")
+    next_release = re.search(r"^## \[", changelog[heading.end() :], re.MULTILINE)
+    end = len(changelog) if next_release is None else heading.end() + next_release.start()
+    return heading.end(), end
+
+
+def _section_bounds(changelog: str, section: str) -> tuple[int, int] | None:
+    unreleased_start, unreleased_end = _unreleased_bounds(changelog)
+    unreleased = changelog[unreleased_start:unreleased_end]
+    wanted = SECTION_TITLES[section]
+    headings = list(SECTION_HEADING.finditer(unreleased))
+    for index, heading in enumerate(headings):
+        if heading.group("title") != wanted:
+            continue
+        start = unreleased_start + heading.end()
+        end = (
+            unreleased_start + headings[index + 1].start()
+            if index + 1 < len(headings)
+            else unreleased_end
+        )
+        return start, end
+    return None
+
+
+def _normalise_newlines(content: str) -> str:
+    return content.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _line_ending(content: str) -> str:
+    return "\r\n" if content.endswith("\r\n") else "\n"
+
+
+def _separate_before(prefix: str) -> str:
+    normalised = _normalise_newlines(prefix)
+    if normalised.endswith("\n\n"):
+        return ""
+    newline = _line_ending(prefix)
+    if normalised.endswith("\n"):
+        return newline
+    return newline * 2
+
+
+def _separate_after(payload: str) -> str:
+    normalised = _normalise_newlines(payload)
+    if normalised.endswith("\n\n"):
+        return ""
+    newline = _line_ending(payload)
+    if normalised.endswith("\n"):
+        return newline
+    return newline * 2
+
+
+def _join_verbatim(contents: list[str]) -> str:
+    payload = ""
+    for content in contents:
+        if payload:
+            payload += _separate_after(payload)
+        payload += content
+    return payload
+
+
+def _append_to_section(changelog: str, section: str, contents: list[str]) -> str:
+    bounds = _section_bounds(changelog, section)
+    if bounds is None:
+        raise AssertionError(f"missing section {section}")
+    _, end = bounds
+    payload = _join_verbatim(contents)
+    prefix = changelog[:end]
+    insertion = _separate_before(prefix) + payload + _separate_after(payload)
+    return prefix + insertion + changelog[end:]
+
+
+def _insert_section(changelog: str, section: str, contents: list[str]) -> str:
+    unreleased_start, unreleased_end = _unreleased_bounds(changelog)
+    unreleased = changelog[unreleased_start:unreleased_end]
+    target_order = SECTIONS.index(section)
+    insertion_at = unreleased_end
+
+    for heading in SECTION_HEADING.finditer(unreleased):
+        title = heading.group("title")
+        known_section = next(
+            (key for key, known_title in SECTION_TITLES.items() if known_title == title), None
+        )
+        if known_section is not None and SECTIONS.index(known_section) > target_order:
+            insertion_at = unreleased_start + heading.start()
+            break
+
+    payload = _join_verbatim(contents)
+    prefix = changelog[:insertion_at]
+    heading = f"### {SECTION_TITLES[section]}\n\n"
+    insertion = _separate_before(prefix) + heading + payload + _separate_after(payload)
+    return prefix + insertion + changelog[insertion_at:]
+
+
+def _apply_fragments(changelog: str, fragments: list[Fragment]) -> str:
+    for section in SECTIONS:
+        pending: list[str] = []
+        for fragment in (item for item in fragments if item.section == section):
+            bounds = _section_bounds(changelog, section)
+            if bounds is not None:
+                section_text = changelog[bounds[0] : bounds[1]]
+                if _normalise_newlines(fragment.content) in _normalise_newlines(section_text):
+                    continue
+                if re.search(rf"(?<!\d)#{fragment.number}(?!\d)", section_text):
+                    raise ChangelogError(
+                        f"CHANGELOG.md: #{fragment.number} already exists in "
+                        f"{SECTION_TITLES[section]} with different text"
+                    )
+            pending.append(fragment.content)
+
+        if not pending:
+            continue
+        if _section_bounds(changelog, section) is None:
+            changelog = _insert_section(changelog, section, pending)
+        else:
+            changelog = _append_to_section(changelog, section, pending)
+    return changelog
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    mode = path.stat().st_mode
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary = Path(handle.name)
+            handle.write(content.encode("utf-8"))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, mode)
+        os.replace(temporary, path)
+    finally:
+        if temporary is not None and temporary.exists():
+            temporary.unlink()
+
+
+def assemble(root: Path | str = ".") -> list[Path]:
+    """Merge every validated fragment into Unreleased, then consume the fragments."""
+    root = Path(root)
+    changelog_path = root / "CHANGELOG.md"
+    fragments = validate_fragments(root)
+    if not fragments:
+        return []
+
+    original = _read_utf8(changelog_path)
+    assembled = _apply_fragments(original, fragments)
+    if assembled != original:
+        _atomic_write(changelog_path, assembled)
+
+    consumed = [fragment.path for fragment in fragments]
+    for path in consumed:
+        path.unlink()
+    for directory in sorted({path.parent for path in consumed}, reverse=True):
+        if not any(directory.iterdir()):
+            directory.rmdir()
+    return consumed
+
+
+def check_empty(root: Path | str = ".") -> None:
+    """Fail a release if any changelog fragment remains unassembled."""
+    fragments = validate_fragments(root)
+    if fragments:
+        paths = ", ".join(str(fragment.path) for fragment in fragments)
+        raise ChangelogError(
+            f"unassembled changelog fragments remain ({paths}); "
+            "assemble them before tagging with `python scripts/assemble_changelog.py`"
+        )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd(), help="repository root")
+    parser.add_argument(
+        "--check-empty",
+        action="store_true",
+        help="fail when a release would leave any fragment behind",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.check_empty:
+            check_empty(args.root)
+            sys.stdout.write("No unassembled changelog fragments remain.\n")
+        else:
+            consumed = assemble(args.root)
+            sys.stdout.write(f"Assembled {len(consumed)} changelog fragment(s).\n")
+    except ChangelogError as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_issue487_changelog_fragments.py
+++ b/tests/test_issue487_changelog_fragments.py
@@ -1,0 +1,263 @@
+"""Acceptance tests for conflict-free changelog fragments (#487)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.assemble_changelog import ChangelogError, assemble, check_empty, validate_fragments
+
+CHANGELOG = """# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Existing addition.
+
+### Fixed
+
+- Existing fix.
+
+## [0.73.3] - 2026-08-18
+
+### Added
+
+- Released addition.
+"""
+
+
+def _write_repo(root: Path, changelog: str = CHANGELOG) -> None:
+    (root / "CHANGELOG.md").write_text(changelog, encoding="utf-8")
+    (root / "changelog.d" / "0.73.3").mkdir(parents=True)
+
+
+def _write_fragment(root: Path, name: str, content: str) -> Path:
+    path = root / "changelog.d" / "0.73.3" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8", newline="")
+    return path
+
+
+def test_assembly_preserves_long_markdown_verbatim(tmp_path: Path) -> None:
+    _write_repo(tmp_path)
+    fragment = """- **A long change (#487 by @contributor).** First paragraph.
+
+  A second paragraph keeps its indentation.
+
+  | column | value |
+  | --- | --- |
+  | alpha | beta |
+
+  ```python
+  result = "spacing stays intact"
+  ```"""
+    path = _write_fragment(tmp_path, "487.changed.md", fragment)
+
+    assembled = assemble(tmp_path)
+    rendered = (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    assert assembled == [path]
+    assert fragment in rendered
+    assert rendered.index("### Changed") < rendered.index(fragment)
+    assert rendered.count(fragment) == 1
+    assert not path.exists()
+    assert not path.parent.exists()
+
+
+def test_fragments_are_sorted_by_number_inside_their_section(tmp_path: Path) -> None:
+    _write_repo(tmp_path)
+    _write_fragment(tmp_path, "902.fixed.md", "- Later identifier (#902).\n")
+    _write_fragment(tmp_path, "101.fixed.md", "- Earlier identifier (#101).\n")
+
+    assemble(tmp_path)
+    rendered = (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    assert rendered.index("Earlier identifier") < rendered.index("Later identifier")
+    assert rendered.index("Existing fix") < rendered.index("Earlier identifier")
+
+
+def test_recovery_after_interrupted_run_does_not_duplicate_entry(tmp_path: Path) -> None:
+    entry = "- Already assembled exactly once (#487).\n"
+    changelog = CHANGELOG.replace("- Existing fix.\n", f"- Existing fix.\n\n{entry}")
+    (tmp_path / "CHANGELOG.md").write_bytes(changelog.replace("\n", "\r\n").encode())
+    (tmp_path / "changelog.d" / "0.73.3").mkdir(parents=True)
+    path = _write_fragment(tmp_path, "487.fixed.md", entry)
+
+    assemble(tmp_path)
+
+    rendered = (tmp_path / "CHANGELOG.md").read_bytes()
+    normalised = rendered.decode().replace("\r\n", "\n")
+    assert normalised.count(entry) == 1
+    assert normalised.count("### Fixed") == 1
+    assert b"- Existing fix.\r\n" in rendered
+    assert not path.exists()
+
+
+def test_crlf_assembly_does_not_add_an_extra_blank_line(tmp_path: Path) -> None:
+    (tmp_path / "CHANGELOG.md").write_bytes(CHANGELOG.replace("\n", "\r\n").encode())
+    (tmp_path / "changelog.d" / "0.73.3").mkdir(parents=True)
+    entry = "- Newly assembled fix (#487).\n"
+    _write_fragment(tmp_path, "487.fixed.md", entry)
+
+    assemble(tmp_path)
+
+    rendered = (tmp_path / "CHANGELOG.md").read_bytes()
+    normalised = rendered.decode().replace("\r\n", "\n")
+    assert f"- Existing fix.\n\n{entry}\n## [0.73.3]" in normalised
+    assert f"- Existing fix.\n\n\n{entry}" not in normalised
+    assert b"- Existing fix.\r\n\r\n" in rendered
+
+
+def test_stale_fragment_fails_loudly_without_mutating_files(tmp_path: Path) -> None:
+    _write_repo(tmp_path)
+    current_dir = tmp_path / "changelog.d" / "0.73.3"
+    current_dir.rmdir()
+    stale_dir = tmp_path / "changelog.d" / "0.73.2"
+    stale_dir.mkdir()
+    path = stale_dir / "487.fixed.md"
+    path.write_text("- Stale entry (#487).\n", encoding="utf-8")
+    before = (tmp_path / "CHANGELOG.md").read_bytes()
+
+    with pytest.raises(ChangelogError, match="0.73.2.*latest release is 0.73.3"):
+        assemble(tmp_path)
+
+    assert (tmp_path / "CHANGELOG.md").read_bytes() == before
+    assert path.exists()
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "message"),
+    [
+        ("0.73.3/not-a-fragment.txt", "invalid fragment filename"),
+        ("loose.md", "must be inside a release-version directory"),
+        ("0.73.3/nested/487.fixed.md", "must be exactly one directory"),
+    ],
+)
+def test_unknown_fragment_layout_is_never_silently_ignored(
+    tmp_path: Path, relative_path: str, message: str
+) -> None:
+    _write_repo(tmp_path)
+    path = tmp_path / "changelog.d" / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("- Entry (#487).\n", encoding="utf-8")
+
+    with pytest.raises(ChangelogError, match=message):
+        validate_fragments(tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("name", "content", "message"),
+    [
+        ("487.fixed.md", "", "must not be empty"),
+        ("487.fixed.md", "No list marker (#487).\n", "must start with a Markdown list item"),
+        ("487.fixed.md", "- Wrong reference (#486).\n", "must reference #487"),
+    ],
+)
+def test_malformed_fragment_is_rejected(
+    tmp_path: Path, name: str, content: str, message: str
+) -> None:
+    _write_repo(tmp_path)
+    _write_fragment(tmp_path, name, content)
+
+    with pytest.raises(ChangelogError, match=message):
+        validate_fragments(tmp_path)
+
+
+def test_one_repository_number_cannot_claim_two_fragments(tmp_path: Path) -> None:
+    _write_repo(tmp_path)
+    _write_fragment(tmp_path, "487.fixed.md", "- Fixed half (#487).\n")
+    _write_fragment(tmp_path, "487.changed.md", "- Changed half (#487).\n")
+
+    with pytest.raises(ChangelogError, match="#487 already has fragment"):
+        validate_fragments(tmp_path)
+
+
+def test_release_gate_refuses_every_remaining_fragment(tmp_path: Path) -> None:
+    _write_repo(tmp_path)
+    _write_fragment(tmp_path, "487.fixed.md", "- Pending entry (#487).\n")
+
+    with pytest.raises(ChangelogError, match="assemble them before tagging"):
+        check_empty(tmp_path)
+
+    (tmp_path / "changelog.d" / "0.73.3" / "487.fixed.md").unlink()
+    (tmp_path / "changelog.d" / "0.73.3").rmdir()
+    check_empty(tmp_path)
+
+
+def test_cli_failure_is_nonzero_and_actionable(tmp_path: Path) -> None:
+    _write_repo(tmp_path)
+    _write_fragment(tmp_path, "487.fixed.md", "- Pending entry (#487).\n")
+    script = Path(__file__).parents[1] / "scripts" / "assemble_changelog.py"
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--root", str(tmp_path), "--check-empty"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "assemble them before tagging" in result.stderr
+
+
+def _git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=root,
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+
+
+def test_two_branches_add_fragments_without_a_merge_conflict(tmp_path: Path) -> None:
+    """The regression in #487: parallel changelog additions must merge cleanly."""
+    _write_repo(tmp_path)
+    (tmp_path / "changelog.d" / "0.73.3").rmdir()
+    _git(tmp_path, "init", "-b", "main")
+    _git(tmp_path, "config", "user.name", "Soup test")
+    _git(tmp_path, "config", "user.email", "soup-test@example.invalid")
+    _git(tmp_path, "add", "CHANGELOG.md")
+    _git(tmp_path, "commit", "-m", "base")
+
+    _git(tmp_path, "checkout", "-b", "change-a")
+    _write_fragment(tmp_path, "101.fixed.md", "- Branch A fix (#101).\n")
+    _git(tmp_path, "add", "changelog.d/0.73.3/101.fixed.md")
+    _git(tmp_path, "commit", "-m", "add branch A fragment")
+
+    _git(tmp_path, "checkout", "main")
+    _git(tmp_path, "checkout", "-b", "change-b")
+    _write_fragment(tmp_path, "102.added.md", "- Branch B feature (#102).\n")
+    _git(tmp_path, "add", "changelog.d/0.73.3/102.added.md")
+    _git(tmp_path, "commit", "-m", "add branch B fragment")
+
+    merged = _git(tmp_path, "merge", "--no-edit", "change-a")
+
+    assert "CONFLICT" not in merged.stdout
+    assert (tmp_path / "changelog.d" / "0.73.3" / "101.fixed.md").is_file()
+    assert (tmp_path / "changelog.d" / "0.73.3" / "102.added.md").is_file()
+
+
+def test_repository_wires_the_release_guard_and_contributor_guidance() -> None:
+    root = Path(__file__).parents[1]
+    workflow = (root / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8")
+    contributing = (root / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    template = (root / ".github" / "pull_request_template.md").read_text(encoding="utf-8")
+
+    assert "python scripts/assemble_changelog.py --check-empty" in workflow
+    assert "changelog.d/<latest-release>/<number>.<category>.md" in contributing
+    assert "changelog fragment" in template.lower()
+
+
+def test_repository_fragments_match_the_newest_release() -> None:
+    """CI must fail after a release until every open fragment is rebased."""
+    root = Path(__file__).parents[1]
+
+    # The call is the assertion: stale or malformed repository fragments raise here.
+    fragments = validate_fragments(root)
+
+    assert all(fragment.path.is_file() for fragment in fragments)


### PR DESCRIPTION
## Summary

- replace shared edits to `CHANGELOG.md` with version-scoped fragments at `changelog.d/<latest-release>/<number>.<category>.md`
- add a standard-library-only assembler that validates every file, preserves fragment Markdown verbatim, and consumes fragments after assembly
- make forgotten assembly loud both in normal CI (stale baselines fail after a release) and in the PyPI tag workflow (any remaining fragment blocks publication)
- document the contributor and release workflows without migrating the existing `[Unreleased]` content

The numeric key may be the issue or pull-request number. GitHub assigns both from one repository-wide namespace, so the filename remains collision-free even when a fragment is written before its PR exists; a second fragment with the same number is rejected.

## Safety properties pinned by tests

- a real two-branch Git merge keeps both independently named fragments without a conflict
- a fragment below an older release version fails before either the changelog or fragment is mutated
- unknown layouts, malformed names, empty/non-list content, mismatched references, and duplicate numeric keys fail rather than being ignored
- long multi-paragraph entries, including tables and fenced code blocks, survive assembly byte-for-byte as a substring
- an interrupted assembly can be rerun without duplicating an entry
- the release workflow refuses to build while any fragment remains

No runtime dependency is added; the assembler uses only the Python standard library.

## Validation

- `PYTHONPATH=src python -m pytest tests/ -q` — 18,304 passed, 285 skipped, 5 deselected; 81.24% coverage
- `python -m pytest tests/test_issue487_changelog_fragments.py -q --no-cov` — 16 passed
- `ruff check src/soup_cli/ scripts/ tests/`
- `actionlint` v1.7.12
- `python -m build` — sdist and wheel built successfully

Closes #487
