### PR TITLE
fix(stream): preserve base model provenance

### DIFF
--- a/changelog.d/0.73.3/537.fixed.md
+++ b/changelog.d/0.73.3/537.fixed.md
@@ -1,0 +1,2 @@
+- Streamed LoRA adapters now preserve the exact configured base-model provenance,
+  restoring automatic base detection across adapter workflows (#537).

--- a/docs/performance-and-quantization.md
+++ b/docs/performance-and-quantization.md
@@ -467,6 +467,11 @@ output: ./output
   state rather than on how many tensors Soup materialised: some PEFT versions
   create real adapters themselves. Include the PEFT version and the named
   parameter from the error when reporting this.
+- **A streamed adapter asks for `--base` when opened** — check
+  `adapter_config.json`. A healthy artifact records the exact configured model
+  reference in `base_model_name_or_path`; an empty value means the adapter was
+  produced by an older streaming path that lost the meta skeleton's origin.
+  Passing `--base` remains a valid workaround for that existing artifact.
 - **"layer streaming needs the base to fit in RAM"** — the base is larger than free RAM. Set `stream_source: auto` to fall back to the NVMe disk tier, free RAM, or pick a smaller base.
 - **"layer streaming needs NVMe or more RAM … the detected disk is 'hdd'"** on a fast cloud disk — a virtio device reports `rotational=1` with no media hint. Detection now measures the disk when the flag is unreliable; if it still misreads yours, set `training.stream_disk_kind: nvme` to force the tier on (`ssd`/`hdd` force it off).
 - **"could not page-lock the base … falling back to a PAGEABLE RAM store"** — expected on a busy machine. Training continues, more slowly. Close other applications to keep the pinned store.

--- a/src/soup_cli/utils/layer_stream_runtime.py
+++ b/src/soup_cli/utils/layer_stream_runtime.py
@@ -1356,6 +1356,13 @@ def build_meta_skeleton(
                 modules_to_not_convert=["lm_head"],
                 quantization_config=quant_config,
             )
+    # ``from_config`` does not reliably preserve the source reference that
+    # ``from_pretrained`` stamps on both the model and its config.  PEFT reads
+    # ``model.__dict__["name_or_path"]`` while wrapping LoRA and copies it to
+    # ``base_model_name_or_path`` in adapter_config.json.  Without this stamp a
+    # healthy streamed adapter cannot be auto-loaded by chat/merge/serve (#531).
+    model.name_or_path = model_id
+    model.config.name_or_path = model_id
     if quant_config is not None:
         _stamp_4bit_markers(model, quant_config)
     return model

--- a/tests/test_issue531_stream_base_provenance.py
+++ b/tests/test_issue531_stream_base_provenance.py
@@ -1,0 +1,111 @@
+"""Regression coverage for streamed adapter base-model provenance (#531)."""
+
+import json
+
+from typer.testing import CliRunner
+
+from soup_cli.cli import app
+from soup_cli.commands.chat import _detect_base_model
+from soup_cli.utils.layer_stream_runtime import build_meta_skeleton
+
+MODEL_ID = "Qwen/Qwen3.8-27B"
+
+
+def _blank_tiny_config():
+    from transformers import LlamaConfig
+
+    config = LlamaConfig(
+        vocab_size=64,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+    )
+    config._name_or_path = ""
+    return config
+
+
+def test_streamed_peft_config_saves_exact_configured_base(monkeypatch, tmp_path):
+    """Pin the saved PEFT contract, not merely the in-memory symptom."""
+    import transformers
+    from peft import LoraConfig, TaskType, get_peft_model
+
+    monkeypatch.setattr(
+        transformers.AutoConfig,
+        "from_pretrained",
+        lambda *_args, **_kwargs: _blank_tiny_config(),
+    )
+
+    model = build_meta_skeleton(MODEL_ID, dtype="float32")
+    assert model.__dict__["name_or_path"] == MODEL_ID
+    assert model.config._name_or_path == MODEL_ID
+
+    adapter = get_peft_model(
+        model,
+        LoraConfig(
+            r=4,
+            lora_alpha=8,
+            target_modules=["q_proj", "v_proj"],
+            task_type=TaskType.CAUSAL_LM,
+        ),
+    )
+    output = tmp_path / "adapter"
+    adapter.peft_config["default"].save_pretrained(output)
+
+    saved = json.loads((output / "adapter_config.json").read_text(encoding="utf-8"))
+    assert saved["base_model_name_or_path"] == MODEL_ID
+    assert _detect_base_model(output / "adapter_config.json") == MODEL_ID
+
+
+def test_blank_provenance_control_breaks_auto_detection(tmp_path):
+    adapter = tmp_path / "blank-adapter"
+    adapter.mkdir()
+    config_path = adapter / "adapter_config.json"
+    config_path.write_text(
+        json.dumps({"base_model_name_or_path": "", "peft_type": "LORA"}),
+        encoding="utf-8",
+    )
+
+    assert _detect_base_model(config_path) == ""
+    assert not _detect_base_model(config_path)
+
+
+def test_explicit_base_still_bypasses_auto_detection(monkeypatch, tmp_path):
+    adapter = tmp_path / "blank-adapter"
+    adapter.mkdir()
+    (adapter / "adapter_config.json").write_text(
+        json.dumps({"base_model_name_or_path": "", "peft_type": "LORA"}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "soup_cli.utils.trust_remote.model_requires_trust_remote_code",
+        lambda *_args, **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        "soup_cli.utils.trust_remote.resolve_trust_remote_code",
+        lambda *_args, **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        "soup_cli.commands.chat._load_model",
+        lambda **_kwargs: (object(), object()),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "chat",
+            "--model",
+            str(adapter),
+            "--base",
+            MODEL_ID,
+            "--device",
+            "cpu",
+        ],
+        input="/quit\n",
+    )
+
+    assert result.exit_code == 0
+    assert "Cannot detect base model" not in result.output
+    assert MODEL_ID in result.output


### PR DESCRIPTION
## What does this PR do?

Layer streaming builds the base model with `from_config`, which can leave both model identity fields blank. PEFT then copies that blank identity into `adapter_config.json`, so otherwise healthy streamed adapters cannot be auto-detected by `soup chat`, merge, serve, export, or other adapter consumers.

This PR stamps the exact configured base reference onto the meta skeleton before PEFT wraps it. The saved `base_model_name_or_path` therefore remains `Qwen/Qwen3.8-27B` (or the exact configured local/base reference), matching the normal `from_pretrained` contract.

Regression coverage verifies:

- the exact configured reference reaches the saved PEFT config;
- chat auto-detection reads the saved reference;
- blank provenance still fails auto-detection as the negative control;
- an explicit `--base` continues to bypass auto-detection unchanged.

The troubleshooting guide now documents the symptom and the explicit-base workaround for already-produced adapters.

Fixes #531.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [x] Tests

## Validation

- Cached `Qwen/Qwen3.8-27B` config reproduction: both meta-model identity fields are now exact before PEFT wrapping (no model weights loaded)
- `pytest --no-cov -q tests/test_issue531_stream_base_provenance.py tests/test_chat.py tests/test_v07201.py` — 24 passed
- `pytest tests/ -q` — 18,789 passed, 82 skipped, 5 deselected; 82.75% coverage
- `ruff check src/soup_cli/ scripts/ tests/` — passed

## Checklist

- [x] `ruff check src/soup_cli/ scripts/ tests/` passes
- [x] `pytest tests/ -v` passes
- [x] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed
- [x] Added changelog fragment `changelog.d/0.73.3/537.fixed.md`
