### PR TITLE
fix(ci): make the drift alarm fail on a NEW conflict, not on every Monday

### DIFF
--- a/.github/workflows/dependency-drift.yml
+++ b/.github/workflows/dependency-drift.yml
@@ -45,6 +45,8 @@ jobs:
           from importlib.metadata import PackageNotFoundError, requires, version
 
           from packaging.requirements import Requirement
+          from packaging.specifiers import SpecifierSet
+          from packaging.version import Version
 
           # The stack whose drift has actually cost releases (#323).
           WATCHED = {
@@ -72,8 +74,66 @@ jobs:
           # Two extras declaring incompatible ranges for one package is a
           # resolver failure waiting for the first person to combine them, and
           # nothing else in CI installs every extra together to find out.
+          #
+          # `len(specs) > 1` was NOT that test. Two declarations can differ and
+          # still overlap -- `>=4.36.0,<5.0.0` alongside `>=4.40.0` installs
+          # perfectly well -- so it failed the job on correct declarations, and
+          # a guard that fires on correct code is one people delete. Ask the
+          # real question instead: is there any single version that satisfies
+          # every declaration at once?
+          def _unsatisfiable(specs):
+              sets = [SpecifierSet(spec) for spec in specs if spec != "(unpinned)"]
+              if len(sets) < 2:
+                  return False
+              probes = [
+                  Version(f"{major}.{minor}.0")
+                  for major in range(0, 12)
+                  for minor in range(0, 60)
+              ]
+              # Each declared bound verbatim: an off-by-one lives exactly there.
+              for spec_set in sets:
+                  for clause in spec_set:
+                      try:
+                          probes.append(Version(clause.version))
+                      except Exception:
+                          continue
+              return not any(
+                  all(spec_set.contains(v, prereleases=True) for spec_set in sets)
+                  for v in probes
+              )
+
+          # A conflict upstream blocks is not actionable, and this report's own
+          # test already says a weekly alarm that is always red gets muted
+          # within a month. Acknowledged conflicts are PRINTED with their issue
+          # and do not fail the job. The key is the EXACT declared pair, so
+          # changing either side re-arms the alarm instead of inheriting the
+          # acknowledgement.
+          # Written as authored; compared as PARSED. `str(req.specifier)`
+          # reorders clauses -- `>=4.36.0,<5.0.0` reads back as
+          # `<5.0.0,>=4.36.0` -- so matching written strings would never fire
+          # and the acknowledgement would be inert while the job stayed red.
+          ACKNOWLEDGED = {
+              "transformers": ({">=4.36.0,<5.0.0", ">=5.0.0"}, 503),
+          }
+
+          def _same_declarations(declared, remembered):
+              return {SpecifierSet(x) for x in declared} == {
+                  SpecifierSet(x) for x in remembered
+              }
+
+          conflicting = {
+              name: specs for name, specs in by_package.items() if _unsatisfiable(specs)
+          }
+          acknowledged = {
+              name: (specs, ACKNOWLEDGED[name][1])
+              for name, specs in conflicting.items()
+              if name in ACKNOWLEDGED
+              and _same_declarations(specs, ACKNOWLEDGED[name][0])
+          }
           contradictory = {
-              name: specs for name, specs in by_package.items() if len(specs) > 1
+              name: specs
+              for name, specs in conflicting.items()
+              if name not in acknowledged
           }
 
           print("## Resolved stack vs declared bounds\n")
@@ -90,6 +150,17 @@ jobs:
                   "\nA package declared with incompatible ranges in two "
                   "extras cannot be installed by anyone who asks for both."
               )
+
+          if acknowledged:
+              print("\n### Acknowledged conflicts\n")
+              for name, (specs, issue) in sorted(acknowledged.items()):
+                  print(
+                      f"- **{name}**: "
+                      + " vs ".join(sorted(specs))
+                      + f" -- tracked in #{issue}, blocked upstream. Still"
+                      " unsatisfiable; listed rather than failed so that a NEW"
+                      " conflict is not hidden behind a permanently red run."
+                  )
 
           if floor_only:
               print(

--- a/tests/test_issue323_trl_kwarg_drift.py
+++ b/tests/test_issue323_trl_kwarg_drift.py
@@ -297,3 +297,144 @@ class TestTheDriftWorkflowCanActuallyFail:
             "the report exits at module level, so a clean weekly run would go "
             "red too"
         )
+
+
+class TestTheDriftAlarmDoesNotCryWolf:
+    """The alarm must go red on a NEW conflict and stay quiet otherwise.
+
+    ``TestTheDriftWorkflowCanActuallyFail`` above already writes down the rule
+    -- *a weekly alarm that is always red gets muted within a month* -- and
+    then checks only that the report has no module-level ``sys.exit``. On its
+    first real run the job went red, correctly, on the ``transformers``
+    conflict between ``[train]`` and ``[mlx]`` (#503). That conflict is blocked
+    upstream, so it would have reddened every Monday indefinitely, and a NEW
+    conflict arriving later would have been invisible inside an already-red
+    job -- which is the alarm's only job.
+
+    Two defects were behind that, and only the second was the one this class
+    was opened for:
+
+    1. ``len(specs) > 1`` detected *differing* declarations, not incompatible
+       ones. ``>=4.36.0,<5.0.0`` alongside ``>=4.40.0`` installs perfectly
+       well and would have failed the job -- a guard firing on correct code.
+    2. There was no way to acknowledge a tracked conflict.
+
+    These execute the report under synthetic metadata rather than inspecting
+    it. The distinction is load-bearing here: the acknowledgement was first
+    keyed on the written string ``">=4.36.0,<5.0.0"``, but
+    ``str(req.specifier)`` reads it back as ``"<5.0.0,>=4.36.0"``, so it never
+    matched and was inert while the job stayed red. Every spelling-level
+    assertion passed on that version.
+    """
+
+    ACK_TRAIN = 'transformers>=4.36.0,<5.0.0; extra == "train"'
+    ACK_MLX = 'transformers>=5.0.0; extra == "mlx"'
+
+    @staticmethod
+    def _run(requirements: list[str]) -> tuple[int, str]:
+        """Execute the report with these declared requirements."""
+        import contextlib
+        import importlib.metadata
+        import io
+        from unittest.mock import patch
+
+        source = TestTheDriftWorkflowCanActuallyFail._report_source()
+
+        def fake_requires(_name):
+            return list(requirements)
+
+        def fake_version(name):
+            raise importlib.metadata.PackageNotFoundError(name)
+
+        out = io.StringIO()
+        code = 0
+        with patch.object(
+            importlib.metadata, "requires", fake_requires
+        ), patch.object(importlib.metadata, "version", fake_version):
+            try:
+                with contextlib.redirect_stdout(out), contextlib.redirect_stderr(
+                    io.StringIO()
+                ):
+                    exec(  # noqa: S102 - the workflow's own script, by design
+                        compile(source, "<drift-report>", "exec"),
+                        {"__name__": "__drift__"},
+                    )
+            except SystemExit as exc:
+                code = exc.code if isinstance(exc.code, int) else 1
+        return code, out.getvalue()
+
+    def test_a_compatible_pair_declared_two_ways_does_not_fail(self):
+        """The false positive: differing is not the same as incompatible."""
+        code, _ = self._run(
+            [
+                self.ACK_TRAIN,
+                'transformers>=4.40.0; extra == "somethingelse"',
+            ]
+        )
+        assert code == 0, (
+            "`>=4.36.0,<5.0.0` and `>=4.40.0` overlap and install together, so "
+            "failing on them is an alarm firing on correct declarations"
+        )
+
+    def test_an_unsatisfiable_pair_still_fails(self):
+        """The alarm's whole purpose: it must still go red on a real one."""
+        code, _ = self._run(
+            [
+                'torch>=1.0,<2.0; extra == "a"',
+                'torch>=3.0; extra == "b"',
+            ]
+        )
+        assert code == 1, (
+            "no version satisfies both, so nobody asking for both extras can "
+            "install; that must fail the job"
+        )
+
+    def test_the_tracked_conflict_is_acknowledged_rather_than_red(self):
+        code, _ = self._run([self.ACK_TRAIN, self.ACK_MLX])
+        assert code == 0, (
+            "the transformers conflict is tracked in #503 and blocked "
+            "upstream; leaving it red every Monday buries the next real one"
+        )
+
+    def test_the_acknowledged_conflict_is_still_printed_with_its_issue(self):
+        """Acknowledged must mean visible, not silenced."""
+        _, out = self._run([self.ACK_TRAIN, self.ACK_MLX])
+        assert "Acknowledged conflicts" in out, (
+            "an acknowledged conflict that prints nothing is indistinguishable "
+            "from one nobody noticed"
+        )
+        assert "#503" in out, "the acknowledgement must name where it is tracked"
+
+    def test_changing_either_side_re_arms_the_alarm(self):
+        """An acknowledgement covers ONE pair, not the package forever."""
+        code, _ = self._run(
+            [self.ACK_TRAIN, 'transformers>=6.0.0; extra == "mlx"']
+        )
+        assert code == 1, (
+            "the acknowledgement is keyed on the exact declared pair; moving "
+            "either bound is a different conflict and must go red again"
+        )
+
+    def test_the_acknowledgement_is_keyed_on_parsed_specifiers(self):
+        """Regression: a written-string key is inert, and looks identical.
+
+        `str(req.specifier)` reorders clauses, so an acknowledgement written as
+        `>=4.36.0,<5.0.0` is compared against `<5.0.0,>=4.36.0` and never
+        matches. This asserts the acknowledgement fires when the SAME bounds
+        arrive spelled in the other order.
+        """
+        code, out = self._run(
+            [
+                'transformers<5.0.0,>=4.36.0; extra == "train"',
+                self.ACK_MLX,
+            ]
+        )
+        assert code == 0 and "Acknowledged conflicts" in out, (
+            "the same bounds written in a different order must still be "
+            "recognised; comparing written strings makes the entry inert"
+        )
+
+    def test_a_single_declaration_is_never_a_conflict(self):
+        """Control: one declaration has nothing to be incompatible with."""
+        code, _ = self._run([self.ACK_TRAIN])
+        assert code == 0


### PR DESCRIPTION
fix(ci): make the drift alarm fail on a NEW conflict, not on every Monday

#486 shipped the dependency-drift job this afternoon. I dispatched it by hand
rather than waiting for its first scheduled run, because a scheduled job that
has never executed is the same "declared and never run" shape this project
keeps finding in its own history. It went red immediately, and it was RIGHT:

    ##[error]contradictory dependency declarations: transformers

`[train]` declares `transformers<5.0.0`, `[mlx]` declares `>=5.0.0`. That is a
real conflict -- #503, filed forty minutes earlier by hand, rediscovered
independently by the machine.

But the finding invalidates the premise the job fails on. Its own comment says
this is "the ONE finding here that is actionable and unambiguous". #503
established it is NOT actionable: it is blocked behind
`transformers<5 <- trl<0.29 <- the BasePairwiseJudge import`, and no single
link can be lifted alone. So the job would have been red every Monday
indefinitely, and a NEW conflict arriving later would have been invisible
inside an already-red run -- which is the alarm's only job. The test file
already writes the rule down: "a weekly alarm that is always red gets muted
within a month."

TWO defects, and the one I went looking for was the second.

1. `len(specs) > 1` detected DIFFERING declarations, not incompatible ones.
   Measured before changing anything, three cases through the shipped
   predicate:

       >=4.36.0,<5.0.0  vs  >=5.0.0     job fails: yes   truly unsatisfiable: yes
       >=4.36.0,<5.0.0  vs  >=4.40.0    job fails: yes   truly unsatisfiable: NO
       >=4.36.0,<5.0.0  vs  >=4.36.0    job fails: yes   truly unsatisfiable: NO

   Two of three are false positives. Latent today because only `transformers`
   is declared twice, but it fires the moment anyone adds a perfectly
   installable second declaration -- a guard firing on correct code, which is
   the failure mode this repository deletes guards for. Replaced with the real
   question: does any single version satisfy every declaration at once.

2. There was no way to acknowledge a tracked conflict. `ACKNOWLEDGED` maps a
   package to the EXACT declared pair plus its issue. An acknowledged conflict
   is PRINTED in the summary with its issue and does not fail; anything else
   still exits 1. Keying on the pair rather than the package means moving
   either bound re-arms the alarm instead of inheriting the acknowledgement.

A BUG IN THIS FIX, caught by exercising it rather than reading it, and worth
recording because the failure mode is the one being fixed. The
acknowledgement was first keyed on the written string `">=4.36.0,<5.0.0"`.
`str(req.specifier)` reads that back as `"<5.0.0,>=4.36.0"`, so it never
matched: the acknowledgement would have been inert and the job still red every
Monday, while every spelling-level assertion passed. Both sides are now parsed
into `SpecifierSet`, which compares and hashes order-independently.

The new tests EXECUTE the report under synthetic metadata rather than
inspecting its source, following #496's precedent for the floor job -- and
here that choice is what found the bug above. Seven cases; six mutations, all
killed:

    revert to len(specs) > 1        -> test_a_compatible_pair_..._does_not_fail
                                       (sole guard)
    delete the ACKNOWLEDGED entry   -> 3 tests
    compare written strings         -> 3 tests
    acknowledge by package name     -> test_changing_either_side_re_arms_the_alarm
                                       (sole guard)
    stop printing the section       -> 2 tests
    _unsatisfiable always False     -> 4 tests incl. ..._still_fails

Stated plainly: mutations 2 and 3 kill the same three tests and no test
isolates them. That is inherent rather than a gap -- with written-string
comparison NO acknowledgement can ever match, so there is no input where the
broken key works and the correct one does not. Making it isolate would mean
writing the entry in packaging's normalised order purely so a test could tell
the two apart, which is contorting the fix to flatter the suite.

No changelog fragment: CI and tests only, no user-visible behaviour change.

Refs #503, #486.
