### PR TITLE
fix(stream): detect Apple internal NVMe through APFS

### DIFF
--- a/changelog.d/0.73.3/539.fixed.md
+++ b/changelog.d/0.73.3/539.fixed.md
@@ -1,0 +1,2 @@
+- Apple internal NVMe volumes behind APFS and Apple Fabric are now detected for
+  the layer-streaming disk tier without requiring a manual override (#539).

--- a/docs/performance-and-quantization.md
+++ b/docs/performance-and-quantization.md
@@ -301,6 +301,12 @@ Untied `embed_tokens` + `lm_head` stay resident and unquantised (2.10 GB of the 
 
 **Honest scope:**
 - **RAM tier + disk overflow (v0.72.3).** `stream_source: auto` picks RAM when it fits, falls back to NVMe disk when not; SATA/HDD rejected. Correctness verified; disk performance unmeasured on the reference box. A paravirtual (virtio) disk reports `rotational=1` with no media hint, so a genuinely NVMe-backed cloud disk was misread as an HDD and refused (#365); detection now measures a bounded O_DIRECT sequential read when the rotational flag is unreliable and admits NVMe-class throughput (>= 1 GB/s), while a genuinely slow disk stays rejected. Set `training.stream_disk_kind: nvme` (or `ssd`/`hdd`) to override when detection is still wrong — the resolved value is printed beside what was detected.
+- **Apple APFS disk detection.** On macOS, an APFS volume may report `Apple Fabric`
+  even when its physical store is Apple's internal NVMe. Soup resolves the target
+  volume to its APFS physical store and admits it only when that exact device is
+  listed by `SPNVMeDataType`; an unmatched solid-state device remains `ssd`, and
+  unknown hardware remains refused. `training.stream_disk_kind` still has final
+  authority when explicitly set.
 - **Llama / Qwen / Qwen3.5 dense and MoE text / Mistral / Gemma / Gemma2 / Gemma3-Text / Phi / Phi3** (`qwen3_5`, `qwen3_5_text`, `qwen3_5_moe`, and `qwen3_5_moe_text` route through the qwen3 streamer), `task: sft`, `backend: transformers`, `modality: text`. The original list is verified bit-exact in bf16 and NF4. Qwen3.5's heterogeneous dense and MoE decoder paths are verified bit-exact against resident controls on CPU; the MoE path also has live streamed-training validation on `Qwen/Qwen3.5-35B-A3B`, whose real 35B run has no resident control because the available hardware could not load it resident.
 - **Heterogeneous layer keys are allowed only at the presence/absence level.** The sharder reads every layer's safetensors header and the runtime builds the RAM/disk source from those per-layer specs, then merges them into one VRAM buffer pool. A key that appears in multiple layers must keep the same stored shape and dtype everywhere; NF4 weights also keep one `NF4WeightSpec` per short key, validate every packed sidecar against the shard header, and share only the small code tables after proving they are equal.
 - **Batch sizes, gradient accumulation, `--resume` / `--hf-resume`** all now work (v0.72.3).

--- a/src/soup_cli/utils/layer_stream.py
+++ b/src/soup_cli/utils/layer_stream.py
@@ -433,6 +433,140 @@ def _resolve_tool(name: str, *fallbacks: str) -> Optional[str]:
 _POWERSHELL_FALLBACK = r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
 
 
+def _darwin_bsd_whole_disk(identifier: Any) -> Optional[str]:
+    """Return the whole-disk BSD name for a validated ``diskNsM`` identifier."""
+    import re
+
+    match = re.fullmatch(r"/?(?:dev/)?(disk\d+)(?:s\d+)*", str(identifier).strip())
+    return match.group(1) if match is not None else None
+
+
+def _darwin_apfs_physical_stores(disk_info: dict) -> set[str]:
+    """Whole disks backing the APFS volume described by ``diskutil info``."""
+    stores = disk_info.get("APFSPhysicalStores")
+    if not isinstance(stores, list):
+        return set()
+    result = set()
+    for entry in stores:
+        if not isinstance(entry, dict):
+            continue
+        identifier = entry.get("APFSPhysicalStore") or entry.get("DeviceIdentifier")
+        whole_disk = _darwin_bsd_whole_disk(identifier)
+        if whole_disk is not None:
+            result.add(whole_disk)
+    return result
+
+
+def _darwin_nvme_whole_disks(profile: dict) -> set[str]:
+    """Whole disks explicitly listed by ``system_profiler SPNVMeDataType``."""
+    sections = profile.get("SPNVMeDataType")
+    if not isinstance(sections, list):
+        return set()
+    result = set()
+    pending: list[Any] = list(sections)
+    while pending:
+        value = pending.pop()
+        if isinstance(value, dict):
+            whole_disk = _darwin_bsd_whole_disk(value.get("bsd_name"))
+            if whole_disk is not None:
+                result.add(whole_disk)
+            pending.extend(value.values())
+        elif isinstance(value, list):
+            pending.extend(value)
+    return result
+
+
+def _darwin_disk_kind(path: str, diskutil: str) -> DiskClassification:
+    """Classify the exact macOS volume, resolving APFS through its physical store."""
+    import json
+    import os
+    import plistlib
+    import subprocess
+
+    resolved = os.path.realpath(os.path.expanduser(path))
+
+    def diskutil_info(target: str) -> Any:
+        return subprocess.run(
+            [diskutil, "info", "-plist", target],
+            capture_output=True,
+            timeout=60,
+            check=False,
+            shell=False,
+        )
+
+    info_result = diskutil_info(resolved)
+    if info_result.returncode != 0:
+        # ``diskutil info`` accepts a device or an exact mount point, not an
+        # arbitrary directory within that volume. Resolve the latter with the
+        # POSIX ``df -P`` format, validate its device token, then retry.
+        df_tool = _resolve_tool("df", "/bin/df")
+        if df_tool is None:
+            return DiskClassification("unknown")
+        df_result = subprocess.run(
+            [df_tool, "-P", resolved],
+            capture_output=True,
+            timeout=60,
+            check=False,
+            shell=False,
+        )
+        if df_result.returncode != 0 or not df_result.stdout:
+            return DiskClassification("unknown")
+        lines = [line for line in df_result.stdout.splitlines() if line.strip()]
+        fields = lines[-1].split() if len(lines) >= 2 else []
+        device = fields[0].decode("ascii", errors="strict") if fields else ""
+        if _darwin_bsd_whole_disk(device) is None:
+            return DiskClassification("unknown")
+        info_result = diskutil_info(device)
+    if info_result.returncode != 0 or not info_result.stdout:
+        return DiskClassification("unknown")
+    try:
+        disk_info = plistlib.loads(info_result.stdout)
+    except (plistlib.InvalidFileException, TypeError, ValueError):
+        return DiskClassification("unknown")
+    if not isinstance(disk_info, dict):
+        return DiskClassification("unknown")
+
+    protocol = str(disk_info.get("BusProtocol", "")).strip().lower()
+    if "nvme" in protocol or "nvmexpress" in protocol:
+        return DiskClassification(_NVME)
+
+    physical_stores = _darwin_apfs_physical_stores(disk_info)
+    if physical_stores:
+        profiler = _resolve_tool("system_profiler", "/usr/sbin/system_profiler")
+        if profiler is not None:
+            profile_result = subprocess.run(
+                [
+                    profiler,
+                    "-json",
+                    "-detailLevel",
+                    "mini",
+                    "SPNVMeDataType",
+                ],
+                capture_output=True,
+                timeout=60,
+                check=False,
+                shell=False,
+            )
+            if profile_result.returncode == 0 and profile_result.stdout:
+                try:
+                    profile = json.loads(profile_result.stdout)
+                except (UnicodeDecodeError, json.JSONDecodeError, TypeError):
+                    profile = None
+                if isinstance(profile, dict):
+                    nvme_disks = _darwin_nvme_whole_disks(profile)
+                    if physical_stores and physical_stores.issubset(nvme_disks):
+                        return DiskClassification(_NVME)
+
+    # ``SolidState`` establishes SSD, not NVMe. A failed or unmatched physical
+    # lookup must never promote an ordinary SATA SSD into the NVMe-only tier.
+    if disk_info.get("SolidState") is True:
+        return DiskClassification("ssd")
+    media_type = str(disk_info.get("MediaType", "")).strip().lower()
+    if "solid state" in media_type or media_type == "ssd":
+        return DiskClassification("ssd")
+    return DiskClassification("unknown")
+
+
 def _classify_measured_read(measured_bps: Optional[float]) -> str:
     """Classify by a measured read a device the rotational flag calls spinning.
 
@@ -590,16 +724,7 @@ def _probe_disk_kind(path: str) -> DiskClassification:
             tool = _resolve_tool("diskutil", "/usr/sbin/diskutil")
             if tool is None:
                 return DiskClassification("unknown")
-            out = subprocess.run(
-                [tool, "info", "-plist", "/"],
-                capture_output=True, text=True, timeout=60, check=False,
-            )
-            text = out.stdout.lower()
-            if "nvme" in text:
-                return DiskClassification(_NVME)
-            if "solid state" in text or ("<true/>" in text and "solidstate" in text):
-                return DiskClassification("ssd")
-            return DiskClassification("unknown")
+            return _darwin_disk_kind(path, tool)
     except (OSError, ValueError, subprocess.SubprocessError):
         return DiskClassification("unknown")
     return DiskClassification("unknown")

--- a/tests/test_issue534_apple_nvme.py
+++ b/tests/test_issue534_apple_nvme.py
@@ -1,0 +1,198 @@
+"""Regression coverage for issue #534: Apple Fabric hides internal NVMe."""
+
+import json
+import platform
+import plistlib
+import subprocess
+
+
+def _completed(args, stdout, returncode=0):
+    return subprocess.CompletedProcess(args=args, returncode=returncode, stdout=stdout, stderr=b"")
+
+
+def test_apple_fabric_apfs_store_is_matched_to_nvme_inventory(monkeypatch):
+    import soup_cli.utils.layer_stream as layer_stream
+
+    disk_info = {
+        "BusProtocol": "Apple Fabric",
+        "SolidState": True,
+        "APFSPhysicalStores": [{"APFSPhysicalStore": "disk0s2"}],
+    }
+    nvme_profile = {
+        "SPNVMeDataType": [
+            {
+                "_name": "Apple SSD Controller",
+                "_items": [
+                    {
+                        "bsd_name": "disk0",
+                        "device_model": "APPLE SSD",
+                        "volumes": [{"bsd_name": "disk0s2"}],
+                    }
+                ],
+            }
+        ]
+    }
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append((args, kwargs))
+        if args[0] == "/usr/sbin/diskutil":
+            return _completed(args, plistlib.dumps(disk_info))
+        return _completed(args, json.dumps(nvme_profile).encode())
+
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(
+        layer_stream,
+        "_resolve_tool",
+        lambda name, *_fallbacks: f"/usr/sbin/{name}",
+    )
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = layer_stream._probe_disk_kind("/private/var/model-shards")
+
+    assert result.kind == "nvme"
+    assert calls[0][0] == [
+        "/usr/sbin/diskutil",
+        "info",
+        "-plist",
+        "/private/var/model-shards",
+    ]
+    assert calls[1][0] == [
+        "/usr/sbin/system_profiler",
+        "-json",
+        "-detailLevel",
+        "mini",
+        "SPNVMeDataType",
+    ]
+    assert all(call[1]["shell"] is False for call in calls)
+
+
+def test_ordinary_sata_ssd_stays_ssd_without_nvme_inventory_probe(monkeypatch):
+    import soup_cli.utils.layer_stream as layer_stream
+
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        return _completed(
+            args,
+            plistlib.dumps({"BusProtocol": "SATA", "SolidState": True}),
+        )
+
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(
+        layer_stream,
+        "_resolve_tool",
+        lambda name, *_fallbacks: f"/usr/sbin/{name}",
+    )
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert layer_stream._probe_disk_kind("/Volumes/SATA").kind == "ssd"
+    assert len(calls) == 1
+
+
+def test_directory_inside_apfs_volume_is_resolved_through_df(monkeypatch):
+    import soup_cli.utils.layer_stream as layer_stream
+
+    disk_info = {
+        "BusProtocol": "Apple Fabric",
+        "SolidState": True,
+        "APFSPhysicalStores": [{"APFSPhysicalStore": "disk0s2"}],
+    }
+    nvme_profile = {"SPNVMeDataType": [{"_items": [{"bsd_name": "disk0"}]}]}
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append((args, kwargs))
+        if args[0].endswith("diskutil") and args[-1] != "/dev/disk3s5":
+            return _completed(args, plistlib.dumps({"Error": "not a mount point"}), 1)
+        if args[0].endswith("df"):
+            return _completed(
+                args,
+                b"Filesystem 512-blocks Used Available Capacity Mounted on\n"
+                b"/dev/disk3s5 100 50 50 50% /System/Volumes/Data\n",
+            )
+        if args[0].endswith("diskutil"):
+            return _completed(args, plistlib.dumps(disk_info))
+        return _completed(args, json.dumps(nvme_profile).encode())
+
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(
+        layer_stream,
+        "_resolve_tool",
+        lambda name, *_fallbacks: f"/usr/sbin/{name}",
+    )
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert layer_stream._probe_disk_kind("relative/shards").kind == "nvme"
+    assert calls[1][0][1:] == ["-P", calls[1][0][-1]]
+    assert calls[2][0][-1] == "/dev/disk3s5"
+
+
+def test_unmatched_apple_fabric_store_is_not_promoted_to_nvme(monkeypatch):
+    import soup_cli.utils.layer_stream as layer_stream
+
+    disk_info = {
+        "BusProtocol": "Apple Fabric",
+        "SolidState": True,
+        "APFSPhysicalStores": [{"APFSPhysicalStore": "disk9s2"}],
+    }
+    nvme_profile = {
+        "SPNVMeDataType": [
+            {"_items": [{"bsd_name": "disk0", "volumes": [{"bsd_name": "disk0s2"}]}]}
+        ]
+    }
+
+    def fake_run(args, **_kwargs):
+        if args[0].endswith("diskutil"):
+            return _completed(args, plistlib.dumps(disk_info))
+        return _completed(args, json.dumps(nvme_profile).encode())
+
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(
+        layer_stream,
+        "_resolve_tool",
+        lambda name, *_fallbacks: f"/usr/sbin/{name}",
+    )
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert layer_stream._probe_disk_kind("/Volumes/UnknownAPFS").kind == "ssd"
+
+
+def test_unknown_darwin_media_remains_conservative(monkeypatch):
+    import soup_cli.utils.layer_stream as layer_stream
+
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(
+        layer_stream,
+        "_resolve_tool",
+        lambda name, *_fallbacks: "/usr/sbin/diskutil" if name == "diskutil" else None,
+    )
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda args, **_kwargs: _completed(
+            args,
+            plistlib.dumps({"BusProtocol": "Apple Fabric", "SolidState": False}),
+        ),
+    )
+
+    assert layer_stream._probe_disk_kind("/Volumes/Unknown").kind == "unknown"
+
+
+def test_malformed_diskutil_plist_fails_closed(monkeypatch):
+    import soup_cli.utils.layer_stream as layer_stream
+
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(
+        layer_stream,
+        "_resolve_tool",
+        lambda name, *_fallbacks: "/usr/sbin/diskutil" if name == "diskutil" else None,
+    )
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda args, **_kwargs: _completed(args, b"not a property list"),
+    )
+
+    assert layer_stream._probe_disk_kind("/Volumes/Broken").kind == "unknown"

--- a/tests/test_issue534_apple_nvme.py
+++ b/tests/test_issue534_apple_nvme.py
@@ -51,12 +51,13 @@ def test_apple_fabric_apfs_store_is_matched_to_nvme_inventory(monkeypatch):
     result = layer_stream._probe_disk_kind("/private/var/model-shards")
 
     assert result.kind == "nvme"
-    assert calls[0][0] == [
+    diskutil_args = calls[0][0]
+    assert diskutil_args[:-1] == [
         "/usr/sbin/diskutil",
         "info",
         "-plist",
-        "/private/var/model-shards",
     ]
+    assert diskutil_args[-1].replace("\\", "/").endswith("/private/var/model-shards")
     assert calls[1][0] == [
         "/usr/sbin/system_profiler",
         "-json",


### PR DESCRIPTION
## What does this PR do?

Fixes #534.

On macOS, `diskutil info` reports an APFS data volume through the logical `Apple Fabric` layer. The previous detector inspected that text and therefore returned `ssd`, even when the APFS physical store was the internal Apple NVMe device.

This change:

- resolves an arbitrary shard directory to its mounted device when necessary;
- parses structured `diskutil info -plist` output;
- resolves `APFSPhysicalStores` to whole-disk BSD identifiers;
- admits the disk tier only when those exact devices are present in the privacy-minimized `SPNVMeDataType` inventory;
- keeps an unmatched solid-state device as `ssd` and unknown hardware as `unknown`;
- preserves `training.stream_disk_kind` as the final explicit authority.

The regression coverage includes Apple Fabric/APFS, an ordinary SATA SSD, an unmatched APFS store, malformed metadata, unknown media, and an arbitrary directory inside an APFS volume.

Hardware verification on Apple Silicon now reports `nvme` without an override.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [x] Tests

## Validation

- `PYTHONPATH=src pytest --no-cov -q tests/test_issue534_apple_nvme.py tests/test_v07203.py tests/test_doctor.py` — 161 passed, 15 skipped
- `PYTHONPATH=src pytest tests/ -q` — 18,848 passed, 82 skipped, 5 deselected; 82.78% coverage
- `ruff check src/soup_cli/ tests/` — passed
- Real Apple Silicon disk classification — `nvme`

## Checklist

- [x] `ruff check src/soup_cli/ scripts/ tests/` passes
- [x] `pytest tests/ -v` passes
- [x] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed
- [x] Added a changelog fragment, or this change has no user-visible impact
