### PR TITLE
feat(recipes): add Qwen3.8 27B text SFT

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ src/soup_cli/
   experiment/         - SQLite experiment tracking
   eval/               - Eval platform (custom tasks, LLM judge, human eval, leaderboard)
   migrate/            - Config migration (LLaMA-Factory, Axolotl, Unsloth)
-  recipes/            - Ready-made configs for popular models (146 recipes)
+  recipes/            - Ready-made configs for popular models (147 recipes)
   autopilot/          - Zero-config decision engine (v0.25.0)
   registry/           - Model Registry (hashing, store, diff, attach) (v0.26.0 + v0.33.0)
   cans/               - Shareable .can artifact format + run/publish orchestrator (v0.26.0 + v0.33.0)

--- a/changelog.d/0.73.3/513.added.md
+++ b/changelog.d/0.73.3/513.added.md
@@ -1,0 +1,4 @@
+- **Added a text-only `qwen3.8-27b-sft` catalog recipe for
+  `Qwen/Qwen3.8-27B` (#477 by @Amix29 in #513).** The recipe explicitly selects
+  `modality: text`, uses the measured Qwen3.5-family decoder path from #507,
+  and includes catalog, configuration, CLI, modality, and count-sync coverage.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -152,7 +152,7 @@ soup migrate --from llamafactory config.yaml  Import config from LLaMA-Factory
 soup migrate --from axolotl config.yml        Import config from Axolotl
 soup migrate --from unsloth notebook.ipynb    Import config from Unsloth notebook
 soup migrate --from llamafactory c.yaml --dry-run  Preview without writing
-soup recipes list                             List all 146 ready-made recipes
+soup recipes list                             List all 147 ready-made recipes
 soup recipes show llama3.1-8b-sft            Print recipe YAML
 soup recipes use llama3.1-8b-sft             Copy recipe to soup.yaml
 soup recipes search "reasoning"              Search by keyword/task/size

--- a/docs/models.md
+++ b/docs/models.md
@@ -16,7 +16,7 @@ Soup works with **any** of the **340,000+** text-generation models on [HuggingFa
 | **Llama 3.x** | Llama-3.1-8B-Instruct, Llama-3.3-70B-Instruct | 1B–70B | Chat, instruction following |
 | **Llama 3.2 Vision** | Llama-3.2-11B-Vision-Instruct, Llama-3.2-90B-Vision | 11B–90B | Image understanding |
 | **Gemma 3** | Gemma-3-4B-IT, Gemma-3-9B-IT, Gemma-3-27B-IT | 4B–27B | Efficient, multilingual |
-| **Qwen 3.5 / 3.6** | Qwen3.5-0.8B…397B-A17B, Qwen3.6-27B, Qwen3.6-35B-A3B | 0.8B–397B | 262K context, native vision, MoE |
+| **Qwen 3.5 / 3.6 / 3.8** | Qwen3.5-0.8B…397B-A17B, Qwen3.6-27B/35B-A3B, Qwen3.8-27B | 0.8B–397B | 262K context, native vision, MoE |
 | **Qwen 3** | Qwen3-8B, Qwen3-14B, Qwen3-32B, Qwen3-235B-A22B | 0.6B–235B | Reasoning, code, MoE |
 | **Qwen 2.5** | Qwen2.5-7B-Instruct, Qwen2.5-Coder-32B-Instruct | 0.5B–72B | Code, math |
 | **DeepSeek** | DeepSeek-R1-Distill-Llama-8B, DeepSeek-V3-0324, DeepSeek-V4-Flash/Pro | 1.5B–1.6T | Reasoning (GRPO), code, MoE |
@@ -32,13 +32,12 @@ Soup works with **any** of the **340,000+** text-generation models on [HuggingFa
 | **InternLM 3** | InternLM3-8B-Instruct | 8B | Chinese + English |
 | **Falcon** | Falcon-11B, Falcon-40B-Instruct | 7B–180B | Open-weight |
 
-Qwen3.5 and Qwen3.6 checkpoints advertise a multimodal conditional-generation
+Qwen3.5, Qwen3.6, and Qwen3.8 checkpoints advertise a multimodal conditional-generation
 architecture on the Hub, but Soup's catalog recipes are deliberately text-only.
 Their explicit `modality: text` selects `AutoModelForCausalLM`, which instantiates the
 language decoder without the visual tower. This is appropriate for text-only SFT,
 pre-training, and GRPO data; it is not a full multimodal fine-tune. The Transformers
-backend cannot load `qwen3_5` under Soup's current `<5.0.0` dependency cap; enabling
-that backend requires a separately validated Transformers 5 migration.
+backend requires Transformers 5.12.1 or newer for the `qwen3_5` architecture.
 
 ### Vision Models (with `modality: vision`)
 

--- a/docs/serving-and-export.md
+++ b/docs/serving-and-export.md
@@ -525,7 +525,7 @@ soup ui
 
 **Pages:**
 - **Dashboard** — view all experiment runs, loss charts, system info, multi-run comparison
-- **New Training** — create configs from templates or 146 ready-made recipes, validate, start training with live SSE log streaming and progress bar
+- **New Training** — create configs from templates or 147 ready-made recipes, validate, start training with live SSE log streaming and progress bar
 - **Data Explorer** — browse and inspect datasets (JSONL, JSON, CSV, Parquet)
 - **Model Chat** — chat with streaming responses, configurable temperature/top_p/max_tokens, system prompt, adapter selection, markdown rendering, chat export
 
@@ -534,7 +534,7 @@ soup ui
 - **Enhanced Metrics** — 2x2 chart grid (loss, LR, grad_norm, throughput) + GPU memory chart, eval results table
 - **Multi-Run Compare** — overlay loss curves from up to 5 runs side-by-side
 - **Chat Upgrade** — SSE streaming via proxy, typing indicator, cancel button, markdown renderer (bold, italic, code blocks), chat export as JSON
-- **Config Builder** — recipe dropdown (146 recipes), config schema API for dynamic form generation
+- **Config Builder** — recipe dropdown (147 recipes), config schema API for dynamic form generation
 
 **Security:** The Web UI generates a random auth token at startup (printed to console). All mutating endpoints (start/stop training, delete runs, inspect data, validate config) require `Authorization: Bearer <token>` header. CORS is restricted to the served origin. Data inspection is sandboxed to the working directory.
 

--- a/src/soup_cli/recipes/catalog.py
+++ b/src/soup_cli/recipes/catalog.py
@@ -48,7 +48,7 @@ def search_recipes(
 
 
 # ---------------------------------------------------------------------------
-# Recipe catalog (146 recipes)
+# Recipe catalog (147 recipes)
 # ---------------------------------------------------------------------------
 
 RECIPES: Dict[str, RecipeMeta] = {
@@ -4111,6 +4111,36 @@ training:
   quantization: 4bit
   moe_lora: true
   moe_aux_loss_coeff: 0.01
+
+output: ./output
+""",
+    ),
+    "qwen3.8-27b-sft": RecipeMeta(
+        model="Qwen/Qwen3.8-27B",
+        task="sft",
+        size="27B",
+        tags=("qwen", "qwen3.8", "sft", "text", "large", "deepspeed"),
+        description="Qwen 3.8 27B text-only SFT (Apache-2.0) with DeepSpeed ZeRO-2",
+        yaml_str="""\
+base: Qwen/Qwen3.8-27B
+task: sft
+modality: text
+
+data:
+  train: ./data/train.jsonl
+  format: auto
+  max_length: 4096
+
+training:
+  epochs: 3
+  lr: 1e-5
+  batch_size: auto
+  gradient_accumulation_steps: 8
+  lora:
+    r: 16
+    alpha: 32
+    target_modules: auto
+  quantization: 4bit
 
 output: ./output
 """,

--- a/tests/test_issue427_qwen35_text_modality.py
+++ b/tests/test_issue427_qwen35_text_modality.py
@@ -22,12 +22,14 @@ EXPECTED_QWEN35_TEXT_RECIPES = {
     # Qwen3.6 exposes the same qwen3_5 / qwen3_5_moe architecture on the Hub.
     "qwen3.6-27b-sft",
     "qwen3.6-35b-a3b-sft",
+    # Qwen3.8-27B exposes the same qwen3_5 text tower.
+    "qwen3.8-27b-sft",
 }
 
 
 def _qwen35_family_recipe_names() -> tuple[str, ...]:
     """Select every catalog recipe covered by the measured architecture decision."""
-    prefixes = ("Qwen/Qwen3.5-", "Qwen/Qwen3.6-")
+    prefixes = ("Qwen/Qwen3.5-", "Qwen/Qwen3.6-", "Qwen/Qwen3.8-")
     return tuple(name for name, recipe in RECIPES.items() if recipe.model.startswith(prefixes))
 
 

--- a/tests/test_issue477_qwen38_catalog.py
+++ b/tests/test_issue477_qwen38_catalog.py
@@ -1,0 +1,57 @@
+"""Regression coverage for #477's Qwen3.8-27B text-only SFT recipe."""
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from soup_cli.cli import app
+from soup_cli.config.loader import load_config_from_string
+from soup_cli.recipes.catalog import get_recipe, search_recipes
+
+runner = CliRunner()
+
+
+def test_qwen38_27b_recipe_has_expected_text_sft_shape() -> None:
+    recipe = get_recipe("qwen3.8-27b-sft")
+
+    assert recipe is not None
+    assert recipe.model == "Qwen/Qwen3.8-27B"
+    assert recipe.task == "sft"
+    assert recipe.size == "27B"
+    assert {"qwen", "qwen3.8", "sft", "text"}.issubset(recipe.tags)
+
+    config = load_config_from_string(recipe.yaml_str)
+    assert config.base == recipe.model
+    assert config.task == "sft"
+    assert config.modality == "text"
+    assert config.data.max_length == 4096
+    assert config.training.quantization == "4bit"
+    assert config.training.lora.r == 16
+    assert config.training.lora.alpha == 32
+    assert config.training.lora.target_modules == "auto"
+
+
+def test_qwen38_27b_recipe_is_searchable() -> None:
+    matches = search_recipes(query="qwen3.8")
+    assert [recipe.model for recipe in matches] == ["Qwen/Qwen3.8-27B"]
+
+
+def test_qwen38_27b_recipe_show_and_use(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    show_result = runner.invoke(app, ["recipes", "show", "qwen3.8-27b-sft"])
+    assert show_result.exit_code == 0
+    assert "Qwen/Qwen3.8-27B" in show_result.output
+    assert "modality: text" in show_result.output
+
+    monkeypatch.chdir(tmp_path)
+    use_result = runner.invoke(
+        app,
+        ["recipes", "use", "qwen3.8-27b-sft", "--yes"],
+    )
+    assert use_result.exit_code == 0
+    content = (tmp_path / "soup.yaml").read_text(encoding="utf-8")
+    assert "base: Qwen/Qwen3.8-27B" in content
+    assert "modality: text" in content

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -427,7 +427,7 @@ class TestV025NewRecipes:
             assert cfg.base == recipe.model
             assert cfg.task == recipe.task
 
-    def test_catalog_size_is_146(self):
+    def test_catalog_size_is_147(self):
         """Total catalog size — grew with each release.
 
         v0.25.0 shipped 43 recipes (29 + 9 Part A + 2 Part B tools + 3 Part E MLX).
@@ -446,10 +446,11 @@ class TestV025NewRecipes:
         Issue #279 added 1 (deepseek-v4-flash-grpo) -> 144.
         Issue #277 added 1 (qwen3.5-9b-grpo) -> 145.
         Issue #280 added 1 (glm-5.1-dpo) -> 146.
+        Issue #477 added 1 (qwen3.8-27b-sft) -> 147.
         """
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 146
+        assert len(RECIPES) == 147
 
     def test_new_recipes_searchable(self):
         """Search returns the new recipes via keyword/task filter."""

--- a/tests/test_v07124.py
+++ b/tests/test_v07124.py
@@ -269,8 +269,8 @@ class TestGlm5RepoIdFix:
 
 
 class TestCatalogCount:
-    def test_total_recipe_count_is_146(self) -> None:
-        assert len(RECIPES) == 146
+    def test_total_recipe_count_is_147(self) -> None:
+        assert len(RECIPES) == 147
 
     def test_list_recipes_matches_dict(self) -> None:
         assert len(list_recipes()) == len(RECIPES)

--- a/tests/test_v07130.py
+++ b/tests/test_v07130.py
@@ -737,10 +737,10 @@ class TestRecipes:
         assert cfg.training.rollout_backend == "openenv"
         assert cfg.training.rollout_func.startswith("soup_cli.envs.")
 
-    def test_catalog_size_is_146(self):
+    def test_catalog_size_is_147(self):
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 146
+        assert len(RECIPES) == 147
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_v07132.py
+++ b/tests/test_v07132.py
@@ -950,7 +950,7 @@ class TestAsrRecipes:
         assert cfg.task == "sft"
         assert cfg.modality == "vision"
 
-    def test_catalog_size_is_146(self):
+    def test_catalog_size_is_147(self):
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 146
+        assert len(RECIPES) == 147


### PR DESCRIPTION
## Summary

- add a focused `qwen3.8-27b-sft` catalog recipe for `Qwen/Qwen3.8-27B`
- declare `modality: text` explicitly, following the architecture decision recorded by #427
- keep the same dense-27B SFT shape as the existing Qwen3.5/Qwen3.6 recipes
- cover catalog lookup, search, configuration parsing, CLI `show`/`use`, explicit text modality, synchronized recipe counts, and the required changelog fragment

## Status

Rebased onto current `main` after #507, which satisfies the Transformers 5 and text-decoder dependency. This PR is now limited to its two Qwen3.8 catalog commits.

## Validation

- focused catalog, modality, CLI, and count-sync suite: `449 passed, 1 skipped`
- changelog-fragment and Qwen3.8 focused suite: `20 passed`
- Ruff: clean
- `git diff --check`: clean

Closes #477.