### PR TITLE
fix(train): support Qwen3.5 on Transformers 5

### DIFF
--- a/.github/constraints/transformers-floor.txt
+++ b/.github/constraints/transformers-floor.txt
@@ -1,7 +1,10 @@
-# #502/#503 — exact pins for the dedicated dependency-floor CI job.
+# #502/#503/#522 — exact pins for the dedicated dependency-floor CI job.
 # Qwen3.5/Qwen3.8 text loading establishes Transformers 5.12.1 as Soup's
 # declared training floor. trl 0.29 is the first release that does not import the
 # Transformers private availability helper whose v5 return type broke trl 0.28.
+# Plotext 6.0.0 is pinned here so one CI cell exercises the real Figure API rather
+# than relying only on the fake 5.x/6.x contract doubles in the unit suite.
 transformers==5.12.1
 trl==0.29.0
 peft==0.20.0
+plotext==6.0.0

--- a/.github/constraints/transformers-floor.txt
+++ b/.github/constraints/transformers-floor.txt
@@ -1,23 +1,7 @@
-# #478 — Transformers pin for the dedicated floor-compat CI job.
-#
-# Declared train floor in pyproject.toml remains:
-#   transformers>=4.36.0,<5.0.0
-#
-# transformers==4.36.0 is not resolvable with the declared trl range
-# (trl>=0.14.0,<0.29): even trl 0.14.0 requires transformers>=4.46.0, and
-# newer trl releases require >=4.56.1 / >=4.56.2. Raising Soup's declared
-# transformers floor in pyproject.toml needs an explicit maintainer
-# dependency-policy decision. Do NOT treat 4.55.4 (the last pre-dtype=
-# release) as the declared floor.
-#
-# This file pins:
-#   transformers==4.46.1 — lowest non-yanked resolvable Transformers version
-#     tested with the lowest declared TRL version
-#   trl==0.14.0 — lowest version in Soup's declared trl range
-#
-# These pins are for the floor CI cell only so pip cannot silently upgrade
-# that job. Do not describe pip's preferred/latest compatible TRL as the
-# floor. Runtime dtype= regressions are caught by the static guard in
-# tests/test_transformers_floor_compat.py (dtype= is >=4.56-only).
-transformers==4.46.1
-trl==0.14.0
+# #502/#503 — exact pins for the dedicated dependency-floor CI job.
+# Qwen3.5/Qwen3.8 text loading establishes Transformers 5.12.1 as Soup's
+# declared training floor. trl 0.29 is the first release that does not import the
+# Transformers private availability helper whose v5 return type broke trl 0.28.
+transformers==5.12.1
+trl==0.29.0
+peft==0.20.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,12 +67,8 @@ jobs:
       - name: Run one-step MLX SFT through the real CLI
         run: pytest -o addopts= -m smoke -k mlx_sft_smoke -q tests/test_smoke_train.py
 
-  # #478: declared transformers floor (4.36.0) cannot resolve against declared
-  # trl>=0.14,<0.29 — see .github/constraints/transformers-floor.txt. Do not
-  # raise Soup's pin without a dependency-policy decision. This job installs
-  # under an explicit transformers(+trl) constraint so pip cannot silently
-  # upgrade the cell, asserts the pinned versions, and runs the static dtype=
-  # guard (the accepted fallback when a true floor runtime cell is impractical).
+  # #502/#503: install the exact Transformers 5.12.1 / trl 0.29 / PEFT 0.20
+  # support floor so pip cannot silently upgrade the cell, then assert versions.
   transformers-floor:
     runs-on: ubuntu-latest
     env:
@@ -104,7 +100,7 @@ jobs:
           )
           expected = dict(pairs)
           assert len(expected) == len(pairs), "duplicate package pin in floor constraints"
-          for name in ("transformers", "trl"):
+          for name in ("transformers", "trl", "peft"):
               assert name in expected, f"floor constraints missing exact {name} pin"
               want = expected[name]
               got = md.version(name)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,9 @@ jobs:
       - name: Run one-step MLX SFT through the real CLI
         run: pytest -o addopts= -m smoke -k mlx_sft_smoke -q tests/test_smoke_train.py
 
-  # #502/#503: install the exact Transformers 5.12.1 / trl 0.29 / PEFT 0.20
-  # support floor so pip cannot silently upgrade the cell, then assert versions.
+  # #502/#503/#522: install the exact Transformers 5.12.1 / trl 0.29 /
+  # PEFT 0.20 support floor and Plotext 6.0.0 so pip cannot silently upgrade
+  # the cell, then assert every pinned compatibility boundary.
   transformers-floor:
     runs-on: ubuntu-latest
     env:
@@ -100,7 +101,7 @@ jobs:
           )
           expected = dict(pairs)
           assert len(expected) == len(pairs), "duplicate package pin in floor constraints"
-          for name in ("transformers", "trl", "peft"):
+          for name in ("transformers", "trl", "peft", "plotext"):
               assert name in expected, f"floor constraints missing exact {name} pin"
               want = expected[name]
               got = md.version(name)
@@ -115,6 +116,7 @@ jobs:
         run: >
           pytest -o addopts= --no-cov -q
           tests/test_transformers_floor_compat.py
+          tests/test_plotext_compat.py
           tests/test_bugfixes.py::TestDiffModelLoading
 
   test:

--- a/changelog.d/0.73.3/507.changed.md
+++ b/changelog.d/0.73.3/507.changed.md
@@ -1,0 +1,10 @@
+- **Transformers training now supports Qwen3.5-family text decoders and can be
+  installed together with MLX (#502 and #503 by @Amix29 in #507).** The shared
+  stack moves to Transformers 5.12.1+, TRL 0.29+, and PEFT 0.20+, with exact
+  floor coverage and capability-based fallbacks for TRL APIs that moved under
+  `trl.experimental`. Transformers LoRA `target_modules: auto` now covers both
+  full- and linear-attention projections in Qwen3.5 text models without
+  changing explicit targets or MLX defaults. The compatibility pass also
+  updates removed Transformers arguments and keeps TRL 0.29's streamed DPO
+  reference adapter off `meta`, so it remains a frozen adapter-sized snapshot
+  instead of requiring a second model.

--- a/changelog.d/0.73.3/507.changed.md
+++ b/changelog.d/0.73.3/507.changed.md
@@ -9,4 +9,5 @@
   reference adapter off `meta`, so it remains a frozen adapter-sized snapshot
   instead of requiring a second model. DPO and ORPO also restore the removed
   prompt cap on TRL's prepared token ids, so `data.max_length` remains an
-  effective sequence bound rather than a configuration-only value.
+  effective sequence bound rather than a configuration-only value. The CLI's
+  histogram and loss-curve renderers now support both plotext 5 and plotext 6.

--- a/changelog.d/0.73.3/507.changed.md
+++ b/changelog.d/0.73.3/507.changed.md
@@ -7,4 +7,6 @@
   changing explicit targets or MLX defaults. The compatibility pass also
   updates removed Transformers arguments and keeps TRL 0.29's streamed DPO
   reference adapter off `meta`, so it remains a frozen adapter-sized snapshot
-  instead of requiring a second model.
+  instead of requiring a second model. DPO and ORPO also restore the removed
+  prompt cap on TRL's prepared token ids, so `data.max_length` remains an
+  effective sequence bound rather than a configuration-only value.

--- a/changelog.d/0.73.3/507.changed.md
+++ b/changelog.d/0.73.3/507.changed.md
@@ -1,8 +1,9 @@
 - **Transformers training now supports Qwen3.5-family text decoders and can be
   installed together with MLX (#502 and #503 by @Amix29 in #507).** The shared
   stack moves to Transformers 5.12.1+, TRL 0.29+, and PEFT 0.20+, with exact
-  floor coverage and capability-based fallbacks for TRL APIs that moved under
-  `trl.experimental`. Transformers LoRA `target_modules: auto` now covers both
+  floor coverage, matching `soup doctor` diagnostics, and capability-based fallbacks
+  for TRL APIs that moved under `trl.experimental`. Transformers LoRA
+  `target_modules: auto` now covers both
   full- and linear-attention projections in Qwen3.5 text models without
   changing explicit targets or MLX defaults. The compatibility pass also
   updates removed Transformers arguments and keeps TRL 0.29's streamed DPO
@@ -10,4 +11,5 @@
   instead of requiring a second model. DPO and ORPO also restore the removed
   prompt cap on TRL's prepared token ids, so `data.max_length` remains an
   effective sequence bound rather than a configuration-only value. The CLI's
-  histogram and loss-curve renderers now support both plotext 5 and plotext 6.
+  histogram and loss-curve renderers now support both plotext 5 and plotext 6, with
+  a real Plotext 6 runtime pinned in the compatibility CI cell.

--- a/changelog.d/0.73.3/522.fixed.md
+++ b/changelog.d/0.73.3/522.fixed.md
@@ -1,6 +1,5 @@
-- Fixed a crash on any fresh install: the unpinned `plotext` dependency started
-  resolving 6.0.0, which removed the plotting API (`clear_figure`/`hist`/`plot`) that
-  `soup data stats` histograms and `soup runs replay` charts are built on — every run
-  raised `AttributeError: module 'plotext' has no attribute 'clear_figure'`. The core
-  dependency is now capped at `<6.0.0`; support for both plotext majors arrives with
-  #507 (#522).
+- Fixed fresh installs with Plotext 6: `soup data stats` histograms and `soup runs`
+  loss charts now dispatch to Plotext 6's Figure API while retaining the Plotext 5
+  module-level path. The temporary `<6.0.0` dependency cap is lifted because both
+  supported majors are covered by the compatibility layer and regression tests
+  (#507, #522).

--- a/docs/backends-and-ops.md
+++ b/docs/backends-and-ops.md
@@ -82,11 +82,12 @@ Fine-tune on M1-M4 Macs via Apple's [MLX](https://github.com/ml-explore/mlx) fra
 pip install "soup-cli[mlx]"
 ```
 
-For SFT with local JSONL, JSON, or CSV data, `[mlx]` is a standalone install:
-do not add `[train]`. The latter is the PyTorch/TRL stack used by the
-Transformers backend. A Hugging Face `datasets` source or streaming dataset
-still needs `datasets` because that data source owns the dependency; the local
-file path below does not.
+For SFT with local JSONL, JSON, or CSV data, `[mlx]` is sufficient on its own.
+It can also be installed with `[train]` when the same environment needs the
+PyTorch/TRL Transformers backend: both extras now share the supported
+`transformers>=5.12.1,<6` range (#502/#503). A Hugging Face `datasets` source or
+streaming dataset still needs `datasets` because that data source owns the
+dependency; the local file path below does not.
 
 `detect_device()` and `get_gpu_info()` recognise Apple Silicon when
 `backend: mlx` is set, preserving `training.quantization: 4bit` for

--- a/docs/peft-and-efficiency.md
+++ b/docs/peft-and-efficiency.md
@@ -209,6 +209,12 @@ training:
 
 Catch-all friendly errors: typos in `optimizer:` are rejected at config-load with the v0.41.0 additions listed in the message; `lr_groups` patterns are validated as compilable regexes (length-capped + benign-string ReDoS probe); `load_in_8bit` mixed with `load_in_16bit` raises rather than picking one silently.
 
+On the Transformers backend, `target_modules: auto` has an explicit Qwen3.5-family
+fallback because PEFT does not yet map `qwen3_5_text`. Soup targets `q_proj` and
+`v_proj` in full-attention layers plus `in_proj_qkv` and `out_proj` in the fused
+linear-attention layers. Explicit target lists still win unchanged. The MLX backend
+keeps its separate full-key default (`self_attn.q_proj`, `self_attn.v_proj`).
+
 See `soup_cli.utils.optimizer_zoo.SUPPORTED_OPTIMIZERS` for the complete optimizer allowlist.
 
 

--- a/docs/serving-and-export.md
+++ b/docs/serving-and-export.md
@@ -252,11 +252,10 @@ soup serve --model ./output --kv-cache-type q8_0   # 8-bit quantized cache (need
 Use [vLLM](https://github.com/vllm-project/vllm) for significantly better throughput in production:
 
 > **Install `[serve-fast]` in a separate environment from `[train]`.** Their
-> resolutions are genuinely incompatible today — `pip install vllm` into a
-> training venv silently downgrades `torch` and pushes `transformers` past
-> Soup's own `<5.0.0` cap. `soup env check` now flags an installed package that
-> violates this distribution's declared bounds (exit code 3), so you can catch a
-> contaminated venv before a run relies on it.
+> accelerator stacks can still resolve different `torch` builds. `soup env
+> check` flags an installed package that violates this distribution's declared
+> bounds (exit code 3), so you can catch a contaminated venv before a run relies
+> on it.
 
 ```bash
 # Install vLLM support (in its own environment, not the training one)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,14 +37,9 @@ dependencies = [
     "pydantic>=2.0.0",
     "pyyaml>=6.0",
     "huggingface-hub>=0.16.0",
-    # Capped below 6 (#522). plotext 6.0 removed the entire imperative plotting
-    # API (`clear_figure`, `hist`, `plot`, `theme` — all verified absent in a
-    # clean venv), which is what `soup data stats` and `soup runs replay` use.
-    # CI resolved 6.0 on 2026-08-23 and failed the same 3 tests in all 9 matrix
-    # cells while local boxes stayed green only because they had no plotext at
-    # all (ImportError -> the histogram silently skips). #507 carries a compat
-    # layer supporting both majors; lifting this cap belongs to that merge.
-    "plotext>=5.2.0,<6.0.0",
+    # Plotext 6 replaced the module-level plotting API with Figure methods.
+    # Soup supports both the 5.x and 6.x surfaces through plotext_compat (#522).
+    "plotext>=5.2.0",
     # `env check` reads declared bounds via packaging (Requirement/marker/version).
     # It ships with pip and is pulled in transitively, but `env check` degrades to
     # a silent "clean" without it — the wrong direction for a checker — so it is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,15 +54,20 @@ dependencies = [
 
 [project.optional-dependencies]
 # v0.71.0 — heavy training stack. `pip install 'soup-cli[train]'` to fine-tune.
-# These were core dependencies through v0.70.0; pins are unchanged.
+# These were core dependencies through v0.70.0.
 train = [
     "torch>=2.0.0",
-    "transformers>=4.36.0,<5.0.0",
-    "peft>=0.7.0",
-    # Capped below 0.29. #326 raised this from `<0.27` after migrating the six
-    # preference trainers (bco, dpo, ipo, kto, orpo, simpo) off the two trl APIs
-    # that moved. The cap is no longer set by those trainers at all — see the
-    # 0.29 note at the bottom, which is about `online_dpo`.
+    # Qwen3.5 classes first ship in Transformers 5.2, but 5.12.1 is the first
+    # validated floor where an outer `qwen3_5` config selects the text-only
+    # Qwen3_5ForCausalLM correctly. The v5 range also makes `[train,mlx]`
+    # resolvable because mlx-lm requires Transformers 5.
+    "transformers>=5.12.1,<6.0.0",
+    # 0.20 is the validated Transformers 5 adapter floor. It still needs Soup's
+    # explicit qwen3_5_text target policy below the automatic PEFT mapping layer.
+    "peft>=0.20.0,<1.0.0",
+    # #326 migrated the six preference trainers (bco, dpo, ipo, kto, orpo,
+    # simpo) across TRL's staged API moves using capability probes instead of
+    # version checks. That lets the supported floor move to 0.29 here.
     #
     # trl removed `max_prompt_length` from the preference configs in STAGES
     # rather than in one release — which is why a single spot-check gives the
@@ -89,30 +94,20 @@ train = [
     # they live on under `trl.experimental.<algo>` — so those three trainers now
     # fall back to that path when the public import is gone.
     #
-    # WHY THE CAP IS 0.29 AND NOT HIGHER: `soup train --task online_dpo` is
-    # broken on 0.29.x, and the cause is not in these trainers. trl 0.29 moved
-    # `BasePairwiseJudge` to `trl.experimental.judges` while still accepting
-    # `judge=`, so the wrapper correctly selects the judge path and then
-    # `eval/judge.py::_base_pairwise_judge_cls` cannot import the base class.
-    # trl 1.x drops `judge=` entirely, so the wrapper falls back to
-    # `reward_funcs=` and online_dpo works again — measured: all nine tasks build
-    # on 1.9.2, and the six preference tasks train there. Raising the cap past
-    # 0.29 therefore needs (a) a `trl.experimental.judges` fallback in
-    # eval/judge.py and (b) validation of the trl surfaces this bump did not
-    # exercise (serve, GRPO variants, PPO with a real reward model). Shipping
-    # against a release nobody has validated is not a substitute for that.
+    # Transformers 5 changed a private availability helper that trl<=0.28
+    # imported, which makes absent optional packages look present and prevents
+    # DPO/GRPO modules from importing (#503). trl 0.29 vendors its own probe and
+    # is the first compatible release. It also moves BasePairwiseJudge to
+    # `trl.experimental.judges`; Soup resolves that capability from either home.
+    # Keep the upper bound below trl 1 because 1.x removes the pairwise `judge=`
+    # API and is a separate online-DPO migration.
     #
     # The underlying bug was latent, not new: the trl imports live inside
     # `setup()`, which no test had ever called on those wrappers, so CI stayed
     # green while anyone pip-installing got a broken install. v0.72.4's
     # end-to-end preference tests are what surfaced it.
     #
-    # The floor is 0.14.0, not 0.7.0: `setup()` imports GRPOTrainer
-    # unconditionally and trl first exports it at 0.14.0 (OnlineDPO / KTO / BCO /
-    # BasePairwiseJudge arrive at 0.11.0; trl 0.7.0 has none of them). Resolvers
-    # normally pick the newest allowed version, so the impossible floor only bit
-    # under a constraints file or anyone reading the metadata as a support claim.
-    "trl>=0.14.0,<0.29",
+    "trl>=0.29.0,<1.0.0",
     "datasets>=2.14.0",
     "bitsandbytes>=0.41.0",
     "accelerate>=0.25.0",
@@ -151,7 +146,7 @@ mlx = [
     "mlx-lm>=0.31.3",
     # mlx-lm imports transformers at runtime; keep the standalone contract from
     # depending on that transitive requirement remaining undeclared here.
-    "transformers>=5.0.0",
+    "transformers>=5.12.1,<6.0.0",
 ]
 cce = ["cut-cross-entropy>=24.10.0"]
 tui = ["textual>=0.50.0"]

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -619,13 +619,17 @@ def stats(
                     pass  # no .buffer (e.g. in tests), keep original
 
             try:
-                plt.clear_figure()
-                plt.hist(lengths, bins=30)
-                plt.title("Text Length Distribution (chars)")
-                plt.xlabel("Length")
-                plt.ylabel("Count")
-                plt.theme("dark")
-                plt.show()
+                from soup_cli.utils.plotext_compat import render_histogram
+
+                render_histogram(
+                    plt,
+                    lengths,
+                    bins=30,
+                    title="Text Length Distribution (chars)",
+                    xlabel="Length",
+                    ylabel="Count",
+                    theme="dark",
+                )
             finally:
                 sys.stdout = original_stdout
     except UnicodeEncodeError:

--- a/src/soup_cli/commands/doctor.py
+++ b/src/soup_cli/commands/doctor.py
@@ -17,9 +17,9 @@ console = Console()
 # Dependencies to check: (import_name, package_name, min_version, required)
 DEPS = [
     ("torch", "torch", "2.0.0", True),
-    ("transformers", "transformers", "4.36.0", True),
-    ("peft", "peft", "0.7.0", True),
-    ("trl", "trl", "0.7.0", True),
+    ("transformers", "transformers", "5.12.1", True),
+    ("peft", "peft", "0.20.0", True),
+    ("trl", "trl", "0.29.0", True),
     ("datasets", "datasets", "2.14.0", True),
     ("bitsandbytes", "bitsandbytes", "0.41.0", True),
     ("accelerate", "accelerate", "0.25.0", True),
@@ -43,12 +43,12 @@ DEPS = [
     ("librosa", "librosa", "0.10.0", False),
 ]
 
-# v0.40.1 Part C / C5 — packages whose major version we explicitly cap.
-# Empty by default; entries gate the dependency table to flag a
-# breaking-major upgrade (e.g. transformers 5.x) as INCOMPATIBLE rather
-# than silently allowing it.
+# Packages whose declared breaking-major ceiling must be reported as
+# incompatible instead of silently green-lighted by ``soup doctor``.
 _MAX_EXCLUSIVE: dict[str, str] = {
-    "transformers": "5.0.0",
+    "transformers": "6.0.0",
+    "peft": "1.0.0",
+    "trl": "1.0.0",
 }
 
 
@@ -119,8 +119,7 @@ def doctor(
                     version = "?"
             version_str = str(version)
 
-            # v0.40.1 Part C / C5 — flag transformers 5.x as INCOMPATIBLE
-            # until the TRL/transformers 5.x migration lands.
+            # Flag versions beyond Soup's validated compatibility band.
             max_excl = _MAX_EXCLUSIVE.get(pkg_name)
             if max_excl and _version_ge(version_str, max_excl):
                 status = f"[red]INCOMPATIBLE (need <{max_excl})[/]"

--- a/src/soup_cli/commands/runs.py
+++ b/src/soup_cli/commands/runs.py
@@ -555,13 +555,18 @@ def _plot_loss_curve(metrics: list[dict]) -> None:
         console.print("[dim]No loss data to plot.[/]")
         return
 
-    plt.clear_figure()
-    plt.plot(steps, losses, label="loss")
-    plt.title("Training Loss")
-    plt.xlabel("Step")
-    plt.ylabel("Loss")
-    plt.theme("dark")
-    plt.show()
+    from soup_cli.utils.plotext_compat import render_line
+
+    render_line(
+        plt,
+        steps,
+        losses,
+        label="loss",
+        title="Training Loss",
+        xlabel="Step",
+        ylabel="Loss",
+        theme="dark",
+    )
 
 
 @app.command(name="curriculum-curve")

--- a/src/soup_cli/eval/judge.py
+++ b/src/soup_cli/eval/judge.py
@@ -514,13 +514,15 @@ def make_judge_reward_func(evaluator: object, *, name: str = "soup_judge"):
 
 def _base_pairwise_judge_cls() -> type:
     """Lazily import TRL's ``BasePairwiseJudge`` with a friendly error."""
+    from soup_cli.trainer._trl_compat import resolve_trl_symbol
+
     try:
-        from trl import BasePairwiseJudge
+        return resolve_trl_symbol("BasePairwiseJudge", "trl.experimental.judges")
     except ImportError as exc:  # pragma: no cover — trl ships in [train]/[dev]
         raise ImportError(
-            "SoupPairwiseJudge needs trl>=0.19 (pip install \"soup-cli[train]\")"
+            "SoupPairwiseJudge needs trl with BasePairwiseJudge support "
+            '(pip install "soup-cli[train]")'
         ) from exc
-    return BasePairwiseJudge
 
 
 def make_soup_pairwise_judge(evaluator: "PairwiseJudge") -> "BasePairwiseJudge":

--- a/src/soup_cli/trainer/_trl_compat.py
+++ b/src/soup_cli/trainer/_trl_compat.py
@@ -16,9 +16,11 @@ Measured by constructing each config with the exact keyword the wrappers pass:
     0.28.0           yes   NO    NO     NO    NO
     0.29.0 - 1.9.2   NO    NO    NO     NO    NO
 
-There is no successor field. ``max_length`` survives on every version and
-prompt truncation is folded into it, so the migration is simply to stop
-passing the keyword to a config that no longer has it — NOT to rename it.
+There is no successor field. ``max_length`` survives on every version, but
+TRL 0.29.0 no longer applies it to prepared DPO prompts and ORPO's legacy
+tokenizer can also emit an over-length pair once ``max_prompt_length`` is
+gone. Soup therefore restores the removed prompt cap on the tokenized dataset
+instead of merely dropping the rejected keyword.
 
 **2. Three configs left the public ``trl`` namespace at 0.29.0.**
 ``ORPOConfig`` / ``CPOConfig`` / ``BCOConfig`` and their trainers were not
@@ -116,3 +118,106 @@ def prompt_length_kwargs(config_cls: type, max_prompt_length: int) -> dict[str, 
     if config_accepts(config_cls, "max_prompt_length"):
         return {"max_prompt_length": max_prompt_length}
     return {}
+
+
+def _truncate_tokens(tokens: list[int], limit: int, mode: str) -> list[int]:
+    """Truncate one token sequence using TRL's preference-side convention."""
+    if limit <= 0:
+        return []
+    if len(tokens) <= limit:
+        return tokens
+    if mode == "keep_end":
+        return tokens[-limit:]
+    return tokens[:limit]
+
+
+def enforce_preference_sequence_limit(
+    dataset: Any,
+    *,
+    max_length: int,
+    max_prompt_length: int,
+    truncation_mode: str,
+) -> Any:
+    """Restore TRL's removed prompt cap on an already-tokenized dataset.
+
+    TRL 0.29 exposes two preference dataset layouts. DPO stores a shared
+    ``prompt_ids`` plus separate completion ids; experimental ORPO stores two
+    combined sequences whose prompt span is identified by ``-100`` labels.
+    Applying the cap after TRL tokenizes keeps text and conversational inputs
+    on the exact same chat-template path while guaranteeing that the tensors
+    reaching the model obey ``data.max_length``.
+    """
+    columns = set(getattr(dataset, "column_names", ()))
+    dpo_columns = {"prompt_ids", "chosen_ids", "rejected_ids"}
+    orpo_columns = {
+        "prompt_input_ids",
+        "prompt_attention_mask",
+        "chosen_input_ids",
+        "chosen_attention_mask",
+        "chosen_labels",
+        "rejected_input_ids",
+        "rejected_attention_mask",
+        "rejected_labels",
+    }
+
+    if dpo_columns <= columns:
+
+        def cap_dpo(row: dict[str, Any]) -> dict[str, Any]:
+            prompt = _truncate_tokens(
+                list(row["prompt_ids"]), max_prompt_length, truncation_mode
+            )
+            completion_limit = max(0, max_length - len(prompt))
+            return {
+                "prompt_ids": prompt,
+                "chosen_ids": list(row["chosen_ids"])[:completion_limit],
+                "rejected_ids": list(row["rejected_ids"])[:completion_limit],
+            }
+
+        return dataset.map(cap_dpo)
+
+    if orpo_columns <= columns:
+
+        def cap_combined(row: dict[str, Any], prefix: str) -> dict[str, list[int]]:
+            input_ids = list(row[f"{prefix}_input_ids"])
+            attention_mask = list(row[f"{prefix}_attention_mask"])
+            labels = list(row[f"{prefix}_labels"])
+            prompt_size = next(
+                (index for index, label in enumerate(labels) if label != -100),
+                len(labels),
+            )
+            prompt_ids = _truncate_tokens(
+                input_ids[:prompt_size], max_prompt_length, truncation_mode
+            )
+            prompt_mask = _truncate_tokens(
+                attention_mask[:prompt_size], max_prompt_length, truncation_mode
+            )
+            completion_limit = max(0, max_length - len(prompt_ids))
+            completion_ids = input_ids[prompt_size:][:completion_limit]
+            completion_mask = attention_mask[prompt_size:][:completion_limit]
+            completion_labels = labels[prompt_size:][:completion_limit]
+            return {
+                f"{prefix}_input_ids": prompt_ids + completion_ids,
+                f"{prefix}_attention_mask": prompt_mask + completion_mask,
+                f"{prefix}_labels": [-100] * len(prompt_ids) + completion_labels,
+            }
+
+        def cap_orpo(row: dict[str, Any]) -> dict[str, Any]:
+            prompt_ids = _truncate_tokens(
+                list(row["prompt_input_ids"]), max_prompt_length, truncation_mode
+            )
+            prompt_mask = _truncate_tokens(
+                list(row["prompt_attention_mask"]), max_prompt_length, truncation_mode
+            )
+            return {
+                "prompt_input_ids": prompt_ids,
+                "prompt_attention_mask": prompt_mask,
+                **cap_combined(row, "chosen"),
+                **cap_combined(row, "rejected"),
+            }
+
+        return dataset.map(cap_orpo)
+
+    raise ValueError(
+        "TRL prepared a preference dataset with an unknown token layout; "
+        f"cannot enforce max_length={max_length}. Columns: {sorted(columns)}"
+    )

--- a/src/soup_cli/trainer/asr.py
+++ b/src/soup_cli/trainer/asr.py
@@ -364,7 +364,7 @@ class AsrTrainerWrapper:
             train_dataset=train_ds,
             eval_dataset=eval_ds,
             data_collator=collator,
-            tokenizer=self.processor.feature_extractor,
+            processing_class=self.processor.feature_extractor,
         )
 
         # #359 - the same exposure #336 fixed in sft.py: with LoRA the

--- a/src/soup_cli/trainer/bco.py
+++ b/src/soup_cli/trainer/bco.py
@@ -291,9 +291,9 @@ class BCOTrainerWrapper:
         if tcfg.quantization in ("4bit", "8bit", "mxfp4"):
             self.model = prepare_model_for_kbit_training(self.model)
 
-        target_modules = tcfg.lora.target_modules
-        if target_modules == "auto":
-            target_modules = None
+        from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+
+        target_modules = resolve_lora_target_modules(self.model, tcfg.lora.target_modules)
 
         lora_config = LoraConfig(
             r=tcfg.lora.r,

--- a/src/soup_cli/trainer/classifier.py
+++ b/src/soup_cli/trainer/classifier.py
@@ -266,11 +266,12 @@ class ClassifierTrainerWrapper:
             from soup_cli.utils.peft_wiring import (
                 apply_post_lora_patches,
                 apply_pre_lora_patches,
+                resolve_lora_target_modules,
             )
 
-            target_modules = tcfg.lora.target_modules
-            if target_modules == "auto":
-                target_modules = None
+            target_modules = resolve_lora_target_modules(
+                self.model, tcfg.lora.target_modules
+            )
             lora_config = LoraConfig(
                 r=tcfg.lora.r,
                 lora_alpha=tcfg.lora.alpha,
@@ -364,7 +365,7 @@ class ClassifierTrainerWrapper:
             args=args,
             train_dataset=train_ds,
             eval_dataset=eval_ds,
-            tokenizer=self.tokenizer,
+            processing_class=self.tokenizer,
             data_collator=DataCollatorWithPadding(tokenizer=self.tokenizer),
         )
 

--- a/src/soup_cli/trainer/distill.py
+++ b/src/soup_cli/trainer/distill.py
@@ -239,9 +239,9 @@ class DistillTrainerWrapper:
         )
 
         # LoRA on the student — bracket with v0.40.6 #67 surgical PEFT patches.
-        target_modules = tcfg.lora.target_modules
-        if target_modules == "auto":
-            target_modules = None
+        from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+
+        target_modules = resolve_lora_target_modules(self.model, tcfg.lora.target_modules)
         lora_config = LoraConfig(
             r=tcfg.lora.r,
             lora_alpha=tcfg.lora.alpha,
@@ -669,7 +669,7 @@ class DistillTrainerWrapper:
             args=args,
             train_dataset=train_ds,
             eval_dataset=eval_ds,
-            tokenizer=self.tokenizer,
+            processing_class=self.tokenizer,
             data_collator=DataCollatorForSeq2Seq(
                 tokenizer=self.tokenizer,
                 label_pad_token_id=-100,

--- a/src/soup_cli/trainer/dpo.py
+++ b/src/soup_cli/trainer/dpo.py
@@ -211,6 +211,14 @@ class DPOTrainerWrapper(StreamingSetupMixin):
             eval_dataset=eval_ds,
             processing_class=self.tokenizer,
         )
+        if tcfg.stream_layers:
+            # TRL 0.29 snapshots the initial policy as a frozen ``ref`` LoRA
+            # adapter. PEFT creates that late adapter on the streamed decoder's
+            # meta skeleton, where TRL's copy_ is a no-op, so give the snapshot
+            # real adapter-sized storage before its first reference forward.
+            from soup_cli.utils.layer_stream_runtime import materialize_meta_adapter_copy
+
+            materialize_meta_adapter_copy(self.model)
 
         # #359 - the same exposure #336 fixed in sft.py: with LoRA the
         # no-decay optimizer group is empty, DeepSpeed drops it, and the LR
@@ -281,9 +289,9 @@ class DPOTrainerWrapper(StreamingSetupMixin):
         if tcfg.quantization in ("4bit", "8bit", "mxfp4"):
             self.model = prepare_model_for_kbit_training(self.model)
 
-        target_modules = tcfg.lora.target_modules
-        if target_modules == "auto":
-            target_modules = None
+        from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+
+        target_modules = resolve_lora_target_modules(self.model, tcfg.lora.target_modules)
 
         lora_config = LoraConfig(
             r=tcfg.lora.r,

--- a/src/soup_cli/trainer/dpo.py
+++ b/src/soup_cli/trainer/dpo.py
@@ -74,7 +74,11 @@ class DPOTrainerWrapper(StreamingSetupMixin):
         from datasets import Dataset
         from trl import DPOConfig, DPOTrainer
 
-        from soup_cli.trainer._trl_compat import prompt_length_kwargs
+        from soup_cli.trainer._trl_compat import (
+            config_accepts,
+            enforce_preference_sequence_limit,
+            prompt_length_kwargs,
+        )
 
         # Enable Rich progress bar for HuggingFace downloads
         from soup_cli.trainer.sft import _enable_hf_transfer_progress
@@ -211,6 +215,22 @@ class DPOTrainerWrapper(StreamingSetupMixin):
             eval_dataset=eval_ds,
             processing_class=self.tokenizer,
         )
+        if not config_accepts(DPOConfig, "max_prompt_length"):
+            # TRL 0.29 removed the prompt cap and its new DPO tokenizer leaves
+            # max_length enforcement to callers. Cap the prepared token ids so
+            # text and conversational rows keep TRL's own rendering semantics.
+            cap_kwargs = {
+                "max_length": cfg.data.max_length,
+                "max_prompt_length": cfg.data.max_length // 2,
+                "truncation_mode": dpo_config.truncation_mode,
+            }
+            self.trainer.train_dataset = enforce_preference_sequence_limit(
+                self.trainer.train_dataset, **cap_kwargs
+            )
+            if self.trainer.eval_dataset is not None:
+                self.trainer.eval_dataset = enforce_preference_sequence_limit(
+                    self.trainer.eval_dataset, **cap_kwargs
+                )
         if tcfg.stream_layers:
             # TRL 0.29 snapshots the initial policy as a frozen ``ref`` LoRA
             # adapter. PEFT creates that late adapter on the streamed decoder's

--- a/src/soup_cli/trainer/embedding.py
+++ b/src/soup_cli/trainer/embedding.py
@@ -252,9 +252,9 @@ class EmbeddingTrainerWrapper:
         if tcfg.quantization in ("4bit", "8bit", "mxfp4"):
             self.model = prepare_model_for_kbit_training(self.model)
 
-        target_modules = tcfg.lora.target_modules
-        if target_modules == "auto":
-            target_modules = None
+        from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+
+        target_modules = resolve_lora_target_modules(self.model, tcfg.lora.target_modules)
 
         lora_config = LoraConfig(
             r=tcfg.lora.r,

--- a/src/soup_cli/trainer/grpo.py
+++ b/src/soup_cli/trainer/grpo.py
@@ -545,9 +545,9 @@ class GRPOTrainerWrapper:
         if tcfg.quantization in ("4bit", "8bit", "mxfp4"):
             self.model = prepare_model_for_kbit_training(self.model)
 
-        target_modules = tcfg.lora.target_modules
-        if target_modules == "auto":
-            target_modules = None
+        from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+
+        target_modules = resolve_lora_target_modules(self.model, tcfg.lora.target_modules)
 
         lora_config = LoraConfig(
             r=tcfg.lora.r,

--- a/src/soup_cli/trainer/ipo.py
+++ b/src/soup_cli/trainer/ipo.py
@@ -238,9 +238,9 @@ class IPOTrainerWrapper:
         if tcfg.quantization in ("4bit", "8bit", "mxfp4"):
             self.model = prepare_model_for_kbit_training(self.model)
 
-        target_modules = tcfg.lora.target_modules
-        if target_modules == "auto":
-            target_modules = None
+        from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+
+        target_modules = resolve_lora_target_modules(self.model, tcfg.lora.target_modules)
 
         lora_config = LoraConfig(
             r=tcfg.lora.r,

--- a/src/soup_cli/trainer/kto.py
+++ b/src/soup_cli/trainer/kto.py
@@ -270,9 +270,9 @@ class KTOTrainerWrapper(StreamingSetupMixin):
         if tcfg.quantization in ("4bit", "8bit", "mxfp4"):
             self.model = prepare_model_for_kbit_training(self.model)
 
-        target_modules = tcfg.lora.target_modules
-        if target_modules == "auto":
-            target_modules = None
+        from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+
+        target_modules = resolve_lora_target_modules(self.model, tcfg.lora.target_modules)
 
         lora_config = LoraConfig(
             r=tcfg.lora.r,

--- a/src/soup_cli/trainer/online_dpo.py
+++ b/src/soup_cli/trainer/online_dpo.py
@@ -8,9 +8,9 @@ DPO generates two completions per prompt ON-POLICY at each step and asks a
 Data is prompt-only (like GRPO): Soup's ``{"messages": [...]}`` rows are
 normalized to the OnlineDPO ``prompt`` column (chat, minus the assistant turn).
 
-**Cross-version adapter.** TRL changed the OnlineDPO API between 0.19.x and 1.x:
+**Cross-version adapter.** TRL changed the OnlineDPO API before 1.0 and in 1.x:
 
-- **trl 0.19.x** — ``from trl import OnlineDPOTrainer``; the judge is a
+- **trl <1** — the trainer and judge may live under ``trl.experimental``; the judge is a
   ``BasePairwiseJudge`` (swap-debiased *pairwise* comparison, via
   :func:`soup_cli.eval.judge.make_soup_pairwise_judge`); a reward model is
   passed as ``reward_model=`` / ``reward_processing_class=``.
@@ -49,29 +49,6 @@ console = Console()
 _ONLINE_DPO_JUDGE_OVERRIDE = None
 
 
-def _import_online_dpo():
-    """Import ``OnlineDPOConfig``/``OnlineDPOTrainer`` across trl versions.
-
-    trl 0.19.x exposes them at the top level; trl 1.x moved them to
-    ``trl.experimental.online_dpo``.
-    """
-    try:
-        from trl import OnlineDPOConfig, OnlineDPOTrainer
-
-        return OnlineDPOConfig, OnlineDPOTrainer
-    except ImportError:
-        pass
-    try:
-        from trl.experimental.online_dpo import OnlineDPOConfig, OnlineDPOTrainer
-
-        return OnlineDPOConfig, OnlineDPOTrainer
-    except ImportError as exc:  # pragma: no cover — trl ships in [train]
-        raise ImportError(
-            "task='online_dpo' requires trl with OnlineDPO support "
-            "(pip install \"soup-cli[train]\")"
-        ) from exc
-
-
 def _trl_accepts(param: str) -> bool:
     """Does the installed ``OnlineDPOTrainer`` actually take this keyword?
 
@@ -104,15 +81,16 @@ def _trl_accepts(param: str) -> bool:
     """
     import inspect
 
-    try:
-        from trl import OnlineDPOTrainer
-    except ImportError:
-        try:
-            from trl.experimental.online_dpo import OnlineDPOTrainer
-        except ImportError:
-            return False
+    from soup_cli.trainer._trl_compat import resolve_trl_symbol
 
-    for base in OnlineDPOTrainer.__mro__:
+    try:
+        online_dpo_trainer_cls = resolve_trl_symbol(
+            "OnlineDPOTrainer", "trl.experimental.online_dpo"
+        )
+    except ImportError:
+        return False
+
+    for base in online_dpo_trainer_cls.__mro__:
         init = base.__dict__.get("__init__")
         if init is None:
             continue
@@ -231,7 +209,14 @@ class OnlineDPOTrainerWrapper:
         """Load model, tokenizer, build the OnlineDPO trainer (judge in loop)."""
         from datasets import Dataset
 
-        OnlineDPOConfig, OnlineDPOTrainer = _import_online_dpo()  # noqa: N806 (classes)
+        from soup_cli.trainer._trl_compat import resolve_trl_symbol
+
+        online_dpo_config_cls = resolve_trl_symbol(
+            "OnlineDPOConfig", "trl.experimental.online_dpo"
+        )
+        online_dpo_trainer_cls = resolve_trl_symbol(
+            "OnlineDPOTrainer", "trl.experimental.online_dpo"
+        )
 
         from soup_cli.trainer.sft import _enable_hf_transfer_progress
 
@@ -287,7 +272,7 @@ class OnlineDPOTrainerWrapper:
         warmup_steps = int(total_steps * tcfg.warmup_ratio)
 
         _bf16, _fp16 = bf16_fp16_flags(self.device)
-        odpo_config = OnlineDPOConfig(
+        odpo_config = online_dpo_config_cls(
             output_dir=str(output_dir),
             num_train_epochs=tcfg.epochs,
             per_device_train_batch_size=batch_size,
@@ -314,7 +299,7 @@ class OnlineDPOTrainerWrapper:
 
         judge_or_reward = self._build_judge_or_reward(tcfg)
 
-        self.trainer = OnlineDPOTrainer(
+        self.trainer = online_dpo_trainer_cls(
             model=self.model,
             args=odpo_config,
             train_dataset=train_ds,
@@ -396,9 +381,9 @@ class OnlineDPOTrainerWrapper:
 
             self.model = prepare_model_for_kbit_training(self.model)
 
-        target_modules = tcfg.lora.target_modules
-        if target_modules == "auto":
-            target_modules = None
+        from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+
+        target_modules = resolve_lora_target_modules(self.model, tcfg.lora.target_modules)
 
         self.peft_config = LoraConfig(
             r=tcfg.lora.r,
@@ -419,7 +404,7 @@ class OnlineDPOTrainerWrapper:
     @staticmethod
     def _judge_kwargs(evaluator, has_judges: bool) -> dict:
         """Adapt a Soup evaluator to the installed trl's judge/reward API."""
-        if has_judges:  # trl 0.19.x — swap-debiased pairwise judge
+        if has_judges:  # trl <1 — swap-debiased pairwise judge
             from soup_cli.eval.judge import make_soup_pairwise_judge
 
             return {"judge": make_soup_pairwise_judge(evaluator)}
@@ -434,7 +419,7 @@ class OnlineDPOTrainerWrapper:
         Precedence: the test seam, then the judge URL, then a reward model. The
         schema cross-validator guarantees exactly one of judge/reward is set for
         a real config. The returned kwargs adapt to the installed trl version
-        (``judge=`` on 0.19.x, ``reward_funcs=`` on 1.x).
+        (``judge=`` before trl 1, ``reward_funcs=`` on trl 1.x).
         """
         has_judges = _trl_has_judges()
         if _ONLINE_DPO_JUDGE_OVERRIDE is not None:

--- a/src/soup_cli/trainer/orpo.py
+++ b/src/soup_cli/trainer/orpo.py
@@ -278,9 +278,9 @@ class ORPOTrainerWrapper(StreamingSetupMixin):
         if tcfg.quantization in ("4bit", "8bit", "mxfp4"):
             self.model = prepare_model_for_kbit_training(self.model)
 
-        target_modules = tcfg.lora.target_modules
-        if target_modules == "auto":
-            target_modules = None
+        from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+
+        target_modules = resolve_lora_target_modules(self.model, tcfg.lora.target_modules)
 
         lora_config = LoraConfig(
             r=tcfg.lora.r,

--- a/src/soup_cli/trainer/orpo.py
+++ b/src/soup_cli/trainer/orpo.py
@@ -75,6 +75,8 @@ class ORPOTrainerWrapper(StreamingSetupMixin):
         from datasets import Dataset
 
         from soup_cli.trainer._trl_compat import (
+            config_accepts,
+            enforce_preference_sequence_limit,
             prompt_length_kwargs,
             resolve_trl_symbol,
         )
@@ -213,6 +215,21 @@ class ORPOTrainerWrapper(StreamingSetupMixin):
             eval_dataset=eval_ds,
             processing_class=self.tokenizer,
         )
+        if not config_accepts(orpo_config_cls, "max_prompt_length"):
+            # TRL's experimental ORPO tokenizer still assumes the removed
+            # prompt cap has already run. Restore it on the prepared token ids.
+            cap_kwargs = {
+                "max_length": cfg.data.max_length,
+                "max_prompt_length": cfg.data.max_length // 2,
+                "truncation_mode": orpo_config.truncation_mode,
+            }
+            self.trainer.train_dataset = enforce_preference_sequence_limit(
+                self.trainer.train_dataset, **cap_kwargs
+            )
+            if self.trainer.eval_dataset is not None:
+                self.trainer.eval_dataset = enforce_preference_sequence_limit(
+                    self.trainer.eval_dataset, **cap_kwargs
+                )
 
         # #359 - the same exposure #336 fixed in sft.py: with LoRA the
         # no-decay optimizer group is empty, DeepSpeed drops it, and the LR

--- a/src/soup_cli/trainer/ppo.py
+++ b/src/soup_cli/trainer/ppo.py
@@ -464,9 +464,9 @@ class PPOTrainerWrapper:
         if tcfg.quantization in ("4bit", "8bit", "mxfp4"):
             self.model = prepare_model_for_kbit_training(self.model)
 
-        target_modules = tcfg.lora.target_modules
-        if target_modules == "auto":
-            target_modules = None
+        from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+
+        target_modules = resolve_lora_target_modules(self.model, tcfg.lora.target_modules)
 
         lora_config = LoraConfig(
             r=tcfg.lora.r,

--- a/src/soup_cli/trainer/pretrain.py
+++ b/src/soup_cli/trainer/pretrain.py
@@ -314,9 +314,9 @@ class PretrainTrainerWrapper:
         apply_block_expansion_if_configured(self.model, tcfg, console)
 
         # LoRA — with MoE-aware target modules if moe_lora is enabled
-        target_modules = tcfg.lora.target_modules
-        if target_modules == "auto":
-            target_modules = None
+        from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+
+        target_modules = resolve_lora_target_modules(self.model, tcfg.lora.target_modules)
 
         if tcfg.moe_lora and is_moe:
             moe_targets = get_moe_target_modules(self.model)

--- a/src/soup_cli/trainer/reward_model.py
+++ b/src/soup_cli/trainer/reward_model.py
@@ -234,9 +234,9 @@ class RewardModelTrainerWrapper:
         if tcfg.quantization in ("4bit", "8bit", "mxfp4"):
             self.model = prepare_model_for_kbit_training(self.model)
 
-        target_modules = tcfg.lora.target_modules
-        if target_modules == "auto":
-            target_modules = None
+        from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+
+        target_modules = resolve_lora_target_modules(self.model, tcfg.lora.target_modules)
 
         lora_config = LoraConfig(
             r=tcfg.lora.r,

--- a/src/soup_cli/trainer/sft.py
+++ b/src/soup_cli/trainer/sft.py
@@ -304,9 +304,9 @@ def _make_vision_trainer(
 
     kwargs = dict(trainer_kwargs)
     kwargs["data_collator"] = VisionLanguageDataCollator(processor, max_length)
-    # Transformers renamed Trainer(tokenizer=...) to processing_class. Soup's
-    # declared floor predates the rename, so keep this narrow compatibility
-    # shim at the construction boundary.
+    # Transformers renamed Trainer(tokenizer=...) to processing_class. Keep a
+    # narrow capability shim for downstream Trainer subclasses that still
+    # expose the legacy constructor name.
     if "processing_class" not in inspect.signature(Trainer.__init__).parameters:
         kwargs["tokenizer"] = kwargs.pop("processing_class")
     return Trainer(**kwargs)
@@ -1387,9 +1387,11 @@ class SFTTrainerWrapper(StreamingSetupMixin):
             )
         else:
             # LoRA — with MoE-aware target modules if moe_lora is enabled
-            target_modules = tcfg.lora.target_modules
-            if target_modules == "auto":
-                target_modules = None
+            from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+
+            target_modules = resolve_lora_target_modules(
+                self.model, tcfg.lora.target_modules
+            )
 
             if tcfg.moe_lora and is_moe:
                 moe_targets = get_moe_target_modules(self.model)
@@ -1481,7 +1483,7 @@ class SFTTrainerWrapper(StreamingSetupMixin):
     def _setup_vision_transformers(self, cfg, tcfg):
         """Load vision-language model via transformers (LLaMA-Vision, Qwen2-VL, etc.)."""
         from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training
-        from transformers import AutoModelForVision2Seq, AutoProcessor
+        from transformers import AutoModelForImageTextToText, AutoProcessor
 
         console.print(f"[dim]Loading vision processor: {cfg.base}[/]")
         self.processor = AutoProcessor.from_pretrained(
@@ -1524,7 +1526,7 @@ class SFTTrainerWrapper(StreamingSetupMixin):
         if quant_config_obj is not None:
             model_kwargs["quantization_config"] = quant_config_obj
 
-        self.model = AutoModelForVision2Seq.from_pretrained(cfg.base, **model_kwargs)
+        self.model = AutoModelForImageTextToText.from_pretrained(cfg.base, **model_kwargs)
         from soup_cli.utils.data_pipeline import apply_vocab_expansion
 
         apply_vocab_expansion(
@@ -1536,9 +1538,9 @@ class SFTTrainerWrapper(StreamingSetupMixin):
             self.model = prepare_model_for_kbit_training(self.model)
 
         # LoRA — target language model layers only
-        target_modules = tcfg.lora.target_modules
-        if target_modules == "auto":
-            target_modules = None
+        from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+
+        target_modules = resolve_lora_target_modules(self.model, tcfg.lora.target_modules)
 
         lora_config = LoraConfig(
             r=tcfg.lora.r,
@@ -1652,9 +1654,9 @@ class SFTTrainerWrapper(StreamingSetupMixin):
             self.model = prepare_model_for_kbit_training(self.model)
 
         # LoRA — target language model layers only
-        target_modules = tcfg.lora.target_modules
-        if target_modules == "auto":
-            target_modules = None
+        from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+
+        target_modules = resolve_lora_target_modules(self.model, tcfg.lora.target_modules)
 
         lora_config = LoraConfig(
             r=tcfg.lora.r,

--- a/src/soup_cli/trainer/simpo.py
+++ b/src/soup_cli/trainer/simpo.py
@@ -280,9 +280,9 @@ class SimPOTrainerWrapper(StreamingSetupMixin):
         if tcfg.quantization in ("4bit", "8bit", "mxfp4"):
             self.model = prepare_model_for_kbit_training(self.model)
 
-        target_modules = tcfg.lora.target_modules
-        if target_modules == "auto":
-            target_modules = None
+        from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+
+        target_modules = resolve_lora_target_modules(self.model, tcfg.lora.target_modules)
 
         lora_config = LoraConfig(
             r=tcfg.lora.r,

--- a/src/soup_cli/trainer/stream_setup.py
+++ b/src/soup_cli/trainer/stream_setup.py
@@ -453,9 +453,9 @@ class StreamingSetupMixin:
                     f"[dim]expandable_segments allocator hint not enabled: {why_not}[/]"
                 )
 
-        target_modules = tcfg.lora.target_modules
-        if target_modules == "auto":
-            target_modules = None
+        from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+
+        target_modules = resolve_lora_target_modules(model_config, tcfg.lora.target_modules)
         if tcfg.moe_lora and is_moe and moe_targets:
             target_modules = moe_targets
             console.print(

--- a/src/soup_cli/utils/env_lock.py
+++ b/src/soup_cli/utils/env_lock.py
@@ -66,10 +66,10 @@ _VALID_SOURCES = frozenset({"pip", "conda", "system", "wheel", "unknown"})
 # Extras that make up a Soup TRAINING install — the environment #368 is about
 # (a training venv later contaminated by `pip install "soup-cli[serve-fast]"`).
 # `[all]` and `[dev]` both re-declare `soup-cli[train,...]`, which pip flattens,
-# so metadata restates the training bounds under each of these three. `[mlx]` is
-# deliberately NOT here: it declares `transformers>=5.0.0` against `[train]`'s
-# `<5.0.0`, an incompatibility by design that no single environment satisfies.
-_TRAINING_INSTALL_EXTRAS: Tuple[str, ...] = ("train", "all", "dev")
+# so metadata restates the training bounds under each of these three. `[mlx]`
+# shares the same Transformers 5 range after #502, so its ABI bound is safe to
+# enforce too (including for a standalone MLX install).
+_TRAINING_INSTALL_EXTRAS: Tuple[str, ...] = ("train", "all", "dev", "mlx")
 
 # ABI-sensitive packages — drift here is most likely to break training.
 TRACKED_PACKAGES: Tuple[str, ...] = (
@@ -274,15 +274,13 @@ def check_declared_bounds(
         # ...except for the ABI-relevant set under a TRAINING extra. Since the
         # v0.71.0 deps-split, `transformers`, `torch` and `trl` live in metadata
         # ONLY under `extra == "train"/"all"/"dev"`, so deselecting every gated
-        # requirement also deselected the `transformers <5.0.0` case #368 was
+        # requirement also deselected the bounded `transformers` case #368 was
         # filed about — leaving `typer` as the single bound this could ever fire
         # on.
         #
         # The extra scope is load-bearing, not decoration: a tracked NAME alone
-        # is not enough, because `[mlx]` declares `transformers>=5.0.0` against
-        # `[train]`'s `<5.0.0`. Those two are deliberately incompatible, so
-        # enforcing both would make EVERY installed transformers violate exactly
-        # one of them — a false positive on every machine.
+        # is not enough because unrelated extras may legitimately carry their
+        # own bounds. Only the supported training/MLX environments are selected.
         def selects(marker, extra: str) -> bool:
             try:
                 return bool(marker.evaluate({"extra": extra}))

--- a/src/soup_cli/utils/layer_stream_runtime.py
+++ b/src/soup_cli/utils/layer_stream_runtime.py
@@ -1340,9 +1340,8 @@ def build_meta_skeleton(
     if quant == QUANT_NF4:
         quant_config = build_nf4_config(dtype, double_quant=double_quant)
     with init_empty_weights():
-        # torch_dtype= is the spelling that works across Soup's declared
-        # transformers range (>=4.36,<5). dtype= is the >=4.56 rename only
-        # (#478 / #471); using it here would TypeError on older installs.
+        # Keep the model-construction spelling aligned with the load-site
+        # compatibility guard in tests/test_transformers_floor_compat.py.
         model = AutoModelForCausalLM.from_config(
             config, torch_dtype=torch_dtype, trust_remote_code=trust_remote_code
         )
@@ -1507,6 +1506,53 @@ def assert_trainable_adapters_materialized(model: Any) -> None:
         "trainable LoRA parameters remain on the meta device after adapter "
         f"materialization: {preview}. Refusing to train adapters without storage."
     )
+
+
+def materialize_meta_adapter_copy(
+    model: Any, *, source_adapter: str = "default", target_adapter: str = "ref"
+) -> int:
+    """Materialize a frozen adapter copy that PEFT created on ``meta``.
+
+    TRL 0.29 creates a ``ref`` adapter when DPO receives an existing PEFT
+    model. On a layer-streamed model the decoder skeleton lives on ``meta``, so
+    PEFT also creates the new adapter there and TRL's subsequent ``copy_`` is a
+    no-op. Copy each matching source parameter into real storage explicitly;
+    the reference remains frozen and still costs only adapter-sized memory.
+    """
+    source_marker = f".{source_adapter}."
+    target_marker = f".{target_adapter}."
+    parameters = dict(model.named_parameters())
+    copied = 0
+
+    for target_name, target_param in list(parameters.items()):
+        if target_marker not in target_name or not target_param.is_meta:
+            continue
+        source_name = target_name.replace(target_marker, source_marker, 1)
+        source_param = parameters.get(source_name)
+        if source_param is None:
+            raise RuntimeError(
+                f"cannot materialize adapter {target_adapter!r}: "
+                f"no source parameter {source_name!r}"
+            )
+        if source_param.is_meta:
+            raise RuntimeError(
+                f"cannot materialize adapter {target_adapter!r}: "
+                f"source parameter {source_name!r} is still on meta"
+            )
+        _set_module_param(model, target_name, source_param.detach().clone())
+        copied += 1
+
+    stranded = [
+        name
+        for name, param in model.named_parameters()
+        if target_marker in name and param.is_meta
+    ]
+    if stranded:
+        raise RuntimeError(
+            f"adapter {target_adapter!r} remains on meta after materialization: "
+            + ", ".join(stranded[:4])
+        )
+    return copied
 
 
 # ==========================================================================

--- a/src/soup_cli/utils/peft_wiring.py
+++ b/src/soup_cli/utils/peft_wiring.py
@@ -19,6 +19,44 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+# PEFT 0.20 has no automatic LoRA mapping for the Qwen3.5 text architectures.
+# Qwen3.5 mixes fused linear-attention blocks with ordinary attention blocks,
+# so the policy covers the input/output projections of both block kinds.
+QWEN35_TEXT_LORA_TARGETS = (
+    "q_proj",
+    "v_proj",
+    "in_proj_qkv",
+    "out_proj",
+)
+
+
+def resolve_lora_target_modules(model: Any, configured: Any) -> Any:
+    """Resolve ``target_modules: auto`` for models PEFT does not know yet.
+
+    Existing architectures remain delegated to PEFT by returning ``None``.
+    Explicit user targets are returned unchanged. Qwen3.5 uses a wrapper
+    config (``qwen3_5``) around ``qwen3_5_text`` and its MoE counterpart, so
+    inspect both configs without importing Transformers or PEFT at module load.
+    """
+    if configured != "auto" and configured != ["auto"]:
+        return configured
+
+    config = getattr(model, "config", model)
+    text_config = getattr(config, "text_config", None)
+    model_types = {
+        getattr(config, "model_type", None),
+        getattr(text_config, "model_type", None),
+    }
+    if model_types & {
+        "qwen3_5",
+        "qwen3_5_text",
+        "qwen3_5_moe",
+        "qwen3_5_moe_text",
+    }:
+        return list(QWEN35_TEXT_LORA_TARGETS)
+    return None
+
+
 def apply_pre_lora_patches(model: Any, base: str) -> None:
     """Run pre-LoRA surgical patches (v0.39.0 Part D, multi-trainer in v0.40.6).
 

--- a/src/soup_cli/utils/plotext_compat.py
+++ b/src/soup_cli/utils/plotext_compat.py
@@ -1,0 +1,75 @@
+"""Compatibility helpers for plotext's module and figure APIs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _v6_figure(plotext: Any) -> Any | None:
+    """Return plotext 6's figure object, or ``None`` for the 5.x API."""
+    figure = getattr(plotext, "figure", None)
+    return figure if figure is not None and not callable(figure) else None
+
+
+def render_histogram(
+    plotext: Any,
+    values: list[int],
+    *,
+    bins: int,
+    title: str,
+    xlabel: str,
+    ylabel: str,
+    theme: str,
+) -> None:
+    """Render a histogram with either plotext 5.x or 6.x."""
+    figure = _v6_figure(plotext)
+    if figure is not None:
+        figure.clear()
+        figure.draw(figure.hist(values, bins=bins))
+        figure.title(title)
+        figure.label(xlabel, axis=0)
+        figure.label(ylabel, axis=1)
+        figure.theme(theme)
+        figure.show()
+        return
+
+    plotext.clf()
+    plotext.hist(values, bins=bins)
+    plotext.title(title)
+    plotext.xlabel(xlabel)
+    plotext.ylabel(ylabel)
+    plotext.theme(theme)
+    plotext.show()
+
+
+def render_line(
+    plotext: Any,
+    x_values: list[int],
+    y_values: list[float],
+    *,
+    label: str,
+    title: str,
+    xlabel: str,
+    ylabel: str,
+    theme: str,
+) -> None:
+    """Render a labelled line with either plotext 5.x or 6.x."""
+    figure = _v6_figure(plotext)
+    if figure is not None:
+        figure.clear()
+        signal = figure.signal(x_values, y_values).lines().label(label)
+        figure.draw(signal)
+        figure.title(title)
+        figure.label(xlabel, axis=0)
+        figure.label(ylabel, axis=1)
+        figure.theme(theme)
+        figure.show()
+        return
+
+    plotext.clf()
+    plotext.plot(x_values, y_values, label=label)
+    plotext.title(title)
+    plotext.xlabel(xlabel)
+    plotext.ylabel(ylabel)
+    plotext.theme(theme)
+    plotext.show()

--- a/tests/test_bugfixes.py
+++ b/tests/test_bugfixes.py
@@ -136,13 +136,7 @@ class TestDiffModelLoading:
     """Test diff command uses Transformers kwargs compatible with the floor."""
 
     def test_load_model_uses_torch_dtype(self):
-        """_load_model must pass torch_dtype= (not the >=4.56-only dtype=).
-
-        dtype= is the rename of torch_dtype= at transformers>=4.56. Soup declares
-        transformers>=4.36.0,<5.0.0; using dtype= TypeErrors on older installs
-        inside that range (#478 / #471). torch_dtype= remains accepted (with a
-        deprecation warning) on current 4.57.x.
-        """
+        """_load_model keeps the guarded Transformers load-kwarg policy (#478)."""
         import inspect
 
         from soup_cli.commands.diff import _load_model

--- a/tests/test_bugfixes.py
+++ b/tests/test_bugfixes.py
@@ -1251,11 +1251,17 @@ class TestStatsHistogramWindows:
         )
 
         try:
-            plt.clear_figure()
-            plt.hist([10, 20, 30, 40, 50], bins=3)
-            plt.title("Test")
-            plt.theme("dark")
-            plt.show()
+            from soup_cli.utils.plotext_compat import render_histogram
+
+            render_histogram(
+                plt,
+                [10, 20, 30, 40, 50],
+                bins=3,
+                title="Test",
+                xlabel="Value",
+                ylabel="Count",
+                theme="dark",
+            )
             # If we got here, no UnicodeEncodeError — success
         finally:
             sys.stdout = original_stdout

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -51,8 +51,9 @@ def test_detect_base_model_bad_json(tmp_path: Path):
 
 # --- _find_quantize_binary ---
 
-def test_find_quantize_binary_not_found(tmp_path: Path):
+def test_find_quantize_binary_not_found(tmp_path: Path, monkeypatch):
     """Should return None if no quantize binary exists."""
+    monkeypatch.setattr("soup_cli.commands.export.shutil.which", lambda _name: None)
     assert _find_quantize_binary(tmp_path) is None
 
 

--- a/tests/test_issue300_online_dpo_train.py
+++ b/tests/test_issue300_online_dpo_train.py
@@ -2,7 +2,7 @@
 
 ``task='online_dpo'`` (v0.71.31) adapts to the installed TRL:
 
-* **trl 0.19.x** — pairwise ``judge=`` (a ``BasePairwiseJudge``),
+* **trl <1** — pairwise ``judge=`` (a ``BasePairwiseJudge``),
 * **trl 1.x** — pointwise ``reward_funcs=[...]`` (pairwise judges were removed;
   ``OnlineDPOTrainer`` moved to ``trl.experimental.online_dpo``).
 
@@ -15,7 +15,7 @@ the reward signal is actually applied.
 Version-agnostic by design: the wrapper adapts the synthetic length-preferring
 evaluator to whichever API the installed trl exposes, so ``pytest -m smoke``
 exercises the ``reward_funcs`` path under trl 1.x and the ``judge`` path under
-trl 0.19.x. Marked ``smoke`` (it runs a real training loop), so it is excluded
+trl <1. Marked ``smoke`` (it runs a real training loop), so it is excluded
 from the default fast suite and run explicitly via ``pytest -m smoke``.
 
 Executed live on trl 0.19.1 + torch 2.5.1 (SmolLM2-scale tiny-random-gpt2, CPU):
@@ -38,7 +38,7 @@ class _LengthJudge:
     """Synthetic length-preferring Soup evaluator (prefers the LONGER response).
 
     Exposes BOTH shapes so the wrapper can adapt it to either trl API:
-    ``compare_pair`` (pairwise, trl 0.19.x) and ``evaluate`` (pointwise, trl 1.x
+    ``compare_pair`` (pairwise, trl <1) and ``evaluate`` (pointwise, trl 1.x
     reward-func path).
     """
 
@@ -65,7 +65,7 @@ class TestOnlineDpoTrainLogsReward:
         """A few real online-DPO steps must log a rewards/* metric.
 
         On trl 1.x this drives the reward_funcs path (the issue's gap); on trl
-        0.19.x it drives the judge path. Either way the reward signal is applied
+        <1 it drives the judge path. Either way the reward signal is applied
         and TRL logs rewards/*.
         """
         import soup_cli.trainer.online_dpo as od
@@ -117,12 +117,12 @@ class TestOnlineDpoTrainLogsReward:
     def test_reward_funcs_path_on_trl_1x(self, tmp_path, monkeypatch):
         """On trl 1.x the build must use the reward_funcs= API (not judge=).
 
-        Skips on trl 0.19.x (pairwise judges present). Complements the train
+        Skips on trl <1 (pairwise judges present). Complements the train
         smoke: it pins that the version the reward_funcs path targets actually
         routes through reward_funcs, so the smoke above is exercising that path.
         """
         if _TRL_HAS_JUDGES:
-            pytest.skip("trl 0.19.x (pairwise judge API) — reward_funcs path is trl 1.x")
+            pytest.skip("trl <1 (pairwise judge API) — reward_funcs path is trl 1.x")
 
         import soup_cli.trainer.online_dpo as od
         from soup_cli.config.loader import load_config_from_string

--- a/tests/test_issue300_online_dpo_train.py
+++ b/tests/test_issue300_online_dpo_train.py
@@ -8,7 +8,7 @@
 
 The pre-existing suite only validated ``setup()`` (trainer *build*) on trl 1.x —
 never a real ``train()`` step on the ``reward_funcs`` path. This smoke test runs
-``OnlineDPOTrainerWrapper.train()`` for a couple of steps on a tiny model and
+``OnlineDPOTrainerWrapper.train()`` on a tiny model and
 asserts a ``rewards/*`` entry appears in ``trainer.state.log_history``, proving
 the reward signal is actually applied.
 
@@ -18,8 +18,9 @@ exercises the ``reward_funcs`` path under trl 1.x and the ``judge`` path under
 trl <1. Marked ``smoke`` (it runs a real training loop), so it is excluded
 from the default fast suite and run explicitly via ``pytest -m smoke``.
 
-Executed live on trl 0.19.1 + torch 2.5.1 (SmolLM2-scale tiny-random-gpt2, CPU):
-logs rewards/chosen, rewards/rejected, rewards/accuracies, rewards/margins. The
+Executed live on the new dependency floor, trl 0.29.0 + transformers 5.12.1,
+on Apple Silicon CPU: the real training loop completed and logged
+rewards/chosen, rewards/rejected, rewards/accuracies, and rewards/margins. The
 trl 1.x reward_funcs execution requires a trl>=1.7 + torch>=2.6 env (e.g. CI's
 torch-2.6 job) — the same test body exercises it there without modification.
 """
@@ -42,12 +43,18 @@ class _LengthJudge:
     reward-func path).
     """
 
+    def __init__(self):
+        self.compare_calls = 0
+        self.evaluate_calls = 0
+
     def compare_pair(self, prompt, resp_a, resp_b):
+        self.compare_calls += 1
         if len(resp_a) == len(resp_b):
             return -1
         return 0 if len(resp_a) > len(resp_b) else 1
 
     def evaluate(self, prompt, response, category="default"):
+        self.evaluate_calls += 1
         return JudgeScore(
             prompt=prompt, response=response, weighted_score=float(len(response))
         )
@@ -86,7 +93,7 @@ class TestOnlineDpoTrainLogsReward:
             "  lr: 1e-4\n"
             "output: ./out\n"
         )
-        # 4 prompts / batch 2 / 1 epoch -> 2 steps (no reaching into internals).
+        # Enough prompts to exercise generation, judging, and an optimizer step.
         dataset = {
             "train": [
                 {"messages": [{"role": "user", "content": "hi there friend"}]},
@@ -96,7 +103,8 @@ class TestOnlineDpoTrainLogsReward:
             ]
         }
 
-        od._ONLINE_DPO_JUDGE_OVERRIDE = _LengthJudge()
+        judge = _LengthJudge()
+        od._ONLINE_DPO_JUDGE_OVERRIDE = judge
         try:
             wrapper = OnlineDPOTrainerWrapper(cfg, device="cpu")
             wrapper.setup(dataset)
@@ -113,6 +121,10 @@ class TestOnlineDpoTrainLogsReward:
         # The core online-DPO reward metrics TRL emits once a reward is applied.
         assert "rewards/chosen" in keys
         assert "rewards/rejected" in keys
+        if _TRL_HAS_JUDGES:
+            assert judge.compare_calls > 0, "TRL never called the pairwise judge"
+        else:
+            assert judge.evaluate_calls > 0, "TRL never called the reward function"
 
     def test_reward_funcs_path_on_trl_1x(self, tmp_path, monkeypatch):
         """On trl 1.x the build must use the reward_funcs= API (not judge=).

--- a/tests/test_issue302_vision_pad_token.py
+++ b/tests/test_issue302_vision_pad_token.py
@@ -189,7 +189,7 @@ class TestVisionSetupWiring:
             lambda *a, **k: fake_proc,
         )
         monkeypatch.setattr(
-            transformers.AutoModelForVision2Seq, "from_pretrained",
+            transformers.AutoModelForImageTextToText, "from_pretrained",
             lambda *a, **k: MagicMock(),
         )
         import peft

--- a/tests/test_issue339_load_dtype.py
+++ b/tests/test_issue339_load_dtype.py
@@ -473,7 +473,7 @@ class TestModelKwargsCaptureAcrossModalities:
 
         fake_transformers = types.SimpleNamespace(
             AutoProcessor=types.SimpleNamespace(from_pretrained=lambda *a, **k: processor),
-            AutoModelForVision2Seq=types.SimpleNamespace(
+            AutoModelForImageTextToText=types.SimpleNamespace(
                 from_pretrained=_capturing_from_pretrained(model, captured)
             ),
         )
@@ -538,14 +538,12 @@ class TestModelKwargsCaptureAcrossModalities:
         assert captured["torch_dtype"] == "auto"
 
     def test_the_kwarg_key_is_torch_dtype_not_dtype_at_all_three_sites(self, monkeypatch):
-        """#492 review — the >=4.56-only spelling was a hard TypeError at
-        model load on this project's declared transformers floor (measured
-        on 4.46.1), and neither CI (always installs the newest transformers)
-        nor a mock built as `def _fake(*args, **kwargs)` (which swallows any
-        kwarg NAME, only exposing a wrong VALUE) can see a reverted spelling.
-        This is the only thing that can: assert the key itself, at all three
-        call sites, and that "dtype" is not ALSO present (no accidental dual
-        emission)."""
+        """#492 review — assert the load kwarg name itself at all three sites.
+
+        A mock built as ``def _fake(*args, **kwargs)`` swallows any kwarg name
+        and exposes only a wrong value, so it cannot catch an accidental dual
+        emission or an uncoordinated spelling change across loaders.
+        """
         from soup_cli.trainer.sft import SFTTrainerWrapper
 
         fake_peft = types.SimpleNamespace(
@@ -594,7 +592,7 @@ class TestModelKwargsCaptureAcrossModalities:
             "transformers",
             types.SimpleNamespace(
                 AutoProcessor=types.SimpleNamespace(from_pretrained=lambda *a, **k: processor),
-                AutoModelForVision2Seq=types.SimpleNamespace(
+                AutoModelForImageTextToText=types.SimpleNamespace(
                     from_pretrained=_capturing_from_pretrained(model, captured)
                 ),
             ),

--- a/tests/test_issue353_seed_every_task.py
+++ b/tests/test_issue353_seed_every_task.py
@@ -317,6 +317,12 @@ class TestEveryConfigClassAcceptsTheSeed:
         from transformers import Seq2SeqTrainingArguments, TrainingArguments
 
         from soup_cli.trainer._trl_compat import resolve_trl_symbol
+        from soup_cli.trainer.ppo import _import_ppo_classes
+
+        online_dpo_config = resolve_trl_symbol(
+            "OnlineDPOConfig", "trl.experimental.online_dpo"
+        )
+        _, ppo_config, _ = _import_ppo_classes()
 
         classes = {
             # classifier, distill, mole_routing, prm, pretrain, embedding, sft
@@ -326,8 +332,10 @@ class TestEveryConfigClassAcceptsTheSeed:
             "KTOConfig": trl.KTOConfig,
             "GRPOConfig": trl.GRPOConfig,
             "RewardConfig": trl.RewardConfig,
-            "OnlineDPOConfig": trl.OnlineDPOConfig,
-            "PPOConfig": trl.PPOConfig,
+            # TRL 0.29 moved both APIs under trl.experimental. Exercise the
+            # same compatibility imports the production wrappers use.
+            "OnlineDPOConfig": online_dpo_config,
+            "PPOConfig": ppo_config,
             # #326 moved these three out of the public namespace.
             "ORPOConfig": resolve_trl_symbol("ORPOConfig", "trl.experimental.orpo"),
             "CPOConfig": resolve_trl_symbol("CPOConfig", "trl.experimental.cpo"),

--- a/tests/test_issue369_canonical_named_parameters.py
+++ b/tests/test_issue369_canonical_named_parameters.py
@@ -191,7 +191,15 @@ class TestCanonicalNamedParameters:
 
         streamed_names = {name for name, _ in canonical_named_parameters(wrapper.model)}
         resident_names = {name for name, _ in resident_peft.named_parameters()}
-        assert streamed_names == resident_names
+        # TRL 0.29 snapshots a pre-existing adapter as ``ref`` so DPO can use
+        # its initial policy as the reference without constructing a second
+        # model. Compare the policy adapter directly, then prove every extra
+        # reference tensor maps back to that same resident adapter.
+        policy_names = {name for name in streamed_names if ".ref." not in name}
+        reference_names = streamed_names - policy_names
+        assert policy_names == resident_names
+        assert reference_names
+        assert {name.replace(".ref.", ".default.") for name in reference_names} <= resident_names
 
 
 class TestAssertCanonicalParametersIntersect:

--- a/tests/test_issue433_meta_adapter_guard.py
+++ b/tests/test_issue433_meta_adapter_guard.py
@@ -90,6 +90,49 @@ class TestAdapterMaterializationPostcondition:
         assert_trainable_adapters_materialized(_Model())
 
 
+class TestFrozenAdapterCopyMaterialization:
+    def test_meta_reference_is_copied_from_the_real_policy_adapter(self):
+        import torch
+        import torch.nn as nn
+
+        from soup_cli.utils.layer_stream_runtime import materialize_meta_adapter_copy
+
+        class _Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lora_A = nn.ModuleDict(
+                    {
+                        "default": nn.Linear(2, 2, bias=False),
+                        "ref": nn.Linear(2, 2, bias=False, device="meta"),
+                    }
+                )
+
+        model = _Model()
+        expected = model.lora_A["default"].weight.detach().clone()
+        assert materialize_meta_adapter_copy(model) == 1
+        assert not model.lora_A["ref"].weight.is_meta
+        assert model.lora_A["ref"].weight.requires_grad is False
+        assert torch.equal(model.lora_A["ref"].weight, expected)
+
+    def test_meta_source_is_refused_instead_of_fabricating_a_reference(self):
+        import torch.nn as nn
+
+        from soup_cli.utils.layer_stream_runtime import materialize_meta_adapter_copy
+
+        class _Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lora_A = nn.ModuleDict(
+                    {
+                        "default": nn.Linear(2, 2, bias=False, device="meta"),
+                        "ref": nn.Linear(2, 2, bias=False, device="meta"),
+                    }
+                )
+
+        with pytest.raises(RuntimeError, match="source parameter.*still on meta"):
+            materialize_meta_adapter_copy(_Model())
+
+
 def test_streamed_build_refuses_a_materializer_that_skips_a_meta_adapter(monkeypatch):
     """Negative control: stub the capability and force the failure state.
 

--- a/tests/test_issue502_qwen35_transformers5.py
+++ b/tests/test_issue502_qwen35_transformers5.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import re
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as distribution_version
 from pathlib import Path
 
+import pytest
 from packaging.requirements import Requirement
-from packaging.version import Version
+from packaging.version import InvalidVersion, Version
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BACKENDS_DOC = REPO_ROOT / "docs" / "backends-and-ops.md"
@@ -27,6 +30,45 @@ def _extra_requirement(extra: str, package: str) -> Requirement:
     ]
     assert len(requirements) == 1
     return requirements[0]
+
+
+def _single_bound(requirement: Requirement, operator: str) -> str:
+    versions = [clause.version for clause in requirement.specifier if clause.operator == operator]
+    assert len(versions) == 1, (
+        f"expected one {operator} bound for {requirement.name}, found {versions}"
+    )
+    return versions[0]
+
+
+_RUNTIME_FLOORS = {
+    "transformers": "5.12.1",
+    "trl": "0.29.0",
+    "peft": "0.20.0",
+}
+
+
+def _missing_runtime_floors() -> list[str]:
+    missing: list[str] = []
+    for package, floor in _RUNTIME_FLOORS.items():
+        try:
+            installed = distribution_version(package)
+            if Version(installed) < Version(floor):
+                missing.append(f"{package}=={installed} (need >={floor})")
+        except (PackageNotFoundError, InvalidVersion):
+            missing.append(f"{package} (need >={floor})")
+    return missing
+
+
+_MISSING_RUNTIME_FLOORS = _missing_runtime_floors()
+_RUNTIME_FLOOR_REASON = (
+    "requires the new #502 training floor; install soup-cli[train] with "
+    "transformers>=5.12.1, trl>=0.29.0, peft>=0.20.0; missing/outdated: "
+    + ", ".join(_MISSING_RUNTIME_FLOORS)
+)
+_REQUIRES_TRAINING_FLOOR = pytest.mark.skipif(
+    bool(_MISSING_RUNTIME_FLOORS),
+    reason=_RUNTIME_FLOOR_REASON,
+)
 
 
 def _transformers_extras_are_disjoint() -> bool:
@@ -103,6 +145,22 @@ def test_peft_floor_is_the_validated_transformers5_adapter_stack():
     assert Version("1.0.0") not in peft.specifier
 
 
+def test_doctor_training_bounds_match_declared_extra():
+    from soup_cli.commands.doctor import _MAX_EXCLUSIVE, DEPS
+
+    doctor_floors = {package: floor for _, package, floor, _ in DEPS}
+    for package in _RUNTIME_FLOORS:
+        requirement = _extra_requirement("train", package)
+        assert doctor_floors[package] == _single_bound(requirement, ">=")
+        assert _MAX_EXCLUSIVE[package] == _single_bound(requirement, "<")
+
+
+def test_runtime_floor_skip_explains_the_required_upgrade():
+    for package, floor in _RUNTIME_FLOORS.items():
+        assert f"{package}>={floor}" in _RUNTIME_FLOOR_REASON
+
+
+@_REQUIRES_TRAINING_FLOOR
 def test_trl029_trainers_and_experimental_pairwise_judge_import():
     import trl.trainer.dpo_trainer  # noqa: F401
     import trl.trainer.grpo_trainer  # noqa: F401
@@ -114,6 +172,7 @@ def test_trl029_trainers_and_experimental_pairwise_judge_import():
     assert base_cls.__module__.startswith("trl.experimental.judges")
 
 
+@_REQUIRES_TRAINING_FLOOR
 def test_qwen35_outer_config_selects_text_causal_model_without_vision():
     import torch
     from transformers import AutoModelForCausalLM
@@ -129,6 +188,7 @@ def test_qwen35_outer_config_selects_text_causal_model_without_vision():
     ]
 
 
+@_REQUIRES_TRAINING_FLOOR
 def test_qwen35_auto_targets_attach_and_reload_a_nonempty_adapter(tmp_path):
     import torch
     from peft import LoraConfig, PeftModel, TaskType, get_peft_model

--- a/tests/test_issue502_qwen35_transformers5.py
+++ b/tests/test_issue502_qwen35_transformers5.py
@@ -9,6 +9,11 @@ from packaging.requirements import Requirement
 from packaging.version import Version
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+BACKENDS_DOC = REPO_ROOT / "docs" / "backends-and-ops.md"
+_DOCS_WARNING = "cannot be installed together"
+_PROBE_VERSIONS = tuple(
+    Version(f"{major}.{minor}.0") for major in range(3, 10) for minor in range(60)
+)
 
 
 def _extra_requirement(extra: str, package: str) -> Requirement:
@@ -22,6 +27,21 @@ def _extra_requirement(extra: str, package: str) -> Requirement:
     ]
     assert len(requirements) == 1
     return requirements[0]
+
+
+def _transformers_extras_are_disjoint() -> bool:
+    """Return whether the declared train/mlx ranges have no shared version."""
+    train = _extra_requirement("train", "transformers").specifier
+    mlx = _extra_requirement("mlx", "transformers").specifier
+    probes = list(_PROBE_VERSIONS)
+    for specifier in (train, mlx):
+        for clause in specifier:
+            probes.append(Version(clause.version))
+    return not any(
+        train.contains(version, prereleases=True)
+        and mlx.contains(version, prereleases=True)
+        for version in probes
+    )
 
 
 def _tiny_qwen35_config():
@@ -55,6 +75,16 @@ def test_training_and_mlx_extras_share_the_transformers5_range():
     assert Version("5.12.0") not in train.specifier
     assert Version("5.15.1") in train.specifier
     assert Version("6.0.0") not in train.specifier
+
+
+def test_docs_warn_exactly_when_training_and_mlx_extras_are_disjoint():
+    disjoint = _transformers_extras_are_disjoint()
+    warned = _DOCS_WARNING in BACKENDS_DOC.read_text(encoding="utf-8")
+
+    assert warned is disjoint, (
+        "docs/backends-and-ops.md must say the train/mlx extras cannot be installed "
+        "together exactly when their declared transformers ranges are disjoint"
+    )
 
 
 def test_trl_floor_crosses_the_transformers5_import_fix():

--- a/tests/test_issue502_qwen35_transformers5.py
+++ b/tests/test_issue502_qwen35_transformers5.py
@@ -1,0 +1,142 @@
+"""#502/#503 — Transformers 5 Qwen3.5 text training compatibility."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _extra_requirement(extra: str, package: str) -> Requirement:
+    text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    block = re.search(rf"^{re.escape(extra)}\s*=\s*\[(.*?)^\]", text, re.MULTILINE | re.DOTALL)
+    assert block is not None
+    requirements = [
+        Requirement(raw)
+        for raw in re.findall(r'"([^"\n]+)"', block.group(1))
+        if Requirement(raw).name == package
+    ]
+    assert len(requirements) == 1
+    return requirements[0]
+
+
+def _tiny_qwen35_config():
+    from transformers import Qwen3_5Config, Qwen3_5TextConfig
+
+    text = Qwen3_5TextConfig(
+        vocab_size=64,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        linear_conv_kernel_dim=2,
+        linear_key_head_dim=4,
+        linear_value_head_dim=4,
+        linear_num_key_heads=2,
+        linear_num_value_heads=2,
+        layer_types=["linear_attention", "full_attention"],
+        max_position_embeddings=64,
+    )
+    return Qwen3_5Config(text_config=text.to_dict())
+
+
+def test_training_and_mlx_extras_share_the_transformers5_range():
+    train = _extra_requirement("train", "transformers")
+    mlx = _extra_requirement("mlx", "transformers")
+
+    assert train.specifier == mlx.specifier
+    assert Version("5.12.1") in train.specifier
+    assert Version("5.12.0") not in train.specifier
+    assert Version("5.15.1") in train.specifier
+    assert Version("6.0.0") not in train.specifier
+
+
+def test_trl_floor_crosses_the_transformers5_import_fix():
+    trl = _extra_requirement("train", "trl")
+
+    assert Version("0.28.0") not in trl.specifier
+    assert Version("0.29.0") in trl.specifier
+    assert Version("1.0.0") not in trl.specifier
+
+
+def test_peft_floor_is_the_validated_transformers5_adapter_stack():
+    peft = _extra_requirement("train", "peft")
+
+    assert Version("0.19.0") not in peft.specifier
+    assert Version("0.20.0") in peft.specifier
+    assert Version("1.0.0") not in peft.specifier
+
+
+def test_trl029_trainers_and_experimental_pairwise_judge_import():
+    import trl.trainer.dpo_trainer  # noqa: F401
+    import trl.trainer.grpo_trainer  # noqa: F401
+
+    from soup_cli.eval.judge import _base_pairwise_judge_cls
+
+    base_cls = _base_pairwise_judge_cls()
+    assert base_cls.__name__ == "BasePairwiseJudge"
+    assert base_cls.__module__.startswith("trl.experimental.judges")
+
+
+def test_qwen35_outer_config_selects_text_causal_model_without_vision():
+    import torch
+    from transformers import AutoModelForCausalLM
+
+    model = AutoModelForCausalLM.from_config(_tiny_qwen35_config(), dtype=torch.float32)
+
+    assert type(model).__name__ == "Qwen3_5ForCausalLM"
+    assert model.config.model_type == "qwen3_5_text"
+    assert not [
+        name
+        for name, _ in model.named_parameters()
+        if "vision" in name or "visual" in name
+    ]
+
+
+def test_qwen35_auto_targets_attach_and_reload_a_nonempty_adapter(tmp_path):
+    import torch
+    from peft import LoraConfig, PeftModel, TaskType, get_peft_model
+    from transformers import AutoModelForCausalLM
+
+    from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+
+    config = _tiny_qwen35_config()
+    base = AutoModelForCausalLM.from_config(config, dtype=torch.float32)
+    targets = resolve_lora_target_modules(base, "auto")
+    assert targets == ["q_proj", "v_proj", "in_proj_qkv", "out_proj"]
+
+    model = get_peft_model(
+        base,
+        LoraConfig(
+            r=2,
+            lora_alpha=4,
+            target_modules=targets,
+            task_type=TaskType.CAUSAL_LM,
+        ),
+    )
+    trainable = [parameter for parameter in model.parameters() if parameter.requires_grad]
+    assert trainable
+    assert sum(parameter.numel() for parameter in trainable) > 0
+
+    adapter = tmp_path / "adapter"
+    model.save_pretrained(adapter)
+    reloaded_base = AutoModelForCausalLM.from_config(config, dtype=torch.float32)
+    reloaded = PeftModel.from_pretrained(reloaded_base, adapter)
+    reloaded_lora = [name for name, _ in reloaded.named_parameters() if "lora_" in name]
+    assert len(reloaded_lora) == 8
+
+
+def test_explicit_peft_targets_and_mlx_defaults_are_unchanged():
+    from soup_cli.trainer.mlx_sft import MLX_DEFAULT_TARGET_KEYS
+    from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+
+    explicit = ["custom_proj"]
+    assert resolve_lora_target_modules(object(), explicit) is explicit
+    assert resolve_lora_target_modules(object(), None) is None
+    assert MLX_DEFAULT_TARGET_KEYS == ["self_attn.q_proj", "self_attn.v_proj"]

--- a/tests/test_plotext_compat.py
+++ b/tests/test_plotext_compat.py
@@ -1,0 +1,163 @@
+"""Plotext 5.x / 6.x compatibility coverage."""
+
+from soup_cli.utils.plotext_compat import render_histogram, render_line
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple, dict]] = []
+
+    def _record(self, name: str, *args, **kwargs):
+        self.calls.append((name, args, kwargs))
+        return self
+
+
+class _Plotext5(_Recorder):
+    def clf(self):
+        return self._record("clf")
+
+    def hist(self, *args, **kwargs):
+        return self._record("hist", *args, **kwargs)
+
+    def plot(self, *args, **kwargs):
+        return self._record("plot", *args, **kwargs)
+
+    def title(self, *args, **kwargs):
+        return self._record("title", *args, **kwargs)
+
+    def xlabel(self, *args, **kwargs):
+        return self._record("xlabel", *args, **kwargs)
+
+    def ylabel(self, *args, **kwargs):
+        return self._record("ylabel", *args, **kwargs)
+
+    def theme(self, *args, **kwargs):
+        return self._record("theme", *args, **kwargs)
+
+    def show(self):
+        return self._record("show")
+
+
+class _Signal(_Recorder):
+    def lines(self):
+        return self._record("lines")
+
+    def label(self, *args, **kwargs):
+        return self._record("label", *args, **kwargs)
+
+
+class _Figure6(_Recorder):
+    def clear(self):
+        return self._record("clear")
+
+    def hist(self, *args, **kwargs):
+        self._record("hist", *args, **kwargs)
+        return _Signal()
+
+    def signal(self, *args, **kwargs):
+        self._record("signal", *args, **kwargs)
+        return _Signal()
+
+    def draw(self, *args, **kwargs):
+        return self._record("draw", *args, **kwargs)
+
+    def title(self, *args, **kwargs):
+        return self._record("title", *args, **kwargs)
+
+    def label(self, *args, **kwargs):
+        return self._record("label", *args, **kwargs)
+
+    def theme(self, *args, **kwargs):
+        return self._record("theme", *args, **kwargs)
+
+    def show(self):
+        return self._record("show")
+
+
+class _Plotext6:
+    def __init__(self) -> None:
+        self.figure = _Figure6()
+
+
+def test_plotext5_module_api_remains_supported() -> None:
+    plotext = _Plotext5()
+    render_histogram(
+        plotext,
+        [1, 2],
+        bins=2,
+        title="Histogram",
+        xlabel="X",
+        ylabel="Y",
+        theme="dark",
+    )
+    render_line(
+        plotext,
+        [1, 2],
+        [0.5, 0.25],
+        label="loss",
+        title="Loss",
+        xlabel="Step",
+        ylabel="Loss",
+        theme="dark",
+    )
+
+    names = [name for name, _, _ in plotext.calls]
+    assert names == [
+        "clf",
+        "hist",
+        "title",
+        "xlabel",
+        "ylabel",
+        "theme",
+        "show",
+        "clf",
+        "plot",
+        "title",
+        "xlabel",
+        "ylabel",
+        "theme",
+        "show",
+    ]
+
+
+def test_plotext6_figure_api_is_used() -> None:
+    plotext = _Plotext6()
+    render_histogram(
+        plotext,
+        [1, 2],
+        bins=2,
+        title="Histogram",
+        xlabel="X",
+        ylabel="Y",
+        theme="dark",
+    )
+    render_line(
+        plotext,
+        [1, 2],
+        [0.5, 0.25],
+        label="loss",
+        title="Loss",
+        xlabel="Step",
+        ylabel="Loss",
+        theme="dark",
+    )
+
+    names = [name for name, _, _ in plotext.figure.calls]
+    assert names == [
+        "clear",
+        "hist",
+        "draw",
+        "title",
+        "label",
+        "label",
+        "theme",
+        "show",
+        "clear",
+        "signal",
+        "draw",
+        "title",
+        "label",
+        "label",
+        "theme",
+        "show",
+    ]

--- a/tests/test_plotext_compat.py
+++ b/tests/test_plotext_compat.py
@@ -1,5 +1,9 @@
 """Plotext 5.x / 6.x compatibility coverage."""
 
+from importlib.metadata import version as distribution_version
+
+from packaging.version import Version
+
 from soup_cli.utils.plotext_compat import render_histogram, render_line
 
 
@@ -161,3 +165,35 @@ def test_plotext6_figure_api_is_used() -> None:
         "theme",
         "show",
     ]
+
+
+def test_installed_plotext_runtime_renders_histogram_and_line(monkeypatch) -> None:
+    """Exercise the installed package, not only the two contract doubles."""
+    import plotext
+
+    major = Version(distribution_version("plotext")).major
+    assert major in {5, 6}
+    runtime = plotext.figure if major == 6 else plotext
+    assert callable(runtime.show)
+    monkeypatch.setattr(runtime, "show", lambda: None)
+    render_histogram(
+        plotext,
+        [1, 2, 3],
+        bins=2,
+        title="Histogram",
+        xlabel="X",
+        ylabel="Y",
+        theme="dark",
+    )
+    render_line(
+        plotext,
+        [1, 2, 3],
+        [0.5, 0.25, 0.125],
+        label="loss",
+        title="Loss",
+        xlabel="Step",
+        ylabel="Loss",
+        theme="dark",
+    )
+    built = runtime.build()
+    assert "Loss" in str(built)

--- a/tests/test_trainer_init.py
+++ b/tests/test_trainer_init.py
@@ -231,7 +231,9 @@ class TestSFTTrainerInit:
 
         fake_transformers = types.SimpleNamespace(
             AutoProcessor=types.SimpleNamespace(from_pretrained=lambda *a, **k: processor),
-            AutoModelForVision2Seq=types.SimpleNamespace(from_pretrained=lambda *a, **k: model),
+            AutoModelForImageTextToText=types.SimpleNamespace(
+                from_pretrained=lambda *a, **k: model
+            ),
         )
 
         fake_peft = types.SimpleNamespace(

--- a/tests/test_transformers_floor_compat.py
+++ b/tests/test_transformers_floor_compat.py
@@ -1,18 +1,10 @@
-"""#478 — Transformers load kwargs must stay compatible with the declared floor.
+"""Transformers floor policy and model-load keyword compatibility.
 
-``pyproject.toml`` declares ``transformers>=4.36.0,<5.0.0``, but CI's normal
-``pip install -e ".[dev]"`` resolves to the newest 4.x. A kwarg that only exists
-on >=4.56 (``dtype=`` on ``from_pretrained`` / ``from_config``, the rename of
-``torch_dtype=``) therefore passes the 12-cell matrix and TypeErrors on older
-installs inside the declared range — exactly what #471 nearly shipped.
-
-``transformers==4.36.0`` cannot resolve against Soup's declared ``trl`` range
-(even ``trl==0.14.0`` requires ``transformers>=4.46.0``; see the floor CI job
-comments and ``.github/constraints/transformers-floor.txt``). Raising Soup's
-declared floor is a dependency-policy call, not something this suite does.
-Until that decision lands, the accepted #478 fallback is a static guard: no
-production model ``from_pretrained`` / ``from_config`` call site governed by
-the Transformers dtype contract may pass ``dtype=``.
+#502 moves the declared floor to Transformers 5.12.1 and #503 moves TRL to 0.29.
+The dedicated CI cell installs those exact versions so the normal newest-version
+matrix cannot hide a floor regression. The historical #478 static guard remains:
+Soup continues using the backward-compatible ``torch_dtype=`` spelling at model
+load sites throughout the supported Transformers 5.x range.
 
 Unsloth's ``FastLanguageModel.from_pretrained(..., dtype=)`` and Soup wrapper
 kwargs that are not Transformers load APIs are out of scope.
@@ -202,8 +194,8 @@ class TestTransformersFloorDtypeGuard:
         hits = iter_production_hits()
         assert hits == [], (
             "Transformers model from_pretrained / from_config calls must use torch_dtype= "
-            "(works across transformers>=4.36,<5). dtype= is the >=4.56-only "
-            "rename and TypeErrors on older installs inside our declared range "
+            "(kept across Soup's Transformers 5.x range). Use of dtype= at these "
+            "sites must be an explicit whole-policy migration "
             f"(#478). Offending sites: {hits}"
         )
 
@@ -291,20 +283,20 @@ class TestFloorConstraintAndWorkflowPins:
         )
         assert _version_key(pinned) >= _version_key(declared)
         _constraint_pin(text, "trl")
-        # Never claim 4.55.4 (or any pre-dtype probe) is the declared floor.
+        _constraint_pin(text, "peft")
         assert "declared" in text.lower() and "floor" in text.lower()
 
-    def test_workflow_runs_pip_check_and_asserts_both_exact_versions(self):
+    def test_workflow_runs_pip_check_and_asserts_floor_versions(self):
         job = _transformers_floor_job_block(CI_WORKFLOW.read_text(encoding="utf-8"))
         assert "python -m pip check" in job
         assert "-c .github/constraints/transformers-floor.txt" in job
 
-    @pytest.mark.parametrize("package", ["transformers", "trl"])
+    @pytest.mark.parametrize("package", ["transformers", "trl", "peft"])
     def test_workflow_version_check_accepts_pins_and_rejects_mismatch(self, package: str):
-        constraints = "transformers==8.8.8\ntrl==9.9.9\n"
+        constraints = "transformers==8.8.8\ntrl==9.9.9\npeft==7.7.7\n"
         installed = {
             name: _constraint_pin(constraints, name)
-            for name in ("transformers", "trl")
+            for name in ("transformers", "trl", "peft")
         }
         _run_transformers_floor_version_check(installed, constraints)
 

--- a/tests/test_transformers_floor_compat.py
+++ b/tests/test_transformers_floor_compat.py
@@ -284,19 +284,23 @@ class TestFloorConstraintAndWorkflowPins:
         assert _version_key(pinned) >= _version_key(declared)
         _constraint_pin(text, "trl")
         _constraint_pin(text, "peft")
+        _constraint_pin(text, "plotext")
         assert "declared" in text.lower() and "floor" in text.lower()
 
     def test_workflow_runs_pip_check_and_asserts_floor_versions(self):
         job = _transformers_floor_job_block(CI_WORKFLOW.read_text(encoding="utf-8"))
         assert "python -m pip check" in job
         assert "-c .github/constraints/transformers-floor.txt" in job
+        assert "tests/test_plotext_compat.py" in job
 
-    @pytest.mark.parametrize("package", ["transformers", "trl", "peft"])
+    @pytest.mark.parametrize("package", ["transformers", "trl", "peft", "plotext"])
     def test_workflow_version_check_accepts_pins_and_rejects_mismatch(self, package: str):
-        constraints = "transformers==8.8.8\ntrl==9.9.9\npeft==7.7.7\n"
+        constraints = (
+            "transformers==8.8.8\ntrl==9.9.9\npeft==7.7.7\nplotext==6.6.6\n"
+        )
         installed = {
             name: _constraint_pin(constraints, name)
-            for name in ("transformers", "trl", "peft")
+            for name in ("transformers", "trl", "peft", "plotext")
         }
         _run_transformers_floor_version_check(installed, constraints)
 

--- a/tests/test_trl_preference_config_contract.py
+++ b/tests/test_trl_preference_config_contract.py
@@ -233,41 +233,34 @@ class TestTheCanaryCoversWhatItClaims:
 
 
 class TestTheTrlBoundsAreConsistentWithTheCode:
-    """The floor shipped as `>=0.7.0` while `setup()` imported `GRPOTrainer`,
-    which trl first exports at 0.14.0 — a declared floor the code could never
-    have run on. Cheap to state as a property: whatever is installed must
-    satisfy the declared bound AND provide the symbols the trainers import."""
+    """The installed TRL must provide every symbol through Soup's real resolver."""
 
     def test_the_installed_trl_provides_every_symbol_the_trainers_import(self):
-        """`getattr`, not `hasattr`: trl exposes these through a lazy module, so
-        a submodule that fails to import raises something other than
-        AttributeError, and `hasattr` would report a clean False without saying
-        why. From 0.29 `ORPOConfig` / `CPOConfig` / `BCOConfig` leave the `trl`
-        namespace altogether — that is the shape of the next break, so it is
-        worth naming the symbol rather than only the version."""
-        import trl
+        """Exercise the same public-first, experimental-second imports as setup()."""
+        from soup_cli.trainer._trl_compat import resolve_trl_symbol
 
         broken = {}
-        for name in (
-            "DPOConfig",
-            "DPOTrainer",
-            "KTOConfig",
-            "KTOTrainer",
-            "ORPOConfig",
-            "ORPOTrainer",
-            "CPOConfig",
-            "CPOTrainer",
-            "BCOConfig",
-            "BCOTrainer",
-            "GRPOTrainer",
-            "GRPOConfig",
-        ):
+        symbols = {
+            "DPOConfig": None,
+            "DPOTrainer": None,
+            "KTOConfig": None,
+            "KTOTrainer": None,
+            "ORPOConfig": "trl.experimental.orpo",
+            "ORPOTrainer": "trl.experimental.orpo",
+            "CPOConfig": "trl.experimental.cpo",
+            "CPOTrainer": "trl.experimental.cpo",
+            "BCOConfig": "trl.experimental.bco",
+            "BCOTrainer": "trl.experimental.bco",
+            "GRPOTrainer": None,
+            "GRPOConfig": None,
+        }
+        for name, experimental_module in symbols.items():
             try:
-                getattr(trl, name)
+                resolve_trl_symbol(name, experimental_module)
             except Exception as exc:  # noqa: BLE001 - reported, not swallowed
                 broken[name] = f"{type(exc).__name__}: {exc}"
         assert not broken, (
-            f"installed trl {trl.__version__} cannot supply "
-            f"{sorted(broken)} — the [train] extra's bounds and the code "
+            f"installed trl cannot supply {sorted(broken)} through Soup's "
+            f"public/experimental resolver — the [train] bounds and the code "
             f"disagree: {broken}"
         )

--- a/tests/test_trl_preference_config_contract.py
+++ b/tests/test_trl_preference_config_contract.py
@@ -79,6 +79,11 @@ def _pref_rows(n=8):
     return [{"prompt": "hi", "chosen": " good answer", "rejected": " bad"} for _ in range(n)]
 
 
+def _long_pref_rows(n=8):
+    prompt = " ".join(["hello"] * 161)
+    return [{"prompt": prompt, "chosen": " good answer", "rejected": " bad"} for _ in range(n)]
+
+
 def _kto_rows(n=8):
     return [{"prompt": "hi", "completion": " good answer", "label": i % 2 == 0} for i in range(n)]
 
@@ -194,6 +199,39 @@ class TestEveryPreferenceTrainerReachesALiveTrlTrainer:
                 f"probe and the object disagree"
             )
         assert args.max_length == 64, (task, args.max_length)
+
+    @pytest.mark.parametrize("task", ("dpo", "orpo"))
+    def test_removed_prompt_cap_is_enforced_on_the_effective_batch(
+        self, tmp_path, monkeypatch, task
+    ):
+        """TRL 0.29 must not turn ``data.max_length`` into a cosmetic field.
+
+        The assertion is on the tensors the model receives, not the config or
+        an intermediate column: 0.29 accepted ``max_length=64`` while emitting
+        164/165-token DPO/ORPO batches from this exact 161-token prompt.
+        """
+        from soup_cli.trainer._trl_compat import config_accepts
+
+        module, cls_name, _ = _WRAPPERS[task]
+        import importlib
+
+        weights = _tiny_llama_dir(tmp_path)
+        _write_tiny_tokenizer(weights)
+        monkeypatch.chdir(tmp_path)
+        cfg = _cfg(weights, tmp_path / "out", task)
+        wrapper = getattr(importlib.import_module(module), cls_name)(cfg, device="cpu")
+        wrapper.setup({"train": _long_pref_rows(8)})
+
+        if config_accepts(type(wrapper.trainer.args), "max_prompt_length"):
+            pytest.skip("installed TRL still enforces its own prompt cap")
+
+        assert len(wrapper.trainer.train_dataset) == 8
+        batch = next(iter(wrapper.trainer.get_train_dataloader()))
+        sequence_keys = [key for key in batch if key.endswith("input_ids")]
+        assert sequence_keys, batch.keys()
+        assert all(batch[key].shape[-1] <= 64 for key in sequence_keys), {
+            key: tuple(batch[key].shape) for key in sequence_keys
+        }
 
 
 class TestTheCanaryCoversWhatItClaims:

--- a/tests/test_v0401_part_c.py
+++ b/tests/test_v0401_part_c.py
@@ -1,4 +1,4 @@
-"""v0.40.1 Part C tests — autopilot fallback / transformers cap / quickstart
+"""v0.40.1 Part C tests — autopilot fallback / dependency cap / quickstart
 GPU-aware model pick / lr_finder import regression.
 """
 
@@ -39,7 +39,7 @@ def test_probe_cache_returns_none_for_missing_repo():
     assert _probe_cache_param_count("nonexistent-org/never-cached-XYZ") is None
 
 
-# --- C5: doctor flags transformers 5.x ------------------------------------
+# --- C5: doctor flags unsupported breaking majors -------------------------
 
 
 def test_version_ge_handles_dev_suffix():
@@ -56,10 +56,10 @@ def test_version_ge_short_version_string():
     assert _version_ge("4.99", "5.0.0") is False
 
 
-def test_max_exclusive_table_caps_transformers():
+def test_max_exclusive_table_allows_transformers5_and_caps_transformers6():
     from soup_cli.commands.doctor import _MAX_EXCLUSIVE
 
-    assert _MAX_EXCLUSIVE.get("transformers") == "5.0.0"
+    assert _MAX_EXCLUSIVE.get("transformers") == "6.0.0"
 
 
 # --- G12: lr_finder real loop uses load_raw_data ---------------------------

--- a/tests/test_v0640_part_c.py
+++ b/tests/test_v0640_part_c.py
@@ -735,30 +735,29 @@ def test_cli_env_lock_null_byte_output_rejected(tmp_path, monkeypatch):
 # lists `transformers` only under `extra == "train"/"all"/"dev"`, so no un-gated
 # transformers row exists — see `_TRAIN_TRANSFORMERS` for the real shape and the
 # tests that cover #368 end to end.
-_UNGATED_TRANSFORMERS = ("transformers>=4.36.0,<5.0.0",)
+_UNGATED_TRANSFORMERS = ("transformers>=5.12.1,<6.0.0",)
 
 # The real shape: the `transformers` cap #368 was reported against, exactly as
 # metadata states it — gated behind the extras that pull it in.
 _TRAIN_TRANSFORMERS = (
-    'transformers>=4.36.0,<5.0.0; extra == "train"',
-    'transformers>=4.36.0,<5.0.0; extra == "all"',
-    'transformers>=4.36.0,<5.0.0; extra == "dev"',
+    'transformers>=5.12.1,<6.0.0; extra == "train"',
+    'transformers>=5.12.1,<6.0.0; extra == "all"',
+    'transformers>=5.12.1,<6.0.0; extra == "dev"',
 )
 
 
 def test_check_declared_bounds_flags_core_bound_over_cap():
     from soup_cli.utils.env_lock import check_declared_bounds
 
-    # `pip install vllm` moved transformers to 5.14.1, past the core <5.0.0 cap.
-    report = check_declared_bounds(_UNGATED_TRANSFORMERS, {"transformers": "5.14.1"})
+    report = check_declared_bounds(_UNGATED_TRANSFORMERS, {"transformers": "6.0.0"})
     assert not report.ok
     assert report.violation_count == 1
     (v,) = report.violations
     assert v.name == "transformers"
-    assert v.installed == "5.14.1"
+    assert v.installed == "6.0.0"
     # The bound is quoted from the requirement string, not a hardcoded copy of
-    # `<5.0.0` — that second copy is exactly the drift this catches.
-    assert "<5.0.0" in v.specifier
+    # `<6.0.0` — that second copy is exactly the drift this catches.
+    assert "<6.0.0" in v.specifier
 
 
 def test_check_declared_bounds_control_compliant_passes():
@@ -766,7 +765,7 @@ def test_check_declared_bounds_control_compliant_passes():
 
     # Control: an in-bounds environment passes, so the check cannot be
     # satisfied by always failing.
-    report = check_declared_bounds(_UNGATED_TRANSFORMERS, {"transformers": "4.57.6"})
+    report = check_declared_bounds(_UNGATED_TRANSFORMERS, {"transformers": "5.15.1"})
     assert report.ok
     assert report.violations == ()
 
@@ -817,31 +816,31 @@ def test_core_bound_counted_once_despite_extra_duplicates():
     from soup_cli.utils.env_lock import check_declared_bounds
 
     reqs = (
-        "transformers>=4.36.0,<5.0.0",
-        'transformers>=4.36.0,<5.0.0; extra == "all"',
-        'transformers>=4.36.0,<5.0.0; extra == "dev"',
-        'transformers>=4.36.0,<5.0.0; extra == "train"',
+        "transformers>=5.12.1,<6.0.0",
+        'transformers>=5.12.1,<6.0.0; extra == "all"',
+        'transformers>=5.12.1,<6.0.0; extra == "dev"',
+        'transformers>=5.12.1,<6.0.0; extra == "train"',
     )
-    report = check_declared_bounds(reqs, {"transformers": "5.14.1"})
+    report = check_declared_bounds(reqs, {"transformers": "6.0.0"})
     assert report.violation_count == 1
     assert report.violations[0].name == "transformers"
 
 
 def test_extra_gated_tracked_bound_is_enforced():
     # #368 review blocker: since the v0.71.0 deps-split, the `transformers`
-    # <5.0.0 cap exists in metadata ONLY under `extra == "train"/"all"/"dev"`.
+    # The bound exists in metadata ONLY under `extra == "train"/"all"/"dev"`.
     # Deselecting every gated requirement made the case #368 was FILED ABOUT
     # unreachable — measured as `ok=True, violation_count=0` against real
     # installed metadata. A TRACKED_PACKAGES name keeps its bound enforced.
     from soup_cli.utils.env_lock import check_declared_bounds
 
-    report = check_declared_bounds(_TRAIN_TRANSFORMERS, {"transformers": "5.14.1"})
+    report = check_declared_bounds(_TRAIN_TRANSFORMERS, {"transformers": "6.0.0"})
     assert not report.ok, report
     assert report.violation_count == 1
     (v,) = report.violations
     assert v.name == "transformers"
-    assert v.installed == "5.14.1"
-    assert "<5.0.0" in v.specifier
+    assert v.installed == "6.0.0"
+    assert "<6.0.0" in v.specifier
 
 
 def test_extra_gated_untracked_bound_stays_deselected():
@@ -856,25 +855,20 @@ def test_extra_gated_untracked_bound_stays_deselected():
     assert report.ok, report.violations
 
 
-def test_mlx_only_bound_on_tracked_package_is_not_enforced():
-    # A tracked NAME is not sufficient to enforce a gated bound. `[mlx]` declares
-    # `transformers>=5.0.0` against `[train]`'s `<5.0.0` — deliberately
-    # incompatible extras. Enforcing both by name would make EVERY installed
-    # transformers violate exactly one of them, a false positive on every
-    # machine. Only the training-install extras lift the marker.
+def test_mlx_only_bound_on_tracked_package_is_enforced():
+    # #502 aligns the MLX and training ranges, so the standalone MLX environment
+    # is now part of the ABI-sensitive bounds audit too.
     from soup_cli.utils.env_lock import check_declared_bounds
 
-    mlx_only = ('transformers>=5.0.0; extra == "mlx"',)
-    # A version the [train] cap is happy with, that the [mlx] floor is not.
-    assert check_declared_bounds(mlx_only, {"transformers": "4.57.6"}).ok
+    mlx_only = ('transformers>=5.12.1,<6.0.0; extra == "mlx"',)
+    assert check_declared_bounds(mlx_only, {"transformers": "5.15.1"}).ok
+    assert not check_declared_bounds(mlx_only, {"transformers": "6.0.0"}).ok
 
-    # And the two together resolve to the training bound alone, not to "both
-    # bounds violated".
+    # The identical training/MLX bounds deduplicate to one violation.
     both = _TRAIN_TRANSFORMERS + mlx_only
-    assert check_declared_bounds(both, {"transformers": "4.57.6"}).ok
-    breached = check_declared_bounds(both, {"transformers": "5.14.1"})
+    breached = check_declared_bounds(both, {"transformers": "6.0.0"})
     assert breached.violation_count == 1
-    assert "<5.0.0" in breached.violations[0].specifier
+    assert "<6.0.0" in breached.violations[0].specifier
 
 
 def test_extra_gated_tracked_bound_counted_once_across_extras():
@@ -885,7 +879,7 @@ def test_extra_gated_tracked_bound_counted_once_across_extras():
     from soup_cli.utils.env_lock import check_declared_bounds
 
     assert len(_TRAIN_TRANSFORMERS) == 3
-    report = check_declared_bounds(_TRAIN_TRANSFORMERS, {"transformers": "5.14.1"})
+    report = check_declared_bounds(_TRAIN_TRANSFORMERS, {"transformers": "6.0.0"})
     assert report.violation_count == 1
 
 
@@ -923,11 +917,11 @@ def test_current_declared_bounds_check_real_path_detects_violation(monkeypatch):
 
     from soup_cli.utils import env_lock
 
-    monkeypatch.setattr(md, "requires", lambda dist: ["transformers>=4.36.0,<5.0.0"])
+    monkeypatch.setattr(md, "requires", lambda dist: ["transformers>=5.12.1,<6.0.0"])
     monkeypatch.setattr(
         env_lock,
         "_detect_package_version",
-        lambda name: "5.14.1" if name == "transformers" else None,
+        lambda name: "6.0.0" if name == "transformers" else None,
     )
     report = env_lock.current_declared_bounds_check("soup-cli")
     assert not report.ok
@@ -943,8 +937,8 @@ def test_cli_env_check_declared_bound_violation_exits_3(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     violation = BoundViolation(
         name="transformers",
-        installed="5.14.1",
-        specifier=">=4.36.0,<5.0.0",
+        installed="6.0.0",
+        specifier=">=5.12.1,<6.0.0",
         extra=None,
     )
     monkeypatch.setattr(
@@ -972,8 +966,8 @@ def test_cli_env_check_bound_violation_escapes_rich_markup(tmp_path, monkeypatch
     monkeypatch.chdir(tmp_path)
     violation = BoundViolation(
         name="[bold]evil[/bold]",
-        installed="5.14.1",
-        specifier=">=4.36.0,<5.0.0",
+        installed="6.0.0",
+        specifier=">=5.12.1,<6.0.0",
         extra=None,
     )
     monkeypatch.setattr(

--- a/tests/test_v07131.py
+++ b/tests/test_v07131.py
@@ -25,13 +25,10 @@ def _plain(text: str) -> str:
 
 
 def _trl_has_judges():
-    """True on trl 0.19.x (pairwise BasePairwiseJudge API), False on trl 1.x."""
-    try:
-        from trl import BasePairwiseJudge  # noqa: F401
+    """True when the installed OnlineDPOTrainer accepts pairwise ``judge=``."""
+    from soup_cli.trainer.online_dpo import _trl_has_judges as has_judges
 
-        return True
-    except ImportError:
-        return False
+    return has_judges()
 
 
 _TRL_HAS_JUDGES = _trl_has_judges()
@@ -187,7 +184,7 @@ class TestCompareePairMethod:
 
 
 # ---------------------------------------------------------------------------
-# Task 2 — make_soup_pairwise_judge (trl 0.19.x pairwise BasePairwiseJudge
+# Task 2 — make_soup_pairwise_judge (trl <1 pairwise BasePairwiseJudge
 # adapter). trl 1.x removed judges -> the 1.x-equivalent coverage is
 # TestJudgeRewardFunc below (the pointwise reward-func adapter). Together they
 # cover whichever adapter the installed trl actually exposes.
@@ -225,11 +222,14 @@ class TestSoupPairwiseJudge:
         assert j.judge(["p"], [["only-one"]]) == [-1]
 
     def test_is_trl_base_pairwise_judge(self):
-        from trl import BasePairwiseJudge
+        from soup_cli.eval.judge import (
+            _base_pairwise_judge_cls,
+            make_soup_pairwise_judge,
+        )
 
-        from soup_cli.eval.judge import make_soup_pairwise_judge
-
-        assert isinstance(make_soup_pairwise_judge(_FakeJudge()), BasePairwiseJudge)
+        assert isinstance(
+            make_soup_pairwise_judge(_FakeJudge()), _base_pairwise_judge_cls()
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -643,10 +643,10 @@ class TestBuildJudgeOrReward:
 
         od._ONLINE_DPO_JUDGE_OVERRIDE = None
         result = _online_dpo_wrapper()._build_judge_or_reward(_Tcfg(judge="ollama://m"))
-        if _TRL_HAS_JUDGES:  # trl 0.19.x -> pairwise judge=
-            from trl import BasePairwiseJudge
+        if _TRL_HAS_JUDGES:  # trl <1 -> pairwise judge=
+            from soup_cli.eval.judge import _base_pairwise_judge_cls
 
-            assert isinstance(result["judge"], BasePairwiseJudge)
+            assert isinstance(result["judge"], _base_pairwise_judge_cls())
             assert "reward_funcs" not in result
         else:  # trl 1.x -> pointwise reward_funcs=
             assert callable(result["reward_funcs"][0])

--- a/tests/test_v07133.py
+++ b/tests/test_v07133.py
@@ -2319,11 +2319,9 @@ class TestVocabSizeOfCompositeConfig:
     VLM target is no longer refused with "could not read model config". It is the
     shared helper, so this covers `measure` and `distill` at once.
 
-    Stubbed configs rather than a real `LlavaConfig`: the repo allows
-    `transformers>=4.36,<5`, and the top-level `vocab_size` this fallback exists
-    for was only dropped from `LlavaConfig` partway through that range — on the
-    older cells a real config would satisfy the assertion without ever reaching
-    the fallback. The shapes below are the ones measured on 4.57.6
+    Stubbed configs rather than a real `LlavaConfig` so changes in the supported
+    Transformers range cannot satisfy the assertion without reaching the
+    fallback. The shapes below are the ones originally measured on 4.57.6
     (`LlavaConfig().vocab_size` missing, `get_text_config().vocab_size == 32000`).
     """
 

--- a/tests/test_v07204.py
+++ b/tests/test_v07204.py
@@ -211,17 +211,43 @@ def _policy_logps(trainer, model, batch):
 def _loss_of(trainer, model, batch):
     """Call the trainer's loss for `model`, across TRL's signature differences.
 
-    `KTOTrainer.get_batch_loss_metrics` takes (model, batch); DPO / ORPO / CPO
-    take (model, batch, train_eval).
+    TRL <=0.28 exposes ``get_batch_loss_metrics``. DPO 0.29 folds that method
+    into a private helper while KTO / the experimental preference trainers
+    retain the older surface. Prefer the old method where it exists. For the
+    new DPO implementation, reconstruct its standard sigmoid loss from the
+    policy and reference log-probability helpers so this test can compare a
+    separate resident control model without changing the trainer under test.
     """
     import inspect
 
-    fn = trainer.get_batch_loss_metrics
-    if "train_eval" in inspect.signature(fn).parameters:
-        loss, _ = fn(model, batch, "train")
-    else:
-        loss, _ = fn(model, batch)
-    return loss
+    fn = getattr(trainer, "get_batch_loss_metrics", None)
+    if fn is not None:
+        if "train_eval" in inspect.signature(fn).parameters:
+            loss, _ = fn(model, batch, "train")
+        else:
+            loss, _ = fn(model, batch)
+        return loss
+    # DPO 0.29 folds the whole standard sigmoid loss into a private
+    # ``_compute_loss``. Rebuild only that public mathematical contract from
+    # the policy and reference log-probability helpers: this gate deliberately
+    # reuses one trainer with a resident control model, while 0.29's private
+    # method reads ``self.model`` even when a different model argument is
+    # supplied. Calling it would therefore compare two different references.
+    import torch.nn.functional as functional
+
+    assert list(trainer.loss_types) == ["sigmoid"]
+    policy = _policy_logps(trainer, model, batch)
+    original_model = trainer.model
+    trainer.model = model
+    try:
+        ref_chosen, ref_rejected = trainer.compute_ref_log_probs(batch)
+    finally:
+        trainer.model = original_model
+    chosen_logratios = policy["chosen_logps"] - ref_chosen
+    rejected_logratios = policy["rejected_logps"] - ref_rejected
+    return -functional.logsigmoid(
+        trainer.beta * (chosen_logratios - rejected_logratios)
+    ).mean()
 
 
 def _match_streamed_dtype(resident, streamed):
@@ -581,17 +607,22 @@ class TestBitExactVsResident:
         wrapper, resident, _ = _build_streamed_wrapper(tmp_path, monkeypatch, task=task)
         _randomise_lora_b(wrapper.model)
 
-        resident_peft = get_peft_model(
-            resident,
-            LoraConfig(
-                r=4,
-                lora_alpha=8,
-                lora_dropout=0.0,
-                bias="none",
-                target_modules=["q_proj", "v_proj"],
-                task_type=TaskType.CAUSAL_LM,
-            ),
+        lora_config = LoraConfig(
+            r=4,
+            lora_alpha=8,
+            lora_dropout=0.0,
+            bias="none",
+            target_modules=["q_proj", "v_proj"],
+            task_type=TaskType.CAUSAL_LM,
         )
+        resident_peft = get_peft_model(resident, lora_config)
+        # TRL 0.29 snapshots a non-zero initial policy as a frozen ``ref``
+        # adapter. Give the resident control the same adapter topology before
+        # copying weights; otherwise its reference is the bare base while the
+        # streamed arm compares against the snapshot, so this is no longer a
+        # streamed-vs-resident comparison.
+        if "ref" in wrapper.model.peft_config:
+            resident_peft.add_adapter("ref", lora_config)
         copied = _sync_adapters(resident_peft, wrapper.model)
         assert copied > 0, "vacuous: no adapter tensors copied"
 

--- a/tests/test_v07204.py
+++ b/tests/test_v07204.py
@@ -182,6 +182,32 @@ def _batch_on(model, batch):
     }
 
 
+def _policy_logps(trainer, model, batch):
+    """Return chosen/rejected policy logps across TRL's DPO implementations.
+
+    TRL 0.29 folded ``concatenated_forward`` into ``_compute_loss``. Keeping
+    this small test adapter lets the gate continue to assert the policy/reference
+    property without requiring a production shim for a removed private method.
+    """
+    if hasattr(trainer, "concatenated_forward"):
+        return trainer.concatenated_forward(model, batch)
+
+    from trl.trainer.utils import selective_log_softmax
+
+    input_ids, attention_mask, completion_mask = trainer._truncate_inputs(
+        batch["input_ids"], batch["attention_mask"], batch["completion_mask"]
+    )
+    outputs = model(input_ids=input_ids, attention_mask=attention_mask, use_cache=False)
+    shift_logits = outputs.logits[..., :-1, :].contiguous()
+    shift_labels = input_ids[..., 1:].contiguous()
+    shift_completion_mask = completion_mask[..., 1:].contiguous()
+    per_token_logps = selective_log_softmax(shift_logits, shift_labels)
+    per_token_logps[shift_completion_mask == 0] = 0.0
+    assert trainer.ld_alpha is None, "the v0.72.4 gate assumes standard sequence logps"
+    chosen_logps, rejected_logps = per_token_logps.sum(dim=1).chunk(2, dim=0)
+    return {"chosen_logps": chosen_logps, "rejected_logps": rejected_logps}
+
+
 def _loss_of(trainer, model, batch):
     """Call the trainer's loss for `model`, across TRL's signature differences.
 
@@ -396,7 +422,19 @@ class TestNoSecondModelInstance:
             f"{task} built a SECOND model instance for the reference — that "
             f"doubles memory and defeats layer streaming entirely"
         )
-        assert getattr(trainer, "is_peft_model", False) is True
+        from accelerate.utils import is_peft_model
+
+        assert is_peft_model(trainer.model)
+        # TRL 0.29 represents the immutable initial policy as a second adapter,
+        # not a second model. It is the correct reference when LoRA starts from
+        # non-zero weights (for example PiSSA or a resumed adapter).
+        if task == "dpo":
+            assert "ref" in trainer.model.peft_config
+            assert not any(
+                param.is_meta
+                for name, param in trainer.model.named_parameters()
+                if ".ref." in name
+            )
 
     @pytest.mark.parametrize("task", _ALL_PREFERENCE)
     def test_exactly_one_weight_store_is_constructed(self, tmp_path, monkeypatch, task):
@@ -434,7 +472,7 @@ class TestNoSecondModelInstance:
         batch = _batch_on(wrapper.model, next(iter(trainer.get_train_dataloader())))
         wrapper.model.eval()
         with torch.no_grad():
-            policy = trainer.concatenated_forward(wrapper.model, batch)
+            policy = _policy_logps(trainer, wrapper.model, batch)
             ref_chosen, ref_rejected = trainer.compute_ref_log_probs(batch)
         assert (policy["chosen_logps"] - ref_chosen).abs().max().item() > 1e-4
         assert (policy["rejected_logps"] - ref_rejected).abs().max().item() > 1e-4
@@ -455,7 +493,7 @@ class TestNoSecondModelInstance:
         batch = _batch_on(wrapper.model, next(iter(trainer.get_train_dataloader())))
         wrapper.model.eval()
         with torch.no_grad():
-            policy = trainer.concatenated_forward(wrapper.model, batch)
+            policy = _policy_logps(trainer, wrapper.model, batch)
             ref_chosen, _ = trainer.compute_ref_log_probs(batch)
         diff = (policy["chosen_logps"] - ref_chosen).abs().max().item()
         assert diff == 0.0, diff

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -402,7 +402,7 @@ class TestSFTVisionIntegration:
         assert wrapper.config.modality == "vision"
 
     def test_sft_setup_vision_calls_automodel(self):
-        """_setup_vision_transformers should use AutoModelForVision2Seq."""
+        """The SFT wrapper exposes the Transformers vision setup path."""
         from soup_cli.trainer.sft import SFTTrainerWrapper
 
         cfg = SoupConfig(


### PR DESCRIPTION
## Summary

- make the `[train]` and `[mlx]` extras co-installable on `transformers>=5.12.1,<6`, with `trl>=0.29,<1` and `peft>=0.20,<1`
- migrate the affected Transformers/TRL call sites and resolve moved TRL symbols through the existing capability helper
- add a Transformers LoRA target policy for the Qwen3.5 hybrid text decoder while leaving explicit targets and MLX defaults unchanged
- pin text-mode loading to `Qwen3_5ForCausalLM`, assert that no vision parameters are instantiated, and save/reload a non-empty adapter
- materialize TRL 0.29's frozen DPO `ref` adapter when layer streaming creates it on `meta`, preserving the one-model memory property
- restore the removed DPO/ORPO prompt cap on TRL's prepared token ids, so `data.max_length` remains an effective model-input bound
- keep the backend documentation and the declared `[train]`/`[mlx]` Transformers ranges linked by a consistency test
- support both Plotext 5's module API and Plotext 6's Figure API, then deliberately lift main's temporary `<6.0.0` safety cap
- keep `soup doctor` synchronized with the validated Transformers/TRL/PEFT compatibility band through a metadata-derived regression test

## Why 5.12.1

Transformers 5.2 contains Qwen3.5 symbols, but its auto-model mapping still passes the outer `Qwen3_5Config` into the text decoder and fails because that wrapper has no direct `vocab_size`. The first tested floor where `AutoModelForCausalLM.from_config(Qwen3_5Config(...))` selects a working text-only `Qwen3_5ForCausalLM` is 5.12.1.

TRL 0.29 is paired with that floor because it vendors its optional-package probe instead of importing Transformers' private helper, and the moved pairwise-judge/Online DPO APIs are now resolved from their experimental homes when absent from the public namespace.

## Measured TRL 0.29 follow-up

- **Online DPO was exercised, not only imported.** On the exact floor (`transformers 5.12.1`, `trl 0.29.0`, `peft 0.20.0`), a real Apple Silicon CPU training run generated completions, called the pairwise judge, completed an optimizer step, and logged `rewards/chosen`, `rewards/rejected`, `rewards/accuracies`, and `rewards/margins`.
- **The streamed DPO reference finding was measured.** Before materialization, every `.ref.` LoRA parameter created by TRL was on `meta`; even the zero-`lora_B` control produced a maximum chosen-logp delta of `0.0028839111328125`. After materialization, the frozen reference parameters are non-meta, the zero-adapter control is exactly `0.0`, and a randomized policy adapter differs from the reference by more than the pinned `1e-4` threshold.
- **The prompt caveat reproduced on 0.29.** A 161-token prompt with `data.max_length: 64` reached the model as 164 tokens in DPO and 165 in ORPO. The follow-up caps TRL's already-rendered token ids (including conversational rows), retains all 8 test rows, and asserts every effective input sequence is at most 64 tokens.

## Plotext 6 follow-up

Main temporarily capped Plotext below 6 in `eb77dd1` after the upstream release removed the module-level plotting API and broke all nine CI matrix cells (#522). This branch routes Plotext 5 through the classic module API and Plotext 6 through its Figure API. After rebasing onto that repair, this PR deliberately lifts the cap again, updates #522's changelog entry, and retains the contract coverage for both paths.

The dedicated compatibility cell now pins the real `plotext==6.0.0`, asserts that installed version, and executes histogram and line rendering against the installed package. The ordinary fake-API tests remain because they independently pin both the 5.x and 6.x dispatch contracts.

## Review follow-up

- rebased onto current `main` through `6580418`, including #471 and #509
- synchronized `soup doctor` with the declared `transformers>=5.12.1,<6`, `trl>=0.29,<1`, and `peft>=0.20,<1` ranges
- added a regression that derives those bounds from `pyproject.toml`, so the doctor table cannot silently drift again
- added explicit new-floor skip guidance for runtime tests collected in a pre-upgrade environment
- updated #471's vision loader doubles to the Transformers 5 `AutoModelForImageTextToText` name after the rebase exposed the stale fixtures

## Validation

Run locally on macOS arm64:

- current latest stack (`transformers 5.15.1`, `trl 0.29.1`, `peft 0.20.0`, `plotext 6.0.0`): `18534 passed, 283 skipped, 5 deselected`; coverage `81.29%`
- exact compatibility cell (`transformers 5.12.1`, `trl 0.29.0`, `peft 0.20.0`, `plotext 6.0.0`): `29 passed`
- post-rebase review and related coverage: `230 passed`
- real Plotext 5.3.2 runtime plus metadata guards: `5 passed`
- focused latest-stack TRL/Qwen/streaming matrix: `112 passed, 19 skipped`
- real Online DPO smoke on both tested stacks: `1 passed, 1 skipped` (the skip is the inapplicable TRL 1.x branch)
- combined `[dev,mlx]` dependency check: clean on both tested stacks
- `ruff check src/soup_cli scripts tests/`
- `actionlint`
- `git diff --check`

Fixes #502
Fixes #503
Closes #522
