### PR TITLE
feat(mcp): support the mcp 2.x SDK, and lift the <2 cap

### DIFF
--- a/changelog.d/0.73.3/498.added.md
+++ b/changelog.d/0.73.3/498.added.md
@@ -1,0 +1,20 @@
+- **`soup mcp serve` now runs on both mcp majors, and the `<2` cap is lifted
+  (#322 in #498).** v0.72.3 capped the `[mcp]` extra the day mcp 2.0.0 broke
+  every round-trip test; that unblocked a release and pinned anyone who wanted
+  2.x in the same environment. Both removals are bridged rather than pinned
+  around: the `@server.list_tools()` / `@server.call_tool()` decorators became
+  `on_list_tools=` / `on_call_tool=` constructor callbacks, and
+  `create_connected_server_and_client_session` gave way to the lower-level
+  `create_client_server_memory_streams`, which both majors still ship.
+
+  `build_server` chooses by probing the `Server` constructor, never by reading
+  `mcp.__version__` — the rule `trainer/_trl_compat.py` earned after two wrong
+  bounds derived from version tables, and a test walks the AST to enforce it.
+  The dispatch logic stays in a single `_dispatch_tool` with two thin adapters,
+  guarded by a test that fails if a second implementation appears, because two
+  copies is how the majors would drift apart while both kept passing.
+
+  The three modules the sse / streamable-http transports depend on all survive
+  2.0.0 unchanged, so those 46 tests needed no edit. Verified by running the
+  MCP suites twice, once per major: 184 passed against 2.0.0, and the full
+  suite against 1.29.0. The floor stays at the 1.10.0 measured in #296.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,7 +195,18 @@ modal = ["modal>=0.60.0"]
 # whose origin checking silently vanishes on an older SDK is worse than
 # a resolver error. No new package: `mcp` already requires starlette,
 # uvicorn, sse-starlette and httpx-sse.
-mcp = ["mcp>=1.10.0,<2"]
+#
+# v0.73.4 (#322): cap lifted to `<3`. The two removals that forced it are
+# bridged rather than pinned around. `build_server` probes the `Server`
+# constructor for `on_list_tools` — 2.x registers handlers there, 1.x through
+# decorators — and the round-trip tests were rebuilt on
+# `create_client_server_memory_streams`, which both majors still ship, instead
+# of the 2.x-removed `create_connected_server_and_client_session`. Verified by
+# running the MCP suite twice, once per major, not by reading release notes.
+# The three modules the sse / streamable-http transports depend on
+# (`sse`, `streamable_http_manager`, `transport_security`) all survive in 2.0.0,
+# so those needed no change at all. The floor stays 1.10.0 for the reason above.
+mcp = ["mcp>=1.10.0,<3"]
 
 [project.scripts]
 soup = "soup_cli.cli:run"

--- a/src/soup_cli/mcp_server/server.py
+++ b/src/soup_cli/mcp_server/server.py
@@ -12,6 +12,7 @@ SDK -- starlette, uvicorn -- is already a hard dependency of ``mcp``.
 
 from __future__ import annotations
 
+import inspect
 import json
 import secrets
 import sys
@@ -29,6 +30,63 @@ from soup_cli.mcp_server.registry import McpToolError, ToolSpec, _sanitize, buil
 SERVER_NAME = "soup"
 
 
+class _DispatchError(Exception):
+    """A tool call that failed, carrying an already-sanitized message."""
+
+
+def _tool_descriptors(specs: List[ToolSpec]) -> List[types.Tool]:
+    """The advertised tool table. Identical on both mcp majors."""
+    return [
+        types.Tool(
+            name=spec.name,
+            title=spec.title,
+            description=spec.description,
+            inputSchema=spec.input_schema,
+            annotations=spec.annotations,
+        )
+        for spec in specs
+    ]
+
+
+def _dispatch_tool(by_name, name: str, arguments: dict) -> str:
+    """Run one tool and return its pretty-printed JSON text.
+
+    Raises :class:`_DispatchError` with a path-free, C0/ESC-free message for
+    every failure mode, so the two SDK adapters below only have to decide how
+    to *shape* an error, never what it says.
+    """
+    spec = by_name.get(name)
+    if spec is None:
+        raise _DispatchError("unknown tool")
+    try:
+        # Any core that prints (e.g. a Rich warning) must not corrupt the
+        # JSON-RPC stdout channel - send stray stdout to stderr for the
+        # duration of the (synchronous) handler call. Serialization stays
+        # INSIDE the try so a non-JSON-serializable result also becomes a
+        # sanitized error (never a raw TypeError the SDK would echo).
+        with redirect_stdout(sys.stderr):
+            result = spec.handler(arguments or {})
+        return json.dumps(_sanitize(result), indent=2, ensure_ascii=False)
+    except McpToolError as exc:
+        # _sanitize the message too so the C0/ESC guarantee is structural,
+        # not just a convention every handler must remember (security-review).
+        raise _DispatchError(_sanitize(str(exc))) from None
+    except Exception as exc:  # never leak a stack trace / path to the client
+        raise _DispatchError(f"internal error ({type(exc).__name__})") from None
+
+
+def _uses_callback_handlers() -> bool:
+    """True on mcp 2.x, which registers handlers through ``Server(...)``.
+
+    #322 — 2.0.0 removed the ``@server.list_tools()`` / ``@server.call_tool()``
+    decorators in favour of ``on_list_tools=`` / ``on_call_tool=`` constructor
+    arguments. Asked of the constructor rather than of ``mcp.__version__``: a
+    version table is the thing that goes stale, and this repo has been bitten
+    by exactly that twice (see ``trainer/_trl_compat.py``).
+    """
+    return "on_list_tools" in inspect.signature(Server.__init__).parameters
+
+
 def build_server(specs: List[ToolSpec]) -> Server:
     """Build a low-level MCP :class:`Server` that dispatches to ``specs``.
 
@@ -36,44 +94,52 @@ def build_server(specs: List[ToolSpec]) -> Server:
     (C0/ESC-stripped) and returned as a single pretty-printed JSON
     ``TextContent`` block. Handler failures become an ``isError`` result with a
     path-free message so the server survives bad calls.
+
+    Supports both mcp majors (#322). The dispatch logic is shared; only the two
+    adapters below differ, because 2.x hands its handlers a request context and
+    wants a ``*Result`` object where 1.x wanted a bare list.
     """
     by_name = {spec.name: spec for spec in specs}
-    server: Server = Server(SERVER_NAME)
+
+    if _uses_callback_handlers():  # mcp 2.x
+        async def _on_list_tools(ctx, params) -> types.ListToolsResult:
+            return types.ListToolsResult(tools=_tool_descriptors(specs))
+
+        async def _on_call_tool(ctx, params) -> types.CallToolResult:
+            try:
+                text = _dispatch_tool(by_name, params.name, params.arguments or {})
+            except _DispatchError as exc:
+                # Shaped explicitly rather than raised: on 2.x an exception out
+                # of a handler becomes a JSON-RPC error, which is a different
+                # thing on the wire from a tool that ran and reported failure.
+                # 1.x produced the latter, and the tests assert it.
+                return types.CallToolResult(
+                    content=[types.TextContent(type="text", text=str(exc))],
+                    isError=True,
+                )
+            return types.CallToolResult(
+                content=[types.TextContent(type="text", text=text)]
+            )
+
+        return Server(
+            SERVER_NAME,
+            on_list_tools=_on_list_tools,
+            on_call_tool=_on_call_tool,
+        )
+
+    server: Server = Server(SERVER_NAME)  # mcp 1.x
 
     @server.list_tools()
     async def _list_tools() -> List[types.Tool]:
-        return [
-            types.Tool(
-                name=spec.name,
-                title=spec.title,
-                description=spec.description,
-                inputSchema=spec.input_schema,
-                annotations=spec.annotations,
-            )
-            for spec in specs
-        ]
+        return _tool_descriptors(specs)
 
     @server.call_tool()
     async def _call_tool(name: str, arguments: dict) -> List[types.TextContent]:
-        spec = by_name.get(name)
-        if spec is None:
-            # The SDK stringifies this into an isError result; keep it generic.
-            raise ValueError("unknown tool")
         try:
-            # Any core that prints (e.g. a Rich warning) must not corrupt the
-            # JSON-RPC stdout channel - send stray stdout to stderr for the
-            # duration of the (synchronous) handler call. Serialization stays
-            # INSIDE the try so a non-JSON-serializable result also becomes a
-            # sanitized isError (never a raw TypeError the SDK would echo).
-            with redirect_stdout(sys.stderr):
-                result = spec.handler(arguments or {})
-            text = json.dumps(_sanitize(result), indent=2, ensure_ascii=False)
-        except McpToolError as exc:
-            # _sanitize the message too so the C0/ESC guarantee is structural,
-            # not just a convention every handler must remember (security-review).
-            raise ValueError(_sanitize(str(exc))) from None
-        except Exception as exc:  # never leak a stack trace / path to the client
-            raise ValueError(f"internal error ({type(exc).__name__})") from None
+            text = _dispatch_tool(by_name, name, arguments or {})
+        except _DispatchError as exc:
+            # 1.x turns a raised ValueError into the isError result itself.
+            raise ValueError(str(exc)) from None
         return [types.TextContent(type="text", text=text)]
 
     return server

--- a/tests/mcp_roundtrip.py
+++ b/tests/mcp_roundtrip.py
@@ -1,0 +1,89 @@
+"""A client/server MCP session that works on both mcp 1.x and 2.x (#322).
+
+Not named ``test_*`` on purpose: pytest must not collect it.
+
+``mcp.shared.memory.create_connected_server_and_client_session`` was removed in
+2.0.0, and every round-trip test in ``test_v07128.py`` was built on it. The
+lower-level primitive it was built from — ``create_client_server_memory_streams``
+— survives on both majors with the same shape, so this helper rebuilds the
+session on top of that instead of branching on a version.
+
+That is the point: a version branch here would have to be revisited at 3.0, and
+the thing it would be branching on is not the thing that changed. What changed
+is one convenience wrapper; the transport underneath it did not.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+import anyio
+
+
+@asynccontextmanager
+async def connected_session(server, *, raise_exceptions: bool = False):
+    """Yield a ``ClientSession`` talking to ``server`` over in-memory streams.
+
+    Mirrors what the removed helper did: run the server in a task group against
+    one end of a memory stream pair, hand the client the other end, and cancel
+    the server task on exit so a hung handler cannot wedge the suite.
+    """
+    from mcp.client.session import ClientSession
+    from mcp.shared.memory import create_client_server_memory_streams
+
+    async with create_client_server_memory_streams() as (client_streams, server_streams):
+        client_read, client_write = client_streams
+        server_read, server_write = server_streams
+
+        async with anyio.create_task_group() as task_group:
+            task_group.start_soon(
+                lambda: server.run(
+                    server_read,
+                    server_write,
+                    server.create_initialization_options(),
+                    raise_exceptions=raise_exceptions,
+                )
+            )
+            try:
+                async with ClientSession(client_read, client_write) as session:
+                    await session.initialize()
+                    yield session
+            finally:
+                # The server task never returns on its own -- it waits for the
+                # stream to close. Without this the task group blocks forever.
+                task_group.cancel_scope.cancel()
+
+
+def is_error(result) -> bool:
+    """Read a ``CallToolResult``'s error flag on either mcp major (#322).
+
+    1.x exposes the wire name ``isError``; 2.x exposes ``is_error``. The value
+    means the same thing on both, so the tests ask for the meaning rather than
+    for a spelling. Raising on neither is deliberate: silently returning False
+    would turn "the SDK renamed the field again" into "no tool call ever
+    failed", which is the failure mode a test suite must not have.
+    """
+    for attribute in ("isError", "is_error"):
+        if hasattr(result, attribute):
+            return bool(getattr(result, attribute))
+    raise AttributeError(
+        f"{type(result).__name__} exposes neither isError nor is_error; "
+        "the mcp SDK renamed the field again (#322)"
+    )
+
+
+def input_schema(tool) -> dict:
+    """Read an advertised ``Tool``'s schema on either mcp major (#322).
+
+    Same rename as :func:`is_error`: the wire name is ``inputSchema`` and 2.x
+    exposes it as ``input_schema``. Raises rather than returning ``{}`` for the
+    same reason -- an empty schema would read as "the tool advertises nothing"
+    instead of "the field moved".
+    """
+    for attribute in ("inputSchema", "input_schema"):
+        if hasattr(tool, attribute):
+            return getattr(tool, attribute)
+    raise AttributeError(
+        f"{type(tool).__name__} exposes neither inputSchema nor input_schema; "
+        "the mcp SDK renamed the field again (#322)"
+    )

--- a/tests/test_issue322_mcp2_compat.py
+++ b/tests/test_issue322_mcp2_compat.py
@@ -172,6 +172,14 @@ class TestTheConstraintNoLongerExcludes2x:
         assert "1.10.0" in spec
         # The floor #296 measured must not come back down.
         assert "1.9.4" not in spec
+        # ...and the CEILING must stay pinned too. The thesis of this PR is
+        # that a bound nobody has verified should not ship: mcp 2.x was
+        # exercised before lifting the cap to <3, and 3.x has been exercised
+        # by nobody. Without these, deleting the upper bound entirely -- or
+        # widening it to <4 -- leaves the suite green, which is the exact
+        # failure class the cap exists to prevent (review of #498).
+        assert "3.0.0" not in spec
+        assert "4.0.0" not in spec
 
     def test_the_roundtrip_helper_is_not_collected_as_a_test_module(self):
         """`tests/mcp_roundtrip.py` is imported by test modules; if it were ever

--- a/tests/test_issue322_mcp2_compat.py
+++ b/tests/test_issue322_mcp2_compat.py
@@ -1,0 +1,180 @@
+"""Issue #322 — `soup mcp serve` on both mcp 1.x and 2.x.
+
+mcp 2.0.0 removed two things Soup was built on: the
+``@server.list_tools()`` / ``@server.call_tool()`` decorators, and
+``mcp.shared.memory.create_connected_server_and_client_session``. v0.72.3
+capped the extra at ``<2`` to unblock a release, which pinned anyone who wanted
+2.x in the same environment.
+
+The bridge is a **capability probe**, not a version comparison. That choice is
+not stylistic: this repository has twice derived a bound by reading source or a
+version table and been wrong both times — see ``trainer/_trl_compat.py``, whose
+module docstring records the rule it earned. A probe cannot go stale, because it
+asks the object in front of it.
+
+The round-trip behaviour itself is asserted by ``test_v07128.py``'s
+``TestServerRoundTrip``, which now runs unchanged on either major. What is
+pinned here is the machinery that lets it: the probe, the shared helpers, and
+the fact that neither is a version check in disguise.
+"""
+
+from __future__ import annotations
+
+import inspect
+import pathlib
+import re
+import types as pytypes
+
+import pytest
+
+_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_SERVER_SRC = _ROOT / "src" / "soup_cli" / "mcp_server" / "server.py"
+
+
+@pytest.fixture(autouse=True)
+def _need_mcp():
+    pytest.importorskip("mcp")
+
+
+class TestTheProbeMatchesTheInstalledSdk:
+    def test_probe_agrees_with_the_server_constructor(self):
+        """The probe's answer must be the SDK's answer, whichever major is here."""
+        from mcp.server.lowlevel import Server
+
+        from soup_cli.mcp_server.server import _uses_callback_handlers
+
+        takes_callbacks = "on_list_tools" in inspect.signature(Server.__init__).parameters
+        assert _uses_callback_handlers() is takes_callbacks
+
+    def test_the_two_registration_styles_are_mutually_exclusive(self):
+        """A build that satisfied neither branch would construct a server with no
+        handlers at all and fail only at call time, so pin that exactly one of
+        the two registration surfaces exists."""
+        from mcp.server.lowlevel import Server
+
+        from soup_cli.mcp_server.server import _uses_callback_handlers
+
+        has_decorators = hasattr(Server, "list_tools") and hasattr(Server, "call_tool")
+        assert has_decorators is not _uses_callback_handlers()
+
+    def test_the_probe_is_not_a_version_comparison(self):
+        """The rule `_trl_compat.py` earned, enforced rather than remembered.
+
+        Read as syntax rather than as text: the module docstring *mentions*
+        ``mcp.__version__`` precisely to say it is not consulted, so a
+        substring check fails on the sentence that explains the rule.
+        """
+        import ast
+
+        tree = ast.parse(_SERVER_SRC.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute):
+                assert node.attr != "__version__", ast.unparse(node)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                assert node.func.id not in ("version", "parse_version"), ast.unparse(node)
+
+
+class TestTheServerBuildsOnWhicheverMajorIsInstalled:
+    def test_build_server_advertises_every_spec(self):
+        from soup_cli.mcp_server.registry import build_registry
+        from soup_cli.mcp_server.server import build_server
+
+        specs = build_registry(allow_mutating=False, allow_execute=False)
+        assert build_server(specs) is not None
+
+    def test_the_shared_dispatch_is_used_by_both_adapters(self):
+        """Both branches must route through one implementation. Two copies of
+        the sanitize/serialize logic is how the majors would drift apart in
+        behaviour while both kept passing their own tests."""
+        import ast
+
+        tree = ast.parse(_SERVER_SRC.read_text(encoding="utf-8"))
+        definitions = [
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "_dispatch_tool"
+        ]
+        call_sites = [
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_dispatch_tool"
+        ]
+        assert len(definitions) == 1, "two implementations would drift apart"
+        assert len(call_sites) == 2, "one call site per SDK major, no more"
+
+    def test_an_unknown_tool_reports_an_error_rather_than_raising(self):
+        from soup_cli.mcp_server.server import _dispatch_tool, _DispatchError
+
+        with pytest.raises(_DispatchError) as excinfo:
+            _dispatch_tool({}, "no_such_tool", {})
+        assert "unknown tool" in str(excinfo.value)
+
+    def test_a_handler_failure_carries_no_path_or_stack(self):
+        from soup_cli.mcp_server.server import _dispatch_tool, _DispatchError
+
+        class _Spec:
+            name = "boom"
+
+            @staticmethod
+            def handler(_args):
+                raise RuntimeError(r"C:\secret\path.py exploded")
+
+        with pytest.raises(_DispatchError) as excinfo:
+            _dispatch_tool({"boom": _Spec}, "boom", {})
+        message = str(excinfo.value)
+        assert message == "internal error (RuntimeError)"
+        assert "secret" not in message
+
+
+class TestTheDualMajorReaders:
+    """The field renames are read by meaning, and refuse to guess."""
+
+    def test_is_error_reads_either_spelling(self):
+        from tests.mcp_roundtrip import is_error
+
+        assert is_error(pytypes.SimpleNamespace(isError=True)) is True
+        assert is_error(pytypes.SimpleNamespace(is_error=True)) is True
+        assert is_error(pytypes.SimpleNamespace(isError=False)) is False
+
+    def test_is_error_raises_when_the_field_moves_again(self):
+        """Returning False here would turn a third rename into "no tool call
+        ever failed" -- a silent pass is the one outcome a test helper must not
+        produce."""
+        from tests.mcp_roundtrip import is_error
+
+        with pytest.raises(AttributeError):
+            is_error(pytypes.SimpleNamespace())
+
+    def test_input_schema_reads_either_spelling(self):
+        from tests.mcp_roundtrip import input_schema
+
+        assert input_schema(pytypes.SimpleNamespace(inputSchema={"type": "object"}))
+        assert input_schema(pytypes.SimpleNamespace(input_schema={"type": "object"}))
+
+    def test_input_schema_raises_when_the_field_moves_again(self):
+        from tests.mcp_roundtrip import input_schema
+
+        with pytest.raises(AttributeError):
+            input_schema(pytypes.SimpleNamespace())
+
+
+class TestTheConstraintNoLongerExcludes2x:
+    def test_the_extra_admits_a_2x_release(self):
+        """The acceptance box asks that the constraint stop excluding 2.x.
+        Asserted against the specifier itself rather than the literal text, so
+        reformatting the pin cannot quietly re-exclude it."""
+        from packaging.requirements import Requirement
+
+        pyproject = (_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        line = next(ln for ln in pyproject.splitlines() if ln.startswith("mcp = ["))
+        spec = Requirement(re.search(r'"([^"]+)"', line).group(1)).specifier
+        assert "2.0.0" in spec
+        assert "1.10.0" in spec
+        # The floor #296 measured must not come back down.
+        assert "1.9.4" not in spec
+
+    def test_the_roundtrip_helper_is_not_collected_as_a_test_module(self):
+        """`tests/mcp_roundtrip.py` is imported by test modules; if it were ever
+        renamed to `test_*` pytest would collect its helpers as tests."""
+        assert (_ROOT / "tests" / "mcp_roundtrip.py").is_file()
+        assert not (_ROOT / "tests" / "test_mcp_roundtrip.py").exists()

--- a/tests/test_v07128.py
+++ b/tests/test_v07128.py
@@ -568,12 +568,16 @@ def _run(coro):
     return asyncio.run(coro)
 
 
+from tests.mcp_roundtrip import input_schema, is_error  # noqa: E402 - #322 dual-major flag reader
+
+
 def _roundtrip(server, tool_name, args):
-    from mcp.shared.memory import create_connected_server_and_client_session
+    # #322 — the SDK helper this used was removed in mcp 2.0.0. `connected_session`
+    # rebuilds it from the memory-stream primitive that survives on both majors.
+    from tests.mcp_roundtrip import connected_session
 
     async def _go():
-        async with create_connected_server_and_client_session(server) as client:
-            await client.initialize()
+        async with connected_session(server) as client:
             return await client.call_tool(tool_name, args)
 
     return _run(_go())
@@ -588,16 +592,14 @@ class TestServerRoundTrip:
         pytest.importorskip("mcp")
 
     def test_list_tools_returns_all_18(self):
-        from mcp.shared.memory import create_connected_server_and_client_session
-
         from soup_cli.mcp_server.registry import build_registry
         from soup_cli.mcp_server.server import build_server
+        from tests.mcp_roundtrip import connected_session
 
         server = build_server(build_registry(allow_mutating=True, allow_execute=False))
 
         async def _go():
-            async with create_connected_server_and_client_session(server) as client:
-                await client.initialize()
+            async with connected_session(server) as client:
                 return await client.list_tools()
 
         result = _run(_go())
@@ -605,7 +607,7 @@ class TestServerRoundTrip:
         assert len(names) == 18
         assert "recipes_search" in names and "train_start" in names
         # every advertised tool carries an inputSchema object
-        assert all(t.inputSchema.get("type") == "object" for t in result.tools)
+        assert all(input_schema(t).get("type") == "object" for t in result.tools)
 
     def test_call_recipes_search_returns_json(self):
         from soup_cli.mcp_server.registry import build_registry
@@ -613,7 +615,7 @@ class TestServerRoundTrip:
 
         server = build_server(build_registry(allow_mutating=False, allow_execute=False))
         res = _roundtrip(server, "recipes_search", {"query": "qwen"})
-        assert res.isError is False
+        assert is_error(res) is False
         payload = json.loads(res.content[0].text)
         assert payload["count"] >= 1
 
@@ -623,7 +625,7 @@ class TestServerRoundTrip:
 
         server = build_server(build_registry(allow_mutating=False, allow_execute=False))
         res = _roundtrip(server, "no_such_tool", {})
-        assert res.isError is True
+        assert is_error(res) is True
 
     def test_mutating_refused_without_allow(self, tmp_path, monkeypatch):
         from soup_cli.mcp_server.registry import build_registry
@@ -633,7 +635,7 @@ class TestServerRoundTrip:
         (tmp_path / "soup.yaml").write_text(_MIN_CONFIG, encoding="utf-8")
         server = build_server(build_registry(allow_mutating=False, allow_execute=False))
         res = _roundtrip(server, "train_start", {"config": "soup.yaml"})
-        assert res.isError is True
+        assert is_error(res) is True
 
     def test_bad_arg_is_error_not_crash(self, tmp_path, monkeypatch):
         from soup_cli.mcp_server.registry import build_registry
@@ -642,7 +644,7 @@ class TestServerRoundTrip:
         monkeypatch.chdir(tmp_path)
         server = build_server(build_registry(allow_mutating=False, allow_execute=False))
         res = _roundtrip(server, "data_inspect", {"data": "does-not-exist.jsonl"})
-        assert res.isError is True
+        assert is_error(res) is True
 
     def test_output_is_sanitized(self):
         from soup_cli.mcp_server.registry import ToolSpec
@@ -678,7 +680,7 @@ class TestServerRoundTrip:
         )
         server = build_server([spec])
         res = _roundtrip(server, "boom", {})
-        assert res.isError is True
+        assert is_error(res) is True
         text = res.content[0].text
         assert "\x1b" not in text and "\x07" not in text
 
@@ -700,7 +702,7 @@ class TestServerRoundTrip:
         )
         server = build_server([spec])
         res = _roundtrip(server, "noisy", {})
-        assert res.isError is False
+        assert is_error(res) is False
         # the handler's stdout print must NOT reach the process stdout channel
         assert "LEAK-TO-STDOUT" not in capsys.readouterr().out
 
@@ -718,7 +720,7 @@ class TestServerRoundTrip:
         )
         server = build_server([spec])
         res = _roundtrip(server, "bad", {})
-        assert res.isError is True
+        assert is_error(res) is True
         assert "internal error" in res.content[0].text
 
 


### PR DESCRIPTION
## What does this PR do?

Closes #322. `soup mcp serve` now works on **both** mcp majors, and the `[mcp]` extra is `>=1.10.0,<3`.

The cap was a stopgap from v0.72.3, added the day mcp 2.0.0 broke every round-trip test. It unblocked that release and pinned anyone who wanted 2.x in the same environment — a cost paid continuously by users for a break that took two adapters to bridge.

## Measured, not read off release notes

I installed the 2.0.0 wheel and checked each surface:

| | 1.29.0 | 2.0.0 |
|---|---|---|
| `@server.list_tools()` / `@server.call_tool()` decorators | yes | **removed** — `on_list_tools=` / `on_call_tool=` constructor callbacks |
| `shared.memory.create_connected_server_and_client_session` | yes | **removed** |
| `shared.memory.create_client_server_memory_streams` | yes | **yes** |
| `Server.run`, `create_initialization_options` | yes | yes, same shape |
| `server/sse.py`, `streamable_http_manager.py`, `transport_security.py` | yes | **yes** |

That last row is the one that shrank this PR. The three modules #296's SSE / streamable-HTTP transports stand on all survive 2.0.0 unchanged, so **those 46 tests pass on 2.x with no edit at all**. My first read of the module listing suggested `memory.py` and `transport_security.py` were gone; they are not, and I checked again rather than building on it.

## The bridge is a probe, not a version check

```python
def _uses_callback_handlers() -> bool:
    return "on_list_tools" in inspect.signature(Server.__init__).parameters
```

This repo has derived a dependency bound by reading a version table twice and been wrong twice — `trainer/_trl_compat.py`'s docstring records the rule that earned: *a version bound derived by reading source is a hypothesis; the experiment that settles it is constructing the object.* A probe cannot go stale.

`test_the_probe_is_not_a_version_comparison` enforces it by walking the AST rather than grepping — the module docstring *mentions* `mcp.__version__` precisely to say it is not consulted, so a substring check fails on the sentence explaining the rule. I found that out by writing the substring version first.

## One dispatch, two thin adapters

The 2.x handlers take a request context and return `ListToolsResult` / `CallToolResult` where 1.x wanted bare lists. Only that shaping differs; sanitizing, serializing and error-flattening stay in a single `_dispatch_tool`, and `test_the_shared_dispatch_is_used_by_both_adapters` fails if a second implementation ever appears. **Two copies is how the majors would drift apart in behaviour while both kept passing their own tests.**

One asymmetry worth naming: on 1.x a raised `ValueError` *becomes* the `isError` result. On 2.x an exception out of a handler becomes a JSON-RPC error, which is a different thing on the wire. So the 2.x adapter returns `CallToolResult(..., isError=True)` explicitly — otherwise "the tool ran and reported failure" would silently become "the call itself failed", and the existing assertions would have been testing two different behaviours under one name.

## The test helper is rebuilt, not branched

`tests/mcp_roundtrip.py` reconstructs the removed convenience wrapper from `create_client_server_memory_streams`, which both majors ship. No version branch: what changed was one wrapper, not the transport underneath it, and a branch here would need revisiting at 3.0 for no reason.

Two field renames — `isError` → `is_error`, `inputSchema` → `input_schema` — are read by meaning through helpers that **raise** when neither spelling is present. Returning a default would turn a third rename into "no tool call ever failed", which is the one outcome a test helper must not produce; both refusals are pinned by tests.

## Verified on both majors

- **mcp 2.0.0**, second environment: `test_issue322_mcp2_compat.py` + `test_v07128.py` + `test_issue296_network_transport.py` + `test_mcp_execute.py` → **184 passed, 0 failed**
- **mcp 1.29.0**, full suite: **18244 passed, 378 skipped**

Three `test_cli_subprocess.py` tests timed out in that full run and pass 69/69 when re-run on an idle box. They spawn `soup` with a 30 s limit and CLI startup alone measures 7.3 s here; nothing in this PR is on that path (`mcp_server/server.py` is lazily imported). Reporting it rather than quietly re-running until green.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Tests

## Checklist

- [x] `ruff check src/soup_cli/ tests/` passes
- [x] `pytest tests/ -v` passes (see the note above on the three load-induced timeouts)
- [x] Updated relevant docs — the `[mcp]` pin comment in `pyproject.toml` carries the reasoning; `changelog.d/0.73.3/<pr>.added.md` added
- [x] No breaking changes — 1.x behaviour is byte-identical, the floor stays at the 1.10.0 #296 measured, and nothing outside `mcp_server/` is touched
