### PR TITLE
fix(data): reject non-finite Best-of-N scores

### DIFF
--- a/changelog.d/0.73.3/547.fixed.md
+++ b/changelog.d/0.73.3/547.fixed.md
@@ -1,0 +1,2 @@
+- Best-of-N now rejects non-finite and boolean judge scores before selecting a
+  winner or emitting invalid JSONL (#547).

--- a/src/soup_cli/utils/best_of_n.py
+++ b/src/soup_cli/utils/best_of_n.py
@@ -11,6 +11,7 @@ provenance under the reserved ``_best_of_n`` key; ``build_dpo_pair`` optionally
 emits a winner-vs-loser preference pair.
 """
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Optional, Protocol
 
@@ -88,7 +89,20 @@ def judge_pick_best(
     """Score each candidate pointwise; argmax wins (ties -> lowest index)."""
     if not candidates:
         raise ValueError("no candidates to judge")
-    scores = [float(evaluator.evaluate(prompt, c).weighted_score) for c in candidates]
+    scores = []
+    for index, candidate in enumerate(candidates):
+        raw_score = evaluator.evaluate(prompt, candidate).weighted_score
+        if isinstance(raw_score, bool):
+            raise ValueError(f"candidate {index} judge score must be a finite number")
+        try:
+            score = float(raw_score)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"candidate {index} judge score must be a finite number"
+            ) from exc
+        if not math.isfinite(score):
+            raise ValueError(f"candidate {index} judge score must be finite")
+        scores.append(score)
     winner_idx = max(range(len(scores)), key=lambda i: scores[i])
     return BestOfNPick(
         winner_idx=winner_idx, winner=candidates[winner_idx], scores=tuple(scores)

--- a/tests/test_v07131.py
+++ b/tests/test_v07131.py
@@ -784,6 +784,49 @@ class TestBestOfN:
         with pytest.raises(ValueError, match="candidate"):
             judge_pick_best("p", [], _ScoreJudge())
 
+    def test_pick_best_rejects_non_finite_scores_in_every_position(self):
+        import math
+
+        import pytest
+
+        from soup_cli.utils.best_of_n import judge_pick_best
+
+        class _Judge:
+            def __init__(self, scores):
+                self.scores = iter(scores)
+
+            def evaluate(self, prompt, response):
+                from soup_cli.eval.judge import JudgeScore
+
+                return JudgeScore(
+                    prompt=prompt,
+                    response=response,
+                    weighted_score=next(self.scores),
+                )
+
+        candidates = ["first", "middle", "last"]
+        for bad_score in (float("nan"), float("inf"), float("-inf")):
+            for bad_index in range(len(candidates)):
+                scores = [1.0, 2.0, 3.0]
+                scores[bad_index] = bad_score
+                with pytest.raises(ValueError, match=rf"candidate {bad_index}.*finite"):
+                    judge_pick_best("private prompt", candidates, _Judge(scores))
+                assert not math.isfinite(bad_score)
+
+    def test_pick_best_rejects_boolean_score(self):
+        import pytest
+
+        from soup_cli.utils.best_of_n import judge_pick_best
+
+        class _BoolJudge:
+            def evaluate(self, prompt, response):
+                from soup_cli.eval.judge import JudgeScore
+
+                return JudgeScore(prompt=prompt, response=response, weighted_score=True)
+
+        with pytest.raises(ValueError, match=r"candidate 0.*finite number"):
+            judge_pick_best("private prompt", ["candidate"], _BoolJudge())
+
     def test_build_sft_row(self):
         from soup_cli.utils.best_of_n import BestOfNPick, build_sft_row
 
@@ -1182,6 +1225,61 @@ class TestBestOfNCli:
             for p in (ppath, opath, dpath):
                 if os.path.exists(p):
                     os.remove(p)
+
+    def test_non_finite_judge_score_does_not_publish_outputs(self, monkeypatch, tmp_path):
+        from types import SimpleNamespace
+
+        from typer.testing import CliRunner
+
+        import soup_cli.commands.data as data_cmd
+        import soup_cli.utils.best_of_n as bon
+        from soup_cli.commands.data import app
+
+        class _NonFiniteJudge:
+            def evaluate(self, _prompt, response):
+                score = float("nan") if response == "bad" else 1.0
+                return SimpleNamespace(weighted_score=score)
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(
+            data_cmd, "_load_bon_model", lambda base, device, trust: (None, None)
+        )
+        monkeypatch.setattr(
+            bon,
+            "sample_candidates",
+            lambda model, tok, prompt, **kwargs: ["bad", "good"],
+        )
+        monkeypatch.setattr(
+            "soup_cli.eval.judge.JudgeEvaluator", lambda **kwargs: _NonFiniteJudge()
+        )
+        prompts = tmp_path / "prompts.jsonl"
+        prompts.write_text('{"prompt":"private"}\n', encoding="utf-8")
+
+        result = CliRunner().invoke(
+            app,
+            [
+                "best-of-n",
+                "--base",
+                "model",
+                "--prompts",
+                str(prompts),
+                "--n",
+                "2",
+                "--judge",
+                "ollama://judge",
+                "--output",
+                "sft.jsonl",
+                "--emit-pairs",
+                "dpo.jsonl",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert isinstance(result.exception, ValueError)
+        assert "candidate 0" in str(result.exception)
+        assert "private" not in str(result.exception)
+        assert not (tmp_path / "sft.jsonl").exists()
+        assert not (tmp_path / "dpo.jsonl").exists()
 
     def test_plan_only(self):
         import os


### PR DESCRIPTION
## Summary

- reject boolean, non-numeric, `NaN`, and infinite Best-of-N judge scores before winner selection
- identify the failing candidate index without echoing private prompt or candidate content
- prove that invalid scores cannot publish SFT or DPO output

The previous `max(...)` selection could retain a first-position `NaN` as the winner and serialize the non-standard `NaN` token into JSONL.

## Validation

- Best-of-N focused suite: `25 passed`
- full non-smoke suite: `18935 passed, 82 skipped, 5 deselected`
- candidate-order coverage for `NaN`, `+inf`, and `-inf`, plus explicit boolean rejection
- Ruff and `git diff --check`: clean

Fixes #547
