### PR TITLE
fix(stream): preserve BF16 on capable MPS

### DIFF
--- a/changelog.d/0.73.3/516.fixed.md
+++ b/changelog.d/0.73.3/516.fixed.md
@@ -1,0 +1,1 @@
+- Layer streaming now preserves BF16 checkpoints on capable MPS runtimes instead of silently doubling the store and disk cache to FP32. (#516)

--- a/docs/performance-and-quantization.md
+++ b/docs/performance-and-quantization.md
@@ -263,9 +263,11 @@ to the MPS allocator while `is_pinned()` is still false (#434). Soup refuses tha
 the source boundary and also disables pinning before allocation. Apple Silicon has unified
 physical memory, so the CUDA capacity and throughput numbers below do not transfer: only
 the MPS allocator's streamed weights are bounded by the buffer pool, while the CPU source
-still consumes unified memory. No claim is made yet that streaming fits a larger model or
-runs faster than resident MPS training. `backend: mlx` remains a separate, incompatible
-model-loading path and is rejected with `stream_layers`.
+still consumes unified memory. On macOS 14+ the store and compute dtype are bfloat16 after
+a live one-element MPS capability probe; an older runtime falls back to float32 explicitly.
+No claim is made yet that streaming fits a larger model or runs faster than resident MPS
+training. `backend: mlx` remains a separate, incompatible model-loading path and is rejected
+with `stream_layers`.
 
 The tradeoff: **1.43× slower than resident training**, measured at 0.5B — the only apples-to-apples comparison available on the reference box, because 1.5B and above cannot run resident there at all.
 

--- a/src/soup_cli/utils/layer_stream.py
+++ b/src/soup_cli/utils/layer_stream.py
@@ -206,16 +206,41 @@ def resolve_stream_dtype(device: str = "cuda") -> str:
     most of the hardware this feature exists for, and it could not fail on the
     Ampere card every published measurement was taken on (#385).
 
-    The capability question is delegated to ``utils.gpu.get_compute_dtype``
-    rather than answered again here — one question, one answer, or the two
-    drift. CPU stays float32: CPU streaming is a test convenience, and
-    half-precision CPU kernels are not uniformly available.
+    The CUDA capability question is delegated to
+    ``utils.gpu.get_compute_dtype`` rather than answered again here — one
+    question, one answer, or the two drift. MPS is separate: PyTorch supports
+    bfloat16 there from macOS 14, so a one-element allocation probes the exact
+    runtime rather than guessing from a version string. CPU stays float32: CPU
+    streaming is a test convenience, and half-precision CPU kernels are not
+    uniformly available.
 
     Correctness is unaffected by the choice. Streamed-vs-resident logits were
     measured bit-exact (``0.000000e+00``) in float16 as well as bfloat16, in
     both quantisations, against resident references of matching numerics.
     """
-    if not str(device).lower().startswith("cuda"):
+    device_name = str(device).lower()
+    if device_name.startswith("mps"):
+        try:
+            import torch
+
+            mps = getattr(torch.backends, "mps", None)
+            if mps is None or not mps.is_available():
+                return "float32"
+            # PyTorch rejects this before model state exists on macOS versions
+            # that predate MPS bfloat16 support.
+            probe = torch.empty(1, dtype=torch.bfloat16, device="mps")
+            del probe
+            return "bfloat16"
+        except (
+            ImportError,
+            RuntimeError,
+            TypeError,
+            NotImplementedError,
+            AssertionError,
+            OSError,
+        ):
+            return "float32"
+    if not device_name.startswith("cuda"):
         return "float32"
 
     from soup_cli.utils.gpu import get_compute_dtype

--- a/tests/test_issue385_stream_dtype.py
+++ b/tests/test_issue385_stream_dtype.py
@@ -55,6 +55,14 @@ class _FakeCuda:
         return (8, 0) if self._bf16 else (7, 5)
 
 
+class _FakeMps:
+    def __init__(self, available: bool):
+        self._available = available
+
+    def is_available(self) -> bool:
+        return self._available
+
+
 @pytest.fixture()
 def fake_torch(monkeypatch):
     """Patch ``torch.cuda`` in place; the resolver imports torch lazily."""
@@ -64,6 +72,31 @@ def fake_torch(monkeypatch):
         fake = _FakeCuda(available, bf16, emulated)
         monkeypatch.setattr(torch, "cuda", fake)
         return fake
+
+    return apply
+
+
+@pytest.fixture()
+def fake_mps(monkeypatch):
+    """Patch the tiny MPS capability allocation without requiring a Mac."""
+    import torch
+
+    real_empty = torch.empty
+    probes = []
+
+    def apply(*, available: bool, bf16: bool):
+        monkeypatch.setattr(torch.backends, "mps", _FakeMps(available))
+
+        def _empty(*args, **kwargs):
+            if str(kwargs.get("device", "")) == "mps":
+                probes.append(kwargs.get("dtype"))
+                if not bf16:
+                    raise TypeError("MPS bfloat16 requires macOS 14 or newer")
+                return real_empty(*args, **{**kwargs, "device": "cpu"})
+            return real_empty(*args, **kwargs)
+
+        monkeypatch.setattr(torch, "empty", _empty)
+        return probes
 
     return apply
 
@@ -117,6 +150,28 @@ class TestResolveStreamDtype:
         fake_torch(available=True, bf16=True)
         assert resolve_stream_dtype("cpu") == "float32"
 
+    def test_available_mps_with_bfloat16_support_gets_bfloat16(self, fake_mps):
+        import torch
+
+        from soup_cli.utils.layer_stream import resolve_stream_dtype
+
+        probes = fake_mps(available=True, bf16=True)
+        assert resolve_stream_dtype("mps") == "bfloat16"
+        assert probes == [torch.bfloat16]
+
+    def test_mps_without_bfloat16_support_falls_back_to_float32(self, fake_mps):
+        from soup_cli.utils.layer_stream import resolve_stream_dtype
+
+        fake_mps(available=True, bf16=False)
+        assert resolve_stream_dtype("mps") == "float32"
+
+    def test_unavailable_mps_does_not_claim_bfloat16(self, fake_mps):
+        from soup_cli.utils.layer_stream import resolve_stream_dtype
+
+        probes = fake_mps(available=False, bf16=True)
+        assert resolve_stream_dtype("mps") == "float32"
+        assert probes == []
+
     def test_cuda_index_is_still_cuda(self, fake_torch):
         from soup_cli.utils.layer_stream import resolve_stream_dtype
 
@@ -156,6 +211,24 @@ class TestResolveStreamDtype:
                 "torch."
             )
         assert torch is not None  # the import is the point of the comparison
+
+    @pytest.mark.skipif(
+        not __import__("torch").backends.mps.is_available(),
+        reason="requires an available Apple Silicon MPS backend",
+    )
+    def test_real_mps_bfloat16_forward_and_backward(self):
+        import torch
+
+        from soup_cli.utils.layer_stream import resolve_stream_dtype
+
+        assert resolve_stream_dtype("mps") == "bfloat16"
+        value = torch.randn(16, 16, device="mps", dtype=torch.bfloat16)
+        value.requires_grad_(True)
+        loss = (value @ value).float().square().mean()
+        loss.backward()
+        torch.mps.synchronize()
+        assert value.grad is not None
+        assert value.grad.dtype == torch.bfloat16
 
 
 class TestStreamSetupUsesTheResolver:


### PR DESCRIPTION
## Summary

- probe BF16 support on the live MPS runtime instead of routing every non-CUDA device to the CPU FP32 fallback
- keep an explicit FP32 fallback when MPS is unavailable or the runtime rejects BF16
- pin the capability decision with platform-independent tests and a real MPS forward/backward smoke test
- document the Apple Silicon dtype behavior

Closes #516.

## Hardware validation

Reproduced and validated on an M4 Max with 128 GB unified memory using the text-only `Qwen/Qwen3.8-27B` BF16 gate. The hardware gate used the local stacked fixes from #507, #510, and #515; this PR itself is an independent one-commit diff against `main`.

Before this fix, one representative layer grew from a 766,546,368-byte BF16 payload to a 1,533,094,080-byte FP32 shard. The complete layer cache grew from the announced 55.56 GB to 111.1 GB and setup refused the run.

After this fix:

- the cache contains BF16 tensors only and remains 48.71 GiB
- the representative layer shard is 766,547,712 bytes including safetensors metadata
- all 64 Qwen3.8 layers stream through two 976 MiB buffers
- rank-64 LoRA exposes 105,906,176 trainable parameters
- one 64-token training step completes in 27.18 seconds without OOM
- final loss is 2.5355 and token accuracy is 0.6364
- the saved adapter contains 256 non-zero tensors; all 256 reload bit-exactly and no adapter tensor remains on `meta`

## Validation

- focused streaming dtype coverage: `42 passed, 4 skipped` (CUDA-only smokes skipped on this Mac)
- real MPS BF16 forward/backward/synchronization smoke: passed
- `ruff check src/soup_cli/ tests/`: passed
- `git diff --check origin/main...HEAD`: passed

Rebased onto current `main` after #507; the effective diff is one commit and four files.