### PR TITLE
fix(monitoring): preserve final loss in live panel

### DIFF
--- a/changelog.d/0.73.3/544.fixed.md
+++ b/changelog.d/0.73.3/544.fixed.md
@@ -1,0 +1,2 @@
+- The final training panel now preserves the last real loss, learning rate, and
+  gradient norm when Transformers emits a summary-only log event (#544).

--- a/src/soup_cli/monitoring/callback.py
+++ b/src/soup_cli/monitoring/callback.py
@@ -54,6 +54,13 @@ class _SoupTrainerCallback_body:  # noqa: N801
         self.run_id = run_id
         self.eval_config = eval_config
         self.output_dir = output_dir
+        # HF emits a summary-only ``on_log`` event after the final optimizer
+        # step. It has runtime/throughput fields but no loss/LR/grad norm. Keep
+        # the last real values so that event cannot reset the dashboards and
+        # tracker to synthetic zeroes (#541).
+        self._last_loss = 0.0
+        self._last_lr = 0.0
+        self._last_grad_norm = 0.0
         # Loss watchdog state
         self._watchdog_enabled = loss_watchdog
         self._watchdog_threshold = loss_watchdog_threshold
@@ -175,9 +182,15 @@ class _SoupTrainerCallback_body:  # noqa: N801
 
         step = state.global_step
         epoch = state.epoch or 0
-        loss = logs.get("loss", 0.0)
-        lr = logs.get("learning_rate", 0.0)
-        grad_norm = logs.get("grad_norm", 0.0)
+        if logs.get("loss") is not None:
+            self._last_loss = logs["loss"]
+        if logs.get("learning_rate") is not None:
+            self._last_lr = logs["learning_rate"]
+        if logs.get("grad_norm") is not None:
+            self._last_grad_norm = logs["grad_norm"]
+        loss = self._last_loss
+        lr = self._last_lr
+        grad_norm = self._last_grad_norm
         speed = logs.get("train_steps_per_second", 0.0)
 
         self.display.update(

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -71,6 +71,60 @@ def test_on_log_none_logs():
     display.update.assert_not_called()
 
 
+def test_summary_log_preserves_last_training_metrics():
+    """HF's final runtime summary must not reset the live panel to zero."""
+    display = MagicMock()
+    callback = SoupTrainerCallback(display=display)
+    state = _make_state(global_step=128, max_steps=128, epoch=1.0)
+
+    callback.on_log(
+        _make_args(),
+        state,
+        MagicMock(),
+        logs={
+            "loss": 1.3589,
+            "learning_rate": 1.2e-8,
+            "grad_norm": 6.55,
+        },
+    )
+    callback.on_log(
+        _make_args(),
+        state,
+        MagicMock(),
+        logs={"train_runtime": 1016.0, "train_steps_per_second": 0.126},
+    )
+
+    final_update = display.update.call_args_list[-1].kwargs
+    assert final_update["loss"] == 1.3589
+    assert final_update["lr"] == 1.2e-8
+    assert final_update["grad_norm"] == 6.55
+
+
+def test_real_zero_metrics_replace_previous_values():
+    """Preservation must not hide a genuine logged zero."""
+    display = MagicMock()
+    callback = SoupTrainerCallback(display=display)
+    state = _make_state()
+
+    callback.on_log(
+        _make_args(),
+        state,
+        MagicMock(),
+        logs={"loss": 1.0, "learning_rate": 1e-4, "grad_norm": 2.0},
+    )
+    callback.on_log(
+        _make_args(),
+        state,
+        MagicMock(),
+        logs={"loss": 0.0, "learning_rate": 0.0, "grad_norm": 0.0},
+    )
+
+    final_update = display.update.call_args_list[-1].kwargs
+    assert final_update["loss"] == 0.0
+    assert final_update["lr"] == 0.0
+    assert final_update["grad_norm"] == 0.0
+
+
 def test_on_log_with_tracker():
     """on_log should forward metrics to tracker if provided."""
     display = MagicMock()


### PR DESCRIPTION
## Summary

- retain the last real loss, learning rate, and gradient norm seen by the training callback
- prevent Hugging Face's final runtime-only log event from replacing those values with synthetic zeroes
- preserve genuine logged `0.0` values

This was observed at the end of the Qwen3.8-27B Apple Silicon smoke test reported in #472: training completed with a final logged loss of `1.3589`, but the completed live panel displayed `0.0000` after the summary event.

## Validation

- focused callback, display, live-monitor, watchdog, and training-intelligence suite: `310 passed`
- regression coverage for both summary-only events and genuine zero-valued metrics
- full non-smoke suite: `18855 passed, 82 skipped, 5 deselected`
- `ruff check` and `git diff --check` pass

Fixes #541
