### PR TITLE
test: cover concrete Transformers model loads

### DIFF
--- a/tests/test_transformers_floor_compat.py
+++ b/tests/test_transformers_floor_compat.py
@@ -31,6 +31,11 @@ CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 CONSTRAINTS = REPO_ROOT / ".github" / "constraints" / "transformers-floor.txt"
 
 _LOAD_METHODS = frozenset({"from_pretrained", "from_config"})
+_MODEL_LOAD_CLASS_SUFFIXES = (
+    "ForCausalLM",
+    "ForConditionalGeneration",
+    "ForSequenceClassification",
+)
 
 
 def _attr_parts(node: ast.AST) -> list[str]:
@@ -44,14 +49,19 @@ def _attr_parts(node: ast.AST) -> list[str]:
     return list(reversed(parts))
 
 
-def _is_auto_model_load(call: ast.Call) -> bool:
-    """True for ``AutoModel*.from_pretrained`` / ``from_config`` (any prefix)."""
+def _is_transformers_model_load(call: ast.Call) -> bool:
+    """True for supported Transformers model factory and concrete-class loads."""
     parts = _attr_parts(call.func)
     if len(parts) < 2:
         return False
     if parts[-1] not in _LOAD_METHODS:
         return False
-    return any(part.startswith("AutoModel") for part in parts[:-1])
+    model_class = parts[-2]
+    return (
+        model_class.startswith("AutoModel")
+        or model_class == "AutoProcessor"
+        or model_class.endswith(_MODEL_LOAD_CLASS_SUFFIXES)
+    )
 
 
 def find_post_floor_dtype_kwargs(source: str, *, filename: str = "<string>") -> list[str]:
@@ -59,7 +69,7 @@ def find_post_floor_dtype_kwargs(source: str, *, filename: str = "<string>") -> 
     tree = ast.parse(source, filename=filename)
     hits: list[str] = []
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Call) or not _is_auto_model_load(node):
+        if not isinstance(node, ast.Call) or not _is_transformers_model_load(node):
             continue
         for kw in node.keywords:
             if kw.arg == "dtype":
@@ -93,10 +103,10 @@ def _transformers_floor_job_block(text: str) -> str:
 
 
 class TestTransformersFloorDtypeGuard:
-    def test_no_production_auto_model_load_uses_dtype_kwarg(self):
+    def test_no_production_transformers_model_load_uses_dtype_kwarg(self):
         hits = iter_production_hits()
         assert hits == [], (
-            "AutoModel*.from_pretrained / from_config must use torch_dtype= "
+            "Transformers model from_pretrained / from_config calls must use torch_dtype= "
             "(works across transformers>=4.36,<5). dtype= is the >=4.56-only "
             "rename and TypeErrors on older installs inside our declared range "
             f"(#478). Offending sites: {hits}"
@@ -110,6 +120,14 @@ class TestTransformersFloorDtypeGuard:
         )
         hits = find_post_floor_dtype_kwargs(bad, filename="mutation.py")
         assert hits == ["mutation.py:2"]
+
+    def test_scanner_flags_concrete_conditional_generation_class(self):
+        bad = (
+            "from transformers import WhisperForConditionalGeneration\n"
+            "WhisperForConditionalGeneration.from_pretrained('x', dtype='auto')\n"
+        )
+        hits = find_post_floor_dtype_kwargs(bad, filename="whisper.py")
+        assert hits == ["whisper.py:2"]
 
     def test_scanner_allows_torch_dtype(self):
         good = (


### PR DESCRIPTION
## What does this PR do?

Fixes #495.

The Transformers floor guard previously recognized only `AutoModel*` factories.
This change widens the AST predicate to cover `AutoProcessor` and the requested
concrete model class suffixes while preserving the existing negative controls.

It also adds a concrete Whisper regression test and renames the production-scan
test and failure message to describe the wider protection accurately.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Tests

## Checklist

- [x] `ruff check src/soup_cli/ scripts/ tests/` passes
- [ ] `pytest tests/ -v` passes
- [x] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed — not needed for this test-only change
- [x] Added a changelog fragment, or this change has no user-visible impact — no user-visible impact

## Testing

- Python 3.12: `python -m pytest -o addopts= -q tests/test_transformers_floor_compat.py` (12 passed)
- Python 3.10: the same test file (12 passed)
- `ruff check src/soup_cli/ scripts/ tests/`
- temporary real mutation at `src/soup_cli/trainer/asr.py:220`, confirmed red with the final named production-scan test and then reverted

The full training-stack test suite was not installed locally; CI can run the
repository's full matrix. The changed scanner test is dependency-light and was
run on the oldest and newest supported Python versions available here.

## AI assistance

AI assistance was used to investigate, implement, and test this change. I
reviewed the scoped diff and mutation evidence.
