### PR TITLE
fix(stream): preflight duplicated disk usage

### DIFF
--- a/changelog.d/0.73.3/510.fixed.md
+++ b/changelog.d/0.73.3/510.fixed.md
@@ -1,0 +1,1 @@
+- Fixed layer streaming's hidden duplicate-disk cost: Soup now reuses regular Hugging Face cache files, preflights materialized-weight and shard-cache writes per volume, refuses before exhausting disk space, and explains source-fingerprint cache rebuilds (#510).

--- a/docs/performance-and-quantization.md
+++ b/docs/performance-and-quantization.md
@@ -525,7 +525,19 @@ does not make it free.
 - A published 14B-on-8 GB reference benchmark — hardware-blocked; it needs an 8 GB card and 32 GB of RAM, which the development box does not have
 - GRPO and PPO are explicitly **not** planned: rollouts need generation, which re-reads the model per token
 
-**Shard cache.** The first streaming run rewrites the checkpoint into one safetensors shard per decoder layer under `~/.soup/layer-stream/` (override with `SOUP_LAYER_STREAM_CACHE_DIR`). That costs disk space roughly equal to the base. The cache is keyed to a fingerprint of the source checkpoint, so a base retrained in place re-shards instead of silently training against stale weights.
+**Disk pre-flight and shard cache.** Before Soup materialises or shards a checkpoint, it
+reports the complete projected footprint: the HF/local source, any regular-file copy Soup
+still needs, and the per-layer shard cache. Required writes are grouped by target volume and
+the run refuses before either write when that volume lacks free space. Override the two cache
+roots with `SOUP_SPECTRUM_CACHE_DIR` and `SOUP_LAYER_STREAM_CACHE_DIR`; both retain Soup's
+home/cwd/tmp containment policy.
+
+Hugging Face snapshots normally expose symlinks into their blob cache, which the sharder
+deliberately does not follow. Soup materialises those weights under its Spectrum cache. If the
+HF cache already exposes real files, Soup now reads them in place instead of creating a second
+copy. The layer shards remain under `~/.soup/layer-stream/`. Their index records each source
+filename, size, and `mtime_ns`, so a necessary re-shard says which component changed instead
+of silently spending minutes rebuilding the cache.
 
 
 ## Correctness First (v0.36.0)

--- a/src/soup_cli/trainer/stream_setup.py
+++ b/src/soup_cli/trainer/stream_setup.py
@@ -22,9 +22,11 @@ NO top-level torch: this module is imported by five trainer modules.
 import contextlib
 import math
 import os
+import shutil
 from dataclasses import dataclass
 
 from rich.console import Console
+from rich.panel import Panel
 
 console = Console()
 
@@ -52,6 +54,85 @@ class _ProbePlan:
     vocab_size: int
     predicted_bytes: int
     available_bytes: int
+
+
+def _existing_disk_anchor(path: str) -> str:
+    """Nearest existing ancestor, for paths whose final cache dir is not made yet."""
+    anchor = os.path.realpath(os.path.expanduser(path))
+    while not os.path.exists(anchor):
+        parent = os.path.dirname(anchor)
+        if parent == anchor:
+            raise OSError(f"cannot locate an existing filesystem ancestor for {path!r}")
+        anchor = parent
+    return anchor
+
+
+def _disk_volume(path: str) -> tuple[int, int]:
+    """Filesystem identity and currently free bytes for a prospective write."""
+    anchor = _existing_disk_anchor(path)
+    return int(os.stat(anchor).st_dev), int(shutil.disk_usage(anchor).free)
+
+
+def _render_stream_disk_preflight(
+    *,
+    source_bytes: int,
+    materialized_copy_bytes: int,
+    materialize_bytes: int,
+    materialized_path: str,
+    shard_bytes: int,
+    shard_write_bytes: int,
+    shard_path: str,
+) -> None:
+    """Print and enforce the complete on-disk cost before either cache writes."""
+    writes = (
+        ("materialized weight copy", materialized_path, materialize_bytes),
+        ("layer-shard cache", shard_path, shard_write_bytes),
+    )
+    required_by_device: dict[int, int] = {}
+    free_by_device: dict[int, int] = {}
+    labels_by_device: dict[int, list[str]] = {}
+    for label, path, required in writes:
+        if required <= 0:
+            continue
+        device, free = _disk_volume(path)
+        required_by_device[device] = required_by_device.get(device, 0) + required
+        free_by_device[device] = min(free_by_device.get(device, free), free)
+        labels_by_device.setdefault(device, []).append(label)
+
+    projected_total = source_bytes + materialized_copy_bytes + shard_bytes
+    additional = materialize_bytes + shard_write_bytes
+    lines = [
+        f"HF/local source: {source_bytes / 1e9:.2f} GB",
+        (
+            f"Soup materialized copy: {materialized_copy_bytes / 1e9:.2f} GB "
+            f"({'write required' if materialize_bytes else 'no write required'})"
+        ),
+        (
+            f"Layer-shard cache: {shard_bytes / 1e9:.2f} GB "
+            f"({'write required' if shard_write_bytes else 'reusable'})"
+        ),
+        f"Projected total on disk: {projected_total / 1e9:.2f} GB",
+        f"Additional writes before training: {additional / 1e9:.2f} GB",
+    ]
+    for device in sorted(required_by_device):
+        required = required_by_device[device]
+        free = free_by_device[device]
+        labels = " + ".join(labels_by_device[device])
+        lines.append(
+            f"Free on target volume ({labels}): {free / 1e9:.2f} GB"
+        )
+        if required > free:
+            console.print(
+                Panel("\n".join(lines), title="Layer streaming disk pre-flight")
+            )
+            raise ValueError(
+                f"layer streaming needs {required / 1e9:.2f} GB of additional "
+                f"disk space for {labels}, but only {free / 1e9:.2f} GB is free. "
+                f"Refusing before copying or sharding. Free disk space, point "
+                f"SOUP_SPECTRUM_CACHE_DIR / SOUP_LAYER_STREAM_CACHE_DIR at a "
+                f"larger contained volume, or choose a smaller base."
+            )
+    console.print(Panel("\n".join(lines), title="Layer streaming disk pre-flight"))
 
 
 def _distributed_launch() -> bool:
@@ -207,6 +288,8 @@ class StreamingSetupMixin:
         from soup_cli.utils.layer_shard import (
             QUANT_NF4,
             QUANT_NONE,
+            fingerprint_source_files,
+            inspect_shard_cache,
             resolve_shard_dir,
             shard_checkpoint,
             source_weight_bytes,
@@ -268,8 +351,41 @@ class StreamingSetupMixin:
         # already keys on double_quant) and the skeleton.
         double_quant = tcfg.double_quant_on
 
-        weights_dir = resolve_model_weights(cfg.base)
         shard_dir = resolve_shard_dir(cfg.base)
+        quant_device_kind = str(self.device).split(":", 1)[0] if quant == QUANT_NF4 else ""
+
+        def _disk_preflight(weights_plan) -> None:
+            shard_estimate = estimate_stream_store_bytes(
+                weights_plan.source_bytes,
+                dtype=dtype,
+                quant=quant,
+                double_quant=double_quant,
+            )
+            cached = None
+            if not weights_plan.needs_materialization:
+                cached, _reason = inspect_shard_cache(
+                    shard_dir,
+                    dtype,
+                    fingerprint_source_files(weights_plan.source_files),
+                    weights_plan.source_files,
+                    quant,
+                    double_quant,
+                    quant_device_kind,
+                )
+            _render_stream_disk_preflight(
+                source_bytes=weights_plan.source_bytes,
+                materialized_copy_bytes=weights_plan.materialized_copy_bytes,
+                materialize_bytes=weights_plan.materialize_bytes,
+                materialized_path=weights_plan.weights_dir,
+                shard_bytes=shard_estimate,
+                shard_write_bytes=0 if cached is not None else shard_estimate,
+                shard_path=shard_dir,
+            )
+
+        weights_dir = resolve_model_weights(
+            cfg.base,
+            before_materialize=_disk_preflight,
+        )
 
         # Cheap size probe BEFORE sharding: re-writing a checkpoint we are
         # about to refuse for not fitting in RAM costs minutes of disk I/O.
@@ -344,6 +460,7 @@ class StreamingSetupMixin:
             # Quantise on the device that will run the model: CPU and CUDA agree
             # on the packed nibbles but not on every float32 nested statistic.
             quant_device=str(self.device),
+            notify=console.print,
         )
 
         layer_specs = RamSource.layer_specs_from_shards(shard_dir, index.n_layers)

--- a/src/soup_cli/utils/hubs.py
+++ b/src/soup_cli/utils/hubs.py
@@ -400,27 +400,29 @@ def _validate_cache_dir(cache_dir: str, *, field: str = "cache_dir") -> str:
 def snapshot_download(
     repo_id: str,
     *,
-    cache_dir: str,
+    cache_dir: str | None,
     revision: str | None = None,
     allow_patterns: list[str] | None = None,
     namespace_check: bool = True,
     allow_namespace_shift: str | None = None,
     _metadata_fn: Optional[Callable[[str], Optional[Tuple[str, str]]]] = None,
 ) -> str:
-    """HF Hub snapshot download into a ``$HOME/.soup``-style cache (v0.71.8 #216).
+    """HF Hub snapshot download, optionally into a contained local directory.
 
     Thin SSRF-hardened wrapper over :func:`huggingface_hub.snapshot_download`
-    used by the SAE / probe weight fetchers. Differs from :func:`download_repo`
-    in that the cache dir may live under ``$HOME`` (not just cwd) so a reusable
-    artifact cache survives a ``cd``; the namespace-pin gate (#186) still runs
-    so a TOFU author-mismatch refuses the download.
+    used by the SAE / probe weight fetchers. A string ``cache_dir`` preserves
+    the historical behaviour and materialises a regular-file snapshot there.
+    ``None`` asks Hugging Face for its canonical cached snapshot instead; this
+    is used by layer streaming to inspect and reuse an existing non-symlinked
+    cache entry before deciding whether a second materialised copy is needed.
+    The namespace-pin gate (#186) runs in both cases.
 
     Returns the absolute path to the downloaded snapshot directory. Raises
     ``ImportError`` (with a pip-install hint) when ``huggingface_hub`` is
     missing, ``ValueError`` for invalid args / a refused namespace.
     """
     _validate_repo_id_shape(repo_id)
-    canonical_cache = _validate_cache_dir(cache_dir)
+    canonical_cache = None if cache_dir is None else _validate_cache_dir(cache_dir)
     if revision is not None:
         if not isinstance(revision, str):
             raise TypeError("revision must be str or None")
@@ -446,13 +448,15 @@ def snapshot_download(
             "huggingface_hub required for snapshot_download; "
             "pip install huggingface-hub"
         ) from exc
+    kwargs = {
+        "repo_id": repo_id,
+        "revision": revision,
+        "allow_patterns": allow_patterns,
+    }
+    if canonical_cache is None:
+        return hf_snapshot_download(**kwargs)
     os.makedirs(canonical_cache, exist_ok=True)
-    return hf_snapshot_download(
-        repo_id=repo_id,
-        local_dir=canonical_cache,
-        revision=revision,
-        allow_patterns=allow_patterns,
-    )
+    return hf_snapshot_download(local_dir=canonical_cache, **kwargs)
 
 
 def download_repo(

--- a/src/soup_cli/utils/layer_shard.py
+++ b/src/soup_cli/utils/layer_shard.py
@@ -28,7 +28,7 @@ import os
 import re
 import tempfile
 from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple
 
 from soup_cli import __version__
 
@@ -178,6 +178,9 @@ class ShardIndex:
     arch: str
     soup_version: str
     source_fingerprint: str = ""
+    #: ``(basename, size, mtime_ns)`` for each source shard. The digest above
+    #: remains the cache key; these components explain a mismatch to the user.
+    source_files: Tuple[Tuple[str, int, int], ...] = ()
     quant: str = QUANT_NONE
     double_quant: bool = False
     #: "cuda" / "cpu" — the device the offline quantisation ran on. CPU and CUDA
@@ -216,6 +219,10 @@ def read_shard_index(out_dir: str) -> ShardIndex:
         arch=str(payload.get("arch", "")),
         soup_version=str(payload.get("soup_version", "")),
         source_fingerprint=str(payload.get("source_fingerprint", "")),
+        source_files=tuple(
+            (str(item[0]), int(item[1]), int(item[2]))
+            for item in (payload.get("source_files") or ())
+        ),
         quant=str(payload.get("quant", QUANT_NONE)),
         double_quant=bool(payload.get("double_quant", False)),
         quant_device=str(payload.get("quant_device", "")),
@@ -310,6 +317,33 @@ def source_weight_bytes(weights_dir: str) -> int:
     return sum(os.path.getsize(path) for path in _discover_safetensors(weights_dir))
 
 
+def _source_file_components(shards: List[str]) -> Tuple[Tuple[str, int, int], ...]:
+    """Components retained beside the digest so a stale cache is explainable."""
+    components = []
+    for path in sorted(shards):
+        stat = os.stat(path)
+        components.append(
+            (os.path.basename(path), int(stat.st_size), int(stat.st_mtime_ns))
+        )
+    return tuple(components)
+
+
+def _fingerprint_components(components: Tuple[Tuple[str, int, int], ...]) -> str:
+    """Hash the exact components that are persisted in ``index.json``."""
+    import hashlib
+
+    digest = hashlib.sha256()
+    for name, size, mtime_ns in components:
+        digest.update(name.encode("utf-8", "replace"))
+        digest.update(f"|{size}|{mtime_ns}|".encode())
+    return digest.hexdigest()
+
+
+def fingerprint_source_files(components: Tuple[Tuple[str, int, int], ...]) -> str:
+    """Public digest helper for the pre-sharding disk planner."""
+    return _fingerprint_components(components)
+
+
 def _source_fingerprint(shards: List[str]) -> str:
     """Identity of the SOURCE checkpoint: basename + size + mtime per shard.
 
@@ -318,14 +352,7 @@ def _source_fingerprint(shards: List[str]) -> str:
     silently reuse stale shards and stream the WRONG WEIGHTS into training —
     no error, just a loss curve describing a different model.
     """
-    import hashlib
-
-    digest = hashlib.sha256()
-    for path in sorted(shards):
-        stat = os.stat(path)
-        digest.update(os.path.basename(path).encode("utf-8", "replace"))
-        digest.update(f"|{stat.st_size}|{int(stat.st_mtime_ns)}|".encode())
-    return digest.hexdigest()
+    return _fingerprint_components(_source_file_components(shards))
 
 
 def _validate_out_dir(out_dir: str) -> str:
@@ -394,15 +421,53 @@ def _atomic_write_index(index: ShardIndex, out_dir: str) -> None:
         raise
 
 
-def _cached_index(
+def _describe_source_change(
+    previous: Tuple[Tuple[str, int, int], ...],
+    current: Tuple[Tuple[str, int, int], ...],
+) -> str:
+    """Name the first fingerprint component that invalidated the cache."""
+    if not previous:
+        return (
+            "source_fingerprint changed; the cached index predates per-file "
+            "component records"
+        )
+    old = {name: (size, mtime) for name, size, mtime in previous}
+    new = {name: (size, mtime) for name, size, mtime in current}
+    if old.keys() != new.keys():
+        added = sorted(new.keys() - old.keys())
+        removed = sorted(old.keys() - new.keys())
+        details = []
+        if added:
+            details.append(f"added {added[0]!r}")
+        if removed:
+            details.append(f"removed {removed[0]!r}")
+        return "source filename set changed (" + ", ".join(details) + ")"
+    for name in sorted(new):
+        old_size, old_mtime = old[name]
+        new_size, new_mtime = new[name]
+        if old_size != new_size:
+            return (
+                f"source size changed for {name!r} "
+                f"({old_size} -> {new_size} bytes)"
+            )
+        if old_mtime != new_mtime:
+            return (
+                f"source mtime_ns changed for {name!r} "
+                f"({old_mtime} -> {new_mtime})"
+            )
+    return "source_fingerprint changed although its recorded components match"
+
+
+def inspect_shard_cache(
     out_dir: str,
     dtype: str,
     fingerprint: str,
+    source_files: Tuple[Tuple[str, int, int], ...],
     quant: str,
     double_quant: bool,
     quant_device: str,
-) -> Optional[ShardIndex]:
-    """Return a reusable index, or None when absent / corrupt / stale.
+) -> Tuple[Optional[ShardIndex], str]:
+    """Return a reusable index or the precise reason it must be rewritten.
 
     A dtype mismatch MUST invalidate: streaming float32 shards into a bfloat16
     pool would quietly train the wrong precision rather than fail. The same
@@ -414,23 +479,29 @@ def _cached_index(
     try:
         index = read_shard_index(out_dir)
     except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError):
-        return None
+        return None, "cache index is missing or unreadable"
     if index.dtype != dtype:
-        return None
+        return None, f"dtype changed ({index.dtype!r} -> {dtype!r})"
     if index.quant != quant:
-        return None
+        return None, f"quantization changed ({index.quant!r} -> {quant!r})"
     if index.quant != QUANT_NONE and index.double_quant != double_quant:
-        return None
+        return None, (
+            f"double_quant changed ({index.double_quant!r} -> {double_quant!r})"
+        )
     if index.quant != QUANT_NONE and index.quant_device != quant_device:
-        return None
+        return None, (
+            f"quantization device changed "
+            f"({index.quant_device!r} -> {quant_device!r})"
+        )
     if index.source_fingerprint != fingerprint:
-        return None  # source checkpoint changed under us
+        return None, _describe_source_change(index.source_files, source_files)
     if not os.path.exists(extras_shard_path(out_dir)):
-        return None
+        return None, f"cached shard {_EXTRAS_NAME!r} is missing"
     for idx in range(index.n_layers):
         if not os.path.exists(layer_shard_path(out_dir, idx)):
-            return None
-    return index
+            name = os.path.basename(layer_shard_path(out_dir, idx))
+            return None, f"cached shard {name!r} is missing"
+    return index, "cache is reusable"
 
 
 # ==========================================================================
@@ -544,6 +615,7 @@ def shard_checkpoint(
     quant_suffixes: Iterable[str] = (),
     double_quant: bool = True,
     quant_device: Optional[str] = None,
+    notify: Optional[Callable[[str], None]] = None,
 ) -> ShardIndex:
     """Rewrite an HF checkpoint into per-layer safetensors shards.
 
@@ -566,13 +638,22 @@ def shard_checkpoint(
     device_kind = str(device).split(":", 1)[0] if quantise else ""
     shards = _discover_safetensors(weights_dir)
     resolved_out = _validate_out_dir(out_dir)
-    fingerprint = _source_fingerprint(shards)
+    source_files = _source_file_components(shards)
+    fingerprint = _fingerprint_components(source_files)
     if not force:
-        cached = _cached_index(
-            resolved_out, dtype, fingerprint, quant, double_quant, device_kind
+        cached, miss_reason = inspect_shard_cache(
+            resolved_out,
+            dtype,
+            fingerprint,
+            source_files,
+            quant,
+            double_quant,
+            device_kind,
         )
         if cached is not None:
             return cached
+        if notify is not None:
+            notify(f"[yellow]Re-sharding layer cache:[/] {miss_reason}.")
 
     from safetensors import safe_open
 
@@ -698,6 +779,7 @@ def shard_checkpoint(
         arch=arch,
         soup_version=__version__,
         source_fingerprint=fingerprint,
+        source_files=source_files,
         quant=quant,
         double_quant=bool(double_quant) if quantise else False,
         quant_device=device_kind,

--- a/src/soup_cli/utils/spectrum_scan.py
+++ b/src/soup_cli/utils/spectrum_scan.py
@@ -72,6 +72,23 @@ _SLUG_RE = re.compile(r"[^A-Za-z0-9._-]+")
 ModulesArg = Union[str, Sequence[str], None]
 
 
+@dataclass(frozen=True)
+class ModelWeightsPlan:
+    """A weight source located before Soup creates a second on-disk copy."""
+
+    model: str
+    source_dir: str
+    weights_dir: str
+    source_bytes: int
+    materialized_copy_bytes: int
+    materialize_bytes: int
+    source_files: Tuple[Tuple[str, int, int], ...]
+
+    @property
+    def needs_materialization(self) -> bool:
+        return self.materialize_bytes > 0
+
+
 def _np():
     import numpy as np  # lazy — keep the CLI import light
 
@@ -541,30 +558,153 @@ def read_cached_scan(
 # ---------------------------------------------------------------------------
 # Resolve + scan orchestration
 # ---------------------------------------------------------------------------
-def resolve_model_weights(model: str) -> str:
-    """Return a local dir of ``.safetensors`` for ``model``.
+def _weight_file_manifest(
+    directory: str,
+    *,
+    permit_symlinks: bool,
+) -> Tuple[Tuple[str, int, int], ...]:
+    """Return ``(basename, size, mtime_ns)`` for top-level safetensors files."""
+    root = os.path.realpath(os.path.expanduser(directory))
+    if not os.path.isdir(root):
+        raise FileNotFoundError(f"weights directory not found: {directory}")
+    files = []
+    for name in sorted(os.listdir(root)):
+        if not name.endswith(".safetensors"):
+            continue
+        path = os.path.join(root, name)
+        if os.path.islink(path) and not permit_symlinks:
+            raise FileNotFoundError(
+                f"weight cache still contains symlinked shard {name!r}"
+            )
+        if not os.path.isfile(path):
+            continue
+        stat = os.stat(path)
+        files.append((name, int(stat.st_size), int(stat.st_mtime_ns)))
+    if not files:
+        raise FileNotFoundError(
+            f"no .safetensors weight files found in {directory}"
+        )
+    return tuple(files)
 
-    A local directory is used as-is; otherwise ``model`` is treated as an HF
-    Hub id and only its weights + config are downloaded (no model load). The
-    download routes through the SSRF-hardened, namespace-pinned
-    :func:`soup_cli.utils.hubs.snapshot_download` (repo-id shape validation +
-    the #186 anti-AI-Jacking TOFU gate), into a contained cache dir — same
-    policy as ``sae_diff.download_sae``.
-    """
+
+def _materialized_matches_hf_snapshot(
+    source_dir: str,
+    materialized_dir: str,
+    source_files: Tuple[Tuple[str, int, int], ...],
+) -> Optional[Tuple[Tuple[str, int, int], ...]]:
+    """Return the real-file manifest when HF metadata proves blob identity."""
+    try:
+        existing = _weight_file_manifest(materialized_dir, permit_symlinks=False)
+    except FileNotFoundError:
+        return None
+    expected_sizes = {name: size for name, size, _mtime in source_files}
+    existing_sizes = {name: size for name, size, _mtime in existing}
+    if existing_sizes != expected_sizes:
+        return None
+    for name, _size, _mtime in source_files:
+        source_path = os.path.join(source_dir, name)
+        if not os.path.islink(source_path):
+            return None
+        blob_id = os.path.basename(os.path.realpath(source_path))
+        metadata_path = os.path.join(
+            materialized_dir,
+            ".cache",
+            "huggingface",
+            "download",
+            name + ".metadata",
+        )
+        try:
+            if os.path.getsize(metadata_path) > 4096:
+                return None
+            with open(metadata_path, encoding="utf-8") as handle:
+                lines = handle.read(4097).splitlines()
+        except OSError:
+            return None
+        # local_dir metadata is: commit hash, blob etag, materialisation time.
+        if len(lines) < 2 or lines[1].strip() != blob_id:
+            return None
+    return existing
+
+
+def plan_model_weights(model: str) -> ModelWeightsPlan:
+    """Locate weights and quantify any copy Soup would need, without making it."""
     if not isinstance(model, str) or not model.strip():
         raise ValueError("model must be a non-empty string")
     if os.path.isdir(model):
-        return os.path.realpath(model)
+        source = os.path.realpath(model)
+        manifest = _weight_file_manifest(source, permit_symlinks=True)
+        return ModelWeightsPlan(
+            model=model,
+            source_dir=source,
+            weights_dir=source,
+            source_bytes=sum(size for _name, size, _mtime in manifest),
+            materialized_copy_bytes=0,
+            materialize_bytes=0,
+            source_files=manifest,
+        )
     from soup_cli.utils.hubs import snapshot_download
 
-    cache_dir = os.path.join(
-        default_spectrum_cache_dir(), "weights", model_slug(model)
-    )
-    return snapshot_download(
+    source = snapshot_download(
         model,
-        cache_dir=cache_dir,
+        cache_dir=None,
         allow_patterns=["*.safetensors", "*.json"],
     )
+    manifest = _weight_file_manifest(source, permit_symlinks=True)
+    source_paths = [os.path.join(source, name) for name, _size, _mtime in manifest]
+    if all(not os.path.islink(path) for path in source_paths):
+        return ModelWeightsPlan(
+            model=model,
+            source_dir=source,
+            weights_dir=source,
+            source_bytes=sum(size for _name, size, _mtime in manifest),
+            materialized_copy_bytes=0,
+            materialize_bytes=0,
+            source_files=manifest,
+        )
+
+    materialized = os.path.join(
+        resolve_cache_dir(), "weights", model_slug(model)
+    )
+    existing = _materialized_matches_hf_snapshot(source, materialized, manifest)
+    needs_copy = existing is None
+    return ModelWeightsPlan(
+        model=model,
+        source_dir=source,
+        weights_dir=materialized,
+        source_bytes=sum(size for _name, size, _mtime in manifest),
+        materialized_copy_bytes=sum(size for _name, size, _mtime in manifest),
+        materialize_bytes=(
+            sum(size for _name, size, _mtime in manifest) if needs_copy else 0
+        ),
+        source_files=manifest if existing is None else existing,
+    )
+
+
+def materialize_model_weights(plan: ModelWeightsPlan) -> str:
+    """Create the planned regular-file copy only when the source requires it."""
+    if not plan.needs_materialization:
+        return plan.weights_dir
+    from soup_cli.utils.hubs import snapshot_download
+
+    resolved = snapshot_download(
+        plan.model,
+        cache_dir=plan.weights_dir,
+        allow_patterns=["*.safetensors", "*.json"],
+    )
+    _weight_file_manifest(resolved, permit_symlinks=False)
+    return resolved
+
+
+def resolve_model_weights(
+    model: str,
+    *,
+    before_materialize: Optional[Callable[[ModelWeightsPlan], None]] = None,
+) -> str:
+    """Return a regular-file weight directory, with an optional pre-copy gate."""
+    plan = plan_model_weights(model)
+    if before_materialize is not None:
+        before_materialize(plan)
+    return materialize_model_weights(plan)
 
 
 def scan_model(

--- a/tests/test_issue374_stream_disk_preflight.py
+++ b/tests/test_issue374_stream_disk_preflight.py
@@ -1,0 +1,289 @@
+"""Regression coverage for #374's layer-streaming disk lifecycle."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+GB = 1_000_000_000
+
+
+def test_hub_cache_snapshot_omits_local_materialization(monkeypatch) -> None:
+    import huggingface_hub
+
+    from soup_cli.utils.hubs import snapshot_download
+
+    captured = {}
+
+    def fake_snapshot_download(**kwargs):
+        captured.update(kwargs)
+        return "/cached/snapshot"
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", fake_snapshot_download)
+    result = snapshot_download(
+        "org/model",
+        cache_dir=None,
+        allow_patterns=["*.safetensors"],
+        namespace_check=False,
+    )
+
+    assert result == "/cached/snapshot"
+    assert "local_dir" not in captured
+    assert "cache_dir" not in captured
+
+
+def test_regular_hf_cache_weights_are_used_in_place(tmp_path, monkeypatch) -> None:
+    from soup_cli.utils import hubs
+    from soup_cli.utils.spectrum_scan import resolve_model_weights
+
+    snapshot = tmp_path / "snapshot"
+    snapshot.mkdir()
+    (snapshot / "model.safetensors").write_bytes(b"regular-cache-entry")
+    calls = []
+
+    def fake_snapshot_download(_model, *, cache_dir, **_kwargs):
+        calls.append(cache_dir)
+        if cache_dir is not None:
+            pytest.fail("a regular HF cache entry must not be materialized again")
+        return str(snapshot)
+
+    monkeypatch.setattr(hubs, "snapshot_download", fake_snapshot_download)
+    plans = []
+    resolved = resolve_model_weights("org/model", before_materialize=plans.append)
+
+    assert resolved == str(snapshot)
+    assert calls == [None]
+    assert plans[0].materialized_copy_bytes == 0
+    assert plans[0].materialize_bytes == 0
+
+
+def test_refusal_callback_runs_before_a_symlinked_snapshot_is_copied(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from soup_cli.utils import hubs
+    from soup_cli.utils.spectrum_scan import resolve_model_weights
+
+    blob = tmp_path / "blob"
+    blob.write_bytes(b"cached-weight")
+    snapshot = tmp_path / "snapshot"
+    snapshot.mkdir()
+    (snapshot / "model.safetensors").symlink_to(blob)
+    calls = []
+
+    def fake_snapshot_download(_model, *, cache_dir, **_kwargs):
+        calls.append(cache_dir)
+        return str(snapshot)
+
+    monkeypatch.setattr(hubs, "snapshot_download", fake_snapshot_download)
+
+    class RefusedError(Exception):
+        pass
+
+    def refuse(plan) -> None:
+        assert plan.needs_materialization
+        assert plan.materialize_bytes == len(b"cached-weight")
+        raise RefusedError
+
+    with pytest.raises(RefusedError):
+        resolve_model_weights("org/model", before_materialize=refuse)
+
+    assert calls == [None], "the materializing download happened before pre-flight"
+
+
+def test_hf_blob_metadata_reuses_an_existing_materialized_copy(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from soup_cli.utils import hubs
+    from soup_cli.utils.spectrum_scan import plan_model_weights
+
+    blob_id = "a" * 64
+    blobs = tmp_path / "blobs"
+    blobs.mkdir()
+    blob = blobs / blob_id
+    blob.write_bytes(b"immutable-blob")
+    snapshot = tmp_path / "snapshot"
+    snapshot.mkdir()
+    (snapshot / "model.safetensors").symlink_to(blob)
+
+    cache_root = tmp_path / "spectrum"
+    materialized = cache_root / "weights" / "org__model"
+    materialized.mkdir(parents=True)
+    (materialized / "model.safetensors").write_bytes(b"immutable-blob")
+    metadata = materialized / ".cache" / "huggingface" / "download"
+    metadata.mkdir(parents=True)
+    (metadata / "model.safetensors.metadata").write_text(
+        f"commit\n{blob_id}\n123.0\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SOUP_SPECTRUM_CACHE_DIR", str(cache_root))
+    monkeypatch.setattr(
+        hubs,
+        "snapshot_download",
+        lambda *_args, **_kwargs: str(snapshot),
+    )
+
+    plan = plan_model_weights("org/model")
+    assert plan.weights_dir == str(materialized)
+    assert plan.materialize_bytes == 0
+    assert plan.source_files[0][2] == (materialized / "model.safetensors").stat().st_mtime_ns
+
+
+def test_spectrum_override_remains_contained_and_is_used(tmp_path, monkeypatch) -> None:
+    from soup_cli.utils import hubs
+    from soup_cli.utils.spectrum_scan import plan_model_weights
+
+    blob = tmp_path / "blob"
+    blob.write_bytes(b"weight")
+    snapshot = tmp_path / "snapshot"
+    snapshot.mkdir()
+    (snapshot / "model.safetensors").symlink_to(blob)
+    cache_root = tmp_path / "spectrum-cache"
+    monkeypatch.setenv("SOUP_SPECTRUM_CACHE_DIR", str(cache_root))
+    monkeypatch.setattr(
+        hubs,
+        "snapshot_download",
+        lambda *_args, **_kwargs: str(snapshot),
+    )
+
+    plan = plan_model_weights("org/model")
+    assert os.path.commonpath([plan.weights_dir, str(cache_root)]) == str(cache_root)
+
+
+class RecordingConsole:
+    def __init__(self) -> None:
+        self.items = []
+
+    def print(self, item) -> None:
+        self.items.append(item)
+
+
+def test_disk_preflight_refuses_combined_writes_on_one_volume(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    import soup_cli.trainer.stream_setup as setup
+
+    recorder = RecordingConsole()
+    monkeypatch.setattr(setup, "console", recorder)
+    monkeypatch.setattr(setup, "_disk_volume", lambda _path: (7, 100 * GB))
+
+    with pytest.raises(ValueError, match="needs 110.00 GB.*only 100.00 GB is free"):
+        setup._render_stream_disk_preflight(
+            source_bytes=80 * GB,
+            materialized_copy_bytes=80 * GB,
+            materialize_bytes=60 * GB,
+            materialized_path=str(tmp_path / "weights"),
+            shard_bytes=70 * GB,
+            shard_write_bytes=50 * GB,
+            shard_path=str(tmp_path / "shards"),
+        )
+
+    assert len(recorder.items) == 1
+    panel_text = str(recorder.items[0].renderable)
+    assert "Projected total on disk: 230.00 GB" in panel_text
+    assert "Additional writes before training: 110.00 GB" in panel_text
+
+
+def test_disk_preflight_checks_distinct_volumes_independently(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    import soup_cli.trainer.stream_setup as setup
+
+    recorder = RecordingConsole()
+    monkeypatch.setattr(setup, "console", recorder)
+
+    def volumes(path):
+        return (1, 70 * GB) if path.endswith("weights") else (2, 60 * GB)
+
+    monkeypatch.setattr(setup, "_disk_volume", volumes)
+    setup._render_stream_disk_preflight(
+        source_bytes=80 * GB,
+        materialized_copy_bytes=80 * GB,
+        materialize_bytes=60 * GB,
+        materialized_path=str(tmp_path / "weights"),
+        shard_bytes=70 * GB,
+        shard_write_bytes=50 * GB,
+        shard_path=str(tmp_path / "shards"),
+    )
+    assert len(recorder.items) == 1
+
+
+def test_fingerprint_mismatch_names_the_changed_component(tmp_path) -> None:
+    from soup_cli.utils.layer_shard import (
+        fingerprint_source_files,
+        inspect_shard_cache,
+    )
+
+    old_files = (("model.safetensors", 100, 10),)
+    new_files = (("model.safetensors", 100, 11),)
+    payload = {
+        "n_layers": 1,
+        "layer_keys": ["self_attn.q_proj.weight"],
+        "extra_keys": [],
+        "dtype": "float32",
+        "total_params": 4,
+        "arch": "llama",
+        "soup_version": "test",
+        "source_fingerprint": fingerprint_source_files(old_files),
+        "source_files": old_files,
+    }
+    (tmp_path / "index.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    cached, reason = inspect_shard_cache(
+        str(tmp_path),
+        "float32",
+        fingerprint_source_files(new_files),
+        new_files,
+        "none",
+        True,
+        "",
+    )
+    assert cached is None
+    assert "mtime_ns changed" in reason
+    assert "model.safetensors" in reason
+
+
+def test_real_reshard_notice_and_index_record_source_components(tmp_path) -> None:
+    import torch
+    from safetensors.torch import save_file
+
+    from soup_cli.utils.layer_shard import read_shard_index, shard_checkpoint
+
+    weights = tmp_path / "weights"
+    shards = tmp_path / "shards"
+    weights.mkdir()
+    source = weights / "model.safetensors"
+    save_file(
+        {
+            "model.layers.0.self_attn.q_proj.weight": torch.ones(2, 2),
+            "model.embed_tokens.weight": torch.ones(4, 2),
+        },
+        str(source),
+    )
+    first_messages = []
+    shard_checkpoint(
+        str(weights),
+        str(shards),
+        dtype="float32",
+        notify=first_messages.append,
+    )
+    first_index = read_shard_index(str(shards))
+    assert first_index.source_files[0][0] == "model.safetensors"
+
+    stat = source.stat()
+    os.utime(source, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000))
+    messages = []
+    shard_checkpoint(
+        str(weights),
+        str(shards),
+        dtype="float32",
+        notify=messages.append,
+    )
+    assert len(messages) == 1
+    assert "mtime_ns changed" in messages[0]
+    assert "model.safetensors" in messages[0]


### PR DESCRIPTION
## Summary

- locate the canonical Hugging Face snapshot before Soup creates a regular-file copy, and reuse cache entries that are already regular files
- verify an existing materialized copy against Hugging Face blob metadata so repeat runs do not copy it again
- print the source, materialized-copy, shard-cache, projected-total, additional-write, and per-volume free-space figures before copying or sharding, then refuse when a target volume is too small
- persist per-file fingerprint components and name the first changed filename, size, or `mtime_ns` when a shard cache must be rebuilt
- retain the existing `SOUP_SPECTRUM_CACHE_DIR` and `SOUP_LAYER_STREAM_CACHE_DIR` containment policies

## Measured checks

- Live HF-cache probe with `hf-internal-testing/tiny-random-LlamaForCausalLM`: first resolution required materialization; the second proved the existing copy through HF blob metadata and projected `0` copy bytes.
- Focused + historical streaming regression set on the original dependency range: `719 passed, 42 skipped`.
- Combined #507 compatibility, plotext command, disk-preflight, and historical streaming regression set on the fresh dependency stack: `782 passed, 57 skipped`.
- Full suite before the dependent rebase: `18486 passed, 286 skipped, 5 deselected` (81.25% coverage).
- `ruff check src/soup_cli/ tests/` and `git diff --check` pass.

## Status

Rebased onto current `main` after #507. The effective diff is now limited to the two #374 commits and seven files described above.

Closes #374.