### PR TITLE
docs(deps): record why the transformers <5.0.0 ceiling is load-bearing

### DIFF
--- a/docs/backends-and-ops.md
+++ b/docs/backends-and-ops.md
@@ -88,6 +88,30 @@ Transformers backend. A Hugging Face `datasets` source or streaming dataset
 still needs `datasets` because that data source owns the dependency; the local
 file path below does not.
 
+> **`[mlx]` and `[train]` cannot be installed together, and that is not a style
+> preference.** `pip install "soup-cli[train,mlx]"` fails with pip's
+> `ResolutionImpossible`, whose output says nothing about the actual cause:
+>
+> - `mlx-lm` requires `transformers>=5.0.0`. The `[mlx]` extra only restates that
+>   upstream requirement, so deleting the line does not help -- the transitive
+>   requirement remains.
+> - `[train]` caps `transformers<5.0.0`, and the cap is load-bearing. On
+>   transformers 5 a private helper that `trl` imports returns a truthy tuple where
+>   it used to return `False`, so `trl`'s optional-import guards invert and
+>   `dpo_trainer` / `grpo_trainer` stop importing. Measured on transformers 5.15.1:
+>   45 test failures, none of them in Soup's own code.
+> - `trl` itself is fixed from **0.29.0**, which vendors its own copy of the helper --
+>   but that is one version above Soup's `trl<0.29` cap, and that cap is held by an
+>   unrelated break (`BasePairwiseJudge` moved to `trl.experimental.judges`). The
+>   chain is `transformers<5` <- `trl<0.29` <- the judge import, so lifting any one
+>   link on its own changes nothing.
+>
+> There is no side to concede -- `mlx-lm` needs transformers 5, transformers 5 breaks
+> `trl`, and `trl` is what trains. Install one extra or the other; use separate
+> virtualenvs if you need both on one machine. The full measurement and the criteria
+> for lifting the cap are in
+> [#503](https://github.com/MakazhanAlpamys/Soup/issues/503).
+
 `detect_device()` and `get_gpu_info()` recognise Apple Silicon when
 `backend: mlx` is set, preserving `training.quantization: 4bit` for
 `mlx-community` pre-quantized checkpoints instead of silently downgrading to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,30 @@ dependencies = [
 # These were core dependencies through v0.70.0; pins are unchanged.
 train = [
     "torch>=2.0.0",
+    # THE <5.0.0 CEILING IS LOAD-BEARING. Do not lift it as a precaution: it was set
+    # 2026-05-08, before transformers 5 existed, which is exactly why it reads like one.
+    # Measured against transformers 5.15.1 -- 45 tests fail, not one of them in Soup.
+    #
+    # transformers 5 changed the return type of a PRIVATE helper that trl imports:
+    #     4.57.6:  _is_package_available("weave") -> False         (bool, falsey)
+    #     5.15.1:  _is_package_available("weave") -> (False, None) (tuple, TRUTHY)
+    # The tuple comes back for present packages too, so the inversion fires on ABSENT
+    # ones: "not installed" reads as true. trl/import_utils.py derives its optional
+    # dependency flags from that helper, so the guarded `import weave` runs anyway and
+    # dpo_trainer / grpo_trainer never import behind the ModuleNotFoundError. 13
+    # module-level flags in trl 0.19.1 are built this way; weave merely fires first.
+    #
+    # The trl boundary is exact, and it is why this bound cannot be lifted alone:
+    # trl 0.28.0 still imports the private helper; trl 0.29.0 vendors its own
+    # _is_package_available (importlib.util.find_spec) and is immune. That is ONE
+    # version above Soup's own `trl<0.29` cap. So the chain is
+    # transformers<5 <- trl<0.29 <- the BasePairwiseJudge import documented below,
+    # and lifting any single link achieves nothing.
+    #
+    # Consequence: [mlx] needs transformers>=5.0.0 -- mlx-lm's own requirement, only
+    # restated in that extra -- so [train] and [mlx] cannot co-install, and there is no
+    # side to concede. Full measurement and the acceptance criteria for lifting this
+    # bound live in issue #503. Guarded by tests/test_transformers_ceiling_compat.py.
     "transformers>=4.36.0,<5.0.0",
     "peft>=0.7.0",
     # Capped below 0.29. #326 raised this from `<0.27` after migrating the six

--- a/tests/test_transformers_ceiling_compat.py
+++ b/tests/test_transformers_ceiling_compat.py
@@ -1,0 +1,172 @@
+"""#503 - the Transformers ``<5.0.0`` ceiling is load-bearing, not caution.
+
+``pyproject.toml`` caps ``transformers<5.0.0`` in the ``train`` extra. The bound was
+set on 2026-05-08, *before* transformers 5 existed, so it reads like a precaution --
+and it was nearly lifted on exactly that reasoning. It is not a precaution.
+
+Measured against ``transformers==5.15.1``: 45 tests fail, none of them in Soup's own
+code. transformers 5 changed the return type of a private helper that ``trl`` imports::
+
+    4.57.6:  _is_package_available("weave") -> False         # bool, falsey
+    5.15.1:  _is_package_available("weave") -> (False, None) # tuple, TRUTHY
+
+The tuple comes back for present packages too, so the inversion fires on *absent*
+ones: "not installed" reads as true. ``trl/import_utils.py`` derives its optional
+dependency flags from that helper, so the guarded ``import weave`` runs anyway and
+``dpo_trainer`` / ``grpo_trainer`` never import behind the ``ModuleNotFoundError``.
+Thirteen module-level flags in trl 0.19.1 are built this way; weave merely fires
+first.
+
+The trl boundary is exact, and it is why this ceiling cannot be lifted on its own:
+trl 0.28.0 still imports the private helper, while trl 0.29.0 vendors its own
+``_is_package_available`` over ``importlib.util.find_spec`` and is immune. That is
+one version above Soup's own ``trl<0.29`` cap, which is itself held by an unrelated
+break (``BasePairwiseJudge`` moved to ``trl.experimental.judges``). The chain is
+``transformers<5`` <- ``trl<0.29`` <- the judge import; lifting one link does nothing.
+
+This module holds two different kinds of guard, and the distinction matters:
+
+``TestCeilingIsPinned`` is a **ratchet**. It fails on purpose when the bound moves,
+because moving it without re-measuring is the exact mistake being prevented. Its
+failure message names what to re-measure.
+
+``TestDocsMatchTheDeclaredBounds`` is a **consistency check**, not a ratchet. It
+asserts that the docs warn *exactly when* the two extras are provably disjoint. If
+upstream is repaired and the extras become co-installable, it does not block that
+work -- it tells you to delete the now-false warning. A guard that fires on correct
+code gets deleted, so this one is written not to.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+BACKENDS_DOC = REPO_ROOT / "docs" / "backends-and-ops.md"
+
+ISSUE_URL = "https://github.com/MakazhanAlpamys/Soup/issues/503"
+
+# The sentence docs/backends-and-ops.md uses to state the incompatibility. Matched as
+# a phrase rather than a whole paragraph so rewording the prose around it is free.
+_DOCS_WARNING = "cannot be installed together"
+
+# Probe grid for disjointness. `packaging` has no specifier-intersection primitive, so
+# emptiness is decided by candidate sampling. The grid spans well past both bounds and
+# includes each declared bound exactly, which is where an off-by-one would live.
+_PROBE_VERSIONS = tuple(
+    Version(f"{major}.{minor}.0") for major in range(3, 10) for minor in range(0, 60)
+)
+
+
+def _extra_body(pyproject: str, extra: str) -> str:
+    """Return the raw dependency list body for one optional-dependency extra."""
+    block = re.search(
+        rf"^{re.escape(extra)}\s*=\s*\[(.*?)^\]",
+        pyproject,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert block, f"pyproject.toml has no `{extra}` optional-dependency list"
+    return block.group(1)
+
+
+def _transformers_requirement(extra_body: str, extra: str) -> str:
+    """Return the full transformers requirement string declared by one extra."""
+    requirement = re.search(r'"(transformers(?:\s*[<>=!~][^"]*)?)"', extra_body)
+    assert requirement, f"the `{extra}` extra declares no transformers requirement"
+    return requirement.group(1)
+
+
+def _specifier(requirement: str) -> SpecifierSet:
+    return SpecifierSet(requirement[len("transformers") :].strip())
+
+
+def _declared(extra: str) -> SpecifierSet:
+    pyproject = PYPROJECT.read_text(encoding="utf-8")
+    body = _extra_body(pyproject, extra)
+    return _specifier(_transformers_requirement(body, extra))
+
+
+def _extras_are_disjoint() -> bool:
+    """True when no transformers version can satisfy both `train` and `mlx`."""
+    train = _declared("train")
+    mlx = _declared("mlx")
+    probes = list(_PROBE_VERSIONS)
+    # Include each declared bound verbatim: a `<=` / `<` slip lives exactly there.
+    for spec in (train, mlx):
+        for clause in spec:
+            try:
+                probes.append(Version(clause.version))
+            except Exception:  # pragma: no cover - a malformed pin fails elsewhere
+                continue
+    return not any(
+        train.contains(v, prereleases=True) and mlx.contains(v, prereleases=True)
+        for v in probes
+    )
+
+
+class TestCeilingIsPinned:
+    """Deliberate ratchet: the bound may move, but not silently."""
+
+    def test_train_extra_still_caps_transformers_below_5(self) -> None:
+        train = _declared("train")
+        upper = [c for c in train if c.operator in {"<", "<="}]
+
+        assert upper, (
+            "The `train` extra no longer caps transformers. That cap is load-bearing: "
+            f"transformers 5 inverts trl's optional-import guards. See {ISSUE_URL} "
+            "for the measurement and the acceptance criteria before removing it."
+        )
+        assert [(c.operator, c.version) for c in upper] == [("<", "5.0.0")], (
+            f"The transformers ceiling moved to {[str(c) for c in upper]}. Before "
+            "raising it, re-measure: in a clean venv install that transformers with "
+            "Soup's trl range and confirm `import trl.trainer.dpo_trainer` and "
+            "`import trl.trainer.grpo_trainer` both succeed, then run the full suite "
+            f"and record the result on {ISSUE_URL}. Update this test in the same PR."
+        )
+
+    def test_the_ceiling_carries_its_reason_in_pyproject(self) -> None:
+        """A bare bound is what gets lifted as a precaution. Keep the why next to it."""
+        pyproject = PYPROJECT.read_text(encoding="utf-8")
+        assert "503" in pyproject, (
+            "The comment explaining why transformers is capped below 5.0.0 lost its "
+            f"reference to {ISSUE_URL}. Without the measurement attached, the bound "
+            "reads like caution and gets lifted -- which is how this issue was filed."
+        )
+
+
+class TestDocsMatchTheDeclaredBounds:
+    """Consistency, not a ratchet: this never blocks repairing the incompatibility."""
+
+    def test_docs_warn_exactly_when_the_extras_cannot_co_install(self) -> None:
+        disjoint = _extras_are_disjoint()
+        warned = _DOCS_WARNING in BACKENDS_DOC.read_text(encoding="utf-8")
+
+        if disjoint:
+            assert warned, (
+                "`train` and `mlx` declare transformers ranges with no version in "
+                "common, so `pip install \"soup-cli[train,mlx]\"` fails with an "
+                "unreadable ResolutionImpossible. docs/backends-and-ops.md must say "
+                f"so in plain words (phrase: {_DOCS_WARNING!r}). See {ISSUE_URL}."
+            )
+        else:
+            assert not warned, (
+                "The `train` and `mlx` extras now share at least one transformers "
+                "version, so they can co-install -- but docs/backends-and-ops.md "
+                f"still says they {_DOCS_WARNING}. Delete that warning and close "
+                f"{ISSUE_URL}; do not leave the docs claiming a resolved conflict."
+            )
+
+    def test_mlx_extra_requires_a_transformers_the_train_extra_forbids(self) -> None:
+        """Pins the shape of the conflict, so a one-sided edit is visible."""
+        mlx = _declared("mlx")
+        lower = [c for c in mlx if c.operator in {">=", ">", "=="}]
+        assert lower, (
+            "The `mlx` extra no longer pins a transformers floor. It exists to "
+            "restate mlx-lm's own `transformers>=5.0.0`; if that changed upstream, "
+            f"re-check whether the conflict in {ISSUE_URL} still holds."
+        )


### PR DESCRIPTION
Closes #503.

The `train` extra caps `transformers<5.0.0`. The bound was set 2026-05-08, **before
transformers 5 existed**, so it reads like plain caution — and it was nearly lifted on
exactly that reasoning. It is not caution. This PR **records** rather than repairs.

> **One reading was withdrawn while writing this, and it was the load-bearing one.**
> The first push said *"trl 1.10.0 is byte-identical, so no trl release fixes it."*
> False. Checked by downloading the wheels instead of reading one version — see the
> table below. The obstacle is a **chain**, not an unfixed upstream, and that is a
> materially different instruction to whoever picks this up next.

## The measurement

Full suite against `transformers==5.15.1`: **45 failed, 18205 passed.** Not one failure
in Soup's own code.

transformers 5 changed the return type of a **private** helper that `trl` imports:

```
4.57.6:  _is_package_available("weave") -> False         # bool, falsey
5.15.1:  _is_package_available("weave") -> (False, None) # tuple, TRUTHY
```

The tuple comes back for present packages too (`numpy` → `(True, None)`), so the
inversion fires specifically on **absent** ones: "not installed" reads as true.
`trl/import_utils.py` derives its optional-dependency flags from that helper, so the
guarded `import weave` runs anyway and `dpo_trainer` / `grpo_trainer` never import
behind the `ModuleNotFoundError`. Thirteen module-level flags in trl 0.19.1 are built
this way; weave merely fires first.

## The obstacle is a chain

| trl | imports the private helper | vendors its own | on transformers 5 |
|---|---|---|---|
| 0.28.0 | yes | no | **breaks** |
| 0.29.0 | no | yes | immune |
| 1.0.0 / 1.10.0 | no | yes | immune |

trl 0.29.0 vendors `_is_package_available` over `importlib.util.find_spec`, so upstream
is **already fixed** — one version above Soup's own `trl<0.29` cap. That cap is held by
a separate break already documented in `pyproject.toml`: `BasePairwiseJudge` moved to
`trl.experimental.judges`, so `eval/judge.py` cannot import it.

```
transformers<5  <-  trl<0.29  <-  the BasePairwiseJudge import
```

Lifting any single link achieves nothing. #503 carries the acceptance criteria that
have to land together.

## Why `[mlx]` and `[train]` cannot co-install

`mlx-lm` itself requires `transformers>=5.0.0`; the `[mlx]` extra only restates that, so
deleting the line does not help. Until now the user got pip's `ResolutionImpossible` and
nothing explaining it, and the docs said only "do not add `[train]`" — a preference, not
a fact.

## What changed

- **`pyproject.toml`** — the measurement and the chain now sit next to the bound. A bare
  bound is what gets lifted as a precaution.
- **`docs/backends-and-ops.md`** — states the incompatibility, both causes, the chain,
  and that separate virtualenvs are the answer.
- **`tests/test_transformers_ceiling_compat.py`** — two *different* kinds of guard, and
  the distinction is the point:
  - `TestCeilingIsPinned` is a **ratchet**. It fails on purpose when the bound moves,
    and names what to re-measure first.
  - `TestDocsMatchTheDeclaredBounds` is a **consistency check, not a ratchet**. It
    asserts the docs warn *exactly when* the two extras are provably disjoint, and
    **computes** that disjointness from the declared specifiers instead of pinning a
    string. If upstream is repaired it does not block the repair — it tells you to
    delete the now-false warning. A guard that fires on correct code gets deleted, so
    this one is written not to.

## Mutation results (target file only)

| mutation | outcome |
|---|---|
| ceiling `<5.0.0` → `<6.0.0` | ratchet fails **and** the consistency check flips to "delete the warning" — proving it computes rather than asserting a constant |
| ceiling lifted **+** docs updated (a legitimate repair) | **only** the ratchet fires (1 failed, 3 passed); the consistency check stays quiet |
| strip `#503` from `pyproject.toml` | `test_the_ceiling_carries_its_reason_in_pyproject` fails |
| delete the docs warning while the extras are disjoint | `test_docs_warn_exactly_when_the_extras_cannot_co_install` fails |

Each of the four tests is the sole guard for its fact. The neighbouring
`test_transformers_floor_compat.py` still extracts `4.36.0` with the new comment inside
the `train` block, and the recipe / CLI-help count ratchets are unaffected.

**No changelog fragment.** Behaviour is unchanged and the incompatibility already
existed; `changelog.d/README.md` scopes fragments to user-visible changes and has no
documentation category.

## Related

#323 / #486 — `trl` declares `transformers>=4.56.2` with **no upper bound**, so a fresh
`pip install trl` next to transformers 5 is broken out of the box for any trl below
0.29. Only a run against the newest stack catches that class of breakage. This is a live
instance of it that arrived while that PR was still waiting.
