### PR TITLE
fix(data): resume Best-of-N from durable checkpoints

### DIFF
--- a/changelog.d/0.73.3/549.fixed.md
+++ b/changelog.d/0.73.3/549.fixed.md
@@ -1,0 +1,2 @@
+- Fixed #549 by making Best-of-N generation durable and resumable per prompt, with exactly-once
+  checkpoint validation and a final hash manifest binding SFT/DPO outputs.

--- a/changelog.d/0.73.3/549.fixed.md
+++ b/changelog.d/0.73.3/549.fixed.md
@@ -1,2 +1,3 @@
 - Fixed #549 by making Best-of-N generation durable and resumable per prompt, with exactly-once
-  checkpoint validation and a final hash manifest binding SFT/DPO outputs.
+  checkpoint validation and rollback-safe, manifest-last publication that never exposes a partial
+  SFT/DPO generation after an output failure.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -301,7 +301,7 @@ soup local-rl train --db <path> --model <id> [--scheduler-dir <dir>] [--hour H] 
 soup build <manifest.yaml> [--dry-run] [--output-dir <dir>]  dbt-for-SFT DAG: validate + plan + live materialise (v0.69.0; live v0.71.6)
 soup expect <data.jsonl> <suite.yaml>         Expectations suite: PII / token-length / refusal / judge (v0.69.0)
 soup data gen-magpie --base <m> --provider ollama|vllm --target N --output <jsonl> [--base-url <url>] [--quality-filter]  Magpie synthetic generator — live (v0.69.0; live v0.71.6)
-soup data best-of-n (--base <m> | --provider ollama|vllm --model <m> [--base-url <url>]) --prompts <jsonl> --n 8 --judge <url> -o <sft.jsonl> [--emit-pairs <dpo.jsonl>]  Best-of-N rejection sampling: sample N locally (default) or through a raw-completion provider, then emit SFT (+ DPO) rows
+soup data best-of-n (--base <m> | --provider ollama|vllm --model <m> [--base-url <url>]) --prompts <jsonl> --n 8 --judge <url> -o <sft.jsonl> [--emit-pairs <dpo.jsonl>] [--resume] [--checkpoint <journal.jsonl>] [--manifest <manifest.json>]  Best-of-N rejection sampling with durable per-prompt recovery and manifest-last publication
 soup data evolve --input <seeds.jsonl> --provider ollama|vllm --model <m> --strategy depth|breadth --rounds N -o <jsonl>  Evol-Instruct (WizardLM) instruction evolution (v0.71.31)
 soup data persona-mix --prompts <jsonl> --n N --output <jsonl>  Persona-Hub diversity sampler (v0.69.0)
 soup data brain-rot <data.jsonl> [--strict]   Brain-rot detector — arXiv 2510.13928 (v0.69.0)
@@ -324,6 +324,23 @@ soup export --model ./output --format bitnet|tq1_0  BitNet 1.58 TQ1_0 ternary GG
 soup version [--full] [--json]                Show version (--full: system info, --json: JSON output)
 soup --verbose <command>                      Full traceback on errors
 ```
+
+### Best-of-N recovery and publication
+
+`soup data best-of-n` appends and synchronizes one checkpoint record after each
+fully sampled and judged prompt. The default journal is
+`<output>.checkpoint.jsonl`; override it with `--checkpoint`. If a sampler or
+judge backend fails, Soup reports the completed prompt count and journal path.
+Rerun the same command with `--resume` to reuse that exact prefix without
+sampling it again. The prompt sequence and generation options are bound into the
+journal, so changing them makes resume fail closed.
+
+Final SFT and optional DPO JSONL files are published only after every prompt is
+complete. The manifest (default `<output>.manifest.json`, or `--manifest`) is
+written last and records their row counts and SHA-256 digests. Consumers should
+treat only files listed by that final manifest as committed output. Invalid
+local data such as a non-finite judge score remains a validation failure rather
+than being presented as a recoverable backend outage.
 
 ## Fine-tune from your coding agent (MCP)
 

--- a/docs/data.md
+++ b/docs/data.md
@@ -213,11 +213,13 @@ Every command applies the project-wide TOCTOU policy (`os.lstat + S_ISLNK` symli
 `best-of-n` fsyncs each completed prompt group to a private recovery journal
 (`<output>.checkpoint.jsonl` by default). `--resume` reuses only a sequential
 prefix whose prompt and run-configuration digest matches exactly, so completed
-prompts are not sampled or judged twice. Final SFT and optional DPO files remain
-atomic outputs; `<output>.manifest.json` is written last and binds their exact
-SHA-256 hashes and row counts as one generation. Keep or archive the checkpoint
-after success if reproducible rematerialization is useful; it contains dataset
-content and should be protected like the generated dataset.
+prompts are not sampled or judged twice. Before final publication, Soup snapshots
+any prior SFT, DPO, and manifest targets. Each file remains an atomic replacement,
+the manifest is written last, and any failed replacement restores the complete old
+generation or removes the newly created set. The manifest binds the exact SHA-256
+hashes and row counts as one generation. Keep or archive the checkpoint after
+success if reproducible rematerialization is useful; it contains dataset content
+and should be protected like the generated dataset.
 
 ### Custom Transforms
 

--- a/docs/data.md
+++ b/docs/data.md
@@ -198,12 +198,26 @@ soup data best-of-n --provider ollama --model qwen2.5:7b \
 # Every non-blank prompt row is validated; accepted SFT rows record source_line
 # in their _best_of_n provenance so input/output completeness can be checked.
 
+# If sampling or judging stops, continue from the last fsynced prompt group.
+soup data best-of-n --provider ollama --model qwen2.5:7b \
+    --prompts prompts.jsonl --n 8 --judge ollama://llama3.1 \
+    -o best_of_n.jsonl --resume
+
 # Evol-Instruct (WizardLM depth/breadth, v0.71.31) — grow instruction diversity
 soup data evolve --input seeds.jsonl --provider ollama --model llama3.1 \
     --strategy depth --rounds 2 -o evolved.jsonl
 ```
 
 Every command applies the project-wide TOCTOU policy (`os.lstat + S_ISLNK` symlink rejection before any open) and cwd containment via the shared `paths.enforce_under_cwd_and_no_symlink` helper. All five are LIVE: `soup build` materialises with five built-in transforms (`identity` / `drop_empty` / `lowercase` / `strip` / `dedup_exact`) and SQLite-tracked incremental re-transform (v0.71.6); `soup data gen-magpie` and provider-backed `best-of-n` harvest via raw completion against `--provider ollama|vllm` (SSRF-validated; `anthropic` rejected because the Messages API has no raw-completion endpoint). Provider-backed `best-of-n` records the sampler provider and model in each row's `_best_of_n` provenance; omit `--provider` to retain the local Transformers `--base` path.
+
+`best-of-n` fsyncs each completed prompt group to a private recovery journal
+(`<output>.checkpoint.jsonl` by default). `--resume` reuses only a sequential
+prefix whose prompt and run-configuration digest matches exactly, so completed
+prompts are not sampled or judged twice. Final SFT and optional DPO files remain
+atomic outputs; `<output>.manifest.json` is written last and binds their exact
+SHA-256 hashes and row counts as one generation. Keep or archive the checkpoint
+after success if reproducible rematerialization is useful; it contains dataset
+content and should be protected like the generated dataset.
 
 ### Custom Transforms
 

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -3062,11 +3062,7 @@ def best_of_n(
     from soup_cli.utils import best_of_n as bon
     from soup_cli.utils import best_of_n_checkpoint as bon_checkpoint
     from soup_cli.utils.magpie import make_magpie_generate_fn
-    from soup_cli.utils.paths import (
-        atomic_write_bytes,
-        atomic_write_text,
-        enforce_under_cwd_and_no_symlink,
-    )
+    from soup_cli.utils.paths import enforce_under_cwd_and_no_symlink
     from soup_cli.utils.trust_remote import (
         model_requires_trust_remote_code,
         resolve_trust_remote_code,
@@ -3286,19 +3282,18 @@ def best_of_n(
         if pair is not None:
             pair_rows.append(pair)
 
-    # Atomic writes (mkstemp + os.replace + re-validated containment) so a
-    # symlink swapped in after the fast-fail check cannot redirect the write.
-    # The manifest is committed last and binds an optional SFT/DPO pair by hash.
+    # Snapshot every prior target before replacement, commit the manifest last,
+    # and restore the complete old generation if any publication step fails.
     sft_text = bon_checkpoint.dataset_text(sft_rows)
     pair_text = bon_checkpoint.dataset_text(pair_rows)
     try:
-        atomic_write_bytes(sft_text.encode("utf-8"), output, field="output")
-        if emit_pairs:
-            atomic_write_bytes(
-                pair_text.encode("utf-8"), emit_pairs, field="emit-pairs"
-            )
-        atomic_write_text(
-            bon_checkpoint.manifest_text(
+        bon_checkpoint.publish_generation(
+            sft_path=output,
+            sft_text=sft_text,
+            pair_path=emit_pairs,
+            pair_text=pair_text,
+            manifest_path=manifest_path,
+            manifest_text_value=bon_checkpoint.manifest_text(
                 digest=digest,
                 sft_path=output,
                 sft_text=sft_text,
@@ -3307,8 +3302,6 @@ def best_of_n(
                 pair_text=pair_text,
                 pair_count=len(pair_rows),
             ),
-            manifest_path,
-            field="manifest",
         )
     except (OSError, ValueError, TypeError) as exc:
         console.print(f"[red]Failed to write output: {_escape(str(exc))}[/]")

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -3262,6 +3262,13 @@ def best_of_n(
             bon_checkpoint.append_checkpoint(
                 checkpoint_path, index=index, sft=row, dpo=pair
             )
+        except bon.BestOfNRuntimeError as exc:
+            console.print(
+                f"[red]Best-of-N stopped after {index}/{len(prompt_list)} prompts.[/]\n"
+                f"Resume with [bold]--resume[/]; checkpoint: "
+                f"[bold]{_escape(os.path.relpath(checkpoint_path))}[/]"
+            )
+            raise typer.Exit(1) from exc
         except ValueError:
             # Deterministic validation failures (for example a non-finite
             # judge score) cannot be repaired by resuming. Preserve the

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -3222,10 +3222,11 @@ def best_of_n(
 
     local_model = None
     tokenizer = None
+    local_torch = None
     if generate_fn is None and len(completed_entries) < len(prompt_list):
         import torch
 
-        torch.manual_seed(seed)
+        local_torch = torch
         local_model, tokenizer = _load_bon_model(base, device, trust)
 
     dev = device or None
@@ -3234,6 +3235,11 @@ def best_of_n(
     for index in range(len(completed_entries), len(prompt_records)):
         prompt, source_line = prompt_records[index]
         try:
+            if local_torch is not None:
+                # Bind stochastic sampling to the prompt index rather than the
+                # process RNG position so an interrupted/resumed run produces
+                # the same candidates as an uninterrupted run (#549).
+                local_torch.manual_seed(bon_checkpoint.prompt_seed(seed, index))
             candidates = bon.sample_candidates(
                 local_model,
                 tokenizer,

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -3262,6 +3262,12 @@ def best_of_n(
             bon_checkpoint.append_checkpoint(
                 checkpoint_path, index=index, sft=row, dpo=pair
             )
+        except ValueError:
+            # Deterministic validation failures (for example a non-finite
+            # judge score) cannot be repaired by resuming. Preserve the
+            # established fail-closed ValueError contract instead of
+            # presenting a misleading recovery instruction.
+            raise
         except Exception as exc:
             console.print(
                 f"[red]Best-of-N stopped after {index}/{len(prompt_list)} prompts.[/]\n"

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -3062,7 +3062,11 @@ def best_of_n(
     from soup_cli.utils import best_of_n as bon
     from soup_cli.utils import best_of_n_checkpoint as bon_checkpoint
     from soup_cli.utils.magpie import make_magpie_generate_fn
-    from soup_cli.utils.paths import atomic_write_text, enforce_under_cwd_and_no_symlink
+    from soup_cli.utils.paths import (
+        atomic_write_bytes,
+        atomic_write_text,
+        enforce_under_cwd_and_no_symlink,
+    )
     from soup_cli.utils.trust_remote import (
         model_requires_trust_remote_code,
         resolve_trust_remote_code,
@@ -3269,9 +3273,11 @@ def best_of_n(
     sft_text = bon_checkpoint.dataset_text(sft_rows)
     pair_text = bon_checkpoint.dataset_text(pair_rows)
     try:
-        atomic_write_text(sft_text, output, field="output")
+        atomic_write_bytes(sft_text.encode("utf-8"), output, field="output")
         if emit_pairs:
-            atomic_write_text(pair_text, emit_pairs, field="emit-pairs")
+            atomic_write_bytes(
+                pair_text.encode("utf-8"), emit_pairs, field="emit-pairs"
+            )
         atomic_write_text(
             bon_checkpoint.manifest_text(
                 digest=digest,

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -3028,6 +3028,13 @@ def best_of_n(
     emit_pairs: str = typer.Option(
         "", "--emit-pairs", help="Also write winner/loser DPO pairs to this JSONL"
     ),
+    checkpoint: str = typer.Option(
+        "", "--checkpoint", help="Recovery journal (default: <output>.checkpoint.jsonl)"
+    ),
+    manifest: str = typer.Option(
+        "", "--manifest", help="Final consistency manifest (default: <output>.manifest.json)"
+    ),
+    resume: bool = typer.Option(False, "--resume", help="Resume a matching checkpoint"),
     temperature: float = typer.Option(1.0, "--temperature", help="Sampling temp [0, 2]"),
     max_new_tokens: int = typer.Option(
         256, "--max-new-tokens", help="Max new tokens per candidate [1, 4096]"
@@ -3053,6 +3060,7 @@ def best_of_n(
     from soup_cli.eval.gate import _parse_judge_url
     from soup_cli.eval.judge import JudgeEvaluator
     from soup_cli.utils import best_of_n as bon
+    from soup_cli.utils import best_of_n_checkpoint as bon_checkpoint
     from soup_cli.utils.magpie import make_magpie_generate_fn
     from soup_cli.utils.paths import atomic_write_text, enforce_under_cwd_and_no_symlink
     from soup_cli.utils.trust_remote import (
@@ -3082,17 +3090,27 @@ def best_of_n(
         raise typer.Exit(2) from exc
 
     # --- Paths ---
+    checkpoint_path = checkpoint or (f"{output}.checkpoint.jsonl" if output else "")
+    manifest_path = manifest or (f"{output}.manifest.json" if output else "")
     try:
         prompt_records = _bon_load_prompt_records(prompts)
         if output:
             enforce_under_cwd_and_no_symlink(output, "--output path")
         if emit_pairs:
             enforce_under_cwd_and_no_symlink(emit_pairs, "--emit-pairs path")
+        if checkpoint_path:
+            enforce_under_cwd_and_no_symlink(checkpoint_path, "--checkpoint path")
+        if manifest_path:
+            enforce_under_cwd_and_no_symlink(manifest_path, "--manifest path")
     except (FileNotFoundError, TypeError, ValueError) as exc:
         console.print(f"[red]{_escape(str(exc))}[/]")
         raise typer.Exit(2) from exc
     if not prompt_records:
         console.print("[red]--prompts produced no usable rows[/]")
+        raise typer.Exit(2)
+    prompt_list = [prompt for prompt, _source_line in prompt_records]
+    if resume and not output:
+        console.print("[red]--resume requires --output[/]")
         raise typer.Exit(2)
 
     # --- Sampler selection ---
@@ -3144,13 +3162,32 @@ def best_of_n(
         )
 
     sampler_label = f"{sampling_provider}:{model}" if generate_fn is not None else base
+    digest = bon_checkpoint.run_digest(
+        prompt_list,
+        {
+            "base": base,
+            "provider": sampling_provider,
+            "model": model,
+            "base_url": base_url,
+            "n": n,
+            "temperature": temperature,
+            "max_new_tokens": max_new_tokens,
+            "device": device,
+            "seed": seed,
+            "trust_remote_code": trust,
+            "judge": judge,
+            "emit_pairs": bool(emit_pairs),
+        },
+    )
 
     console.print(
         Panel(
             f"Sampler:      [bold]{_escape(sampler_label)}[/]\n"
             f"Prompts:      [bold]{len(prompt_records)}[/]\n"
             f"N candidates: [bold]{n}[/]\n"
-            f"Judge:        [bold]{_escape(judge)}[/]",
+            f"Judge:        [bold]{_escape(judge)}[/]\n"
+            f"Checkpoint:   [bold]"
+            f"{_escape(os.path.relpath(checkpoint_path)) if checkpoint_path else '-'}[/]",
             title="soup data best-of-n — plan",
         )
     )
@@ -3160,57 +3197,99 @@ def best_of_n(
         console.print("[red]--output is required unless --plan-only is set.[/]")
         raise typer.Exit(2)
 
+    try:
+        targets = [output, checkpoint_path, manifest_path]
+        if emit_pairs:
+            targets.append(emit_pairs)
+        if len({os.path.normcase(os.path.realpath(path)) for path in targets}) != len(targets):
+            raise ValueError("output, pairs, checkpoint, and manifest paths must be distinct")
+        if resume:
+            completed_entries = bon_checkpoint.load_checkpoint(
+                checkpoint_path, digest=digest, total=len(prompt_list)
+            )
+        else:
+            bon_checkpoint.initialise_checkpoint(
+                checkpoint_path, digest=digest, total=len(prompt_list)
+            )
+            completed_entries = []
+    except (FileNotFoundError, OSError, TypeError, ValueError) as exc:
+        console.print(f"[red]Invalid checkpoint: {_escape(str(exc))}[/]")
+        raise typer.Exit(2) from exc
+
     local_model = None
     tokenizer = None
-    if generate_fn is None:
+    if generate_fn is None and len(completed_entries) < len(prompt_list):
         import torch
 
         torch.manual_seed(seed)
         local_model, tokenizer = _load_bon_model(base, device, trust)
 
     dev = device or None
-    sft_lines: list = []
-    pair_lines: list = []
-    for prompt, source_line in prompt_records:
-        candidates = bon.sample_candidates(
-            local_model,
-            tokenizer,
-            prompt,
-            n=n,
-            temperature=temperature,
-            max_new_tokens=max_new_tokens,
-            device=dev,
-            generate_fn=generate_fn,
-        )
-        pick = bon.judge_pick_best(prompt, candidates, evaluator)
-        row = bon.build_sft_row(prompt, pick, judge_model=judge)
-        row["_best_of_n"]["source_line"] = source_line
-        if generate_fn is not None:
-            row["_best_of_n"]["sampler"] = {
-                "provider": sampling_provider,
-                "model": model,
-            }
-        sft_lines.append(json.dumps(row, ensure_ascii=False))
-        if emit_pairs:
-            pair = bon.build_dpo_pair(prompt, pick, candidates)
-            if pair is not None:
-                pair_lines.append(json.dumps(pair, ensure_ascii=False))
+    sft_rows = [entry[0] for entry in completed_entries]
+    pair_rows = [entry[1] for entry in completed_entries if entry[1] is not None]
+    for index in range(len(completed_entries), len(prompt_records)):
+        prompt, source_line = prompt_records[index]
+        try:
+            candidates = bon.sample_candidates(
+                local_model,
+                tokenizer,
+                prompt,
+                n=n,
+                temperature=temperature,
+                max_new_tokens=max_new_tokens,
+                device=dev,
+                generate_fn=generate_fn,
+            )
+            pick = bon.judge_pick_best(prompt, candidates, evaluator)
+            row = bon.build_sft_row(prompt, pick, judge_model=judge)
+            row["_best_of_n"]["source_line"] = source_line
+            if generate_fn is not None:
+                row["_best_of_n"]["sampler"] = {
+                    "provider": sampling_provider,
+                    "model": model,
+                }
+            pair = bon.build_dpo_pair(prompt, pick, candidates) if emit_pairs else None
+            bon_checkpoint.append_checkpoint(
+                checkpoint_path, index=index, sft=row, dpo=pair
+            )
+        except Exception as exc:
+            console.print(
+                f"[red]Best-of-N stopped after {index}/{len(prompt_list)} prompts.[/]\n"
+                f"Resume with [bold]--resume[/]; checkpoint: "
+                f"[bold]{_escape(os.path.relpath(checkpoint_path))}[/]"
+            )
+            raise typer.Exit(1) from exc
+        sft_rows.append(row)
+        if pair is not None:
+            pair_rows.append(pair)
 
     # Atomic writes (mkstemp + os.replace + re-validated containment) so a
     # symlink swapped in after the fast-fail check cannot redirect the write.
+    # The manifest is committed last and binds an optional SFT/DPO pair by hash.
+    sft_text = bon_checkpoint.dataset_text(sft_rows)
+    pair_text = bon_checkpoint.dataset_text(pair_rows)
     try:
-        atomic_write_text("\n".join(sft_lines) + "\n", output, field="output")
+        atomic_write_text(sft_text, output, field="output")
         if emit_pairs:
-            atomic_write_text(
-                ("\n".join(pair_lines) + "\n") if pair_lines else "",
-                emit_pairs,
-                field="emit-pairs",
-            )
+            atomic_write_text(pair_text, emit_pairs, field="emit-pairs")
+        atomic_write_text(
+            bon_checkpoint.manifest_text(
+                digest=digest,
+                sft_path=output,
+                sft_text=sft_text,
+                sft_count=len(sft_rows),
+                pair_path=emit_pairs,
+                pair_text=pair_text,
+                pair_count=len(pair_rows),
+            ),
+            manifest_path,
+            field="manifest",
+        )
     except (OSError, ValueError, TypeError) as exc:
         console.print(f"[red]Failed to write output: {_escape(str(exc))}[/]")
         raise typer.Exit(1) from exc
-    sft_count = len(sft_lines)
-    pair_count = len(pair_lines)
+    sft_count = len(sft_rows)
+    pair_count = len(pair_rows)
 
     body = (
         f"SFT rows:   [bold]{sft_count}[/]\n"
@@ -3221,6 +3300,7 @@ def best_of_n(
             f"\nDPO pairs:  [bold]{pair_count}[/]\n"
             f"Pairs out:  [bold]{_escape(os.path.relpath(emit_pairs))}[/]"
         )
+    body += f"\nManifest:   [bold]{_escape(os.path.relpath(manifest_path))}[/]"
     console.print(Panel(body, title="soup data best-of-n — done"))
 
 

--- a/src/soup_cli/utils/best_of_n.py
+++ b/src/soup_cli/utils/best_of_n.py
@@ -27,6 +27,10 @@ class PointwiseJudge(Protocol):
     def evaluate(self, prompt: str, response: str) -> "JudgeScore": ...
 
 
+class BestOfNRuntimeError(RuntimeError):
+    """A sampler or judge backend failed and the checkpoint can be resumed."""
+
+
 @dataclass(frozen=True)
 class BestOfNPick:
     """The judged winner among N candidates + the per-candidate scores."""
@@ -49,38 +53,44 @@ def sample_candidates(
 ) -> "list[str]":
     """Sample ``n`` continuations locally or through a raw-completion provider."""
     if generate_fn is not None:
-        return [generate_fn(prompt).strip() for _ in range(n)]
+        try:
+            return [generate_fn(prompt).strip() for _ in range(n)]
+        except Exception as exc:
+            raise BestOfNRuntimeError("provider sampler failed") from exc
 
     if model is None or tokenizer is None:
         raise ValueError("local best-of-N sampling requires a model and tokenizer")
 
     import torch
 
-    messages = [{"role": "user", "content": prompt}]
-    # return_dict=True so an attention_mask is passed to generate() — without it
-    # transformers warns of unreliable output when pad_token == eos_token.
-    enc = tokenizer.apply_chat_template(
-        messages, add_generation_prompt=True, return_tensors="pt", return_dict=True
-    )
-    if device:
-        enc = enc.to(device)
-    pad_id = tokenizer.pad_token_id
-    if pad_id is None:
-        pad_id = tokenizer.eos_token_id
-    with torch.no_grad():
-        out = model.generate(
-            **enc,
-            do_sample=True,
-            temperature=temperature,
-            max_new_tokens=max_new_tokens,
-            num_return_sequences=n,
-            pad_token_id=pad_id,
+    try:
+        messages = [{"role": "user", "content": prompt}]
+        # return_dict=True so an attention_mask is passed to generate() — without it
+        # transformers warns of unreliable output when pad_token == eos_token.
+        enc = tokenizer.apply_chat_template(
+            messages, add_generation_prompt=True, return_tensors="pt", return_dict=True
         )
-    prompt_len = enc["input_ids"].shape[1]
-    return [
-        tokenizer.decode(seq[prompt_len:], skip_special_tokens=True).strip()
-        for seq in out
-    ]
+        if device:
+            enc = enc.to(device)
+        pad_id = tokenizer.pad_token_id
+        if pad_id is None:
+            pad_id = tokenizer.eos_token_id
+        with torch.no_grad():
+            out = model.generate(
+                **enc,
+                do_sample=True,
+                temperature=temperature,
+                max_new_tokens=max_new_tokens,
+                num_return_sequences=n,
+                pad_token_id=pad_id,
+            )
+        prompt_len = enc["input_ids"].shape[1]
+        return [
+            tokenizer.decode(seq[prompt_len:], skip_special_tokens=True).strip()
+            for seq in out
+        ]
+    except Exception as exc:
+        raise BestOfNRuntimeError("local sampler failed") from exc
 
 
 def judge_pick_best(
@@ -91,7 +101,10 @@ def judge_pick_best(
         raise ValueError("no candidates to judge")
     scores = []
     for index, candidate in enumerate(candidates):
-        raw_score = evaluator.evaluate(prompt, candidate).weighted_score
+        try:
+            raw_score = evaluator.evaluate(prompt, candidate).weighted_score
+        except Exception as exc:
+            raise BestOfNRuntimeError("judge backend failed") from exc
         if isinstance(raw_score, bool):
             raise ValueError(f"candidate {index} judge score must be a finite number")
         try:

--- a/src/soup_cli/utils/best_of_n_checkpoint.py
+++ b/src/soup_cli/utils/best_of_n_checkpoint.py
@@ -23,6 +23,12 @@ def run_digest(prompts: list[str], config: dict[str, Any]) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
+def prompt_seed(seed: int, index: int) -> int:
+    """Derive a stable torch seed for one prompt, independent of resume position."""
+    encoded = f"{seed}:{index}".encode("ascii")
+    return int.from_bytes(hashlib.sha256(encoded).digest()[:8], "big") & ((1 << 63) - 1)
+
+
 def _record_digest(record: dict[str, Any]) -> str:
     encoded = json.dumps(
         record, ensure_ascii=False, sort_keys=True, separators=(",", ":")
@@ -60,10 +66,48 @@ def _open_checkpoint(path: str):
         raise
 
 
+def _discard_incomplete_tail(path: str) -> None:
+    """Drop an uncommitted final JSONL fragment left by an interrupted append.
+
+    ``append_checkpoint`` commits records with a trailing newline followed by
+    ``fsync``. A final fragment without that newline is therefore never a
+    committed record and can be discarded safely before validation.
+    """
+    enforce_under_cwd_and_no_symlink(path, "--checkpoint path")
+    flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_BINARY", 0)
+    fd = os.open(path, flags)
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            raise ValueError("checkpoint must be a regular file")
+        size = os.lseek(fd, 0, os.SEEK_END)
+        if size == 0:
+            return
+        os.lseek(fd, size - 1, os.SEEK_SET)
+        if os.read(fd, 1) == b"\n":
+            return
+
+        cursor = size
+        truncate_at = 0
+        while cursor:
+            chunk_start = max(0, cursor - 8192)
+            os.lseek(fd, chunk_start, os.SEEK_SET)
+            chunk = os.read(fd, cursor - chunk_start)
+            newline = chunk.rfind(b"\n")
+            if newline >= 0:
+                truncate_at = chunk_start + newline + 1
+                break
+            cursor = chunk_start
+        os.ftruncate(fd, truncate_at)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
 def load_checkpoint(
     path: str, *, digest: str, total: int
 ) -> list[tuple[dict, dict | None]]:
     """Validate a journal and return its exactly-once completed prompt prefix."""
+    _discard_incomplete_tail(path)
     entries: list[tuple[dict, dict | None]] = []
     with _open_checkpoint(path) as handle:
         for line_number, raw in enumerate(handle, 1):

--- a/src/soup_cli/utils/best_of_n_checkpoint.py
+++ b/src/soup_cli/utils/best_of_n_checkpoint.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import stat
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -179,6 +180,128 @@ def dataset_text(rows: list[dict]) -> str:
         json.dumps(row, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
         for row in rows
     )
+
+
+def _snapshot_for_rollback(path: str, *, field: str) -> str | None:
+    """Copy an existing regular file to a private sibling for rollback."""
+    enforce_under_cwd_and_no_symlink(path, field)
+    if not os.path.lexists(path):
+        return None
+
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_BINARY", 0)
+    source_fd = os.open(path, flags)
+    backup_path = ""
+    backup_fd = -1
+    copied = False
+    try:
+        source_stat = os.fstat(source_fd)
+        if not stat.S_ISREG(source_stat.st_mode):
+            raise ValueError(f"{field} must be a regular file")
+        parent = os.path.dirname(os.path.abspath(path)) or "."
+        backup_fd, backup_path = tempfile.mkstemp(
+            prefix=".soup.rollback.", suffix=".tmp", dir=parent
+        )
+        if hasattr(os, "fchmod"):
+            os.fchmod(backup_fd, stat.S_IMODE(source_stat.st_mode))
+        while True:
+            chunk = os.read(source_fd, 1024 * 1024)
+            if not chunk:
+                break
+            view = memoryview(chunk)
+            while view:
+                written = os.write(backup_fd, view)
+                if written <= 0:
+                    raise OSError("rollback snapshot made no progress")
+                view = view[written:]
+        os.fsync(backup_fd)
+        copied = True
+    finally:
+        os.close(source_fd)
+        if backup_fd >= 0:
+            os.close(backup_fd)
+        if not copied and backup_path:
+            try:
+                os.unlink(backup_path)
+            except OSError:
+                pass
+    return backup_path
+
+
+def _cleanup_snapshot(path: str | None) -> None:
+    if path and os.path.exists(path):
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def publish_generation(
+    *,
+    sft_path: str,
+    sft_text: str,
+    pair_path: str,
+    pair_text: str,
+    manifest_path: str,
+    manifest_text_value: str,
+) -> None:
+    """Publish one SFT/DPO/manifest generation with all-or-old rollback.
+
+    Filesystems cannot atomically replace several independent paths in one
+    operation. Snapshot every pre-existing target before the first replacement,
+    publish the manifest last, and restore the complete old generation (or
+    remove newly created targets) if any replacement fails.
+    """
+    from soup_cli.utils import paths as path_utils
+
+    artifacts = [(sft_text.encode("utf-8"), sft_path, "output")]
+    if pair_path:
+        artifacts.append((pair_text.encode("utf-8"), pair_path, "emit-pairs"))
+    artifacts.append(
+        (manifest_text_value.encode("utf-8"), manifest_path, "manifest")
+    )
+
+    snapshots: dict[str, str | None] = {}
+    try:
+        for _data, path, field in artifacts:
+            snapshots[path] = _snapshot_for_rollback(path, field=field)
+    except Exception:
+        for backup_path in snapshots.values():
+            _cleanup_snapshot(backup_path)
+        raise
+
+    attempted: list[tuple[str, str]] = []
+    cleanup_snapshots = True
+    try:
+        for data, path, field in artifacts:
+            attempted.append((path, field))
+            path_utils.atomic_write_bytes(data, path, field=field)
+    except BaseException as publish_error:
+        rollback_errors: list[str] = []
+        for path, field in reversed(attempted):
+            backup_path = snapshots[path]
+            try:
+                if backup_path is not None:
+                    os.replace(backup_path, path)
+                    snapshots[path] = None
+                elif os.path.lexists(path):
+                    enforce_under_cwd_and_no_symlink(path, field)
+                    os.unlink(path)
+            except (OSError, TypeError, ValueError) as rollback_error:
+                rollback_errors.append(
+                    f"{field}: {type(rollback_error).__name__}"
+                )
+        if rollback_errors:
+            cleanup_snapshots = False
+            joined = ", ".join(rollback_errors)
+            raise OSError(
+                "Best-of-N publication failed and rollback was incomplete "
+                f"({joined}); private .soup.rollback.* snapshots were retained"
+            ) from publish_error
+        raise
+    finally:
+        if cleanup_snapshots:
+            for backup_path in snapshots.values():
+                _cleanup_snapshot(backup_path)
 
 
 def manifest_text(

--- a/src/soup_cli/utils/best_of_n_checkpoint.py
+++ b/src/soup_cli/utils/best_of_n_checkpoint.py
@@ -1,0 +1,167 @@
+"""Durable checkpoint journal for Best-of-N generation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+from pathlib import Path
+from typing import Any
+
+from soup_cli.utils.paths import atomic_write_text, enforce_under_cwd_and_no_symlink
+
+_CHECKPOINT_VERSION = 1
+
+
+def run_digest(prompts: list[str], config: dict[str, Any]) -> str:
+    """Bind reusable work to the exact prompt sequence and generation config."""
+    payload = {"prompts": prompts, "config": config}
+    encoded = json.dumps(
+        payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _record_digest(record: dict[str, Any]) -> str:
+    encoded = json.dumps(
+        record, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def initialise_checkpoint(path: str, *, digest: str, total: int) -> None:
+    """Create a new private journal containing its versioned run header."""
+    if os.path.lexists(path):
+        raise ValueError("checkpoint already exists; pass --resume to reuse it")
+    header = {
+        "_best_of_n_checkpoint": {
+            "version": _CHECKPOINT_VERSION,
+            "run_digest": digest,
+            "total": total,
+        }
+    }
+    text = json.dumps(header, sort_keys=True, separators=(",", ":")) + "\n"
+    written = atomic_write_text(text, path, field="--checkpoint path")
+    if os.name != "nt":
+        os.chmod(written, 0o600)
+
+
+def _open_checkpoint(path: str):
+    enforce_under_cwd_and_no_symlink(path, "--checkpoint path")
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_BINARY", 0)
+    fd = os.open(path, flags)
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            raise ValueError("checkpoint must be a regular file")
+        return os.fdopen(fd, "r", encoding="utf-8")
+    except Exception:
+        os.close(fd)
+        raise
+
+
+def load_checkpoint(
+    path: str, *, digest: str, total: int
+) -> list[tuple[dict, dict | None]]:
+    """Validate a journal and return its exactly-once completed prompt prefix."""
+    entries: list[tuple[dict, dict | None]] = []
+    with _open_checkpoint(path) as handle:
+        for line_number, raw in enumerate(handle, 1):
+            try:
+                record = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"checkpoint has invalid JSON on line {line_number}") from exc
+            if line_number == 1:
+                header = record.get("_best_of_n_checkpoint") if isinstance(record, dict) else None
+                if not isinstance(header, dict):
+                    raise ValueError("checkpoint header is missing")
+                if header.get("version") != _CHECKPOINT_VERSION:
+                    raise ValueError("checkpoint version is not supported")
+                if header.get("run_digest") != digest or header.get("total") != total:
+                    raise ValueError("checkpoint does not match prompts or run configuration")
+                continue
+            if not isinstance(record, dict) or record.get("index") != len(entries):
+                raise ValueError("checkpoint prompt indexes must be sequential and exactly once")
+            core = {key: value for key, value in record.items() if key != "entry_digest"}
+            if record.get("entry_digest") != _record_digest(core):
+                raise ValueError(f"checkpoint entry {len(entries)} has a digest mismatch")
+            sft = record.get("sft")
+            dpo = record.get("dpo")
+            if not isinstance(sft, dict) or (dpo is not None and not isinstance(dpo, dict)):
+                raise ValueError(f"checkpoint entry {len(entries)} is malformed")
+            entries.append((sft, dpo))
+            if len(entries) > total:
+                raise ValueError("checkpoint contains more prompt groups than the input")
+    if not entries and not os.path.getsize(path):
+        raise ValueError("checkpoint is empty")
+    return entries
+
+
+def append_checkpoint(path: str, *, index: int, sft: dict, dpo: dict | None) -> None:
+    """Append and fsync one completed prompt group before moving to the next."""
+    core = {"index": index, "sft": sft, "dpo": dpo}
+    record = {**core, "entry_digest": _record_digest(core)}
+    payload = (
+        json.dumps(record, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        + os.linesep
+    ).encode("utf-8")
+    enforce_under_cwd_and_no_symlink(path, "--checkpoint path")
+    flags = (
+        os.O_WRONLY
+        | os.O_APPEND
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_BINARY", 0)
+    )
+    fd = os.open(path, flags)
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            raise ValueError("checkpoint must be a regular file")
+        view = memoryview(payload)
+        while view:
+            written = os.write(fd, view)
+            if written <= 0:
+                raise OSError("checkpoint append made no progress")
+            view = view[written:]
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def dataset_text(rows: list[dict]) -> str:
+    """Serialize rows deterministically for final atomic publication."""
+    if not rows:
+        return ""
+    return "".join(
+        json.dumps(row, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
+        for row in rows
+    )
+
+
+def manifest_text(
+    *,
+    digest: str,
+    sft_path: str,
+    sft_text: str,
+    sft_count: int,
+    pair_path: str,
+    pair_text: str,
+    pair_count: int,
+) -> str:
+    """Describe one consistent final generation; this file is published last."""
+    manifest: dict[str, Any] = {
+        "schema": "soup.best_of_n.manifest.v1",
+        "run_digest": digest,
+        "sft": {
+            "file": Path(sft_path).name,
+            "rows": sft_count,
+            "sha256": hashlib.sha256(sft_text.encode("utf-8")).hexdigest(),
+        },
+        "dpo": None,
+    }
+    if pair_path:
+        manifest["dpo"] = {
+            "file": Path(pair_path).name,
+            "rows": pair_count,
+            "sha256": hashlib.sha256(pair_text.encode("utf-8")).hexdigest(),
+        }
+    return json.dumps(manifest, indent=2, sort_keys=True) + "\n"

--- a/tests/test_issue549_bon_resume.py
+++ b/tests/test_issue549_bon_resume.py
@@ -1,0 +1,207 @@
+"""Regression tests for #549: durable, exactly-once Best-of-N resume."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from types import SimpleNamespace
+
+from typer.testing import CliRunner
+
+
+def _args(tmp_path, *extra: str) -> list[str]:
+    return [
+        "best-of-n",
+        "--provider",
+        "ollama",
+        "--model",
+        "sampler",
+        "--prompts",
+        str(tmp_path / "prompts.jsonl"),
+        "--n",
+        "3",
+        "--judge",
+        "ollama://judge",
+        "--output",
+        str(tmp_path / "sft.jsonl"),
+        "--emit-pairs",
+        str(tmp_path / "dpo.jsonl"),
+        *extra,
+    ]
+
+
+def test_late_failure_resumes_without_replaying_completed_prefix(tmp_path, monkeypatch):
+    from soup_cli.commands.data import app
+
+    monkeypatch.chdir(tmp_path)
+    prompts = ["first-private-prompt", "second-private-prompt", "third-private-prompt"]
+    (tmp_path / "prompts.jsonl").write_text(
+        "".join(json.dumps({"prompt": prompt}) + "\n" for prompt in prompts),
+        encoding="utf-8",
+    )
+
+    sampling_calls: list[str] = []
+    judge_calls: list[str] = []
+    fail_second = {"value": True}
+
+    def make_generate(*_args, **_kwargs):
+        def generate(prompt: str) -> str:
+            sampling_calls.append(prompt)
+            return "x" * len(sampling_calls)
+
+        return generate
+
+    class Judge:
+        def evaluate(self, prompt: str, response: str):
+            judge_calls.append(prompt)
+            if fail_second["value"] and prompt == prompts[1]:
+                raise RuntimeError("simulated late judge outage containing private data")
+            return SimpleNamespace(weighted_score=float(len(response)))
+
+    monkeypatch.setattr("soup_cli.utils.magpie.make_magpie_generate_fn", make_generate)
+    monkeypatch.setattr("soup_cli.eval.judge.JudgeEvaluator", lambda **_kwargs: Judge())
+
+    first = CliRunner().invoke(app, _args(tmp_path))
+    assert first.exit_code == 1, (first.output, repr(first.exception))
+    assert "1/3 prompts" in first.output
+    assert "--resume" in first.output
+    assert "simulated late" not in first.output
+    assert not (tmp_path / "sft.jsonl").exists()
+    assert not (tmp_path / "dpo.jsonl").exists()
+    checkpoint = tmp_path / "sft.jsonl.checkpoint.jsonl"
+    assert checkpoint.exists()
+    if os.name != "nt":
+        assert checkpoint.stat().st_mode & 0o777 == 0o600
+
+    sample_split = len(sampling_calls)
+    judge_split = len(judge_calls)
+    fail_second["value"] = False
+    resumed = CliRunner().invoke(app, _args(tmp_path, "--resume"))
+    assert resumed.exit_code == 0, (resumed.output, repr(resumed.exception))
+    assert prompts[0] not in sampling_calls[sample_split:]
+    assert prompts[0] not in judge_calls[judge_split:]
+    assert sampling_calls[sample_split:] == [prompts[1]] * 3 + [prompts[2]] * 3
+    assert judge_calls[judge_split:] == [prompts[1]] * 3 + [prompts[2]] * 3
+
+    sft_rows = [json.loads(line) for line in (tmp_path / "sft.jsonl").read_text().splitlines()]
+    assert [row["messages"][0]["content"] for row in sft_rows] == prompts
+    assert len((tmp_path / "dpo.jsonl").read_text().splitlines()) == 3
+
+    manifest = json.loads((tmp_path / "sft.jsonl.manifest.json").read_text())
+    assert manifest["schema"] == "soup.best_of_n.manifest.v1"
+    assert manifest["sft"]["rows"] == 3
+    assert manifest["dpo"]["rows"] == 3
+    assert manifest["sft"]["sha256"] == hashlib.sha256(
+        (tmp_path / "sft.jsonl").read_bytes()
+    ).hexdigest()
+    assert manifest["dpo"]["sha256"] == hashlib.sha256(
+        (tmp_path / "dpo.jsonl").read_bytes()
+    ).hexdigest()
+
+    stable_sft = (tmp_path / "sft.jsonl").read_bytes()
+    stable_dpo = (tmp_path / "dpo.jsonl").read_bytes()
+    sample_split = len(sampling_calls)
+    judge_split = len(judge_calls)
+    replay = CliRunner().invoke(app, _args(tmp_path, "--resume"))
+    assert replay.exit_code == 0, (replay.output, repr(replay.exception))
+    assert sampling_calls[sample_split:] == []
+    assert judge_calls[judge_split:] == []
+    assert (tmp_path / "sft.jsonl").read_bytes() == stable_sft
+    assert (tmp_path / "dpo.jsonl").read_bytes() == stable_dpo
+
+
+def test_resume_rejects_changed_run_before_sampling(tmp_path, monkeypatch):
+    from soup_cli.commands.data import app
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "prompts.jsonl").write_text('{"prompt":"one"}\n', encoding="utf-8")
+    generate_calls: list[str] = []
+
+    def make_generate(*_args, **_kwargs):
+        def generate(prompt: str) -> str:
+            generate_calls.append(prompt)
+            return "candidate"
+
+        return generate
+
+    monkeypatch.setattr("soup_cli.utils.magpie.make_magpie_generate_fn", make_generate)
+    monkeypatch.setattr(
+        "soup_cli.eval.judge.JudgeEvaluator",
+        lambda **_kwargs: SimpleNamespace(
+            evaluate=lambda _prompt, response: SimpleNamespace(
+                weighted_score=float(len(response))
+            )
+        ),
+    )
+
+    first = CliRunner().invoke(app, _args(tmp_path))
+    assert first.exit_code == 0, (first.output, repr(first.exception))
+    generate_calls.clear()
+    changed = _args(tmp_path, "--resume")
+    changed[changed.index("3")] = "4"
+    result = CliRunner().invoke(app, changed)
+    assert result.exit_code == 2, (result.output, repr(result.exception))
+    assert "does not match prompts or run configuration" in result.output
+    assert generate_calls == []
+
+
+def test_checkpoint_rejects_duplicate_or_reordered_indexes(tmp_path, monkeypatch):
+    from soup_cli.utils.best_of_n_checkpoint import load_checkpoint
+
+    monkeypatch.chdir(tmp_path)
+    checkpoint = tmp_path / "checkpoint.jsonl"
+    checkpoint.write_text(
+        '{"_best_of_n_checkpoint":{"version":1,"run_digest":"d","total":2}}\n'
+        '{"index":1,"sft":{},"dpo":null}\n',
+        encoding="utf-8",
+    )
+    try:
+        load_checkpoint(str(checkpoint), digest="d", total=2)
+    except ValueError as exc:
+        assert "sequential and exactly once" in str(exc)
+    else:
+        raise AssertionError("non-sequential checkpoint must fail closed")
+
+
+def test_checkpoint_symlink_is_rejected(tmp_path, monkeypatch):
+    import pytest
+
+    from soup_cli.utils.best_of_n_checkpoint import load_checkpoint
+
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / "target.jsonl"
+    target.write_text("{}\n", encoding="utf-8")
+    link = tmp_path / "checkpoint.jsonl"
+    try:
+        link.symlink_to(target)
+    except OSError:
+        pytest.skip("symlink creation is unavailable")
+    with pytest.raises(ValueError, match="symlink"):
+        load_checkpoint(str(link), digest="d", total=1)
+
+
+def test_checkpoint_entry_digest_detects_parseable_corruption(tmp_path, monkeypatch):
+    from soup_cli.utils.best_of_n_checkpoint import (
+        append_checkpoint,
+        initialise_checkpoint,
+        load_checkpoint,
+    )
+
+    monkeypatch.chdir(tmp_path)
+    checkpoint = tmp_path / "checkpoint.jsonl"
+    initialise_checkpoint(str(checkpoint), digest="d", total=1)
+    append_checkpoint(
+        str(checkpoint),
+        index=0,
+        sft={"messages": [{"role": "user", "content": "private"}]},
+        dpo=None,
+    )
+    text = checkpoint.read_text().replace("private", "changed")
+    checkpoint.write_text(text, encoding="utf-8")
+    try:
+        load_checkpoint(str(checkpoint), digest="d", total=1)
+    except ValueError as exc:
+        assert "digest mismatch" in str(exc)
+    else:
+        raise AssertionError("parseable checkpoint corruption must fail closed")

--- a/tests/test_issue549_bon_resume.py
+++ b/tests/test_issue549_bon_resume.py
@@ -7,6 +7,7 @@ import json
 import os
 from types import SimpleNamespace
 
+import pytest
 from typer.testing import CliRunner
 
 
@@ -128,6 +129,47 @@ def test_late_failure_resumes_without_replaying_completed_prefix(tmp_path, monke
     assert judge_calls[judge_split:] == []
     assert (tmp_path / "sft.jsonl").read_bytes() == stable_sft
     assert (tmp_path / "dpo.jsonl").read_bytes() == stable_dpo
+
+
+@pytest.mark.parametrize("failure_stage", ["sampler", "judge"])
+def test_late_value_error_reports_checkpoint_recovery(
+    tmp_path, monkeypatch, failure_stage
+):
+    from soup_cli.commands.data import app
+
+    monkeypatch.chdir(tmp_path)
+    prompts = ["completed prompt", "failing prompt"]
+    (tmp_path / "prompts.jsonl").write_text(
+        "".join(json.dumps({"prompt": prompt}) + "\n" for prompt in prompts),
+        encoding="utf-8",
+    )
+
+    def make_generate(*_args, **_kwargs):
+        def generate(prompt: str) -> str:
+            if failure_stage == "sampler" and prompt == prompts[1]:
+                raise ValueError("private sampler failure")
+            return "candidate"
+
+        return generate
+
+    class Judge:
+        def evaluate(self, prompt: str, _response: str):
+            if failure_stage == "judge" and prompt == prompts[1]:
+                raise ValueError("private judge failure")
+            return SimpleNamespace(weighted_score=1.0)
+
+    monkeypatch.setattr("soup_cli.utils.magpie.make_magpie_generate_fn", make_generate)
+    monkeypatch.setattr("soup_cli.eval.judge.JudgeEvaluator", lambda **_kwargs: Judge())
+
+    result = CliRunner().invoke(app, _args(tmp_path))
+
+    assert result.exit_code == 1, (result.output, repr(result.exception))
+    assert "1/2 prompts" in result.output
+    assert "--resume" in result.output
+    assert "sft.jsonl.checkpoint.jsonl" in result.output
+    assert "private" not in result.output
+    checkpoint_lines = (tmp_path / "sft.jsonl.checkpoint.jsonl").read_text().splitlines()
+    assert len(checkpoint_lines) == 2
 
 
 def test_resume_rejects_changed_run_before_sampling(tmp_path, monkeypatch):

--- a/tests/test_issue549_bon_resume.py
+++ b/tests/test_issue549_bon_resume.py
@@ -247,6 +247,67 @@ def test_final_datasets_use_exact_utf8_bytes_for_manifest_hashes(tmp_path, monke
     ).hexdigest()
 
 
+@pytest.mark.parametrize("pre_existing", [False, True])
+@pytest.mark.parametrize("failure_after_replace", [False, True])
+@pytest.mark.parametrize("failure_field", ["emit-pairs", "manifest"])
+def test_final_publication_rolls_back_as_a_group_on_member_failure(
+    tmp_path, monkeypatch, pre_existing, failure_after_replace, failure_field
+):
+    from soup_cli.commands.data import app
+    from soup_cli.utils.paths import atomic_write_bytes as real_bytes_write
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "prompts.jsonl").write_text(
+        '{"prompt":"one"}\n', encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        "soup_cli.utils.magpie.make_magpie_generate_fn",
+        lambda *_args, **_kwargs: lambda _prompt: "candidate",
+    )
+    monkeypatch.setattr(
+        "soup_cli.eval.judge.JudgeEvaluator",
+        lambda **_kwargs: SimpleNamespace(
+            evaluate=lambda _prompt, response: SimpleNamespace(
+                weighted_score=float(len(response))
+            )
+        ),
+    )
+
+    artifacts = {
+        tmp_path / "sft.jsonl": b"previous sft\n",
+        tmp_path / "dpo.jsonl": b"previous dpo\n",
+        tmp_path / "sft.jsonl.manifest.json": b"previous manifest\n",
+    }
+    if pre_existing:
+        for path, content in artifacts.items():
+            path.write_bytes(content)
+
+    def fail_group_write(data, path, *, prefix=".soup.", suffix=".tmp", field):
+        if field == failure_field:
+            if failure_after_replace:
+                real_bytes_write(
+                    data, path, prefix=prefix, suffix=suffix, field=field
+                )
+            raise OSError("simulated grouped publication failure")
+        return real_bytes_write(
+            data, path, prefix=prefix, suffix=suffix, field=field
+        )
+
+    monkeypatch.setattr(
+        "soup_cli.utils.paths.atomic_write_bytes", fail_group_write
+    )
+    result = CliRunner().invoke(app, _args(tmp_path))
+
+    assert result.exit_code == 1, (result.output, repr(result.exception))
+    assert "Failed to write output" in result.output
+    for path, old_content in artifacts.items():
+        if pre_existing:
+            assert path.read_bytes() == old_content
+        else:
+            assert not path.exists()
+    assert not list(tmp_path.glob(".soup.rollback.*"))
+
+
 def test_checkpoint_rejects_duplicate_or_reordered_indexes(tmp_path, monkeypatch):
     from soup_cli.utils.best_of_n_checkpoint import load_checkpoint
 

--- a/tests/test_issue549_bon_resume.py
+++ b/tests/test_issue549_bon_resume.py
@@ -31,6 +31,25 @@ def _args(tmp_path, *extra: str) -> list[str]:
     ]
 
 
+def _local_args(tmp_path, *extra: str) -> list[str]:
+    return [
+        "best-of-n",
+        "--base",
+        "local-model",
+        "--prompts",
+        str(tmp_path / "prompts.jsonl"),
+        "--n",
+        "2",
+        "--judge",
+        "ollama://judge",
+        "--output",
+        str(tmp_path / "sft.jsonl"),
+        "--seed",
+        "17",
+        *extra,
+    ]
+
+
 def test_late_failure_resumes_without_replaying_completed_prefix(tmp_path, monkeypatch):
     from soup_cli.commands.data import app
 
@@ -245,3 +264,78 @@ def test_checkpoint_entry_digest_detects_parseable_corruption(tmp_path, monkeypa
         assert "digest mismatch" in str(exc)
     else:
         raise AssertionError("parseable checkpoint corruption must fail closed")
+
+
+def test_resume_discards_only_an_uncommitted_final_fragment(tmp_path, monkeypatch):
+    from soup_cli.utils.best_of_n_checkpoint import (
+        append_checkpoint,
+        initialise_checkpoint,
+        load_checkpoint,
+    )
+
+    monkeypatch.chdir(tmp_path)
+    checkpoint = tmp_path / "checkpoint.jsonl"
+    initialise_checkpoint(str(checkpoint), digest="d", total=2)
+    append_checkpoint(
+        str(checkpoint), index=0, sft={"messages": []}, dpo=None
+    )
+    with checkpoint.open("ab") as handle:
+        handle.write(b'{"index":1,"sft":')
+
+    entries = load_checkpoint(str(checkpoint), digest="d", total=2)
+
+    assert entries == [({"messages": []}, None)]
+    assert checkpoint.read_bytes().endswith(b"\n")
+    assert b'"index":1' not in checkpoint.read_bytes()
+
+
+def test_local_sampling_is_identical_after_resume(tmp_path, monkeypatch):
+    import torch
+
+    from soup_cli.commands.data import app
+
+    monkeypatch.chdir(tmp_path)
+    prompts = ["first", "second"]
+    (tmp_path / "prompts.jsonl").write_text(
+        "".join(json.dumps({"prompt": prompt}) + "\n" for prompt in prompts),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "soup_cli.commands.data._load_bon_model", lambda *_args: (object(), object())
+    )
+    monkeypatch.setattr(
+        "soup_cli.utils.trust_remote.model_requires_trust_remote_code",
+        lambda _model: False,
+    )
+
+    sampled: list[tuple[str, list[str]]] = []
+
+    def sample_candidates(_model, _tokenizer, prompt, *, n, **_kwargs):
+        candidates = [f"{torch.rand(1).item():.12f}" for _ in range(n)]
+        sampled.append((prompt, candidates))
+        return candidates
+
+    fail_second = {"value": True}
+
+    class Judge:
+        def evaluate(self, prompt: str, response: str):
+            if prompt == "second" and fail_second["value"]:
+                raise RuntimeError("simulated interruption")
+            return SimpleNamespace(weighted_score=float(response))
+
+    monkeypatch.setattr(
+        "soup_cli.utils.best_of_n.sample_candidates", sample_candidates
+    )
+    monkeypatch.setattr(
+        "soup_cli.eval.judge.JudgeEvaluator", lambda **_kwargs: Judge()
+    )
+
+    first = CliRunner().invoke(app, _local_args(tmp_path))
+    assert first.exit_code == 1, (first.output, repr(first.exception))
+    interrupted_candidates = sampled[-1][1]
+
+    fail_second["value"] = False
+    resumed = CliRunner().invoke(app, _local_args(tmp_path, "--resume"))
+
+    assert resumed.exit_code == 0, (resumed.output, repr(resumed.exception))
+    assert sampled[-1] == ("second", interrupted_candidates)

--- a/tests/test_issue549_bon_resume.py
+++ b/tests/test_issue549_bon_resume.py
@@ -289,17 +289,23 @@ def test_resume_discards_only_an_uncommitted_final_fragment(tmp_path, monkeypatc
     assert b'"index":1' not in checkpoint.read_bytes()
 
 
-def test_local_sampling_is_identical_after_resume(tmp_path, monkeypatch):
+def test_local_sampling_matches_uninterrupted_run_across_prompt_indices(
+    tmp_path, monkeypatch
+):
     import torch
 
     from soup_cli.commands.data import app
 
     monkeypatch.chdir(tmp_path)
-    prompts = ["first", "second"]
-    (tmp_path / "prompts.jsonl").write_text(
-        "".join(json.dumps({"prompt": prompt}) + "\n" for prompt in prompts),
-        encoding="utf-8",
-    )
+    prompts = ["first", "second", "third"]
+    uninterrupted_dir = tmp_path / "uninterrupted"
+    resumed_dir = tmp_path / "resumed"
+    for run_dir in (uninterrupted_dir, resumed_dir):
+        run_dir.mkdir()
+        (run_dir / "prompts.jsonl").write_text(
+            "".join(json.dumps({"prompt": prompt}) + "\n" for prompt in prompts),
+            encoding="utf-8",
+        )
     monkeypatch.setattr(
         "soup_cli.commands.data._load_bon_model", lambda *_args: (object(), object())
     )
@@ -308,18 +314,23 @@ def test_local_sampling_is_identical_after_resume(tmp_path, monkeypatch):
         lambda _model: False,
     )
 
-    sampled: list[tuple[str, list[str]]] = []
+    phase = {"name": "uninterrupted"}
+    sampled: dict[str, dict[str, list[list[str]]]] = {
+        "uninterrupted": {prompt: [] for prompt in prompts},
+        "resumed": {prompt: [] for prompt in prompts},
+    }
 
     def sample_candidates(_model, _tokenizer, prompt, *, n, **_kwargs):
         candidates = [f"{torch.rand(1).item():.12f}" for _ in range(n)]
-        sampled.append((prompt, candidates))
+        sampled[phase["name"]][prompt].append(candidates)
         return candidates
 
-    fail_second = {"value": True}
+    fail_second = {"value": False}
 
     class Judge:
         def evaluate(self, prompt: str, response: str):
             if prompt == "second" and fail_second["value"]:
+                fail_second["value"] = False
                 raise RuntimeError("simulated interruption")
             return SimpleNamespace(weighted_score=float(response))
 
@@ -330,12 +341,41 @@ def test_local_sampling_is_identical_after_resume(tmp_path, monkeypatch):
         "soup_cli.eval.judge.JudgeEvaluator", lambda **_kwargs: Judge()
     )
 
-    first = CliRunner().invoke(app, _local_args(tmp_path))
-    assert first.exit_code == 1, (first.output, repr(first.exception))
-    interrupted_candidates = sampled[-1][1]
+    uninterrupted_args = _local_args(
+        uninterrupted_dir,
+        "--emit-pairs",
+        str(uninterrupted_dir / "dpo.jsonl"),
+    )
+    uninterrupted = CliRunner().invoke(app, uninterrupted_args)
+    assert uninterrupted.exit_code == 0, (
+        uninterrupted.output,
+        repr(uninterrupted.exception),
+    )
 
-    fail_second["value"] = False
-    resumed = CliRunner().invoke(app, _local_args(tmp_path, "--resume"))
+    phase["name"] = "resumed"
+    fail_second["value"] = True
+    resumed_args = _local_args(
+        resumed_dir,
+        "--emit-pairs",
+        str(resumed_dir / "dpo.jsonl"),
+    )
+    first = CliRunner().invoke(app, resumed_args)
+    assert first.exit_code == 1, (first.output, repr(first.exception))
+
+    resumed = CliRunner().invoke(app, [*resumed_args, "--resume"])
 
     assert resumed.exit_code == 0, (resumed.output, repr(resumed.exception))
-    assert sampled[-1] == ("second", interrupted_candidates)
+    uninterrupted_final = {
+        prompt: calls[-1] for prompt, calls in sampled["uninterrupted"].items()
+    }
+    resumed_final = {
+        prompt: calls[-1] for prompt, calls in sampled["resumed"].items()
+    }
+    assert resumed_final == uninterrupted_final
+    assert len({tuple(candidates) for candidates in uninterrupted_final.values()}) == 3
+    assert [len(sampled["resumed"][prompt]) for prompt in prompts] == [1, 2, 1]
+
+    for artifact in ("sft.jsonl", "dpo.jsonl", "sft.jsonl.manifest.json"):
+        assert (resumed_dir / artifact).read_bytes() == (
+            uninterrupted_dir / artifact
+        ).read_bytes()

--- a/tests/test_issue549_bon_resume.py
+++ b/tests/test_issue549_bon_resume.py
@@ -146,6 +146,46 @@ def test_resume_rejects_changed_run_before_sampling(tmp_path, monkeypatch):
     assert generate_calls == []
 
 
+def test_final_datasets_use_exact_utf8_bytes_for_manifest_hashes(tmp_path, monkeypatch):
+    from soup_cli.commands.data import app
+    from soup_cli.utils.paths import atomic_write_text as real_text_write
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "prompts.jsonl").write_text(
+        '{"prompt":"one"}\n', encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        "soup_cli.utils.magpie.make_magpie_generate_fn",
+        lambda *_args, **_kwargs: lambda _prompt: "candidate",
+    )
+    monkeypatch.setattr(
+        "soup_cli.eval.judge.JudgeEvaluator",
+        lambda **_kwargs: SimpleNamespace(
+            evaluate=lambda _prompt, response: SimpleNamespace(
+                weighted_score=float(len(response))
+            )
+        ),
+    )
+
+    def reject_dataset_text_writes(text, path, *, field):
+        if field in {"output", "emit-pairs"}:
+            raise AssertionError("dataset JSONL must use exact UTF-8 byte writes")
+        return real_text_write(text, path, field=field)
+
+    monkeypatch.setattr(
+        "soup_cli.utils.paths.atomic_write_text", reject_dataset_text_writes
+    )
+    result = CliRunner().invoke(app, _args(tmp_path))
+    assert result.exit_code == 0, (result.output, repr(result.exception))
+    manifest = json.loads((tmp_path / "sft.jsonl.manifest.json").read_text())
+    assert manifest["sft"]["sha256"] == hashlib.sha256(
+        (tmp_path / "sft.jsonl").read_bytes()
+    ).hexdigest()
+    assert manifest["dpo"]["sha256"] == hashlib.sha256(
+        (tmp_path / "dpo.jsonl").read_bytes()
+    ).hexdigest()
+
+
 def test_checkpoint_rejects_duplicate_or_reordered_indexes(tmp_path, monkeypatch):
     from soup_cli.utils.best_of_n_checkpoint import load_checkpoint
 

--- a/tests/test_v07131.py
+++ b/tests/test_v07131.py
@@ -1042,7 +1042,12 @@ class TestBestOfNCli:
                 "model": "sampler-model",
             }
         finally:
-            for path in (prompt_path, output_path):
+            for path in (
+                prompt_path,
+                output_path,
+                output_path + ".checkpoint.jsonl",
+                output_path + ".manifest.json",
+            ):
                 if os.path.exists(path):
                     os.remove(path)
 
@@ -1224,7 +1229,13 @@ class TestBestOfNCli:
             pairs = [json.loads(x) for x in open(dpath, encoding="utf-8") if x.strip()]
             assert pairs[0] == {"prompt": "q1", "chosen": "abcd", "rejected": "a"}
         finally:
-            for p in (ppath, opath, dpath):
+            for p in (
+                ppath,
+                opath,
+                dpath,
+                opath + ".checkpoint.jsonl",
+                opath + ".manifest.json",
+            ):
                 if os.path.exists(p):
                     os.remove(p)
 


### PR DESCRIPTION
## Summary

- fsync one private, checksummed checkpoint entry after each completed prompt group
- add `--resume` with exact prompt/config digest validation and sequential exactly-once replay
- skip all already completed sampling and judging, including fully completed checkpoints
- report completed/total progress and the recovery artifact after a late failure without echoing prompt data
- atomically publish final datasets and write a final manifest that binds SFT/DPO hashes and counts
- reject checkpoint path collisions, symlinks, reordered indexes, content corruption, and config drift

## Validation

- `PYTHONPATH=src pytest tests/ -q --no-cov --tb=short` (18,936 passed, 82 skipped, 5 deselected)
- final checkpoint/replay regression pass after checksum hardening (22 passed)
- `ruff check src/soup_cli/ tests/`
- `git diff --check`

Fixes #549
