### PR TITLE
fix(data): support system-first Qwen3.8 masking

### DIFF
--- a/changelog.d/0.73.3/543.fixed.md
+++ b/changelog.d/0.73.3/543.fixed.md
@@ -1,0 +1,2 @@
+- Response-only masking now supports system-first conversations with native chat
+  templates that reject transient prefixes without a user query (#543).

--- a/src/soup_cli/data/loss_mask.py
+++ b/src/soup_cli/data/loss_mask.py
@@ -19,12 +19,14 @@ Two strategies:
 
 2. **Fallback**: Render ``messages[:i]`` vs ``messages[:i+1]`` for each turn and
    take the token delta. The delta is the new turn's tokens (prefix + content +
-   suffix). Special tokens like BOS are added by the Jinja template itself
-   (not by the tokenizer ``__call__``), so monotone-prefix templates produce
-   stable deltas. We pass ``add_special_tokens=False`` to incremental tokenize
-   calls so HF does not double-prepend BOS at the front of each render. This
-   path is necessarily looser than the preferred path — the role-prefix tokens
-   (e.g. ``<|assistant|>``) end up in the loss too. Users wanting strict
+   suffix). Leading non-trainable context is deferred until the first user turn,
+   because some native templates reject an otherwise-transient system-only
+   prefix. Special tokens like BOS are added by the Jinja template itself (not
+   by the tokenizer ``__call__``), so monotone-prefix templates produce stable
+   deltas. We pass ``add_special_tokens=False`` to incremental tokenize calls so
+   HF does not double-prepend BOS at the front of each render. This path is
+   necessarily looser than the preferred path — the role-prefix tokens (e.g.
+   ``<|assistant|>``) end up in the loss too. Users wanting strict
    assistant-content-only must pass a tokenizer with ``{% generation %}`` markers.
 """
 
@@ -171,6 +173,17 @@ def _tokenize_only(tokenizer: Any, messages: Sequence[dict]) -> list[int]:
     return coerce_token_ids(out)
 
 
+def _has_user_turn(messages: Sequence[dict]) -> bool:
+    """Whether a cumulative conversation contains a user query.
+
+    Qwen3.8's native template refuses a system-only prefix. The incremental
+    fallback does not need to render leading ignored context by itself: the
+    first user render includes that context and establishes the same boundary
+    before an assistant turn is unmasked.
+    """
+    return any(message.get("role") == "user" for message in messages)
+
+
 def _truncate(
     input_ids: list[int], labels: list[int], max_length: int
 ) -> dict[str, list[int]]:
@@ -258,6 +271,11 @@ def build_assistant_only_labels(
     cumulative: list[dict] = []
     for msg in messages:
         cumulative.append(msg)
+        if msg.get("role") != "assistant" and not _has_user_turn(cumulative):
+            # Do not feed a transient system/developer-only prefix to native
+            # templates that require a user query (#540). Those tokens remain
+            # ignored and are included in the first renderable user prefix.
+            continue
         rendered = _tokenize_only(tokenizer, cumulative)
         new_len = len(rendered)
         if msg.get("role") == "assistant":
@@ -343,11 +361,15 @@ def build_per_message_train_labels(
     cumulative: list[dict] = []
     for msg in messages:
         cumulative.append(msg)
-        rendered = _tokenize_only(tokenizer, cumulative)
-        new_len = len(rendered)
         train_flag = msg.get("train")
         if train_flag is None:
             train_flag = msg.get("role") == "assistant"
+        if not train_flag and not _has_user_turn(cumulative):
+            # Match the response-only fallback: ignored leading context need
+            # not be rendered until a valid user-bearing prefix exists (#540).
+            continue
+        rendered = _tokenize_only(tokenizer, cumulative)
+        new_len = len(rendered)
         if train_flag:
             end = min(new_len, len(full_ids))
             labels[prev_len:end] = full_ids[prev_len:end]

--- a/src/soup_cli/data/loss_mask.py
+++ b/src/soup_cli/data/loss_mask.py
@@ -33,6 +33,7 @@ Two strategies:
 from __future__ import annotations
 
 from collections.abc import Mapping
+from difflib import SequenceMatcher
 from operator import index
 from typing import Any, Optional, Sequence
 
@@ -182,6 +183,38 @@ def _has_user_turn(messages: Sequence[dict]) -> bool:
     before an assistant turn is unmasked.
     """
     return any(message.get("role") == "user" for message in messages)
+
+
+def _unmask_render_insertions(
+    labels: list[int],
+    full_ids: Sequence[int],
+    *,
+    baseline_ids: Sequence[int],
+    rendered_ids: Sequence[int],
+) -> None:
+    """Unmask tokens introduced by one message in a renderable prefix."""
+    matcher = SequenceMatcher(a=baseline_ids, b=rendered_ids, autojunk=False)
+    for tag, _a1, _a2, b1, b2 in matcher.get_opcodes():
+        if tag not in {"insert", "replace"}:
+            continue
+        end = min(b2, len(full_ids))
+        labels[b1:end] = full_ids[b1:end]
+
+
+def _unmask_aligned_render(
+    labels: list[int],
+    full_ids: Sequence[int],
+    *,
+    selected_ids: Sequence[int],
+    rendered_ids: Sequence[int],
+) -> None:
+    """Unmask the tokens from a valid standalone turn inside a larger render."""
+    matcher = SequenceMatcher(a=selected_ids, b=rendered_ids, autojunk=False)
+    for tag, _a1, _a2, b1, b2 in matcher.get_opcodes():
+        if tag != "equal":
+            continue
+        end = min(b2, len(full_ids))
+        labels[b1:end] = full_ids[b1:end]
 
 
 def _truncate(
@@ -359,6 +392,7 @@ def build_per_message_train_labels(
     labels: list[int] = [IGNORE_INDEX] * len(full_ids)
     prev_len = 0
     cumulative: list[dict] = []
+    deferred: list[tuple[dict, bool]] = []
     for msg in messages:
         cumulative.append(msg)
         train_flag = msg.get("train")
@@ -367,9 +401,45 @@ def build_per_message_train_labels(
         if not _has_user_turn(cumulative):
             # Template validity is independent of the per-message train flag:
             # defer every user-less prefix until it can be rendered (#540).
+            deferred.append((msg, bool(train_flag)))
             continue
         rendered = _tokenize_only(tokenizer, cumulative)
         new_len = len(rendered)
+
+        if deferred:
+            # The first valid render contains both the deferred prefix and the
+            # first user turn. Recover each requested prefix span by comparing
+            # that render with the same conversation minus one deferred
+            # message. This preserves an explicit ``train: true`` without ever
+            # asking a native template to render an invalid system-only prefix.
+            for deferred_msg, deferred_train_flag in deferred:
+                if not deferred_train_flag:
+                    continue
+                without_message = [
+                    item for item in cumulative if item is not deferred_msg
+                ]
+                _unmask_render_insertions(
+                    labels,
+                    full_ids,
+                    baseline_ids=_tokenize_only(tokenizer, without_message),
+                    rendered_ids=rendered,
+                )
+
+            # A trainable first user must not accidentally absorb ignored
+            # system/developer tokens merely because the initial boundary was
+            # deferred. Align its valid standalone render back into the full
+            # prefix instead.
+            if train_flag:
+                _unmask_aligned_render(
+                    labels,
+                    full_ids,
+                    selected_ids=_tokenize_only(tokenizer, [msg]),
+                    rendered_ids=rendered,
+                )
+            deferred.clear()
+            prev_len = new_len
+            continue
+
         if train_flag:
             end = min(new_len, len(full_ids))
             labels[prev_len:end] = full_ids[prev_len:end]

--- a/src/soup_cli/data/loss_mask.py
+++ b/src/soup_cli/data/loss_mask.py
@@ -364,9 +364,9 @@ def build_per_message_train_labels(
         train_flag = msg.get("train")
         if train_flag is None:
             train_flag = msg.get("role") == "assistant"
-        if not train_flag and not _has_user_turn(cumulative):
-            # Match the response-only fallback: ignored leading context need
-            # not be rendered until a valid user-bearing prefix exists (#540).
+        if not _has_user_turn(cumulative):
+            # Template validity is independent of the per-message train flag:
+            # defer every user-less prefix until it can be rendered (#540).
             continue
         rendered = _tokenize_only(tokenizer, cumulative)
         new_len = len(rendered)

--- a/tests/test_assistant_mask.py
+++ b/tests/test_assistant_mask.py
@@ -488,7 +488,31 @@ class TestPerMessageTrainField:
 
         assert ("system",) not in tok.rendered_roles
         assert ("system", "user") in tok.rendered_roles
-        assert any(label != IGNORE_INDEX for label in out["labels"])
+        system_end = len("<system>:Follow the format.\n")
+        user_end = system_end + len("<user>:Q\n")
+        assert all(label != IGNORE_INDEX for label in out["labels"][:system_end])
+        assert all(
+            label == IGNORE_INDEX for label in out["labels"][system_end:user_end]
+        )
+
+    def test_trainable_first_user_does_not_absorb_ignored_system_prefix(self):
+        from soup_cli.data.loss_mask import (
+            IGNORE_INDEX,
+            build_per_message_train_labels,
+        )
+
+        tok = _RequiresUserTokenizer()
+        out = build_per_message_train_labels(
+            [
+                {"role": "system", "content": "Follow the format.", "train": False},
+                {"role": "user", "content": "Q", "train": True},
+            ],
+            tok,
+        )
+
+        system_end = len("<system>:Follow the format.\n")
+        assert all(label == IGNORE_INDEX for label in out["labels"][:system_end])
+        assert any(label != IGNORE_INDEX for label in out["labels"][system_end:])
 
 
 class TestEdgeCases:

--- a/tests/test_assistant_mask.py
+++ b/tests/test_assistant_mask.py
@@ -97,6 +97,21 @@ class _BatchEncodingTokenizer(_FakeTokenizer):
         return BatchEncoding({"input_ids": ids})
 
 
+class _RequiresUserTokenizer(_FakeTokenizer):
+    """Qwen3.8-like fallback tokenizer that rejects system-only prefixes."""
+
+    def __init__(self):
+        super().__init__(supports_assistant_mask=False)
+        self.rendered_roles: list[tuple[str, ...]] = []
+
+    def apply_chat_template(self, messages, **kwargs):
+        roles = tuple(message.get("role", "") for message in messages)
+        self.rendered_roles.append(roles)
+        if "user" not in roles:
+            raise AssertionError("No user query found in messages.")
+        return super().apply_chat_template(messages, **kwargs)
+
+
 # ---------------------------------------------------------------------------
 # Schema field
 # ---------------------------------------------------------------------------
@@ -286,6 +301,24 @@ class TestFallbackPath:
         assert labels[-2] == IGNORE_INDEX  # '2'
         assert labels[-3] == IGNORE_INDEX  # 'Q'
 
+    def test_system_prefix_is_deferred_for_template_requiring_user(self):
+        from soup_cli.data.loss_mask import IGNORE_INDEX, build_assistant_only_labels
+
+        tok = _RequiresUserTokenizer()
+        messages = [
+            {"role": "system", "content": "Follow the format."},
+            {"role": "user", "content": "Q"},
+            {"role": "assistant", "content": "A"},
+        ]
+
+        out = build_assistant_only_labels(messages, tok)
+
+        assert ("system",) not in tok.rendered_roles
+        assert ("system", "user") in tok.rendered_roles
+        assert any(label != IGNORE_INDEX for label in out["labels"])
+        system_end = len("<system>:Follow the format.\n")
+        assert all(label == IGNORE_INDEX for label in out["labels"][:system_end])
+
 
 class TestTokenIdNormalisation:
     def test_real_batch_encoding_returns_values_not_mapping_keys(self):
@@ -417,6 +450,25 @@ class TestPerMessageTrainField:
         # Default-include assistant when no flag.
         non_masked = [lab for lab in out["labels"] if lab != IGNORE_INDEX]
         assert len(non_masked) >= 1
+
+    def test_ignored_system_prefix_is_deferred_for_template_requiring_user(self):
+        from soup_cli.data.loss_mask import (
+            IGNORE_INDEX,
+            build_per_message_train_labels,
+        )
+
+        tok = _RequiresUserTokenizer()
+        out = build_per_message_train_labels(
+            [
+                {"role": "system", "content": "Follow the format.", "train": False},
+                {"role": "user", "content": "Q", "train": False},
+                {"role": "assistant", "content": "A", "train": True},
+            ],
+            tok,
+        )
+
+        assert ("system",) not in tok.rendered_roles
+        assert any(label != IGNORE_INDEX for label in out["labels"])
 
 
 class TestEdgeCases:

--- a/tests/test_assistant_mask.py
+++ b/tests/test_assistant_mask.py
@@ -470,6 +470,26 @@ class TestPerMessageTrainField:
         assert ("system",) not in tok.rendered_roles
         assert any(label != IGNORE_INDEX for label in out["labels"])
 
+    def test_explicitly_trained_system_prefix_is_deferred_until_user(self):
+        from soup_cli.data.loss_mask import (
+            IGNORE_INDEX,
+            build_per_message_train_labels,
+        )
+
+        tok = _RequiresUserTokenizer()
+        out = build_per_message_train_labels(
+            [
+                {"role": "system", "content": "Follow the format.", "train": True},
+                {"role": "user", "content": "Q", "train": False},
+                {"role": "assistant", "content": "A", "train": True},
+            ],
+            tok,
+        )
+
+        assert ("system",) not in tok.rendered_roles
+        assert ("system", "user") in tok.rendered_roles
+        assert any(label != IGNORE_INDEX for label in out["labels"])
+
 
 class TestEdgeCases:
     def test_empty_messages_raises(self):


### PR DESCRIPTION
## Summary

- defer ignored system/developer-only prefixes in the incremental masking fallback until a user-bearing prefix can be rendered
- preserve the existing assistant boundary and ignored-prefix semantics
- cover both response-only and per-message `train` masking paths

This was found during the Qwen3.8-27B Apple Silicon smoke test reported in #472. The native Qwen3.8 chat template rejects a transient system-only prefix with `TemplateError: No user query found in messages.`, even though the complete conversation is valid.

## Validation

- `18855 passed, 82 skipped, 5 deselected` in the full non-smoke suite
- `356 passed` across focused masking and chat-template tests
- real cached `Qwen/Qwen3.8-27B` native tokenizer: all 128 smoke-test training rows preprocess successfully and retain supervised tokens
- `ruff check` and `git diff --check` pass

Fixes #540
