### PR TITLE
feat: add kimi-k2.6-grpo and qwen3.5-35b-a3b-dpo recipes (#281, #276)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ src/soup_cli/
   experiment/         - SQLite experiment tracking
   eval/               - Eval platform (custom tasks, LLM judge, human eval, leaderboard)
   migrate/            - Config migration (LLaMA-Factory, Axolotl, Unsloth)
-  recipes/            - Ready-made configs for popular models (147 recipes)
+  recipes/            - Ready-made configs for popular models (149 recipes)
   autopilot/          - Zero-config decision engine (v0.25.0)
   registry/           - Model Registry (hashing, store, diff, attach) (v0.26.0 + v0.33.0)
   cans/               - Shareable .can artifact format + run/publish orchestrator (v0.26.0 + v0.33.0)

--- a/changelog.d/0.73.3/512.added.md
+++ b/changelog.d/0.73.3/512.added.md
@@ -1,0 +1,1 @@
+- Added `kimi-k2.6-grpo` and `qwen3.5-35b-a3b-dpo` recipes (#512).

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -152,7 +152,7 @@ soup migrate --from llamafactory config.yaml  Import config from LLaMA-Factory
 soup migrate --from axolotl config.yml        Import config from Axolotl
 soup migrate --from unsloth notebook.ipynb    Import config from Unsloth notebook
 soup migrate --from llamafactory c.yaml --dry-run  Preview without writing
-soup recipes list                             List all 147 ready-made recipes
+soup recipes list                             List all 149 ready-made recipes
 soup recipes show llama3.1-8b-sft            Print recipe YAML
 soup recipes use llama3.1-8b-sft             Copy recipe to soup.yaml
 soup recipes search "reasoning"              Search by keyword/task/size

--- a/docs/serving-and-export.md
+++ b/docs/serving-and-export.md
@@ -529,7 +529,7 @@ soup ui
 
 **Pages:**
 - **Dashboard** — view all experiment runs, loss charts, system info, multi-run comparison
-- **New Training** — create configs from templates or 147 ready-made recipes, validate, start training with live SSE log streaming and progress bar
+- **New Training** — create configs from templates or 149 ready-made recipes, validate, start training with live SSE log streaming and progress bar
 - **Data Explorer** — browse and inspect datasets (JSONL, JSON, CSV, Parquet)
 - **Model Chat** — chat with streaming responses, configurable temperature/top_p/max_tokens, system prompt, adapter selection, markdown rendering, chat export
 
@@ -538,7 +538,7 @@ soup ui
 - **Enhanced Metrics** — 2x2 chart grid (loss, LR, grad_norm, throughput) + GPU memory chart, eval results table
 - **Multi-Run Compare** — overlay loss curves from up to 5 runs side-by-side
 - **Chat Upgrade** — SSE streaming via proxy, typing indicator, cancel button, markdown renderer (bold, italic, code blocks), chat export as JSON
-- **Config Builder** — recipe dropdown (147 recipes), config schema API for dynamic form generation
+- **Config Builder** — recipe dropdown (149 recipes), config schema API for dynamic form generation
 
 **Security:** The Web UI generates a random auth token at startup (printed to console). All mutating endpoints (start/stop training, delete runs, inspect data, validate config) require `Authorization: Bearer <token>` header. CORS is restricted to the served origin. Data inspection is sandboxed to the working directory.
 

--- a/src/soup_cli/recipes/catalog.py
+++ b/src/soup_cli/recipes/catalog.py
@@ -48,7 +48,7 @@ def search_recipes(
 
 
 # ---------------------------------------------------------------------------
-# Recipe catalog (147 recipes)
+# Recipe catalog (149 recipes)
 # ---------------------------------------------------------------------------
 
 RECIPES: Dict[str, RecipeMeta] = {
@@ -3949,6 +3949,39 @@ training:
 output: ./output
 """,
     ),
+    "qwen3.5-35b-a3b-dpo": RecipeMeta(
+        model="Qwen/Qwen3.5-35B-A3B",
+        task="dpo",
+        size="35B",
+        tags=("qwen", "qwen3.5", "dpo", "moe", "mixture-of-experts"),
+        description="Qwen 3.5 35B-A3B MoE DPO (Apache-2.0, 3B active)",
+        yaml_str="""\
+base: Qwen/Qwen3.5-35B-A3B
+task: dpo
+modality: text
+
+data:
+  train: ./data/train.jsonl
+  format: dpo
+  max_length: 4096
+
+training:
+  epochs: 3
+  lr: 1e-5
+  batch_size: auto
+  gradient_accumulation_steps: 8
+  dpo_beta: 0.1
+  lora:
+    r: 16
+    alpha: 32
+    target_modules: auto
+  quantization: 4bit
+  moe_lora: true
+  moe_aux_loss_coeff: 0.01
+
+output: ./output
+""",
+    ),
     "qwen3.5-35b-a3b-sft": RecipeMeta(
         model="Qwen/Qwen3.5-35B-A3B",
         task="sft",
@@ -4344,6 +4377,43 @@ training:
   quantization: 4bit
   moe_lora: true
   moe_aux_loss_coeff: 0.01
+  gradient_checkpointing: true
+
+output: ./output
+""",
+    ),
+    "kimi-k2.6-grpo": RecipeMeta(
+        model="moonshotai/Kimi-K2.6",
+        task="grpo",
+        size="1T",
+        tags=("kimi", "moonshot", "grpo", "moe", "large", "multi-gpu"),
+        description=(
+            "Kimi K2.6 MoE GRPO (Modified MIT, ~1T / 32B active). "
+            "Requires multi-node DeepSpeed."
+        ),
+        yaml_str="""\
+base: moonshotai/Kimi-K2.6
+task: grpo
+
+data:
+  train: ./data/reasoning_train.jsonl
+  format: auto
+  max_length: 8192
+
+training:
+  epochs: 1
+  lr: 5e-6
+  batch_size: 1
+  gradient_accumulation_steps: 32
+  lora:
+    r: 32
+    alpha: 64
+    target_modules: auto
+  quantization: 4bit
+  grpo_beta: 0.1
+  num_generations: 4
+  reward_fn: accuracy
+  moe_lora: true
   gradient_checkpointing: true
 
 output: ./output

--- a/tests/test_issue427_qwen35_text_modality.py
+++ b/tests/test_issue427_qwen35_text_modality.py
@@ -17,6 +17,7 @@ EXPECTED_QWEN35_TEXT_RECIPES = {
     "qwen3.5-9b-grpo",
     "qwen3.5-27b-sft",
     "qwen3.5-35b-a3b-sft",
+    "qwen3.5-35b-a3b-dpo",
     "qwen3.5-122b-a10b-sft",
     "qwen3.5-397b-a17b-sft",
     # Qwen3.6 exposes the same qwen3_5 / qwen3_5_moe architecture on the Hub.

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -427,7 +427,7 @@ class TestV025NewRecipes:
             assert cfg.base == recipe.model
             assert cfg.task == recipe.task
 
-    def test_catalog_size_is_147(self):
+    def test_catalog_size_is_149(self):
         """Total catalog size — grew with each release.
 
         v0.25.0 shipped 43 recipes (29 + 9 Part A + 2 Part B tools + 3 Part E MLX).
@@ -447,10 +447,12 @@ class TestV025NewRecipes:
         Issue #277 added 1 (qwen3.5-9b-grpo) -> 145.
         Issue #280 added 1 (glm-5.1-dpo) -> 146.
         Issue #477 added 1 (qwen3.8-27b-sft) -> 147.
+        Issue #281 added 1 (kimi-k2.6-grpo) -> 148.
+        Issue #276 added 1 (qwen3.5-35b-a3b-dpo) -> 149.
         """
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 147
+        assert len(RECIPES) == 149
 
     def test_new_recipes_searchable(self):
         """Search returns the new recipes via keyword/task filter."""

--- a/tests/test_v07124.py
+++ b/tests/test_v07124.py
@@ -269,8 +269,8 @@ class TestGlm5RepoIdFix:
 
 
 class TestCatalogCount:
-    def test_total_recipe_count_is_147(self) -> None:
-        assert len(RECIPES) == 147
+    def test_total_recipe_count_is_149(self) -> None:
+        assert len(RECIPES) == 149
 
     def test_list_recipes_matches_dict(self) -> None:
         assert len(list_recipes()) == len(RECIPES)

--- a/tests/test_v07130.py
+++ b/tests/test_v07130.py
@@ -737,10 +737,10 @@ class TestRecipes:
         assert cfg.training.rollout_backend == "openenv"
         assert cfg.training.rollout_func.startswith("soup_cli.envs.")
 
-    def test_catalog_size_is_147(self):
+    def test_catalog_size_is_149(self):
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 147
+        assert len(RECIPES) == 149
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_v07132.py
+++ b/tests/test_v07132.py
@@ -950,7 +950,7 @@ class TestAsrRecipes:
         assert cfg.task == "sft"
         assert cfg.modality == "vision"
 
-    def test_catalog_size_is_147(self):
+    def test_catalog_size_is_149(self):
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 147
+        assert len(RECIPES) == 149


### PR DESCRIPTION
## What does this PR do?

Closes #281 and closes #276.

Adds two new ready-made recipes to the catalog:
- `kimi-k2.6-grpo` for `moonshotai/Kimi-K2.6` (GRPO reasoning variant)
- `qwen3.5-35b-a3b-dpo` for `Qwen/Qwen3.5-35B-A3B` (DPO variant)

The total recipe catalog count has been bumped from 146 to 148 across all tests and documentation.

## Type of change

- [x] New feature
- [x] Documentation
- [x] Tests

## Checklist

- [x] `ruff check src/soup_cli/ scripts/ tests/` passes
- [x] `pytest tests/ -v` passes
- [x] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed
- [x] Added a changelog fragment, or this change has no user-visible impact
