### PR TITLE
fix(recipes): pin Qwen3.5 text-only decoder intent

### DIFF
--- a/changelog.d/0.73.3/501.changed.md
+++ b/changelog.d/0.73.3/501.changed.md
@@ -1,0 +1,5 @@
+- **Qwen3.5 and Qwen3.6 text recipes now state their decoder-only intent (#427 by
+  @Amix29 in #501).** Apple Silicon measurements confirmed that Soup's text path loads
+  `Qwen3_5ForCausalLM` without the visual tower, so all twelve catalog recipes now set
+  `modality: text` explicitly and regression coverage prevents that decision from falling
+  back to the schema default.

--- a/docs/models.md
+++ b/docs/models.md
@@ -32,6 +32,14 @@ Soup works with **any** of the **340,000+** text-generation models on [HuggingFa
 | **InternLM 3** | InternLM3-8B-Instruct | 8B | Chinese + English |
 | **Falcon** | Falcon-11B, Falcon-40B-Instruct | 7B–180B | Open-weight |
 
+Qwen3.5 and Qwen3.6 checkpoints advertise a multimodal conditional-generation
+architecture on the Hub, but Soup's catalog recipes are deliberately text-only.
+Their explicit `modality: text` selects `AutoModelForCausalLM`, which instantiates the
+language decoder without the visual tower. This is appropriate for text-only SFT,
+pre-training, and GRPO data; it is not a full multimodal fine-tune. The Transformers
+backend cannot load `qwen3_5` under Soup's current `<5.0.0` dependency cap; enabling
+that backend requires a separately validated Transformers 5 migration.
+
 ### Vision Models (with `modality: vision`)
 
 | Model | Size | Supported Formats |

--- a/src/soup_cli/recipes/catalog.py
+++ b/src/soup_cli/recipes/catalog.py
@@ -3749,6 +3749,7 @@ output: ./output
         yaml_str="""\
 base: Qwen/Qwen3.5-0.8B
 task: sft
+modality: text
 
 data:
   train: ./data/train.jsonl
@@ -3777,6 +3778,7 @@ output: ./output
         yaml_str="""\
 base: Qwen/Qwen3.5-2B
 task: sft
+modality: text
 
 data:
   train: ./data/train.jsonl
@@ -3805,6 +3807,7 @@ output: ./output
         yaml_str="""\
 base: Qwen/Qwen3.5-4B
 task: sft
+modality: text
 
 data:
   train: ./data/train.jsonl
@@ -3833,6 +3836,7 @@ output: ./output
         yaml_str="""\
 base: Qwen/Qwen3.5-4B-Base
 task: pretrain
+modality: text
 
 data:
   train: ./data/corpus.jsonl
@@ -3862,6 +3866,7 @@ output: ./output
         yaml_str="""\
 base: Qwen/Qwen3.5-9B
 task: sft
+modality: text
 
 data:
   train: ./data/train.jsonl
@@ -3890,6 +3895,7 @@ output: ./output
         yaml_str="""\
 base: Qwen/Qwen3.5-9B
 task: grpo
+modality: text
 
 data:
   train: ./data/reasoning_train.jsonl
@@ -3922,6 +3928,7 @@ output: ./output
         yaml_str="""\
 base: Qwen/Qwen3.5-27B
 task: sft
+modality: text
 
 data:
   train: ./data/train.jsonl
@@ -3951,6 +3958,7 @@ output: ./output
         yaml_str="""\
 base: Qwen/Qwen3.5-35B-A3B
 task: sft
+modality: text
 
 data:
   train: ./data/train.jsonl
@@ -3985,6 +3993,7 @@ output: ./output
         yaml_str="""\
 base: Qwen/Qwen3.5-122B-A10B
 task: sft
+modality: text
 
 data:
   train: ./data/train.jsonl
@@ -4020,6 +4029,7 @@ output: ./output
         yaml_str="""\
 base: Qwen/Qwen3.5-397B-A17B
 task: sft
+modality: text
 
 data:
   train: ./data/train.jsonl
@@ -4052,6 +4062,7 @@ output: ./output
         yaml_str="""\
 base: Qwen/Qwen3.6-27B
 task: sft
+modality: text
 
 data:
   train: ./data/train.jsonl
@@ -4081,6 +4092,7 @@ output: ./output
         yaml_str="""\
 base: Qwen/Qwen3.6-35B-A3B
 task: sft
+modality: text
 
 data:
   train: ./data/train.jsonl

--- a/tests/test_issue427_qwen35_text_modality.py
+++ b/tests/test_issue427_qwen35_text_modality.py
@@ -1,0 +1,50 @@
+"""Regression coverage for #427's deliberate Qwen3.5 text-only recipes."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from soup_cli.config.loader import load_config_from_string
+from soup_cli.recipes.catalog import RECIPES
+
+EXPECTED_QWEN35_TEXT_RECIPES = {
+    "qwen3.5-0.8b-sft",
+    "qwen3.5-2b-sft",
+    "qwen3.5-4b-sft",
+    "qwen3.5-4b-pretrain",
+    "qwen3.5-9b-sft",
+    "qwen3.5-9b-grpo",
+    "qwen3.5-27b-sft",
+    "qwen3.5-35b-a3b-sft",
+    "qwen3.5-122b-a10b-sft",
+    "qwen3.5-397b-a17b-sft",
+    # Qwen3.6 exposes the same qwen3_5 / qwen3_5_moe architecture on the Hub.
+    "qwen3.6-27b-sft",
+    "qwen3.6-35b-a3b-sft",
+}
+
+
+def _qwen35_family_recipe_names() -> tuple[str, ...]:
+    """Select every catalog recipe covered by the measured architecture decision."""
+    prefixes = ("Qwen/Qwen3.5-", "Qwen/Qwen3.6-")
+    return tuple(name for name, recipe in RECIPES.items() if recipe.model.startswith(prefixes))
+
+
+QWEN35_TEXT_RECIPES = _qwen35_family_recipe_names()
+
+
+def test_qwen35_family_audit_covers_every_current_recipe() -> None:
+    """A newly catalogued sibling must join the explicit-modality contract."""
+    assert set(QWEN35_TEXT_RECIPES) == EXPECTED_QWEN35_TEXT_RECIPES
+
+
+@pytest.mark.parametrize("name", QWEN35_TEXT_RECIPES)
+def test_qwen35_family_recipes_explicitly_select_language_tower(name: str) -> None:
+    """Do not let the decoder-only decision fall back to the schema default."""
+    recipe = RECIPES[name]
+    raw = yaml.safe_load(recipe.yaml_str)
+    config = load_config_from_string(recipe.yaml_str)
+
+    assert raw["modality"] == "text"
+    assert config.modality == "text"


### PR DESCRIPTION
## Summary

- make `modality: text` explicit across the ten Qwen3.5 and two Qwen3.6 catalog recipes that deliberately train the language decoder
- document why the Hub's multimodal architecture and Soup's text-only recipe are both correct
- add a family-derived regression guard so the decision cannot silently fall back to the schema default

Fixes #427.

## Measurement

Measured on an Apple M4 Max with 128 GB unified memory using
`Qwen/Qwen3.5-0.8B` (Hub snapshot `2fc06364715b967f1860aea9cf38778875588b17`).
The structural loads were repeated offline after rebasing this branch onto current `main`:

| load path | instantiated class | parameters | vision parameters |
|---|---|---:|---:|
| text (`AutoModelForCausalLM`) | `Qwen3_5ForCausalLM` | 752,393,024 | 0 |
| multimodal (`AutoModelForMultimodalLM`) | `Qwen3_5ForConditionalGeneration` | 852,985,920 | 100,592,896 across 153 tensors |

The text load receives `Qwen3_5TextConfig` (`model_type: qwen3_5_text`); the full
load receives the outer `Qwen3_5Config` (`model_type: qwen3_5`). This is a real
language-tower selection, not an incidental class-name difference.

I also repeated one real Soup SFT step on four text-only ChatML rows through both Apple
paths from the rebased tree:

- MLX: 86 tokens, loss 2.8328, 6.273 GB peak allocation; the 24-tensor LoRA adapter
  reloaded over `mlx_lm.models.qwen3_5.Model` with zero vision parameters
- Transformers/MPS 5.12.1: 86 tokens, loss 0.7884, 159,744 trainable parameters;
  the 24-tensor adapter reloaded over `Qwen3_5ForCausalLM` with zero vision parameters

This establishes that `modality: text` is the correct catalog decision for text-only
training. It intentionally fine-tunes the language component, not the complete
multimodal model.

## Scope boundaries found during review

This PR does **not** lift Soup's `transformers<5.0.0` training bound. The latest permitted
release, 4.57.6, does not recognize `model_type: qwen3_5`; Transformers 5 does, but that
migration has broader compatibility failures and needs separate validation.

The Transformers 5 measurement required explicit `q_proj` / `v_proj` PEFT targets because
PEFT has no automatic mapping for `qwen3_5_text`. I deliberately kept the catalog's
`target_modules: auto` unchanged here: MLX resolves that value to the backend-specific
full keys `self_attn.q_proj` / `self_attn.v_proj`, while recipe-level short keys would match
no MLX modules. Dependency support and a cross-backend target policy are separate follow-ups,
not safe additions to this modality PR.

## Catalog audit

I parsed all 146 recipes (111 unique model IDs) and compared their declared/default
modality with current Hub metadata. Ninety-nine model IDs were queryable; twelve returned
404 and are an explicit audit limitation.

Other Hub-multimodal families currently taking the implicit text default include Gemma 3 /
MedGemma, Llama 4, Kimi K2.5/K2.6, and MiniMax M3. They need family-specific intent checks
rather than a blanket switch to vision. The three Whisper ASR recipes also leave modality
unset despite their ASR Hub metadata. Qwen3.6 is included in this PR because its checkpoints
report the same `qwen3_5` / `qwen3_5_moe` architecture and the same measured decoder-only
decision applies.

## Regression proof

The test derives the covered recipe names from the catalog and separately pins the audited
set. Removing `modality: text` from only `qwen3.5-0.8b-sft` produced one named failure while
the other eleven cases stayed green; restoring it returned the file to 13/13 passing.

## Validation

- focused issue + recipe suites: **1,241 passed**
- full suite: **18,358 passed, 285 skipped, 5 deselected** (81.30% coverage)
- Ruff: clean across `src/soup_cli/`, `tests/`, and `scripts/`
- `git diff --check`: clean
- two real one-step Apple Silicon runs and both adapter reloads: passed
