### PR TITLE
fix(export): fail fast when tensorrt_llm has no convert_checkpoint entry point (#337)

### DIFF
--- a/changelog.d/0.73.3/508.fixed.md
+++ b/changelog.d/0.73.3/508.fixed.md
@@ -1,0 +1,10 @@
+- **TensorRT-LLM export now fails immediately with a clear message instead of
+  silently producing zero artifact bytes (#337 in #508).** `_export_tensorrt()`
+  shelled out to `python -m tensorrt_llm.commands.convert_checkpoint`, a module
+  absent from every current TensorRT-LLM release (`tensorrt_llm.commands` ships
+  only `bench/build/eval/prune/refit/serve`; conversion now lives as a
+  per-architecture `examples/<arch>/convert_checkpoint.py` script instead). The
+  entry point is checked right after the existing `tensorrt_llm` availability
+  check, before the LoRA merge and checkpoint directory are touched. Docs now
+  warn that installing `tensorrt_llm` can downgrade a training environment's
+  `torch`/`transformers`/`numpy`/`datasets` pins.

--- a/docs/serving-and-export.md
+++ b/docs/serving-and-export.md
@@ -112,6 +112,10 @@ soup export --model ./output --format tensorrt
 soup export --model ./output --format tensorrt --output ./model_trt
 ```
 
+`pip install tensorrt_llm` pins its own `torch`/`transformers`/`numpy`/`datasets`
+versions, which can downgrade a training environment's stack. Install it in a
+separate environment from the one you trained in, and export there.
+
 ### BitNet 1.58 TQ1_0 GGUF Export (live in v0.71.20)
 
 Export a BitNet 1.58-bit model as a `TQ1_0` (1.58-bit ternary) GGUF via

--- a/src/soup_cli/commands/export.py
+++ b/src/soup_cli/commands/export.py
@@ -709,6 +709,20 @@ def _export_tensorrt(
         )
         raise typer.Exit(1)
 
+    try:
+        import tensorrt_llm.commands.convert_checkpoint  # noqa: F401
+    except ImportError:
+        console.print(
+            "[red]tensorrt_llm.commands.convert_checkpoint not found in the "
+            "installed tensorrt_llm package.[/]\n"
+            "This entry point does not exist in current TensorRT-LLM releases; "
+            "checkpoint conversion now ships as a per-architecture "
+            "examples/<arch>/convert_checkpoint.py script in the NVIDIA/TensorRT-LLM "
+            "source tree instead.\n"
+            "See: https://github.com/NVIDIA/TensorRT-LLM#installation"
+        )
+        raise typer.Exit(1)
+
     # Check if LoRA adapter
     adapter_config_path = model_path / "adapter_config.json"
     is_adapter = adapter_config_path.exists()

--- a/tests/test_onnx_tensorrt_export.py
+++ b/tests/test_onnx_tensorrt_export.py
@@ -3,6 +3,9 @@
 from unittest.mock import MagicMock
 from unittest.mock import patch as mock_patch
 
+import pytest
+import typer
+
 from soup_cli.commands.export import SUPPORTED_FORMATS
 
 # ─── Format Support Tests ────────────────────────────────────────────────
@@ -145,6 +148,8 @@ class TestTensorrtExportFunction:
             "optimum.exporters": MagicMock(),
             "optimum.exporters.onnx": MagicMock(),
             "tensorrt_llm": MagicMock(),
+            "tensorrt_llm.commands": MagicMock(),
+            "tensorrt_llm.commands.convert_checkpoint": MagicMock(),
         }), mock_patch("subprocess.run", return_value=mock_result) as mock_run:
             import soup_cli.commands.export as export_mod
 
@@ -153,6 +158,28 @@ class TestTensorrtExportFunction:
             )
             # Should call subprocess at least twice (checkpoint + build)
             assert mock_run.call_count >= 2
+
+    def test_tensorrt_export_missing_convert_checkpoint_fails_fast(self, tmp_path):
+        """#337: current TensorRT-LLM releases ship no `commands.convert_checkpoint`
+        submodule, so a plain `tensorrt_llm` install (present but without that entry
+        point registered) must abort before any subprocess call, not fail deep inside
+        checkpoint conversion."""
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+
+        with mock_patch.dict("sys.modules", {
+            "optimum": MagicMock(),
+            "optimum.exporters": MagicMock(),
+            "optimum.exporters.onnx": MagicMock(),
+            "tensorrt_llm": MagicMock(),
+        }), mock_patch("subprocess.run") as mock_run:
+            import soup_cli.commands.export as export_mod
+
+            with pytest.raises(typer.Exit):
+                export_mod._export_tensorrt(
+                    model_dir, str(tmp_path / "trt_out"), None
+                )
+            mock_run.assert_not_called()
 
 
 # ─── Unsupported Format Test ─────────────────────────────────────────────


### PR DESCRIPTION
`_export_tensorrt()` shells out to `python -m tensorrt_llm.commands.convert_checkpoint`
before checking the module exists. It never has, in any current TensorRT-LLM release:
`tensorrt_llm.commands` ships only `bench/build/eval/prune/refit/serve`, and checkpoint
conversion now lives as a per-architecture `examples/<arch>/convert_checkpoint.py`
script in the NVIDIA/TensorRT-LLM source tree instead. The old code did surface the
subprocess's stderr on failure, but that read as a transient conversion problem rather
than naming what was actually missing, and it ran only after building the export plan
panel and merging any LoRA adapter.

## Fix

Import the entry point directly right after the existing `tensorrt_llm` availability
check, and exit with a message naming the missing module before any further work
happens. This is the "fail immediately with a message naming what is missing" branch
from the issue's acceptance criteria; vendoring the per-architecture conversion scripts
is a separate, hardware-verifiable piece of work this PR does not attempt.

Also added a docs note warning that installing `tensorrt_llm` can downgrade a training
environment's `torch`/`transformers`/`numpy`/`datasets` pins, per the issue's second
finding.

## Verification

- New regression test mocks `tensorrt_llm` as importable but without
  `commands.convert_checkpoint` registered: fails on `main` (`subprocess.run` is called
  and returns a generic conversion error), passes on this branch (`typer.Exit` is raised
  and `subprocess.run` is never called). Ran on Python 3.10 and 3.12 in Docker.
- `ruff check src/soup_cli/ scripts/ tests/` is clean.
- Not verified: the actual checkpoint conversion path against real TensorRT-LLM
  hardware. I do not have a GPU box for that, and this fix does not change what happens
  when the entry point exists, only what happens when it is missing.

Fixes #337
