### PR TITLE
fix(sft): reject rows without causal targets

### DIFF
--- a/changelog.d/0.73.3/535.fixed.md
+++ b/changelog.d/0.73.3/535.fixed.md
@@ -1,0 +1,2 @@
+- SFT now refuses examples without causal loss targets and final training states
+  containing non-finite metrics or parameters before saving artifacts (#535).

--- a/docs/performance-and-quantization.md
+++ b/docs/performance-and-quantization.md
@@ -560,6 +560,11 @@ data:
 
 When the tokenizer ships a chat template with `{% generation %}` markers, the mask is exact. Without those markers, Soup falls back to an incremental tokenize-delta walk and documents the looseness.
 
+After tokenization and truncation, every response-only row must retain at least one shifted
+causal-loss target. Soup rejects the row by split and row number when
+`data.max_length` truncates the complete assistant response, rather than training on an
+all-masked sequence or saving a non-finite adapter.
+
 ### `--trust-remote-code` opt-in (every command, every trainer)
 
 Every command that loads a model now requires `--trust-remote-code` to execute custom Python from a model repo (`auto_map` in `config.json`). First-party orgs (Meta, Mistral, Qwen, Google, etc.) suppress the warning panel; everything else prints a `REMOTE CODE WARNING` panel before loading. Unknown-org local checkpoints with `auto_map` raise a friendly `ValueError` at construction time instead of silently exec'ing inside `from_pretrained`.

--- a/src/soup_cli/data/loss_mask.py
+++ b/src/soup_cli/data/loss_mask.py
@@ -38,6 +38,10 @@ IGNORE_INDEX = -100
 _MISSING = object()
 
 
+class NoCausalLossTargetError(ValueError):
+    """Raised when truncation leaves a row with no shifted causal-LM target."""
+
+
 def _coerce_int_list(
     values: Any, *, field: str, allow_bool: bool = False
 ) -> list[int]:
@@ -178,6 +182,23 @@ def _truncate(
         "labels": labels,
         "attention_mask": attention_mask,
     }
+
+
+def ensure_causal_loss_target(labels: Sequence[int], *, max_length: int) -> None:
+    """Reject a row that contributes no token to shifted causal-LM loss.
+
+    Causal language-model losses compare ``logits[:-1]`` with ``labels[1:]``.
+    A non-ignored label in position zero therefore does not make a trainable
+    row. Check the shifted label surface, not merely ``labels`` itself.
+    """
+    _validate_max_length(max_length)
+    if any(label != IGNORE_INDEX for label in labels[1:]):
+        return
+    raise NoCausalLossTargetError(
+        "no causal-loss target remains after tokenization/truncation at "
+        f"data.max_length={max_length}; the assistant response is absent or "
+        "fully truncated. Increase data.max_length or shorten the prompt."
+    )
 
 
 def build_assistant_only_labels(

--- a/src/soup_cli/trainer/sft.py
+++ b/src/soup_cli/trainer/sft.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import math
 import os
 import time
 from pathlib import Path
@@ -46,6 +47,104 @@ _PROCESSOR_TOKEN_ATTRS = (
     "bos_token",
     "bos_token_id",
 )
+
+_FINITE_TRAINING_METRICS = (
+    "loss",
+    "grad_norm",
+    "entropy",
+    "train_loss",
+    "eval_loss",
+)
+
+
+def _assert_finite_training_state(
+    log_history: list[dict[str, Any]], model: Any | None = None
+) -> None:
+    """Refuse the final save when metrics or trainable weights are non-finite."""
+    for entry in log_history:
+        if not isinstance(entry, dict):
+            continue
+        for metric in _FINITE_TRAINING_METRICS:
+            if metric not in entry:
+                continue
+            value = entry[metric]
+            try:
+                finite = math.isfinite(float(value))
+            except (TypeError, ValueError):
+                continue
+            if finite:
+                continue
+            step = entry.get("step", "unknown")
+            raise RuntimeError(
+                f"non-finite training metric {metric}={value} at step {step}; "
+                "refusing to save the final model because its weights may be corrupted"
+            )
+    if model is None:
+        return
+
+    import torch
+
+    for name, parameter in model.named_parameters():
+        if not parameter.requires_grad or getattr(parameter, "is_meta", False):
+            continue
+        if not parameter.is_floating_point():
+            continue
+        if torch.isfinite(parameter.detach()).all().item():
+            continue
+        raise RuntimeError(
+            f"non-finite trainable parameter {name!r}; refusing to save the final "
+            "model because its weights are corrupted"
+        )
+
+
+def _map_text_sft_rows(
+    rows: list[dict],
+    *,
+    format_row: Any,
+    split: str,
+    max_length: int,
+) -> Any:
+    """Tokenize text SFT rows and attach their human-facing row number to failures."""
+    from datasets import Dataset
+
+    from soup_cli.data.loss_mask import (
+        NoCausalLossTargetError,
+        ensure_causal_loss_target,
+    )
+
+    def checked_format_row(example: dict, row_index: int) -> dict:
+        try:
+            formatted = format_row(example)
+            labels = formatted.get("labels")
+            if labels is not None:
+                ensure_causal_loss_target(labels, max_length=max_length)
+            return formatted
+        except NoCausalLossTargetError as exc:
+            raise ValueError(f"{split} row {row_index + 1}: {exc}") from exc
+
+    return Dataset.from_list(rows).map(
+        checked_format_row,
+        with_indices=True,
+        remove_columns=["messages"],
+    )
+
+
+def _validate_pretokenized_targets(dataset: Any, *, split: str, max_length: int) -> None:
+    """Apply the same target invariant to trusted pre-tokenized datasets."""
+    from soup_cli.data.loss_mask import (
+        NoCausalLossTargetError,
+        ensure_causal_loss_target,
+    )
+
+    if "labels" not in getattr(dataset, "column_names", ()):
+        return
+    for row_index in range(len(dataset)):
+        try:
+            ensure_causal_loss_target(
+                dataset[row_index]["labels"], max_length=max_length
+            )
+        except NoCausalLossTargetError as exc:
+            raise ValueError(f"{split} row {row_index + 1}: {exc}") from exc
 
 
 def _ensure_vision_processor_pad_token(processor: object) -> None:
@@ -457,7 +556,6 @@ class SFTTrainerWrapper(StreamingSetupMixin):
 
     def setup(self, dataset: dict):
         """Load model, tokenizer, apply LoRA, create trainer."""
-        from datasets import Dataset
         from transformers import TrainingArguments
         from trl import SFTTrainer
 
@@ -605,6 +703,13 @@ class SFTTrainerWrapper(StreamingSetupMixin):
         pretok = _maybe_load_pretokenized(cfg.data, cfg.base, console)
         if pretok is not None:
             train_ds, eval_ds = pretok
+            _validate_pretokenized_targets(
+                train_ds, split="train", max_length=cfg.data.max_length
+            )
+            if eval_ds is not None:
+                _validate_pretokenized_targets(
+                    eval_ds, split="validation", max_length=cfg.data.max_length
+                )
         elif self._raft_epoch_shuffle:
             train_ds, eval_ds = self._prepare_raft_raw_dataset(dataset, cfg, tcfg)
         elif self._is_raft:
@@ -622,13 +727,19 @@ class SFTTrainerWrapper(StreamingSetupMixin):
                 console=console,
                 training_cfg=tcfg,
             )
-            train_ds = Dataset.from_list(dataset["train"]).map(
-                format_row, remove_columns=["messages"]
+            train_ds = _map_text_sft_rows(
+                dataset["train"],
+                format_row=format_row,
+                split="train",
+                max_length=cfg.data.max_length,
             )
             eval_ds = None
             if "val" in dataset and dataset["val"]:
-                eval_ds = Dataset.from_list(dataset["val"]).map(
-                    format_row, remove_columns=["messages"]
+                eval_ds = _map_text_sft_rows(
+                    dataset["val"],
+                    format_row=format_row,
+                    split="validation",
+                    max_length=cfg.data.max_length,
                 )
 
         # --- Output dir ---
@@ -1851,6 +1962,10 @@ class SFTTrainerWrapper(StreamingSetupMixin):
             )
             self.trainer.train(resume_from_checkpoint=resume_from_checkpoint)
         duration = time.time() - start
+
+        _assert_finite_training_state(
+            self.trainer.state.log_history, model=self.trainer.model
+        )
 
         # Save final model (LoRA adapter)
         self.trainer.save_model(self._output_dir)

--- a/tests/test_issue532_supervised_token_guard.py
+++ b/tests/test_issue532_supervised_token_guard.py
@@ -1,0 +1,153 @@
+"""Regression coverage for issue #532's silent all-NaN SFT adapter."""
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+
+class _BoundaryTokenizer:
+    """Put one assistant token either inside or just beyond max_length=3."""
+
+    chat_template = "{% generation %}"
+
+    def apply_chat_template(self, messages, **kwargs):
+        kept = messages[-1]["content"] == "kept"
+        if kept:
+            input_ids = [10, 11, 12]
+            assistant_mask = [0, 0, 1]
+        else:
+            input_ids = [10, 11, 12, 13]
+            assistant_mask = [0, 0, 0, 1]
+        if kwargs.get("return_assistant_tokens_mask"):
+            return {
+                "input_ids": input_ids,
+                "assistant_masks": assistant_mask,
+            }
+        return input_ids
+
+
+def _data_cfg(max_length: int = 3) -> SimpleNamespace:
+    return SimpleNamespace(
+        train_on_responses_only=True,
+        train_on_messages_with_train_field=False,
+        max_length=max_length,
+        chat_template=None,
+        prompt_strategy=None,
+    )
+
+
+def _row(answer: str) -> dict:
+    return {
+        "messages": [
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": answer},
+        ]
+    }
+
+
+def test_one_surviving_assistant_target_is_accepted() -> None:
+    from soup_cli.data.loss_mask import IGNORE_INDEX
+    from soup_cli.data.sft_format import build_format_row
+
+    formatted = build_format_row(_BoundaryTokenizer(), _data_cfg())(_row("kept"))
+
+    assert formatted["labels"] == [IGNORE_INDEX, IGNORE_INDEX, 12]
+
+
+def test_fully_truncated_target_names_row_and_max_length() -> None:
+    from soup_cli.data.sft_format import build_format_row
+    from soup_cli.trainer.sft import _map_text_sft_rows
+
+    format_row = build_format_row(_BoundaryTokenizer(), _data_cfg())
+
+    with pytest.raises(
+        ValueError,
+        match=r"train row 2.*no causal-loss target.*data\.max_length=3",
+    ):
+        _map_text_sft_rows(
+            [_row("kept"), _row("truncated")],
+            format_row=format_row,
+            split="train",
+            max_length=3,
+        )
+
+
+def test_position_zero_alone_is_not_a_causal_loss_target() -> None:
+    from soup_cli.data.loss_mask import ensure_causal_loss_target
+
+    with pytest.raises(ValueError, match="no causal-loss target"):
+        ensure_causal_loss_target([7, -100, -100], max_length=3)
+
+
+def test_non_finite_training_metric_is_rejected() -> None:
+    from soup_cli.trainer.sft import _assert_finite_training_state
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"non-finite training metric grad_norm=nan.*step 2.*refusing to save",
+    ):
+        _assert_finite_training_state(
+            [{"loss": 0.0, "grad_norm": float("nan"), "step": 2}]
+        )
+
+
+def test_finite_training_metrics_are_accepted() -> None:
+    from soup_cli.trainer.sft import _assert_finite_training_state
+
+    _assert_finite_training_state(
+        [{"loss": 2.2, "grad_norm": 1.5, "entropy": 0.9, "step": 1}]
+    )
+
+
+def test_non_finite_trainable_parameter_is_rejected() -> None:
+    torch = pytest.importorskip("torch")
+    from soup_cli.trainer.sft import _assert_finite_training_state
+
+    model = torch.nn.Linear(2, 2, bias=False)
+    with torch.no_grad():
+        model.weight[0, 0] = float("nan")
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"non-finite trainable parameter 'weight'.*refusing to save",
+    ):
+        _assert_finite_training_state([], model=model)
+
+
+def test_pretokenized_zero_target_row_is_rejected() -> None:
+    from soup_cli.trainer.sft import _validate_pretokenized_targets
+
+    class _Pretokenized:
+        column_names = ["input_ids", "labels"]
+
+        def __init__(self) -> None:
+            self.rows = [
+                {"input_ids": [1, 2], "labels": [-100, 2]},
+                {"input_ids": [3, 4], "labels": [-100, -100]},
+            ]
+
+        def __len__(self) -> int:
+            return len(self.rows)
+
+        def __getitem__(self, index: int) -> dict:
+            return self.rows[index]
+
+    with pytest.raises(
+        ValueError,
+        match=r"validation row 2.*data\.max_length=8",
+    ):
+        _validate_pretokenized_targets(
+            _Pretokenized(), split="validation", max_length=8
+        )
+
+
+def test_training_state_is_checked_before_final_save() -> None:
+    from soup_cli.trainer.sft import SFTTrainerWrapper
+
+    source = inspect.getsource(SFTTrainerWrapper.train)
+    assert source.index("_assert_finite_training_state") < source.index(
+        "self.trainer.save_model"
+    )


### PR DESCRIPTION
## Summary

- reject text SFT rows when tokenization/truncation leaves no shifted causal-LM target in `labels[1:]`
- name the failing split, human-facing row number, and `data.max_length`
- apply the same invariant to pre-tokenized datasets without changing low-level mask-preview behavior
- refuse the final model save when logged training metrics or trainable floating-point parameters are non-finite

## Reproduction and validation

The original two-row `Qwen/Qwen3.8-27B` reproducer was rerun against the locally cached tokenizer on Apple Silicon:

- `max_length=64`: refused before Trainer construction at `train row 2`, as expected
- `max_length=128`: accepted with 12 and 11 shifted causal-loss targets

The regression suite includes the boundary control with one surviving assistant token, the fully truncated failing row, the causal-shift position-zero edge case, pre-tokenized input, non-finite metrics, non-finite trainable parameters, and the pre-save ordering invariant. Removing the zero-target check makes `test_fully_truncated_target_names_row_and_max_length` fail.

Validation:

- `460 passed, 21 skipped` across assistant-mask, SFT, streaming, and adapter-save tests
- full suite: `18,794 passed, 82 skipped, 5 deselected`
- coverage: `82.74%`
- `ruff check src/soup_cli/ scripts/ tests/`
- `git diff --check`

Fixes #532
