### PR TITLE
fix(deps): keep Plotext on compatible major

### DIFF
--- a/changelog.d/0.73.3/517.fixed.md
+++ b/changelog.d/0.73.3/517.fixed.md
@@ -1,0 +1,1 @@
+- Fresh installs no longer select Plotext 6, whose incompatible figure API broke `data stats` and run charts. (#517)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,10 @@ dependencies = [
     "pydantic>=2.0.0",
     "pyyaml>=6.0",
     "huggingface-hub>=0.16.0",
-    "plotext>=5.2.0",
+    # Plotext 6 replaced the module-level plotting API used by Soup with an
+    # explicit figure API. Keep fresh installs on the compatible major until
+    # both rendering paths can be supported and tested (#517).
+    "plotext>=5.2.0,<6.0.0",
     # `env check` reads declared bounds via packaging (Requirement/marker/version).
     # It ships with pip and is pulled in transitively, but `env check` degrades to
     # a silent "clean" without it — the wrong direction for a checker — so it is

--- a/tests/test_issue517_plotext_bound.py
+++ b/tests/test_issue517_plotext_bound.py
@@ -1,0 +1,23 @@
+"""Regression coverage for the Plotext 6 API break reported in #517."""
+
+import re
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+
+def _plotext_requirement() -> Requirement:
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    text = pyproject.read_text(encoding="utf-8")
+    match = re.search(r'^\s*"(plotext[^"]+)"', text, flags=re.MULTILINE)
+    assert match, "pyproject.toml has no Plotext dependency"
+    return Requirement(match.group(1))
+
+
+def test_declared_plotext_range_keeps_the_supported_module_api() -> None:
+    specifier = _plotext_requirement().specifier
+
+    assert Version("5.2.0") in specifier
+    assert Version("5.3.2") in specifier
+    assert Version("6.0.0") not in specifier


### PR DESCRIPTION
## Summary

- cap the core Plotext dependency below 6.0
- document why Soup still requires Plotext's module-level plotting API
- add a dependency-contract test that accepts the supported 5.x range and rejects 6.0

Closes #517.

## Why a bound instead of an API shim

Plotext 6 replaced the module-level API used by both `data stats` and run charts with an explicit `figure` API. A fresh Soup install therefore resolves successfully but crashes at runtime because `clear_figure`, `hist`, `plot`, and `show` are no longer module attributes. Supporting both majors would require migrating and validating every plotting path; this focused fix makes the currently declared behavior truthful again.

## Validation

- clean Python 3.12 environment resolved Plotext 5.3.2 under the new bound
- the four `data stats` failures reproduced with Plotext 6 all pass with the bound
- dependency-contract regression: 1 passed
- Ruff: passed