### PR TITLE
fix(trainer): resolve frozen-base load dtype in the twelve non-SFT trainers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,7 +201,7 @@ reproducing 70+ versions of notes.
 - **The twelve non-SFT trainers (`dpo`, `kto`, `orpo`, `simpo`, `ipo`, `bco`,
   `online_dpo`, `grpo`, `ppo`, `pretrain`, `reward_model`, `embedding`) loaded
   a frozen LoRA base as float32 regardless of the checkpoint's own dtype
-  (#491 by @AmirF194).** #471 fixed this for the SFT trainer; the
+  (#491 by @AmirF194 in #492).** #471 fixed this for the SFT trainer; the
   same `model_kwargs` shape, missing the same key, was unchanged in the
   other twelve. None of them has a full fine-tuning branch, so every load
   there is a frozen base: the new shared `resolve_frozen_base_load_dtype()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,17 @@ reproducing 70+ versions of notes.
 
 ### Fixed
 
+- **The twelve non-SFT trainers (`dpo`, `kto`, `orpo`, `simpo`, `ipo`, `bco`,
+  `online_dpo`, `grpo`, `ppo`, `pretrain`, `reward_model`, `embedding`) loaded
+  a frozen LoRA base as float32 regardless of the checkpoint's own dtype
+  (#491 by @AmirF194).** #471 fixed this for the SFT trainer; the
+  same `model_kwargs` shape, missing the same key, was unchanged in the
+  other twelve. None of them has a full fine-tuning branch, so every load
+  there is a frozen base: the new shared `resolve_frozen_base_load_dtype()`
+  keeps the checkpoint's own dtype (`torch_dtype="auto"`), except on a
+  pre-Ampere CUDA card, where it now matches the float16 compute dtype
+  those cards already use instead of leaving the base in bf16 storage.
+
 - **Layer streaming now keeps its host store on CPU on Apple Silicon
   (#434 by @Amix29 in #480).**
   PyTorch 2.7+ can return an MPS tensor for

--- a/src/soup_cli/trainer/bco.py
+++ b/src/soup_cli/trainer/bco.py
@@ -23,6 +23,7 @@ from soup_cli.utils.gpu import (
     estimate_batch_size,
     model_size_from_name,
     resolve_device_map,
+    resolve_frozen_base_load_dtype,
 )
 from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
@@ -263,6 +264,7 @@ class BCOTrainerWrapper:
         dev_map = resolve_device_map(self.device)
         model_kwargs = {
             "trust_remote_code": self._trust_remote_code, "device_map": dev_map,
+            "torch_dtype": resolve_frozen_base_load_dtype(self.device),
         }
         if quant_config_obj is not None:
             model_kwargs["quantization_config"] = quant_config_obj

--- a/src/soup_cli/trainer/dpo.py
+++ b/src/soup_cli/trainer/dpo.py
@@ -13,6 +13,7 @@ from soup_cli.utils.gpu import (
     estimate_batch_size,
     model_size_from_name,
     resolve_device_map,
+    resolve_frozen_base_load_dtype,
 )
 from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
@@ -253,6 +254,7 @@ class DPOTrainerWrapper(StreamingSetupMixin):
         dev_map = resolve_device_map(self.device)
         model_kwargs = {
             "trust_remote_code": self._trust_remote_code, "device_map": dev_map,
+            "torch_dtype": resolve_frozen_base_load_dtype(self.device),
         }
         if quant_config_obj is not None:
             model_kwargs["quantization_config"] = quant_config_obj

--- a/src/soup_cli/trainer/embedding.py
+++ b/src/soup_cli/trainer/embedding.py
@@ -13,6 +13,7 @@ from soup_cli.utils.gpu import (
     estimate_batch_size,
     model_size_from_name,
     resolve_device_map,
+    resolve_frozen_base_load_dtype,
 )
 from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
@@ -229,6 +230,7 @@ class EmbeddingTrainerWrapper:
         dev_map = resolve_device_map(self.device)
         model_kwargs = {
             "trust_remote_code": self._trust_remote_code, "device_map": dev_map,
+            "torch_dtype": resolve_frozen_base_load_dtype(self.device),
         }
         if quant_config_obj is not None:
             model_kwargs["quantization_config"] = quant_config_obj

--- a/src/soup_cli/trainer/grpo.py
+++ b/src/soup_cli/trainer/grpo.py
@@ -16,6 +16,7 @@ from soup_cli.utils.gpu import (
     estimate_batch_size,
     model_size_from_name,
     resolve_device_map,
+    resolve_frozen_base_load_dtype,
 )
 from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
@@ -517,6 +518,7 @@ class GRPOTrainerWrapper:
         model_kwargs = {
             "trust_remote_code": self._trust_remote_code,
             "device_map": dev_map,
+            "torch_dtype": resolve_frozen_base_load_dtype(self.device),
         }
         if quant_config_obj is not None:
             model_kwargs["quantization_config"] = quant_config_obj

--- a/src/soup_cli/trainer/ipo.py
+++ b/src/soup_cli/trainer/ipo.py
@@ -13,6 +13,7 @@ from soup_cli.utils.gpu import (
     estimate_batch_size,
     model_size_from_name,
     resolve_device_map,
+    resolve_frozen_base_load_dtype,
 )
 from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
@@ -210,6 +211,7 @@ class IPOTrainerWrapper:
         dev_map = resolve_device_map(self.device)
         model_kwargs = {
             "trust_remote_code": self._trust_remote_code, "device_map": dev_map,
+            "torch_dtype": resolve_frozen_base_load_dtype(self.device),
         }
         if quant_config_obj is not None:
             model_kwargs["quantization_config"] = quant_config_obj

--- a/src/soup_cli/trainer/kto.py
+++ b/src/soup_cli/trainer/kto.py
@@ -14,6 +14,7 @@ from soup_cli.utils.gpu import (
     estimate_batch_size,
     model_size_from_name,
     resolve_device_map,
+    resolve_frozen_base_load_dtype,
 )
 from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
@@ -242,6 +243,7 @@ class KTOTrainerWrapper(StreamingSetupMixin):
         dev_map = resolve_device_map(self.device)
         model_kwargs = {
             "trust_remote_code": self._trust_remote_code, "device_map": dev_map,
+            "torch_dtype": resolve_frozen_base_load_dtype(self.device),
         }
         if quant_config_obj is not None:
             model_kwargs["quantization_config"] = quant_config_obj

--- a/src/soup_cli/trainer/online_dpo.py
+++ b/src/soup_cli/trainer/online_dpo.py
@@ -38,6 +38,7 @@ from soup_cli.utils.gpu import (
     estimate_batch_size,
     model_size_from_name,
     resolve_device_map,
+    resolve_frozen_base_load_dtype,
 )
 from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
@@ -365,6 +366,7 @@ class OnlineDPOTrainerWrapper:
         dev_map = resolve_device_map(self.device)
         model_kwargs = {
             "trust_remote_code": self._trust_remote_code, "device_map": dev_map,
+            "torch_dtype": resolve_frozen_base_load_dtype(self.device),
         }
         if quant_config_obj is not None:
             model_kwargs["quantization_config"] = quant_config_obj

--- a/src/soup_cli/trainer/orpo.py
+++ b/src/soup_cli/trainer/orpo.py
@@ -14,6 +14,7 @@ from soup_cli.utils.gpu import (
     estimate_batch_size,
     model_size_from_name,
     resolve_device_map,
+    resolve_frozen_base_load_dtype,
 )
 from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
@@ -250,6 +251,7 @@ class ORPOTrainerWrapper(StreamingSetupMixin):
         dev_map = resolve_device_map(self.device)
         model_kwargs = {
             "trust_remote_code": self._trust_remote_code, "device_map": dev_map,
+            "torch_dtype": resolve_frozen_base_load_dtype(self.device),
         }
         if quant_config_obj is not None:
             model_kwargs["quantization_config"] = quant_config_obj

--- a/src/soup_cli/trainer/ppo.py
+++ b/src/soup_cli/trainer/ppo.py
@@ -18,6 +18,7 @@ from soup_cli.utils.gpu import (
     estimate_batch_size,
     model_size_from_name,
     resolve_device_map,
+    resolve_frozen_base_load_dtype,
 )
 from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
@@ -442,6 +443,7 @@ class PPOTrainerWrapper:
         dev_map = resolve_device_map(self.device)
         model_kwargs = {
             "trust_remote_code": self._trust_remote_code, "device_map": dev_map,
+            "torch_dtype": resolve_frozen_base_load_dtype(self.device),
         }
         if quant_config_obj is not None:
             model_kwargs["quantization_config"] = quant_config_obj

--- a/src/soup_cli/trainer/pretrain.py
+++ b/src/soup_cli/trainer/pretrain.py
@@ -13,6 +13,7 @@ from soup_cli.utils.gpu import (
     estimate_batch_size,
     model_size_from_name,
     resolve_device_map,
+    resolve_frozen_base_load_dtype,
 )
 from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
@@ -273,6 +274,7 @@ class PretrainTrainerWrapper:
         dev_map = resolve_device_map(self.device)
         model_kwargs = {
             "trust_remote_code": self._trust_remote_code, "device_map": dev_map,
+            "torch_dtype": resolve_frozen_base_load_dtype(self.device),
         }
         if quant_config_obj is not None:
             model_kwargs["quantization_config"] = quant_config_obj

--- a/src/soup_cli/trainer/reward_model.py
+++ b/src/soup_cli/trainer/reward_model.py
@@ -19,6 +19,7 @@ from soup_cli.utils.gpu import (
     estimate_batch_size,
     model_size_from_name,
     resolve_device_map,
+    resolve_frozen_base_load_dtype,
 )
 from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
@@ -210,6 +211,7 @@ class RewardModelTrainerWrapper:
             "trust_remote_code": self._trust_remote_code,
             "device_map": dev_map,
             "num_labels": 1,
+            "torch_dtype": resolve_frozen_base_load_dtype(self.device),
         }
         if quant_config_obj is not None:
             model_kwargs["quantization_config"] = quant_config_obj

--- a/src/soup_cli/trainer/reward_model.py
+++ b/src/soup_cli/trainer/reward_model.py
@@ -246,6 +246,16 @@ class RewardModelTrainerWrapper:
         self.model = get_peft_model(self.model, lora_config)
         apply_post_lora_patches(self.model)
 
+        # #491 review: get_peft_model's adapter autocast (default
+        # autocast_adapter_dtype=True) upcasts lora_A/lora_B to fp32 but not the
+        # SEQ_CLS head's auto-added modules_to_save wrapper, so the reward head
+        # would otherwise train in the frozen base's load dtype (e.g. bf16, no
+        # fp32 master weights). Already-fp32 adapter params are a no-op here.
+        import torch
+        for param in self.model.parameters():
+            if param.requires_grad and param.dtype != torch.float32:
+                param.data = param.data.to(torch.float32)
+
         # v0.35.0 #60 — multi-trainer wiring of v0.28.0 speed/memory features.
         # Reward model is a regression head; cut_ce no-ops gracefully.
         from soup_cli.utils.v028_features import apply_v028_speed_memory

--- a/src/soup_cli/trainer/simpo.py
+++ b/src/soup_cli/trainer/simpo.py
@@ -14,6 +14,7 @@ from soup_cli.utils.gpu import (
     estimate_batch_size,
     model_size_from_name,
     resolve_device_map,
+    resolve_frozen_base_load_dtype,
 )
 from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
@@ -252,6 +253,7 @@ class SimPOTrainerWrapper(StreamingSetupMixin):
         dev_map = resolve_device_map(self.device)
         model_kwargs = {
             "trust_remote_code": self._trust_remote_code, "device_map": dev_map,
+            "torch_dtype": resolve_frozen_base_load_dtype(self.device),
         }
         if quant_config_obj is not None:
             model_kwargs["quantization_config"] = quant_config_obj

--- a/src/soup_cli/utils/gpu.py
+++ b/src/soup_cli/utils/gpu.py
@@ -445,6 +445,28 @@ def bf16_fp16_flags(device: str) -> tuple[bool, bool]:
     return (supported, not supported)
 
 
+def resolve_frozen_base_load_dtype(device: str):
+    """``torch_dtype`` for ``from_pretrained`` when loading a frozen (LoRA) base.
+
+    A frozen base never receives an optimizer step, so there is no reason to
+    upcast it to the HF default of float32 on load: keep the checkpoint's own
+    dtype (``"auto"``). The one exception is a pre-Ampere CUDA card (T4, P100,
+    V100, GTX 16xx, RTX 20xx): ``bf16_fp16_flags`` already routes mixed
+    precision compute to float16 there, since those cards have no bf16 units.
+    An ``"auto"`` load of a bf16-saved checkpoint would then leave the
+    resident weights in bf16 storage while every other tensor on the card is
+    float16, the same storage/compute split v0.73.1 (#385/#387) removed from
+    the other bf16-hardcoded call sites. Returning ``torch.float16`` there
+    keeps storage and compute in the same dtype.
+    """
+    _, fp16_only = bf16_fp16_flags(device)
+    if fp16_only:
+        import torch
+
+        return torch.float16
+    return "auto"
+
+
 def get_compute_dtype():
     """Return the best compute dtype for the current device.
 

--- a/src/soup_cli/utils/gpu.py
+++ b/src/soup_cli/utils/gpu.py
@@ -457,7 +457,10 @@ def resolve_frozen_base_load_dtype(device: str):
     resident weights in bf16 storage while every other tensor on the card is
     float16, the same storage/compute split v0.73.1 (#385/#387) removed from
     the other bf16-hardcoded call sites. Returning ``torch.float16`` there
-    keeps storage and compute in the same dtype.
+    keeps storage and compute in the same dtype. On CPU this still returns
+    ``"auto"``: the VRAM-saving reason for keeping the checkpoint's own dtype
+    does not apply there, but CPU use in this codebase is smoke tests only,
+    so a bf16-saved checkpoint loading bf16 on CPU is harmless in practice.
     """
     _, fp16_only = bf16_fp16_flags(device)
     if fp16_only:

--- a/tests/test_issue491_frozen_base_load_dtype.py
+++ b/tests/test_issue491_frozen_base_load_dtype.py
@@ -159,10 +159,62 @@ class TestWrapperModelKwargsCarryDtype:
         fake_tokenizer = MagicMock()
         load_mock = MagicMock(side_effect=_StopAtLoadError())
 
+        # A sentinel, not the literal "auto" the resolver happens to return on
+        # cpu: proves the wrapper wires the resolver's *return value* through
+        # to from_pretrained, not merely that it passes cpu's own default.
+        # Patched in the wrapper module's own namespace (each trainer imports
+        # the name directly), mirroring the real dtype-resolution call site.
+        sentinel = object()
         with patch("transformers.AutoTokenizer.from_pretrained", return_value=fake_tokenizer), \
-             patch(f"transformers.{model_class_name}.from_pretrained", load_mock):
+             patch(f"transformers.{model_class_name}.from_pretrained", load_mock), \
+             patch(f"{module_path}.resolve_frozen_base_load_dtype", return_value=sentinel):
             with pytest.raises(_StopAtLoadError):
                 wrapper._setup_transformers(cfg, cfg.training)
 
         assert load_mock.call_args is not None, "from_pretrained was never called"
-        assert load_mock.call_args.kwargs.get("torch_dtype") == "auto"
+        assert load_mock.call_args.kwargs.get("torch_dtype") is sentinel
+
+
+class TestRewardModelHeadUpcastToFp32:
+    """PR #492 review: a SEQ_CLS LoRA base auto-adds a ``modules_to_save``
+    wrapper around ``score`` that ``get_peft_model``'s adapter autocast does
+    not reach, so a bf16-resolved frozen base left the reward head training
+    in pure bf16 with no fp32 master weights. Uses a real tiny model (not a
+    mock) since the bug is in peft's own autocast scope, not in this
+    codebase's kwargs wiring.
+    """
+
+    def test_score_head_is_fp32_even_when_base_resolves_to_bf16(self):
+        import torch
+
+        from soup_cli.trainer.reward_model import RewardModelTrainerWrapper
+
+        cfg = SoupConfig(
+            base="hf-internal-testing/tiny-random-gpt2",
+            task="reward_model",
+            data={"train": "./data.jsonl"},
+            training={"quantization": "none"},
+        )
+        wrapper = RewardModelTrainerWrapper(cfg, device="cpu")
+
+        with patch(
+            "soup_cli.trainer.reward_model.resolve_frozen_base_load_dtype",
+            return_value=torch.bfloat16,
+        ):
+            wrapper._setup_transformers(cfg, cfg.training)
+
+        head_params = [
+            p for n, p in wrapper.model.named_parameters()
+            if p.requires_grad and "score" in n
+        ]
+        assert head_params, "no trainable score-head parameter found on the PEFT model"
+        assert all(p.dtype == torch.float32 for p in head_params), (
+            "reward head stayed in the frozen base's bf16 load dtype"
+        )
+        # The base itself really did load bf16 (proves the fixture reproduces
+        # the bug's precondition, not just that everything is fp32 already).
+        base_dtype = next(
+            p.dtype for n, p in wrapper.model.named_parameters()
+            if not p.requires_grad and "lora_" not in n and "score" not in n
+        )
+        assert base_dtype == torch.bfloat16

--- a/tests/test_issue_frozen_base_load_dtype.py
+++ b/tests/test_issue_frozen_base_load_dtype.py
@@ -1,0 +1,168 @@
+"""The twelve non-SFT trainer wrappers never passed a dtype to
+``from_pretrained`` (follow-on to issue #339 / PR #471).
+
+PR #471 fixes ``SFTTrainerWrapper``: a frozen (LoRA) base keeps the
+checkpoint's own dtype instead of the HF default of upcasting every load to
+float32. The other twelve trainer wrappers build the identical
+``model_kwargs`` shape (``trust_remote_code`` + ``device_map`` + optional
+``quantization_config``) with the same gap. None of them has a full
+fine-tuning branch: ``unfrozen_parameters``/``lisa_enabled`` are schema-gated
+to ``task='sft'`` and ``lora.r=0`` has no wired effect outside ``sft``, so
+``get_peft_model``/``peft_config`` runs unconditionally in every one of
+them and every load is a frozen LoRA base.
+
+``TestResolveFrozenBaseLoadDtype`` pins the shared helper in isolation.
+``TestWrapperModelKwargsCarryDtype`` proves the wiring for real: each
+wrapper's own ``_setup_transformers`` is called with the model class's
+``from_pretrained`` mocked to capture kwargs and stop before any real load.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from soup_cli.config.schema import SoupConfig
+
+
+class _FakeCuda:
+    """Stands in for ``torch.cuda`` (mirrors tests/test_issue385_stream_dtype.py's
+    fixture of the same shape)."""
+
+    def __init__(self, available: bool, bf16: bool, emulated: bool = True):
+        self._available = available
+        self._bf16 = bf16
+        self._emulated = emulated
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def is_bf16_supported(self, including_emulation: bool = True) -> bool:
+        if not including_emulation:
+            return self._bf16
+        return self._bf16 or self._emulated
+
+    def get_device_capability(self, device=None):
+        return (8, 0) if self._bf16 else (7, 5)
+
+
+@pytest.fixture()
+def fake_torch_cuda(monkeypatch):
+    import torch
+
+    def apply(available: bool, bf16: bool, emulated: bool = True) -> _FakeCuda:
+        fake = _FakeCuda(available, bf16, emulated)
+        monkeypatch.setattr(torch, "cuda", fake)
+        return fake
+
+    return apply
+
+
+class TestResolveFrozenBaseLoadDtype:
+    def test_cpu_resolves_to_auto(self):
+        from soup_cli.utils.gpu import resolve_frozen_base_load_dtype
+
+        assert resolve_frozen_base_load_dtype("cpu") == "auto"
+
+    def test_cuda_unavailable_resolves_to_auto(self, fake_torch_cuda):
+        from soup_cli.utils.gpu import resolve_frozen_base_load_dtype
+
+        fake_torch_cuda(available=False, bf16=False)
+        assert resolve_frozen_base_load_dtype("cuda") == "auto"
+
+    def test_bf16_capable_card_resolves_to_auto(self, fake_torch_cuda):
+        from soup_cli.utils.gpu import resolve_frozen_base_load_dtype
+
+        fake_torch_cuda(available=True, bf16=True)
+        assert resolve_frozen_base_load_dtype("cuda") == "auto"
+
+    def test_pre_ampere_card_resolves_to_explicit_float16(self, fake_torch_cuda):
+        import torch
+
+        from soup_cli.utils.gpu import resolve_frozen_base_load_dtype
+
+        fake_torch_cuda(available=True, bf16=False, emulated=True)
+        assert resolve_frozen_base_load_dtype("cuda") == torch.float16
+
+
+class _StopAtLoadError(Exception):
+    """Raised by the mocked ``from_pretrained`` to stop the wrapper right
+    after it captures the model-load kwargs, so the rest of the method
+    (LoRA construction, trainer wiring) never has to run against a fake
+    model."""
+
+
+def _base_kwargs(task: str, **training_overrides):
+    training = {"quantization": "none", **training_overrides}
+    return dict(base="some-model", task=task, data={"train": "./data.jsonl"}, training=training)
+
+
+WRAPPER_CASES = [
+    ("soup_cli.trainer.dpo", "DPOTrainerWrapper", "AutoModelForCausalLM", _base_kwargs("dpo")),
+    ("soup_cli.trainer.kto", "KTOTrainerWrapper", "AutoModelForCausalLM", _base_kwargs("kto")),
+    ("soup_cli.trainer.orpo", "ORPOTrainerWrapper", "AutoModelForCausalLM", _base_kwargs("orpo")),
+    (
+        "soup_cli.trainer.simpo",
+        "SimPOTrainerWrapper",
+        "AutoModelForCausalLM",
+        _base_kwargs("simpo"),
+    ),
+    ("soup_cli.trainer.ipo", "IPOTrainerWrapper", "AutoModelForCausalLM", _base_kwargs("ipo")),
+    ("soup_cli.trainer.bco", "BCOTrainerWrapper", "AutoModelForCausalLM", _base_kwargs("bco")),
+    (
+        "soup_cli.trainer.online_dpo",
+        "OnlineDPOTrainerWrapper",
+        "AutoModelForCausalLM",
+        _base_kwargs("online_dpo", online_dpo_judge="test-judge"),
+    ),
+    ("soup_cli.trainer.grpo", "GRPOTrainerWrapper", "AutoModelForCausalLM", _base_kwargs("grpo")),
+    ("soup_cli.trainer.ppo", "PPOTrainerWrapper", "AutoModelForCausalLM", _base_kwargs("ppo")),
+    (
+        "soup_cli.trainer.pretrain",
+        "PretrainTrainerWrapper",
+        "AutoModelForCausalLM",
+        _base_kwargs("pretrain"),
+    ),
+    (
+        "soup_cli.trainer.reward_model",
+        "RewardModelTrainerWrapper",
+        "AutoModelForSequenceClassification",
+        _base_kwargs("reward_model"),
+    ),
+    (
+        "soup_cli.trainer.embedding",
+        "EmbeddingTrainerWrapper",
+        "AutoModel",
+        _base_kwargs("embedding"),
+    ),
+]
+
+
+class TestWrapperModelKwargsCarryDtype:
+    @pytest.mark.parametrize(
+        "module_path,class_name,model_class_name,config_kwargs",
+        WRAPPER_CASES,
+        ids=[c[1] for c in WRAPPER_CASES],
+    )
+    def test_setup_transformers_passes_resolved_dtype(
+        self, module_path, class_name, model_class_name, config_kwargs
+    ):
+        import importlib
+
+        module = importlib.import_module(module_path)
+        wrapper_cls = getattr(module, class_name)
+
+        cfg = SoupConfig(**config_kwargs)
+        wrapper = wrapper_cls(cfg, device="cpu")
+
+        fake_tokenizer = MagicMock()
+        load_mock = MagicMock(side_effect=_StopAtLoadError())
+
+        with patch("transformers.AutoTokenizer.from_pretrained", return_value=fake_tokenizer), \
+             patch(f"transformers.{model_class_name}.from_pretrained", load_mock):
+            with pytest.raises(_StopAtLoadError):
+                wrapper._setup_transformers(cfg, cfg.training)
+
+        assert load_mock.call_args is not None, "from_pretrained was never called"
+        assert load_mock.call_args.kwargs.get("torch_dtype") == "auto"


### PR DESCRIPTION
Follows #471, which fixes the missing `dtype`/`torch_dtype` kwarg (#339) for `SFTTrainerWrapper`. The same `model_kwargs` shape, missing the same key, exists unchanged in the other twelve trainer wrappers: `dpo`, `kto`, `orpo`, `simpo`, `ipo`, `bco`, `online_dpo`, `grpo`, `ppo`, `pretrain`, `reward_model`, `embedding`.

None of these trainers has a full-fine-tuning branch: `unfrozen_parameters`/`lisa_enabled` are schema-gated to `task='sft'`, and `lora.r=0` has no wired effect outside `sft` (peft would just reject `r=0`), so `get_peft_model`/`peft_config` runs unconditionally in every one of them. Every load in these twelve tasks is therefore a frozen LoRA base, so the fix is the simpler half of #471's split: keep the checkpoint's own dtype (`torch_dtype="auto"`), except on a pre-Ampere CUDA card (T4/P100/V100/GTX 16xx/RTX 20xx), where `bf16_fp16_flags` already routes training compute to float16 and an `"auto"` load would leave the resident weights in bf16 storage against float16 compute.

Added `resolve_frozen_base_load_dtype(device)` to `soup_cli.utils.gpu`, next to `bf16_fp16_flags`, and wired it into the `model_kwargs` of all twelve wrappers.

## Verification

- New tests: unit coverage of `resolve_frozen_base_load_dtype` (CPU, bf16-capable CUDA, pre-Ampere CUDA, no CUDA runtime) plus one test per wrapper asserting the resolved `torch_dtype` reaches the real `from_pretrained` call.
- `pytest tests/test_issue_frozen_base_load_dtype.py -v`: 16 passed on this branch, 16 failed on `main` (the assertion on the missing `torch_dtype` kwarg).
- `pytest tests/test_bco.py tests/test_kto.py tests/test_orpo.py tests/test_simpo.py tests/test_ipo.py tests/test_grpo.py tests/test_ppo.py tests/test_pretrain.py tests/test_embedding.py tests/test_performance.py tests/test_gpu.py tests/test_issue385_stream_dtype.py`: 512 passed, 4 skipped (GPU-only), no regressions.
- `ruff check src/soup_cli/ tests/` clean.
- Not verified: actual VRAM savings on real hardware (no GPU in this environment); this mirrors #471's own measurement rather than re-measuring it. Also not run: the `[dev]` extra's `trl`/`bitsandbytes`/`deepspeed`, or the macOS/Windows CI legs.

Fixes #491
