### PR TITLE
fix(data): fail closed on invalid Best-of-N prompts

### DIFF
--- a/changelog.d/0.73.3/548.fixed.md
+++ b/changelog.d/0.73.3/548.fixed.md
@@ -1,0 +1,2 @@
+- Best-of-N now rejects malformed prompt rows with line-numbered errors and
+  records each accepted row's source line instead of silently losing data (#548).

--- a/docs/data.md
+++ b/docs/data.md
@@ -195,6 +195,9 @@ soup data best-of-n --provider ollama --model qwen2.5:7b \
     --base-url http://localhost:11434 --prompts prompts.jsonl --n 8 \
     --judge ollama://llama3.1 -o best_of_n.jsonl
 
+# Every non-blank prompt row is validated; accepted SFT rows record source_line
+# in their _best_of_n provenance so input/output completeness can be checked.
+
 # Evol-Instruct (WizardLM depth/breadth, v0.71.31) — grow instruction diversity
 soup data evolve --input seeds.jsonl --provider ollama --model llama3.1 \
     --strategy depth --rounds 2 -o evolved.jsonl

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -2920,8 +2920,31 @@ def _load_bon_model(base: str, device: str, trust: bool):
     return model, tok
 
 
-def _bon_load_prompts(path: str) -> list:
-    """Read a JSONL of {prompt|messages|instruction} rows -> list[str]."""
+def _bon_prompt_text(row: dict, line_number: int) -> str:
+    """Extract one prompt without echoing private row contents in errors."""
+    text = None
+    if isinstance(row.get("prompt"), str):
+        text = row["prompt"]
+    elif isinstance(row.get("instruction"), str):
+        text = row["instruction"]
+    elif isinstance(row.get("messages"), list):
+        users = [
+            message.get("content")
+            for message in row["messages"]
+            if isinstance(message, dict) and message.get("role") == "user"
+        ]
+        if users and isinstance(users[-1], str):
+            text = users[-1]
+    if text is None or not text.strip():
+        raise ValueError(
+            f"prompt JSONL line {line_number} has no non-empty prompt, "
+            "instruction, or user message"
+        )
+    return text
+
+
+def _bon_load_prompt_records(path: str) -> list[tuple[str, int]]:
+    """Read prompt JSONL strictly as ``(text, source_line)`` records."""
     from soup_cli.utils.paths import enforce_under_cwd_and_no_symlink
 
     enforce_under_cwd_and_no_symlink(path, "--prompts path")
@@ -2930,9 +2953,9 @@ def _bon_load_prompts(path: str) -> list:
         raise FileNotFoundError(path)
     if os.path.getsize(real) > _BON_MAX_JSONL_BYTES:
         raise ValueError(f"--prompts file exceeds {_BON_MAX_JSONL_BYTES} bytes")
-    prompts: list = []
+    prompts: list[tuple[str, int]] = []
     with open(real, "r", encoding="utf-8") as handle:
-        for raw_line in handle:
+        for line_number, raw_line in enumerate(handle, start=1):
             stripped = raw_line.strip()
             if not stripped:
                 continue
@@ -2940,26 +2963,19 @@ def _bon_load_prompts(path: str) -> list:
                 raise ValueError(f"--prompts file exceeds {_BON_MAX_PROMPTS} rows")
             try:
                 row = json.loads(stripped)
-            except json.JSONDecodeError:
-                continue
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"prompt JSONL line {line_number} is not valid JSON"
+                ) from exc
             if not isinstance(row, dict):
-                continue
-            text = None
-            if isinstance(row.get("prompt"), str):
-                text = row["prompt"]
-            elif isinstance(row.get("instruction"), str):
-                text = row["instruction"]
-            elif isinstance(row.get("messages"), list):
-                users = [
-                    m.get("content")
-                    for m in row["messages"]
-                    if isinstance(m, dict) and m.get("role") == "user"
-                ]
-                if users and isinstance(users[-1], str):
-                    text = users[-1]
-            if text:
-                prompts.append(text)
+                raise ValueError(f"prompt JSONL line {line_number} must be a JSON object")
+            prompts.append((_bon_prompt_text(row, line_number), line_number))
     return prompts
+
+
+def _bon_load_prompts(path: str) -> list[str]:
+    """Compatibility helper returning strict prompt texts without provenance."""
+    return [text for text, _line_number in _bon_load_prompt_records(path)]
 
 
 @app.command(name="best-of-n")
@@ -3034,7 +3050,7 @@ def best_of_n(
 
     # --- Paths ---
     try:
-        prompt_list = _bon_load_prompts(prompts)
+        prompt_records = _bon_load_prompt_records(prompts)
         if output:
             enforce_under_cwd_and_no_symlink(output, "--output path")
         if emit_pairs:
@@ -3042,7 +3058,7 @@ def best_of_n(
     except (FileNotFoundError, TypeError, ValueError) as exc:
         console.print(f"[red]{_escape(str(exc))}[/]")
         raise typer.Exit(2) from exc
-    if not prompt_list:
+    if not prompt_records:
         console.print("[red]--prompts produced no usable rows[/]")
         raise typer.Exit(2)
 
@@ -3099,7 +3115,7 @@ def best_of_n(
     console.print(
         Panel(
             f"Sampler:      [bold]{_escape(sampler_label)}[/]\n"
-            f"Prompts:      [bold]{len(prompt_list)}[/]\n"
+            f"Prompts:      [bold]{len(prompt_records)}[/]\n"
             f"N candidates: [bold]{n}[/]\n"
             f"Judge:        [bold]{_escape(judge)}[/]",
             title="soup data best-of-n — plan",
@@ -3122,7 +3138,7 @@ def best_of_n(
     dev = device or None
     sft_lines: list = []
     pair_lines: list = []
-    for prompt in prompt_list:
+    for prompt, source_line in prompt_records:
         candidates = bon.sample_candidates(
             local_model,
             tokenizer,
@@ -3135,6 +3151,7 @@ def best_of_n(
         )
         pick = bon.judge_pick_best(prompt, candidates, evaluator)
         row = bon.build_sft_row(prompt, pick, judge_model=judge)
+        row["_best_of_n"]["source_line"] = source_line
         if generate_fn is not None:
             row["_best_of_n"]["sampler"] = {
                 "provider": sampling_provider,

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -2920,8 +2920,8 @@ def _load_bon_model(base: str, device: str, trust: bool):
     return model, tok
 
 
-def _bon_prompt_text(row: dict, line_number: int) -> str:
-    """Extract one prompt without echoing private row contents in errors."""
+def _prompt_text_or_none(row: dict) -> str | None:
+    """Extract one usable prompt without exposing row contents."""
     text = None
     if isinstance(row.get("prompt"), str):
         text = row["prompt"]
@@ -2936,6 +2936,14 @@ def _bon_prompt_text(row: dict, line_number: int) -> str:
         if users and isinstance(users[-1], str):
             text = users[-1]
     if text is None or not text.strip():
+        return None
+    return text
+
+
+def _bon_prompt_text(row: dict, line_number: int) -> str:
+    """Extract one strict Best-of-N prompt with a private, line-numbered error."""
+    text = _prompt_text_or_none(row)
+    if text is None:
         raise ValueError(
             f"prompt JSONL line {line_number} has no non-empty prompt, "
             "instruction, or user message"
@@ -2973,9 +2981,34 @@ def _bon_load_prompt_records(path: str) -> list[tuple[str, int]]:
     return prompts
 
 
-def _bon_load_prompts(path: str) -> list[str]:
-    """Compatibility helper returning strict prompt texts without provenance."""
-    return [text for text, _line_number in _bon_load_prompt_records(path)]
+def _evolve_load_prompts(path: str) -> list[str]:
+    """Read evolve seeds while preserving its historical skip-invalid policy."""
+    from soup_cli.utils.paths import enforce_under_cwd_and_no_symlink
+
+    enforce_under_cwd_and_no_symlink(path, "--input path")
+    real = os.path.realpath(path)
+    if not os.path.isfile(real):
+        raise FileNotFoundError(path)
+    if os.path.getsize(real) > _BON_MAX_JSONL_BYTES:
+        raise ValueError(f"--input file exceeds {_BON_MAX_JSONL_BYTES} bytes")
+    prompts: list[str] = []
+    with open(real, "r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            stripped = raw_line.strip()
+            if not stripped:
+                continue
+            if len(prompts) >= _BON_MAX_PROMPTS:
+                raise ValueError(f"--input file exceeds {_BON_MAX_PROMPTS} rows")
+            try:
+                row = json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(row, dict):
+                continue
+            text = _prompt_text_or_none(row)
+            if text is not None:
+                prompts.append(text)
+    return prompts
 
 
 @app.command(name="best-of-n")
@@ -3233,7 +3266,7 @@ def evolve(
         raise typer.Exit(2)
 
     try:
-        seeds = _bon_load_prompts(input_path)
+        seeds = _evolve_load_prompts(input_path)
         if output:
             enforce_under_cwd_and_no_symlink(output, "--output path")
         generate_fn = make_magpie_generate_fn(

--- a/tests/test_v07131.py
+++ b/tests/test_v07131.py
@@ -1175,7 +1175,9 @@ class TestBestOfNCli:
                 "winner_idx",
                 "judge_model",
                 "scores",
+                "source_line",
             }
+            assert [row["_best_of_n"]["source_line"] for row in rows] == [1, 2]
             pairs = [json.loads(x) for x in open(dpath, encoding="utf-8") if x.strip()]
             assert pairs[0] == {"prompt": "q1", "chosen": "abcd", "rejected": "a"}
         finally:
@@ -1202,6 +1204,61 @@ class TestBestOfNCli:
             assert result.exit_code == 0, (result.output, repr(result.exception))
         finally:
             os.remove(path)
+
+    def test_prompt_loader_fails_closed_with_line_number(self, monkeypatch, tmp_path):
+        from typer.testing import CliRunner
+
+        from soup_cli.commands.data import app
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("soup_cli.eval.judge.JudgeEvaluator", lambda **kw: _ScoreJudge())
+        invalid_rows = (
+            "{not json}",
+            "[]",
+            '{"messages":[{"role":"assistant","content":"private answer"}]}',
+            '{"prompt":""}',
+            '{"prompt":"   "}',
+        )
+
+        for index, invalid_row in enumerate(invalid_rows):
+            prompts = tmp_path / f"invalid-{index}.jsonl"
+            prompts.write_text(
+                '{"prompt":"valid private prompt"}\n' + invalid_row + "\n",
+                encoding="utf-8",
+            )
+            result = CliRunner().invoke(
+                app,
+                [
+                    "best-of-n",
+                    "--base",
+                    "model",
+                    "--prompts",
+                    str(prompts),
+                    "--n",
+                    "2",
+                    "--judge",
+                    "ollama://judge",
+                    "--plan-only",
+                ],
+            )
+
+            assert result.exit_code == 2
+            assert "line 2" in result.output
+            assert "private" not in result.output
+
+    def test_blank_lines_are_ignored_but_source_lines_remain_physical(
+        self, monkeypatch, tmp_path
+    ):
+        from soup_cli.commands.data import _bon_load_prompt_records
+
+        monkeypatch.chdir(tmp_path)
+        prompts = tmp_path / "blank-lines.jsonl"
+        prompts.write_text(
+            '\n{"prompt":"first"}\n\n{"instruction":"second"}\n',
+            encoding="utf-8",
+        )
+
+        assert _bon_load_prompt_records(str(prompts)) == [("first", 2), ("second", 4)]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_v07131.py
+++ b/tests/test_v07131.py
@@ -1529,3 +1529,57 @@ class TestEvolveCli:
             for p in (ipath, opath):
                 if os.path.exists(p):
                     os.remove(p)
+
+    def test_malformed_seed_rows_remain_skipped(self, monkeypatch, tmp_path):
+        import json
+
+        from typer.testing import CliRunner
+
+        from soup_cli.commands.data import app
+
+        counter = {"i": 0}
+
+        def _fake_make(*args, **kwargs):
+            def _gen(prompt):
+                counter["i"] += 1
+                return f"evolved {counter['i']}"
+
+            return _gen
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("soup_cli.utils.magpie.make_magpie_generate_fn", _fake_make)
+        seeds = tmp_path / "mixed-seeds.jsonl"
+        seeds.write_text(
+            '{"prompt":"good seed one"}\n'
+            "{not valid json}\n"
+            "[]\n"
+            '{"messages":[{"role":"assistant","content":"no user seed"}]}\n'
+            '{"prompt":"   "}\n'
+            '{"instruction":"good seed two"}\n',
+            encoding="utf-8",
+        )
+        output = tmp_path / "evolved.jsonl"
+
+        result = CliRunner().invoke(
+            app,
+            [
+                "evolve",
+                "--input",
+                str(seeds),
+                "--provider",
+                "ollama",
+                "--model",
+                "m",
+                "--rounds",
+                "1",
+                "--output",
+                str(output),
+            ],
+        )
+
+        assert result.exit_code == 0, (result.output, repr(result.exception))
+        rows = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
+        assert [row["_evolve"]["seed"] for row in rows] == [
+            "good seed one",
+            "good seed two",
+        ]


### PR DESCRIPTION
## Summary

- fail closed on malformed, non-object, or unusable nonblank prompt rows
- report the physical JSONL line number without echoing private prompt content
- preserve each accepted row's `source_line` in Best-of-N provenance
- keep intentional blank-line handling while preventing silent cardinality drift

## Validation

- `PYTHONPATH=src pytest tests/test_v07131.py -q --no-cov --tb=short` (41 passed, 53 deselected)
- `PYTHONPATH=src pytest tests/ -q --no-cov --tb=short` (18,934 passed, 82 skipped, 5 deselected)
- `ruff check src/soup_cli/ tests/`
- `git diff --check`

Fixes #548
