### PR TITLE
fix(repro): capture Apple Silicon accelerator metadata

### DIFF
--- a/changelog.d/0.73.3/545.fixed.md
+++ b/changelog.d/0.73.3/545.fixed.md
@@ -1,0 +1,2 @@
+- Reproducibility receipts now record the MPS backend, Apple chip name, and
+  unified-memory capacity without collecting unique hardware identifiers (#545).

--- a/docs/adapters-and-governance.md
+++ b/docs/adapters-and-governance.md
@@ -481,7 +481,9 @@ best-effort — a broken audit log never crashes the CLI.
 ## Reproducibility Receipt (`soup train --repro-receipt`)
 
 SR 11-7-style reproducibility receipt captures seeds (torch + numpy + python), kernel
-versions (CUDA + cuDNN + NCCL), GPU model + driver, OS + arch:
+versions (CUDA + cuDNN + NCCL), accelerator backend, GPU model + driver, OS + arch.
+On Apple Silicon it records the privacy-safe chip name and unified-memory capacity, but
+never a serial number, hardware UUID, or user-specific path:
 
 ```bash
 soup train --config soup.yaml --repro-receipt repro.json

--- a/src/soup_cli/utils/repro_receipt.py
+++ b/src/soup_cli/utils/repro_receipt.py
@@ -3,8 +3,8 @@
 Captures the minimum environment fingerprint needed for a regulated-org
 audit: seeds (torch + numpy + python), Python interpreter version, OS +
 arch, soup_cli version, kernel versions (CUDA / cuDNN / NCCL — best-effort
-from torch when available), GPU model + driver (best-effort from
-``torch.cuda.get_device_name`` + ``nvidia-smi`` proxy).
+from torch when available), accelerator backend, GPU model + driver, and
+Apple unified memory when MPS is available.
 
 Pure-stdlib at module top; ``torch`` is lazy-imported so this module
 loads in <50 ms on CPU-only hosts.
@@ -16,6 +16,7 @@ import json
 import logging
 import platform
 import re
+import subprocess
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Mapping, Optional, Tuple
@@ -27,6 +28,7 @@ _LOG = logging.getLogger(__name__)
 _MAX_RUN_ID = 128
 _MAX_VERSION = 64
 _RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._\-]{0,127}$")
+_SAFE_MACOS_SYSCTL_KEYS = frozenset({"hw.memsize", "machdep.cpu.brand_string"})
 
 
 @dataclass(frozen=True)
@@ -46,6 +48,8 @@ class ReproReceipt:
     gpu_models: Tuple[str, ...]
     driver_version: Optional[str]
     created_at: str
+    accelerator_backend: Optional[str] = None
+    unified_memory_bytes: Optional[int] = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.run_id, str) or not _RUN_ID_RE.match(self.run_id):
@@ -70,21 +74,77 @@ class ReproReceipt:
                 raise ValueError(f"seeds[{key}] must be int (got {type(val).__name__})")
         if not isinstance(self.gpu_models, tuple):
             raise ValueError("gpu_models must be a tuple")
+        if self.accelerator_backend not in (None, "cuda", "mps"):
+            raise ValueError("accelerator_backend must be cuda, mps, or None")
+        if self.unified_memory_bytes is not None and (
+            isinstance(self.unified_memory_bytes, bool)
+            or not isinstance(self.unified_memory_bytes, int)
+            or self.unified_memory_bytes <= 0
+        ):
+            raise ValueError("unified_memory_bytes must be a positive int or None")
+
+
+def _read_macos_sysctl(name: str) -> Optional[str]:
+    """Read one fixed macOS sysctl key without collecting unique identifiers."""
+    if platform.system() != "Darwin" or name not in _SAFE_MACOS_SYSCTL_KEYS:
+        return None
+    try:
+        result = subprocess.run(  # noqa: S603 — fixed executable and key allowlist.
+            ["/usr/sbin/sysctl", "-n", name],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    value = result.stdout.strip()
+    return value if result.returncode == 0 and value else None
+
+
+def _detect_mps_metadata(torch_module) -> dict:
+    """Return privacy-safe Apple accelerator metadata when MPS is available."""
+    out = {
+        "accelerator_backend": None,
+        "gpu_models": (),
+        "unified_memory_bytes": None,
+    }
+    try:
+        if not torch_module.backends.mps.is_available():
+            return out
+    except Exception as exc:  # noqa: BLE001
+        _LOG.debug("repro_receipt MPS probe failed: %s", exc)
+        return out
+
+    out["accelerator_backend"] = "mps"
+    chip = _read_macos_sysctl("machdep.cpu.brand_string")
+    out["gpu_models"] = (chip or "Apple Silicon",)
+    memory = _read_macos_sysctl("hw.memsize")
+    try:
+        memory_bytes = int(memory) if memory is not None else None
+        if memory_bytes is not None and memory_bytes > 0:
+            out["unified_memory_bytes"] = memory_bytes
+    except ValueError:
+        pass
+    return out
 
 
 def _detect_torch_kernel_versions() -> dict:
     """Best-effort torch / CUDA / cuDNN / NCCL detection.
 
     Returns a dict with optional ``torch_version`` / ``cuda_version`` /
-    ``cudnn_version`` / ``nccl_version`` / ``gpu_models`` / ``driver_version``
-    keys. Each is ``None`` when not detected. Lazy-imports torch.
+    ``cudnn_version`` / ``nccl_version`` / ``accelerator_backend`` /
+    ``gpu_models`` / ``unified_memory_bytes`` / ``driver_version`` keys.
+    Optional scalar values are ``None`` when not detected. Lazy-imports torch.
     """
     out = {
         "torch_version": None,
         "cuda_version": None,
         "cudnn_version": None,
         "nccl_version": None,
+        "accelerator_backend": None,
         "gpu_models": (),
+        "unified_memory_bytes": None,
         "driver_version": None,
     }
     try:
@@ -114,12 +174,15 @@ def _detect_torch_kernel_versions() -> dict:
         _LOG.debug("repro_receipt torch probe failed: %s", exc)
     try:
         if torch.cuda.is_available():
+            out["accelerator_backend"] = "cuda"
             names = []
             for i in range(torch.cuda.device_count()):
                 names.append(str(torch.cuda.get_device_name(i)))
             out["gpu_models"] = tuple(names)
     except Exception as exc:  # noqa: BLE001
         _LOG.debug("repro_receipt torch probe failed: %s", exc)
+    if out["accelerator_backend"] is None:
+        out.update(_detect_mps_metadata(torch))
     return out
 
 
@@ -150,7 +213,9 @@ def build_repro_receipt(
         cuda_version=kernel.get("cuda_version"),
         cudnn_version=kernel.get("cudnn_version"),
         nccl_version=kernel.get("nccl_version"),
+        accelerator_backend=kernel.get("accelerator_backend"),
         gpu_models=tuple(kernel.get("gpu_models", ())),
+        unified_memory_bytes=kernel.get("unified_memory_bytes"),
         driver_version=kernel.get("driver_version"),
         created_at=created_at,
     )
@@ -168,7 +233,9 @@ def receipt_to_dict(r: ReproReceipt) -> dict:
         "cuda_version": r.cuda_version,
         "cudnn_version": r.cudnn_version,
         "nccl_version": r.nccl_version,
+        "accelerator_backend": r.accelerator_backend,
         "gpu_models": list(r.gpu_models),
+        "unified_memory_bytes": r.unified_memory_bytes,
         "driver_version": r.driver_version,
         "created_at": r.created_at,
     }

--- a/tests/test_v0590.py
+++ b/tests/test_v0590.py
@@ -792,6 +792,84 @@ class TestReproReceipt:
         # OS, python_version captured
         assert d.get("python_version")
         assert d.get("os")
+        assert "accelerator_backend" in d
+        assert "unified_memory_bytes" in d
+
+    def test_mps_receipt_captures_chip_and_unified_memory(self, monkeypatch):
+        from soup_cli.utils import repro_receipt
+
+        class _AvailableMPS:
+            @staticmethod
+            def is_available():
+                return True
+
+        class _Backends:
+            mps = _AvailableMPS()
+
+        class _Torch:
+            backends = _Backends()
+
+        values = {
+            "machdep.cpu.brand_string": "Apple M4 Max",
+            "hw.memsize": "137438953472",
+        }
+        monkeypatch.setattr(
+            repro_receipt,
+            "_read_macos_sysctl",
+            lambda name: values.get(name),
+        )
+
+        metadata = repro_receipt._detect_mps_metadata(_Torch())
+
+        assert metadata == {
+            "accelerator_backend": "mps",
+            "gpu_models": ("Apple M4 Max",),
+            "unified_memory_bytes": 137438953472,
+        }
+
+    def test_new_accelerator_fields_preserve_old_constructor_signature(self):
+        from soup_cli.utils.repro_receipt import ReproReceipt
+
+        receipt = ReproReceipt(
+            "run",
+            "0.73.3",
+            "3.12.0",
+            "Darwin",
+            "arm64",
+            {},
+            "2.12.1",
+            None,
+            None,
+            None,
+            (),
+            None,
+            "2026-08-25T00:00:00+00:00",
+        )
+
+        assert receipt.accelerator_backend is None
+        assert receipt.unified_memory_bytes is None
+
+    def test_mps_receipt_falls_back_without_sysctl_values(self, monkeypatch):
+        from soup_cli.utils import repro_receipt
+
+        class _AvailableMPS:
+            @staticmethod
+            def is_available():
+                return True
+
+        class _Backends:
+            mps = _AvailableMPS()
+
+        class _Torch:
+            backends = _Backends()
+
+        monkeypatch.setattr(repro_receipt, "_read_macos_sysctl", lambda _name: None)
+
+        metadata = repro_receipt._detect_mps_metadata(_Torch())
+
+        assert metadata["accelerator_backend"] == "mps"
+        assert metadata["gpu_models"] == ("Apple Silicon",)
+        assert metadata["unified_memory_bytes"] is None
 
     def test_receipt_frozen(self):
         from soup_cli.utils.repro_receipt import build_repro_receipt

--- a/tests/test_v0590.py
+++ b/tests/test_v0590.py
@@ -17,6 +17,7 @@ import dataclasses
 import json
 import os
 import stat
+import sys
 from pathlib import Path
 
 import pytest
@@ -826,6 +827,60 @@ class TestReproReceipt:
             "gpu_models": ("Apple M4 Max",),
             "unified_memory_bytes": 137438953472,
         }
+
+    def test_mps_metadata_reaches_serialized_receipt(self, monkeypatch):
+        from soup_cli.utils import repro_receipt
+
+        class _UnavailableCudnn:
+            @staticmethod
+            def is_available():
+                return False
+
+        class _AvailableMPS:
+            @staticmethod
+            def is_available():
+                return True
+
+        class _Backends:
+            cudnn = _UnavailableCudnn()
+            mps = _AvailableMPS()
+
+        class _Cuda:
+            nccl = None
+
+            @staticmethod
+            def is_available():
+                return False
+
+        class _Version:
+            cuda = None
+
+        class _Torch:
+            __version__ = "2.12.1"
+            backends = _Backends()
+            cuda = _Cuda()
+            version = _Version()
+
+        values = {
+            "machdep.cpu.brand_string": "Apple M4 Max",
+            "hw.memsize": "137438953472",
+        }
+        monkeypatch.setitem(sys.modules, "torch", _Torch())
+        monkeypatch.setattr(
+            repro_receipt,
+            "_read_macos_sysctl",
+            lambda name: values.get(name),
+        )
+
+        receipt = repro_receipt.build_repro_receipt(
+            seeds={"torch": 42},
+            run_id="mps-integration",
+        )
+        serialized = repro_receipt.receipt_to_dict(receipt)
+
+        assert serialized["accelerator_backend"] == "mps"
+        assert serialized["gpu_models"] == ["Apple M4 Max"]
+        assert serialized["unified_memory_bytes"] == 137438953472
 
     def test_new_accelerator_fields_preserve_old_constructor_signature(self):
         from soup_cli.utils.repro_receipt import ReproReceipt


### PR DESCRIPTION
## Summary

- identify MPS as the accelerator backend in reproducibility receipts
- record the Apple chip name and unified-memory capacity through a strict allowlist of privacy-safe macOS sysctl keys
- preserve the existing `ReproReceipt` constructor signature by making the new fields optional
- document that serial numbers, hardware UUIDs, and user-specific paths are not collected

This was found while reviewing the reproducibility receipt from the Qwen3.8-27B Apple Silicon smoke test reported in #472. The receipt captured PyTorch and Darwin, but left `gpu_models` empty and did not identify MPS or unified memory.

## Validation

- focused governance and receipt suite: `196 passed`
- live Apple Silicon probe reports `mps`, `Apple M4 Max`, and `137438953472` bytes of unified memory
- missing-sysctl fallback and old positional constructor coverage
- full non-smoke suite: `18856 passed, 82 skipped, 5 deselected`
- `ruff check` and `git diff --check` pass

Fixes #542
