### PR TITLE
fix(stream): materialize cached HF snapshots offline

### DIFF
--- a/changelog.d/0.73.3/538.fixed.md
+++ b/changelog.d/0.73.3/538.fixed.md
@@ -1,0 +1,2 @@
+- Fully cached Hugging Face snapshots can now be materialized and sharded with
+  outgoing traffic disabled, while preserving commit and blob integrity (#538).

--- a/docs/performance-and-quantization.md
+++ b/docs/performance-and-quantization.md
@@ -541,6 +541,13 @@ copy. The layer shards remain under `~/.soup/layer-stream/`. Their index records
 filename, size, and `mtime_ns`, so a necessary re-shard says which component changed instead
 of silently spending minutes rebuilding the cache.
 
+This materialisation also works with `HF_HUB_OFFLINE=1` when the standard Hugging Face
+snapshot is complete. Soup pins the commit resolved by the initial cache lookup and copies
+only verified snapshot files from that commit's blob store; it does not perform a second Hub
+metadata request for the regular-file directory. A missing blob or an escaping symlink aborts
+before the destination is published, rather than leaving a partial checkpoint that the sharder
+could consume.
+
 
 ## Correctness First (v0.36.0)
 

--- a/src/soup_cli/utils/spectrum_scan.py
+++ b/src/soup_cli/utils/spectrum_scan.py
@@ -31,7 +31,10 @@ import logging
 import math
 import os
 import re
+import shutil
+import stat
 import tempfile
+import time
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
@@ -68,6 +71,7 @@ _VALID_MODULE_TYPES = ("mlp", "attn", "other")
 
 _LAYER_IDX_RE = re.compile(r"(?:^|\.)(?:layers|h)\.\d+\.")
 _SLUG_RE = re.compile(r"[^A-Za-z0-9._-]+")
+_HF_COMMIT_RE = re.compile(r"^[A-Fa-f0-9]{40}$")
 
 ModulesArg = Union[str, Sequence[str], None]
 
@@ -83,6 +87,7 @@ class ModelWeightsPlan:
     materialized_copy_bytes: int
     materialize_bytes: int
     source_files: Tuple[Tuple[str, int, int], ...]
+    source_revision: Optional[str] = None
 
     @property
     def needs_materialization(self) -> bool:
@@ -591,6 +596,8 @@ def _materialized_matches_hf_snapshot(
     source_dir: str,
     materialized_dir: str,
     source_files: Tuple[Tuple[str, int, int], ...],
+    *,
+    source_revision: Optional[str] = None,
 ) -> Optional[Tuple[Tuple[str, int, int], ...]]:
     """Return the real-file manifest when HF metadata proves blob identity."""
     try:
@@ -623,7 +630,182 @@ def _materialized_matches_hf_snapshot(
         # local_dir metadata is: commit hash, blob etag, materialisation time.
         if len(lines) < 2 or lines[1].strip() != blob_id:
             return None
+        if source_revision is not None and lines[0].strip() != source_revision:
+            return None
     return existing
+
+
+def _hf_snapshot_revision(source_dir: str) -> Optional[str]:
+    """Commit carried by a canonical ``snapshots/<sha>`` cache directory."""
+    source = os.path.realpath(os.path.expanduser(source_dir))
+    if os.path.basename(os.path.dirname(source)) != "snapshots":
+        return None
+    revision = os.path.basename(source)
+    return revision if _HF_COMMIT_RE.fullmatch(revision) else None
+
+
+def _snapshot_materialization_entries(
+    source_dir: str,
+    *,
+    source_revision: Optional[str],
+) -> list[Tuple[str, str, Optional[str]]]:
+    """Validate and list cached files before any destination is created.
+
+    Canonical Hugging Face snapshots contain symlinks into their sibling
+    ``blobs`` directory.  Only those links are followed: a crafted snapshot
+    cannot turn Soup's regular-file copy into an arbitrary-file disclosure.
+    """
+    from soup_cli.utils.paths import is_under
+
+    source = os.path.realpath(os.path.expanduser(source_dir))
+    if not os.path.isdir(source):
+        raise FileNotFoundError(f"cached snapshot directory not found: {source_dir}")
+
+    blob_root = None
+    if source_revision is not None:
+        repo_root = os.path.dirname(os.path.dirname(source))
+        expected = os.path.realpath(
+            os.path.join(repo_root, "snapshots", source_revision)
+        )
+        if source != expected:
+            raise ValueError("cached snapshot path does not match its resolved revision")
+        blob_root = os.path.realpath(os.path.join(repo_root, "blobs"))
+        if not os.path.isdir(blob_root):
+            raise FileNotFoundError("cached Hugging Face blob store is missing")
+
+    entries: list[Tuple[str, str, Optional[str]]] = []
+    for root, dirnames, filenames in os.walk(source, followlinks=False):
+        for dirname in dirnames:
+            directory = os.path.join(root, dirname)
+            if os.path.islink(directory):
+                raise ValueError(
+                    f"cached snapshot directory symlink is not allowed: {dirname!r}"
+                )
+        for filename in filenames:
+            if not filename.endswith((".safetensors", ".json")):
+                continue
+            snapshot_path = os.path.join(root, filename)
+            relative = os.path.relpath(snapshot_path, source)
+            blob_id = None
+            if os.path.islink(snapshot_path):
+                resolved = os.path.realpath(snapshot_path)
+                if blob_root is not None and not is_under(resolved, blob_root):
+                    raise ValueError(
+                        f"cached snapshot file {relative!r} points outside the "
+                        "Hugging Face blob store"
+                    )
+                blob_id = os.path.basename(resolved)
+            else:
+                resolved = snapshot_path
+            if not os.path.isfile(resolved):
+                raise FileNotFoundError(
+                    f"cached snapshot file {relative!r} is missing its blob"
+                )
+            entries.append((relative, resolved, blob_id))
+    return entries
+
+
+def _copy_regular_file(source: str, destination: str) -> None:
+    """Copy through a no-follow descriptor so validation cannot be race-swapped."""
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(source, flags)
+    try:
+        source_stat = os.fstat(descriptor)
+        if not stat.S_ISREG(source_stat.st_mode):
+            raise ValueError(f"cached snapshot source is not a regular file: {source!r}")
+        with os.fdopen(descriptor, "rb") as source_handle:
+            descriptor = -1
+            with open(destination, "xb") as destination_handle:
+                shutil.copyfileobj(source_handle, destination_handle)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def _reject_materialized_target_link(target: str) -> None:
+    """Keep cache replacement from following a symlink, junction, or mount."""
+    if not os.path.lexists(target):
+        return
+    target_stat = os.lstat(target)
+    if stat.S_ISLNK(target_stat.st_mode):
+        raise ValueError("materialized weights path must not be a symlink")
+    if os.path.ismount(target):
+        raise ValueError("materialized weights path must not be a mount point")
+    if os.name == "nt":
+        reparse = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+        if getattr(target_stat, "st_file_attributes", 0) & reparse:
+            raise ValueError(
+                "materialized weights path must not be a reparse point / junction"
+            )
+
+
+def _materialize_cached_snapshot(plan: ModelWeightsPlan) -> str:
+    """Copy one already-resolved snapshot without asking the Hub again."""
+    from soup_cli.utils.paths import is_under
+
+    if plan.source_revision is None:
+        raise ValueError(
+            "cannot materialize a symlinked Hub snapshot without its resolved commit"
+        )
+    requested_target = os.path.abspath(os.path.expanduser(plan.weights_dir))
+    _reject_materialized_target_link(requested_target)
+    target = os.path.realpath(requested_target)
+    weights_root = os.path.realpath(os.path.join(resolve_cache_dir(), "weights"))
+    if target == weights_root or not is_under(target, weights_root):
+        raise ValueError("materialized weights path must stay inside Soup's cache")
+
+    entries = _snapshot_materialization_entries(
+        plan.source_dir,
+        source_revision=plan.source_revision,
+    )
+    os.makedirs(weights_root, exist_ok=True)
+    staging = tempfile.mkdtemp(
+        prefix=f".{os.path.basename(target)}.",
+        dir=os.path.dirname(target),
+    )
+    try:
+        metadata_root = os.path.join(
+            staging, ".cache", "huggingface", "download"
+        )
+        for relative, source_path, blob_id in entries:
+            destination = os.path.join(staging, relative)
+            os.makedirs(os.path.dirname(destination), exist_ok=True)
+            _copy_regular_file(source_path, destination)
+            if relative.endswith(".safetensors") and blob_id is not None:
+                metadata_path = os.path.join(metadata_root, relative + ".metadata")
+                os.makedirs(os.path.dirname(metadata_path), exist_ok=True)
+                with open(metadata_path, "w", encoding="utf-8") as handle:
+                    handle.write(
+                        f"{plan.source_revision or ''}\n{blob_id}\n{time.time()}\n"
+                    )
+
+        staged_manifest = _weight_file_manifest(staging, permit_symlinks=False)
+        expected_sizes = {name: size for name, size, _mtime in plan.source_files}
+        staged_sizes = {name: size for name, size, _mtime in staged_manifest}
+        if staged_sizes != expected_sizes:
+            raise FileNotFoundError(
+                "cached snapshot changed while Soup materialized its weight files"
+            )
+
+        if os.path.isdir(target):
+            existing = _materialized_matches_hf_snapshot(
+                plan.source_dir,
+                target,
+                plan.source_files,
+                source_revision=plan.source_revision,
+            )
+            if existing is not None:
+                return target
+            _reject_materialized_target_link(requested_target)
+            shutil.rmtree(target)
+        elif os.path.lexists(target):
+            raise ValueError("materialized weights path must be a directory")
+        os.replace(staging, target)
+        staging = ""
+        return target
+    finally:
+        if staging and os.path.isdir(staging):
+            shutil.rmtree(staging)
 
 
 def plan_model_weights(model: str) -> ModelWeightsPlan:
@@ -649,6 +831,8 @@ def plan_model_weights(model: str) -> ModelWeightsPlan:
         cache_dir=None,
         allow_patterns=["*.safetensors", "*.json"],
     )
+    source = os.path.realpath(source)
+    source_revision = _hf_snapshot_revision(source)
     manifest = _weight_file_manifest(source, permit_symlinks=True)
     source_paths = [os.path.join(source, name) for name, _size, _mtime in manifest]
     if all(not os.path.islink(path) for path in source_paths):
@@ -660,12 +844,18 @@ def plan_model_weights(model: str) -> ModelWeightsPlan:
             materialized_copy_bytes=0,
             materialize_bytes=0,
             source_files=manifest,
+            source_revision=source_revision,
         )
 
     materialized = os.path.join(
         resolve_cache_dir(), "weights", model_slug(model)
     )
-    existing = _materialized_matches_hf_snapshot(source, materialized, manifest)
+    existing = _materialized_matches_hf_snapshot(
+        source,
+        materialized,
+        manifest,
+        source_revision=source_revision,
+    )
     needs_copy = existing is None
     return ModelWeightsPlan(
         model=model,
@@ -677,6 +867,7 @@ def plan_model_weights(model: str) -> ModelWeightsPlan:
             sum(size for _name, size, _mtime in manifest) if needs_copy else 0
         ),
         source_files=manifest if existing is None else existing,
+        source_revision=source_revision,
     )
 
 
@@ -684,15 +875,7 @@ def materialize_model_weights(plan: ModelWeightsPlan) -> str:
     """Create the planned regular-file copy only when the source requires it."""
     if not plan.needs_materialization:
         return plan.weights_dir
-    from soup_cli.utils.hubs import snapshot_download
-
-    resolved = snapshot_download(
-        plan.model,
-        cache_dir=plan.weights_dir,
-        allow_patterns=["*.safetensors", "*.json"],
-    )
-    _weight_file_manifest(resolved, permit_symlinks=False)
-    return resolved
+    return _materialize_cached_snapshot(plan)
 
 
 def resolve_model_weights(

--- a/tests/test_issue533_offline_hf_materialization.py
+++ b/tests/test_issue533_offline_hf_materialization.py
@@ -1,0 +1,187 @@
+"""Offline Hugging Face cache materialization regression tests (#533)."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+COMMIT = "a" * 40
+WEIGHT_BLOB = "b" * 64
+CONFIG_BLOB = "c" * 64
+
+
+def _cached_snapshot(tmp_path: Path) -> tuple[Path, Path, Path]:
+    import torch
+    from safetensors.torch import save_file
+
+    repo = tmp_path / "models--org--model"
+    blobs = repo / "blobs"
+    snapshot = repo / "snapshots" / COMMIT
+    blobs.mkdir(parents=True)
+    snapshot.mkdir(parents=True)
+
+    weight = blobs / WEIGHT_BLOB
+    config = blobs / CONFIG_BLOB
+    save_file(
+        {"model.layers.0.self_attn.q_proj.weight": torch.eye(2)},
+        str(weight),
+    )
+    config.write_text('{"model_type":"llama"}\n', encoding="utf-8")
+    (snapshot / "model.safetensors").symlink_to(Path("../../blobs") / WEIGHT_BLOB)
+    (snapshot / "config.json").symlink_to(Path("../../blobs") / CONFIG_BLOB)
+    return snapshot, weight, config
+
+
+@pytest.mark.skipif(os.name == "nt", reason="standard HF cache uses POSIX symlinks")
+def test_complete_cached_snapshot_materializes_without_a_second_hub_call(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from soup_cli.utils import hubs
+    from soup_cli.utils.layer_shard import shard_checkpoint
+    from soup_cli.utils.spectrum_scan import resolve_model_weights
+
+    snapshot, weight, _config = _cached_snapshot(tmp_path)
+    cache_root = tmp_path / "soup-cache"
+    monkeypatch.setenv("SOUP_SPECTRUM_CACHE_DIR", str(cache_root))
+    calls = []
+
+    def cached_only(_model, *, cache_dir, **_kwargs):
+        calls.append(cache_dir)
+        if cache_dir is not None:
+            pytest.fail("materialization must not make a second Hub metadata call")
+        return str(snapshot)
+
+    monkeypatch.setattr(hubs, "snapshot_download", cached_only)
+
+    resolved = Path(resolve_model_weights("org/model"))
+
+    assert calls == [None]
+    assert resolved == cache_root / "weights" / "org__model"
+    assert not (resolved / "model.safetensors").is_symlink()
+    assert (resolved / "model.safetensors").read_bytes() == weight.read_bytes()
+    assert (resolved / "config.json").read_text(encoding="utf-8") == (
+        '{"model_type":"llama"}\n'
+    )
+    metadata = (
+        resolved
+        / ".cache"
+        / "huggingface"
+        / "download"
+        / "model.safetensors.metadata"
+    ).read_text(encoding="utf-8").splitlines()
+    assert metadata[:2] == [COMMIT, WEIGHT_BLOB]
+
+    index = shard_checkpoint(
+        str(resolved),
+        str(tmp_path / "shards"),
+        dtype="float32",
+        arch="llama",
+    )
+    assert index.n_layers == 1
+
+
+@pytest.mark.skipif(os.name == "nt", reason="standard HF cache uses POSIX symlinks")
+def test_resolved_commit_is_carried_by_the_materialization_plan(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from soup_cli.utils import hubs
+    from soup_cli.utils.spectrum_scan import materialize_model_weights, plan_model_weights
+
+    snapshot, _weight, _config = _cached_snapshot(tmp_path)
+    monkeypatch.setenv("SOUP_SPECTRUM_CACHE_DIR", str(tmp_path / "soup-cache"))
+    monkeypatch.setattr(
+        hubs,
+        "snapshot_download",
+        lambda *_args, **_kwargs: str(snapshot),
+    )
+
+    plan = plan_model_weights("org/model")
+
+    assert plan.source_revision == COMMIT
+    assert plan.source_dir == str(snapshot)
+
+    with pytest.raises(ValueError, match="without its resolved commit"):
+        materialize_model_weights(replace(plan, source_revision=None))
+
+
+@pytest.mark.skipif(os.name == "nt", reason="standard HF cache uses POSIX symlinks")
+def test_missing_blob_fails_without_publishing_a_partial_copy(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from soup_cli.utils import hubs
+    from soup_cli.utils.spectrum_scan import materialize_model_weights, plan_model_weights
+
+    snapshot, weight, _config = _cached_snapshot(tmp_path)
+    cache_root = tmp_path / "soup-cache"
+    monkeypatch.setenv("SOUP_SPECTRUM_CACHE_DIR", str(cache_root))
+    monkeypatch.setattr(
+        hubs,
+        "snapshot_download",
+        lambda *_args, **_kwargs: str(snapshot),
+    )
+    plan = plan_model_weights("org/model")
+    weight.unlink()
+
+    with pytest.raises(FileNotFoundError, match="cached snapshot file"):
+        materialize_model_weights(plan)
+
+    assert not os.path.lexists(plan.weights_dir)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="standard HF cache uses POSIX symlinks")
+def test_snapshot_symlink_cannot_escape_the_hf_blob_store(tmp_path, monkeypatch) -> None:
+    from soup_cli.utils import hubs
+    from soup_cli.utils.spectrum_scan import materialize_model_weights, plan_model_weights
+
+    snapshot, _weight, _config = _cached_snapshot(tmp_path)
+    outside = tmp_path / "outside.json"
+    outside.write_text('{"unsafe":true}\n', encoding="utf-8")
+    (snapshot / "config.json").unlink()
+    (snapshot / "config.json").symlink_to(outside)
+    monkeypatch.setenv("SOUP_SPECTRUM_CACHE_DIR", str(tmp_path / "soup-cache"))
+    monkeypatch.setattr(
+        hubs,
+        "snapshot_download",
+        lambda *_args, **_kwargs: str(snapshot),
+    )
+    plan = plan_model_weights("org/model")
+
+    with pytest.raises(ValueError, match="outside the Hugging Face blob store"):
+        materialize_model_weights(plan)
+
+    assert not os.path.lexists(plan.weights_dir)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="control requires a POSIX symlink")
+def test_materialized_target_symlink_cannot_redirect_cache_replacement(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from soup_cli.utils import hubs
+    from soup_cli.utils.spectrum_scan import materialize_model_weights, plan_model_weights
+
+    snapshot, _weight, _config = _cached_snapshot(tmp_path)
+    cache_root = tmp_path / "soup-cache"
+    monkeypatch.setenv("SOUP_SPECTRUM_CACHE_DIR", str(cache_root))
+    monkeypatch.setattr(
+        hubs,
+        "snapshot_download",
+        lambda *_args, **_kwargs: str(snapshot),
+    )
+    plan = plan_model_weights("org/model")
+    victim = cache_root / "weights" / "victim"
+    victim.mkdir(parents=True)
+    marker = victim / "keep.txt"
+    marker.write_text("keep", encoding="utf-8")
+    Path(plan.weights_dir).symlink_to(victim, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="must not be a symlink"):
+        materialize_model_weights(plan)
+
+    assert marker.read_text(encoding="utf-8") == "keep"


### PR DESCRIPTION
## What does this PR do?

A complete standard Hugging Face cache could be resolved offline, but Soup then called `snapshot_download` a second time with a fresh `local_dir`. Hugging Face keeps the repository tree metadata for `local_dir` separately, so that second call cannot populate a new directory offline even when every source blob is already cached.

This PR carries the commit SHA from the resolved `snapshots/<commit>` directory into `ModelWeightsPlan` and materializes the already-validated snapshot directly. No second Hub metadata request is made.

The materialization boundary remains fail-closed:

- only `.safetensors` and `.json` files from the pinned snapshot are copied;
- snapshot symlinks must resolve inside that repository's HF blob store;
- files are opened with no-follow semantics where supported;
- missing blobs abort before a destination is published;
- the regular-file copy is assembled in a staging directory and atomically published;
- destination symlinks, junctions, reparse points, mounts, and cache escapes are refused;
- the saved HF metadata binds reused copies to both the commit and blob identity.

Regression coverage materializes a valid cached symlink snapshot with the Hub unavailable and then successfully shards the result. Negative controls cover a missing blob, an escaping source symlink, a redirected destination, and a missing resolved commit.

Fixes #533.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [x] Tests

## Validation

- Real cached `Qwen/Qwen3.8-27B` offline plan: 18 shards, 51.75 GiB, resolved commit pinned; no 51.75 GiB duplicate was created during validation
- `pytest --no-cov -q tests/test_issue533_offline_hf_materialization.py tests/test_issue374_stream_disk_preflight.py tests/test_v0718.py` — 160 passed
- `pytest tests/ -q` — 18,846 passed, 82 skipped, 5 deselected; 82.77% coverage
- `ruff check src/soup_cli/ scripts/ tests/` — passed

## Checklist

- [x] `ruff check src/soup_cli/ scripts/ tests/` passes
- [x] `pytest tests/ -v` passes
- [x] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed
- [x] Added changelog fragment `changelog.d/0.73.3/538.fixed.md`

