### PR TITLE
feat(data): add offline Best-of-N materialization

### DIFF
--- a/changelog.d/0.73.3/550.added.md
+++ b/changelog.d/0.73.3/550.added.md
@@ -1,0 +1,2 @@
+- Added #550: a content-addressed two-phase Best-of-N workflow for exporting local
+  candidates and materializing verified offline judgments without model or network access.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -302,6 +302,8 @@ soup build <manifest.yaml> [--dry-run] [--output-dir <dir>]  dbt-for-SFT DAG: va
 soup expect <data.jsonl> <suite.yaml>         Expectations suite: PII / token-length / refusal / judge (v0.69.0)
 soup data gen-magpie --base <m> --provider ollama|vllm --target N --output <jsonl> [--base-url <url>] [--quality-filter]  Magpie synthetic generator — live (v0.69.0; live v0.71.6)
 soup data best-of-n (--base <m> | --provider ollama|vllm --model <m> [--base-url <url>]) --prompts <jsonl> --n 8 --judge <url> -o <sft.jsonl> [--emit-pairs <dpo.jsonl>] [--resume] [--checkpoint <journal.jsonl>] [--manifest <manifest.json>]  Best-of-N rejection sampling with durable per-prompt recovery and manifest-last publication
+soup data best-of-n (--base <m> [--revision <rev>] | --provider ollama|vllm --model <m>) --prompts <jsonl> --n 8 --export-candidates <jsonl>  Sampling-only phase; no judge is constructed
+soup data best-of-n --candidate-artifact <jsonl> --judgments <jsonl> -o <sft.jsonl> [--emit-pairs <dpo.jsonl>]  Validate offline judgments and materialize byte-stable training rows without a model or network
 soup data evolve --input <seeds.jsonl> --provider ollama|vllm --model <m> --strategy depth|breadth --rounds N -o <jsonl>  Evol-Instruct (WizardLM) instruction evolution (v0.71.31)
 soup data persona-mix --prompts <jsonl> --n N --output <jsonl>  Persona-Hub diversity sampler (v0.69.0)
 soup data brain-rot <data.jsonl> [--strict]   Brain-rot detector — arXiv 2510.13928 (v0.69.0)

--- a/docs/data.md
+++ b/docs/data.md
@@ -203,6 +203,17 @@ soup data best-of-n --provider ollama --model qwen2.5:7b \
     --prompts prompts.jsonl --n 8 --judge ollama://llama3.1 \
     -o best_of_n.jsonl --resume
 
+# Two-phase / air-gapped workflow: sample first, without constructing a judge.
+soup data best-of-n --base Qwen/Qwen3.8-27B --revision <commit> \
+    --prompts prompts.jsonl --n 8 --export-candidates candidates.jsonl
+
+# An offline human, deterministic program, CI job, or Codex writes one judgment
+# per candidate group, copying prompt_id and group_digest from candidates.jsonl:
+# {"prompt_id":"...","group_digest":"...","winner_idx":2,
+#  "scores":[0.1,0.4,0.9,...],"verifier":{"name":"Codex","version":"offline-v1"}}
+soup data best-of-n --candidate-artifact candidates.jsonl \
+    --judgments judgments.jsonl -o best_of_n.jsonl --emit-pairs pairs.jsonl
+
 # Evol-Instruct (WizardLM depth/breadth, v0.71.31) — grow instruction diversity
 soup data evolve --input seeds.jsonl --provider ollama --model llama3.1 \
     --strategy depth --rounds 2 -o evolved.jsonl
@@ -220,6 +231,17 @@ generation or removes the newly created set. The manifest binds the exact SHA-25
 hashes and row counts as one generation. Keep or archive the checkpoint after
 success if reproducible rematerialization is useful; it contains dataset content
 and should be protected like the generated dataset.
+
+The candidate artifact preserves every ordered candidate with prompt, candidate,
+group, and whole-artifact SHA-256 bindings plus a public sampler specification.
+The offline phase validates complete one-to-one coverage before writing anything:
+missing or duplicate prompt ids, changed group digests, invalid winner indexes,
+score-count drift, non-finite scores, and winner/score disagreement all fail
+closed. It does not construct a sampler or judge. SFT and DPO rows retain the
+candidate-artifact and judgment-file digests, group id, public sampler settings,
+and bounded verifier identity. Endpoint URLs and local model paths are never
+copied into those artifacts. Reusing the same two input files produces identical
+training-row bytes.
 
 ### Custom Transforms
 

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -3077,7 +3077,11 @@ def best_of_n(
     from soup_cli.utils import best_of_n_checkpoint as bon_checkpoint
     from soup_cli.utils import best_of_n_artifact as bon_artifact
     from soup_cli.utils.magpie import make_magpie_generate_fn
-    from soup_cli.utils.paths import atomic_write_bytes, enforce_under_cwd_and_no_symlink
+    from soup_cli.utils.paths import (
+        atomic_write_bytes,
+        atomic_write_bytes_group,
+        enforce_under_cwd_and_no_symlink,
+    )
     from soup_cli.utils.trust_remote import (
         model_requires_trust_remote_code,
         resolve_trust_remote_code,
@@ -3162,17 +3166,22 @@ def best_of_n(
         if plan_only:
             return
         try:
-            atomic_write_bytes(
-                bon_artifact.stable_jsonl(sft_rows).encode("utf-8"),
-                output,
-                field="output",
-            )
-            if emit_pairs:
-                atomic_write_bytes(
-                    bon_artifact.stable_jsonl(dpo_rows).encode("utf-8"),
-                    emit_pairs,
-                    field="emit-pairs",
+            publication = [
+                (
+                    bon_artifact.stable_jsonl(sft_rows).encode("utf-8"),
+                    output,
+                    "output",
                 )
+            ]
+            if emit_pairs:
+                publication.append(
+                    (
+                        bon_artifact.stable_jsonl(dpo_rows).encode("utf-8"),
+                        emit_pairs,
+                        "emit-pairs",
+                    )
+                )
+            atomic_write_bytes_group(publication)
         except (OSError, TypeError, ValueError) as exc:
             console.print(f"[red]Failed to write output: {_escape(str(exc))}[/]")
             raise typer.Exit(1) from exc

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -3074,8 +3074,8 @@ def best_of_n(
     from rich.panel import Panel
 
     from soup_cli.utils import best_of_n as bon
-    from soup_cli.utils import best_of_n_checkpoint as bon_checkpoint
     from soup_cli.utils import best_of_n_artifact as bon_artifact
+    from soup_cli.utils import best_of_n_checkpoint as bon_checkpoint
     from soup_cli.utils.magpie import make_magpie_generate_fn
     from soup_cli.utils.paths import (
         atomic_write_bytes,
@@ -3415,7 +3415,7 @@ def best_of_n(
     if export_mode:
         groups = []
         try:
-            for index, prompt in enumerate(prompt_list):
+            for index, (prompt, source_line) in enumerate(prompt_records):
                 candidates = bon.sample_candidates(
                     local_model,
                     tokenizer,
@@ -3428,7 +3428,11 @@ def best_of_n(
                 )
                 groups.append(
                     bon_artifact.build_candidate_group(
-                        prompt, index, candidates, sampler_spec
+                        prompt,
+                        index,
+                        candidates,
+                        sampler_spec,
+                        source_line=source_line,
                     )
                 )
             atomic_write_bytes(

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import ntpath
 import os
 import random
 from pathlib import Path
@@ -2906,16 +2907,21 @@ _BON_MAX_JSONL_BYTES = 100 * 1024 * 1024  # 100 MiB
 _BON_PROVIDER_SAMPLERS = ("ollama", "vllm")
 
 
-def _load_bon_model(base: str, device: str, trust: bool):
+def _load_bon_model(
+    base: str, device: str, trust: bool, revision: Optional[str] = None
+):
     """Seam: load ``(model, tokenizer)`` for best-of-n (patched in tests)."""
     from transformers import AutoModelForCausalLM, AutoTokenizer
 
-    tok = AutoTokenizer.from_pretrained(base, trust_remote_code=trust)
+    load_kwargs: dict[str, object] = {"trust_remote_code": trust}
+    if revision:
+        load_kwargs["revision"] = revision
+    tok = AutoTokenizer.from_pretrained(base, **load_kwargs)
     if tok.pad_token is None:
         tok.pad_token = tok.eos_token
     dev_map = "cpu" if device == "cpu" else "auto"
     model = AutoModelForCausalLM.from_pretrained(
-        base, trust_remote_code=trust, device_map=dev_map
+        base, device_map=dev_map, **load_kwargs
     )
     return model, tok
 
@@ -3014,9 +3020,9 @@ def _evolve_load_prompts(path: str) -> list[str]:
 @app.command(name="best-of-n")
 def best_of_n(
     base: str = typer.Option("", "--base", help="Local base model id/path to sample from"),
-    prompts: str = typer.Option(..., "--prompts", help="JSONL of {prompt|messages} rows"),
+    prompts: str = typer.Option("", "--prompts", help="JSONL of {prompt|messages} rows"),
     judge: str = typer.Option(
-        ..., "--judge", help="Judge URL (ollama://|https://|http://localhost)"
+        "", "--judge", help="Judge URL (ollama://|https://|http://localhost)"
     ),
     provider: str = typer.Option("", "--provider", help="Provider sampler: ollama | vllm"),
     model: str = typer.Option("", "--model", help="Provider sampler model id"),
@@ -3035,12 +3041,22 @@ def best_of_n(
         "", "--manifest", help="Final consistency manifest (default: <output>.manifest.json)"
     ),
     resume: bool = typer.Option(False, "--resume", help="Resume a matching checkpoint"),
+    export_candidates: str = typer.Option(
+        "", "--export-candidates", help="Sampling-only candidate artifact JSONL"
+    ),
+    candidate_artifact: str = typer.Option(
+        "", "--candidate-artifact", help="Offline candidate artifact to materialize"
+    ),
+    judgments: str = typer.Option(
+        "", "--judgments", help="Offline verified judgments JSONL"
+    ),
     temperature: float = typer.Option(1.0, "--temperature", help="Sampling temp [0, 2]"),
     max_new_tokens: int = typer.Option(
         256, "--max-new-tokens", help="Max new tokens per candidate [1, 4096]"
     ),
     device: str = typer.Option("", "--device", help="Local sampler device: cuda | cpu"),
     seed: int = typer.Option(0, "--seed", help="Local sampling seed"),
+    revision: str = typer.Option("", "--revision", help="Pinned local model revision"),
     trust_remote_code: bool = typer.Option(
         False, "--trust-remote-code", help="Allow custom model code on local --base"
     ),
@@ -3057,12 +3073,11 @@ def best_of_n(
     from rich.markup import escape as _escape
     from rich.panel import Panel
 
-    from soup_cli.eval.gate import _parse_judge_url
-    from soup_cli.eval.judge import JudgeEvaluator
     from soup_cli.utils import best_of_n as bon
     from soup_cli.utils import best_of_n_checkpoint as bon_checkpoint
+    from soup_cli.utils import best_of_n_artifact as bon_artifact
     from soup_cli.utils.magpie import make_magpie_generate_fn
-    from soup_cli.utils.paths import enforce_under_cwd_and_no_symlink
+    from soup_cli.utils.paths import atomic_write_text, enforce_under_cwd_and_no_symlink
     from soup_cli.utils.trust_remote import (
         model_requires_trust_remote_code,
         resolve_trust_remote_code,
@@ -3079,19 +3094,131 @@ def best_of_n(
         console.print("[red]--max-new-tokens must be in [1, 4096][/]")
         raise typer.Exit(2)
 
-    # --- Judge URL (SSRF via JudgeEvaluator construction) ---
-    try:
-        judge_provider, judge_model_id, api_base = _parse_judge_url(judge)
-        evaluator = JudgeEvaluator(
-            provider=judge_provider, model=judge_model_id, api_base=api_base
+    offline_mode = bool(candidate_artifact or judgments)
+    export_mode = bool(export_candidates)
+    if offline_mode and export_mode:
+        console.print("[red]offline materialization and --export-candidates are exclusive[/]")
+        raise typer.Exit(2)
+    if offline_mode:
+        if not candidate_artifact or not judgments:
+            console.print("[red]provide both --candidate-artifact and --judgments[/]")
+            raise typer.Exit(2)
+        if any(
+            (
+                base,
+                prompts,
+                judge,
+                provider,
+                model,
+                base_url,
+                device,
+                revision,
+                trust_remote_code,
+                seed != 0,
+            )
+        ):
+            console.print(
+                "[red]offline materialization does not accept sampler or judge options[/]"
+            )
+            raise typer.Exit(2)
+        if not output and not plan_only:
+            console.print("[red]--output is required unless --plan-only is set.[/]")
+            raise typer.Exit(2)
+        try:
+            paths = [candidate_artifact, judgments]
+            if output:
+                enforce_under_cwd_and_no_symlink(output, "--output path")
+                paths.append(output)
+            if emit_pairs:
+                enforce_under_cwd_and_no_symlink(emit_pairs, "--emit-pairs path")
+                paths.append(emit_pairs)
+            if len({os.path.normcase(os.path.realpath(path)) for path in paths}) != len(paths):
+                raise ValueError("offline input and output paths must be distinct")
+            groups, sampler_spec, candidate_sha = bon_artifact.load_candidate_artifact(
+                candidate_artifact
+            )
+            verified, judgments_sha = bon_artifact.load_judgments(judgments, groups)
+            sft_rows, dpo_rows = bon_artifact.materialize_rows(
+                groups,
+                verified,
+                sampler=sampler_spec,
+                candidate_artifact_sha256=candidate_sha,
+                judgments_sha256=judgments_sha,
+            )
+        except (FileNotFoundError, OSError, TypeError, ValueError) as exc:
+            console.print(f"[red]Invalid offline artifact: {_escape(str(exc))}[/]")
+            raise typer.Exit(2) from exc
+        console.print(
+            Panel(
+                f"Candidate groups: [bold]{len(groups)}[/]\n"
+                f"Verified rows:    [bold]{len(verified)}[/]\n"
+                "Network/model:    [bold]disabled[/]",
+                title="soup data best-of-n — offline plan",
+            )
         )
-    except (ValueError, TypeError) as exc:
-        console.print(f"[red]Invalid --judge: {_escape(str(exc))}[/]")
-        raise typer.Exit(2) from exc
+        if plan_only:
+            return
+        try:
+            atomic_write_text(
+                bon_artifact.stable_jsonl(sft_rows), output, field="output"
+            )
+            if emit_pairs:
+                atomic_write_text(
+                    bon_artifact.stable_jsonl(dpo_rows),
+                    emit_pairs,
+                    field="emit-pairs",
+                )
+        except (OSError, TypeError, ValueError) as exc:
+            console.print(f"[red]Failed to write output: {_escape(str(exc))}[/]")
+            raise typer.Exit(1) from exc
+        body = (
+            f"SFT rows:   [bold]{len(sft_rows)}[/]\n"
+            f"Output:     [bold]{_escape(os.path.relpath(output))}[/]"
+        )
+        if emit_pairs:
+            body += (
+                f"\nDPO pairs:  [bold]{len(dpo_rows)}[/]\n"
+                f"Pairs out:  [bold]{_escape(os.path.relpath(emit_pairs))}[/]"
+            )
+        console.print(Panel(body, title="soup data best-of-n — offline done"))
+        return
 
-    # --- Paths ---
-    checkpoint_path = checkpoint or (f"{output}.checkpoint.jsonl" if output else "")
-    manifest_path = manifest or (f"{output}.manifest.json" if output else "")
+    if export_mode:
+        if judge or output or emit_pairs or checkpoint or manifest or resume:
+            console.print(
+                "[red]--export-candidates cannot be combined with judge, final-output, "
+                "or online-recovery options[/]"
+            )
+            raise typer.Exit(2)
+    elif not judge:
+        console.print("[red]--judge is required for the online workflow[/]")
+        raise typer.Exit(2)
+    if not prompts:
+        console.print("[red]--prompts is required for sampling[/]")
+        raise typer.Exit(2)
+
+    evaluator = None
+    if not export_mode:
+        from soup_cli.eval.gate import _parse_judge_url
+        from soup_cli.eval.judge import JudgeEvaluator
+
+        # JudgeEvaluator construction validates the URL against SSRF.
+        try:
+            judge_provider, judge_model_id, api_base = _parse_judge_url(judge)
+            evaluator = JudgeEvaluator(
+                provider=judge_provider, model=judge_model_id, api_base=api_base
+            )
+        except (ValueError, TypeError) as exc:
+            console.print(f"[red]Invalid --judge: {_escape(str(exc))}[/]")
+            raise typer.Exit(2) from exc
+
+    checkpoint_path = ""
+    manifest_path = ""
+    if not export_mode:
+        checkpoint_path = checkpoint or (f"{output}.checkpoint.jsonl" if output else "")
+        manifest_path = manifest or (f"{output}.manifest.json" if output else "")
+
+    # --- Prompt and output paths ---
     try:
         prompt_records = _bon_load_prompt_records(prompts)
         if output:
@@ -3102,6 +3229,10 @@ def best_of_n(
             enforce_under_cwd_and_no_symlink(checkpoint_path, "--checkpoint path")
         if manifest_path:
             enforce_under_cwd_and_no_symlink(manifest_path, "--manifest path")
+        if export_candidates:
+            enforce_under_cwd_and_no_symlink(
+                export_candidates, "--export-candidates path"
+            )
     except (FileNotFoundError, TypeError, ValueError) as exc:
         console.print(f"[red]{_escape(str(exc))}[/]")
         raise typer.Exit(2) from exc
@@ -3121,9 +3252,10 @@ def best_of_n(
         if base:
             console.print("[red]--base and --provider are mutually exclusive[/]")
             raise typer.Exit(2)
-        if device or trust_remote_code or seed != 0:
+        if device or revision or trust_remote_code or seed != 0:
             console.print(
-                "[red]--device, --seed and --trust-remote-code apply only to local --base[/]"
+                "[red]--device, --revision, --seed and --trust-remote-code "
+                "apply only to local --base[/]"
             )
             raise typer.Exit(2)
         sampling_provider = provider.strip().lower()
@@ -3162,30 +3294,56 @@ def best_of_n(
         )
 
     sampler_label = f"{sampling_provider}:{model}" if generate_fn is not None else base
-    digest = bon_checkpoint.run_digest(
-        prompt_list,
-        {
-            "base": base,
+    if generate_fn is not None:
+        sampler_spec = {
+            "kind": "provider",
             "provider": sampling_provider,
             "model": model,
-            "base_url": base_url,
             "n": n,
             "temperature": temperature,
             "max_new_tokens": max_new_tokens,
-            "device": device,
+        }
+    else:
+        is_local_path = os.path.exists(base) or os.path.isabs(base) or ntpath.isabs(base)
+        public_model = "<local-model>" if is_local_path else base
+        sampler_spec = {
+            "kind": "local",
+            "model": public_model,
+            "revision": revision or "unspecified",
+            "n": n,
+            "temperature": temperature,
+            "max_new_tokens": max_new_tokens,
+            "device": device or "auto",
             "seed": seed,
             "trust_remote_code": trust,
-            "judge": judge,
-            "emit_pairs": bool(emit_pairs),
-        },
-    )
+        }
+
+    digest = ""
+    if not export_mode:
+        digest = bon_checkpoint.run_digest(
+            prompt_list,
+            {
+                "base": base,
+                "provider": sampling_provider,
+                "model": model,
+                "base_url": base_url,
+                "n": n,
+                "temperature": temperature,
+                "max_new_tokens": max_new_tokens,
+                "device": device,
+                "seed": seed,
+                "trust_remote_code": trust,
+                "judge": judge,
+                "emit_pairs": bool(emit_pairs),
+            },
+        )
 
     console.print(
         Panel(
             f"Sampler:      [bold]{_escape(sampler_label)}[/]\n"
             f"Prompts:      [bold]{len(prompt_records)}[/]\n"
             f"N candidates: [bold]{n}[/]\n"
-            f"Judge:        [bold]{_escape(judge)}[/]\n"
+            f"Judge:        [bold]{_escape(judge) if judge else 'offline artifact'}[/]\n"
             f"Checkpoint:   [bold]"
             f"{_escape(os.path.relpath(checkpoint_path)) if checkpoint_path else '-'}[/]",
             title="soup data best-of-n — plan",
@@ -3193,41 +3351,92 @@ def best_of_n(
     )
     if plan_only:
         return
-    if not output:
+    if not export_mode and not output:
         console.print("[red]--output is required unless --plan-only is set.[/]")
         raise typer.Exit(2)
 
-    try:
-        targets = [output, checkpoint_path, manifest_path]
-        if emit_pairs:
-            targets.append(emit_pairs)
-        if len({os.path.normcase(os.path.realpath(path)) for path in targets}) != len(targets):
-            raise ValueError("output, pairs, checkpoint, and manifest paths must be distinct")
-        if resume:
-            completed_entries = bon_checkpoint.load_checkpoint(
-                checkpoint_path, digest=digest, total=len(prompt_list)
-            )
-        else:
-            bon_checkpoint.initialise_checkpoint(
-                checkpoint_path, digest=digest, total=len(prompt_list)
-            )
-            completed_entries = []
-    except (FileNotFoundError, OSError, TypeError, ValueError) as exc:
-        console.print(f"[red]Invalid checkpoint: {_escape(str(exc))}[/]")
-        raise typer.Exit(2) from exc
+    completed_entries = []
+    if not export_mode:
+        try:
+            targets = [output, checkpoint_path, manifest_path]
+            if emit_pairs:
+                targets.append(emit_pairs)
+            if len({os.path.normcase(os.path.realpath(path)) for path in targets}) != len(
+                targets
+            ):
+                raise ValueError(
+                    "output, pairs, checkpoint, and manifest paths must be distinct"
+                )
+            if resume:
+                completed_entries = bon_checkpoint.load_checkpoint(
+                    checkpoint_path, digest=digest, total=len(prompt_list)
+                )
+            else:
+                bon_checkpoint.initialise_checkpoint(
+                    checkpoint_path, digest=digest, total=len(prompt_list)
+                )
+        except (FileNotFoundError, OSError, TypeError, ValueError) as exc:
+            console.print(f"[red]Invalid checkpoint: {_escape(str(exc))}[/]")
+            raise typer.Exit(2) from exc
 
     local_model = None
     tokenizer = None
     local_torch = None
-    if generate_fn is None and len(completed_entries) < len(prompt_list):
+    if generate_fn is None and (
+        export_mode or len(completed_entries) < len(prompt_list)
+    ):
         import torch
 
         local_torch = torch
-        local_model, tokenizer = _load_bon_model(base, device, trust)
+        if export_mode:
+            torch.manual_seed(seed)
+        if revision:
+            local_model, tokenizer = _load_bon_model(
+                base, device, trust, revision=revision
+            )
+        else:
+            local_model, tokenizer = _load_bon_model(base, device, trust)
 
     dev = device or None
+    if export_mode:
+        groups = []
+        try:
+            for index, prompt in enumerate(prompt_list):
+                candidates = bon.sample_candidates(
+                    local_model,
+                    tokenizer,
+                    prompt,
+                    n=n,
+                    temperature=temperature,
+                    max_new_tokens=max_new_tokens,
+                    device=dev,
+                    generate_fn=generate_fn,
+                )
+                groups.append(
+                    bon_artifact.build_candidate_group(
+                        prompt, index, candidates, sampler_spec
+                    )
+                )
+            atomic_write_text(
+                bon_artifact.candidate_artifact_text(groups, sampler_spec),
+                export_candidates,
+                field="export-candidates",
+            )
+        except Exception as exc:
+            console.print("[red]Candidate export failed before publication.[/]")
+            raise typer.Exit(1) from exc
+        console.print(
+            Panel(
+                f"Candidate groups: [bold]{len(groups)}[/]\n"
+                f"Output:           [bold]{_escape(os.path.relpath(export_candidates))}[/]",
+                title="soup data best-of-n — candidates exported",
+            )
+        )
+        return
+
     sft_rows = [entry[0] for entry in completed_entries]
     pair_rows = [entry[1] for entry in completed_entries if entry[1] is not None]
+    assert evaluator is not None
     for index in range(len(completed_entries), len(prompt_records)):
         prompt, source_line = prompt_records[index]
         try:

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -3077,7 +3077,7 @@ def best_of_n(
     from soup_cli.utils import best_of_n_checkpoint as bon_checkpoint
     from soup_cli.utils import best_of_n_artifact as bon_artifact
     from soup_cli.utils.magpie import make_magpie_generate_fn
-    from soup_cli.utils.paths import atomic_write_text, enforce_under_cwd_and_no_symlink
+    from soup_cli.utils.paths import atomic_write_bytes, enforce_under_cwd_and_no_symlink
     from soup_cli.utils.trust_remote import (
         model_requires_trust_remote_code,
         resolve_trust_remote_code,
@@ -3115,10 +3115,13 @@ def best_of_n(
                 revision,
                 trust_remote_code,
                 seed != 0,
+                n != 8,
+                temperature != 1.0,
+                max_new_tokens != 256,
             )
         ):
             console.print(
-                "[red]offline materialization does not accept sampler or judge options[/]"
+                "[red]offline materialization does not accept sampling or judge options[/]"
             )
             raise typer.Exit(2)
         if not output and not plan_only:
@@ -3159,12 +3162,14 @@ def best_of_n(
         if plan_only:
             return
         try:
-            atomic_write_text(
-                bon_artifact.stable_jsonl(sft_rows), output, field="output"
+            atomic_write_bytes(
+                bon_artifact.stable_jsonl(sft_rows).encode("utf-8"),
+                output,
+                field="output",
             )
             if emit_pairs:
-                atomic_write_text(
-                    bon_artifact.stable_jsonl(dpo_rows),
+                atomic_write_bytes(
+                    bon_artifact.stable_jsonl(dpo_rows).encode("utf-8"),
                     emit_pairs,
                     field="emit-pairs",
                 )
@@ -3417,8 +3422,10 @@ def best_of_n(
                         prompt, index, candidates, sampler_spec
                     )
                 )
-            atomic_write_text(
-                bon_artifact.candidate_artifact_text(groups, sampler_spec),
+            atomic_write_bytes(
+                bon_artifact.candidate_artifact_text(groups, sampler_spec).encode(
+                    "utf-8"
+                ),
                 export_candidates,
                 field="export-candidates",
             )

--- a/src/soup_cli/utils/best_of_n_artifact.py
+++ b/src/soup_cli/utils/best_of_n_artifact.py
@@ -56,12 +56,13 @@ def _validate_sampler(sampler: Any) -> dict:
     max_new_tokens = sampler.get("max_new_tokens")
     if isinstance(n, bool) or not isinstance(n, int) or not 2 <= n <= 64:
         raise ValueError("candidate sampler n is invalid")
-    if (
-        isinstance(temperature, bool)
-        or not isinstance(temperature, (int, float))
-        or not math.isfinite(float(temperature))
-        or not 0 <= float(temperature) <= 2
-    ):
+    if isinstance(temperature, bool) or not isinstance(temperature, (int, float)):
+        raise ValueError("candidate sampler temperature is invalid")
+    try:
+        temperature_value = float(temperature)
+    except (OverflowError, ValueError) as exc:
+        raise ValueError("candidate sampler temperature is invalid") from exc
+    if not math.isfinite(temperature_value) or not 0 <= temperature_value <= 2:
         raise ValueError("candidate sampler temperature is invalid")
     if (
         isinstance(max_new_tokens, bool)

--- a/src/soup_cli/utils/best_of_n_artifact.py
+++ b/src/soup_cli/utils/best_of_n_artifact.py
@@ -1,0 +1,334 @@
+"""Content-addressed artifacts for two-phase Best-of-N workflows."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import ntpath
+import os
+import re
+import stat
+from typing import Any
+
+from soup_cli.utils.paths import enforce_under_cwd_and_no_symlink
+
+_CANDIDATE_SCHEMA = "soup.best_of_n.candidates.v1"
+_VERIFIER_VALUE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 ._-]{0,127}$")
+
+
+def _canonical(value: Any) -> bytes:
+    return json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+
+
+def _sha(value: Any) -> str:
+    data = value if isinstance(value, bytes) else _canonical(value)
+    return hashlib.sha256(data).hexdigest()
+
+
+def _validate_sampler(sampler: Any) -> dict:
+    if not isinstance(sampler, dict):
+        raise ValueError("candidate sampler specification must be an object")
+    kind = sampler.get("kind")
+    common = {"kind", "model", "n", "temperature", "max_new_tokens"}
+    expected = (
+        common | {"provider"}
+        if kind == "provider"
+        else common | {"revision", "device", "seed", "trust_remote_code"}
+    )
+    if kind not in {"provider", "local"} or set(sampler) != expected:
+        raise ValueError("candidate sampler specification has unsupported fields")
+    model = sampler.get("model")
+    if (
+        not isinstance(model, str)
+        or not model
+        or len(model) > 256
+        or os.path.isabs(model)
+        or ntpath.isabs(model)
+        or "\\" in model
+        or model.startswith(("./", "../", "~/"))
+    ):
+        raise ValueError("candidate sampler model must be a public identifier")
+    n = sampler.get("n")
+    temperature = sampler.get("temperature")
+    max_new_tokens = sampler.get("max_new_tokens")
+    if isinstance(n, bool) or not isinstance(n, int) or not 2 <= n <= 64:
+        raise ValueError("candidate sampler n is invalid")
+    if (
+        isinstance(temperature, bool)
+        or not isinstance(temperature, (int, float))
+        or not math.isfinite(float(temperature))
+        or not 0 <= float(temperature) <= 2
+    ):
+        raise ValueError("candidate sampler temperature is invalid")
+    if (
+        isinstance(max_new_tokens, bool)
+        or not isinstance(max_new_tokens, int)
+        or not 1 <= max_new_tokens <= 4096
+    ):
+        raise ValueError("candidate sampler max_new_tokens is invalid")
+    if kind == "provider":
+        if sampler.get("provider") not in {"ollama", "vllm"}:
+            raise ValueError("candidate sampler provider is invalid")
+    else:
+        revision = sampler.get("revision")
+        if (
+            not isinstance(revision, str)
+            or not revision
+            or len(revision) > 256
+            or os.path.isabs(revision)
+            or ntpath.isabs(revision)
+            or "\\" in revision
+            or revision.startswith(("./", "../", "~/"))
+        ):
+            raise ValueError("candidate sampler revision is invalid")
+        device = sampler.get("device")
+        if not isinstance(device, str) or not re.fullmatch(
+            r"(?:auto|cpu|mps|cuda(?::\d+)?)", device
+        ):
+            raise ValueError("candidate sampler device is invalid")
+        seed = sampler.get("seed")
+        if isinstance(seed, bool) or not isinstance(seed, int):
+            raise ValueError("candidate sampler seed is invalid")
+        if not isinstance(sampler.get("trust_remote_code"), bool):
+            raise ValueError("candidate sampler trust flag is invalid")
+    return sampler
+
+
+def build_candidate_group(
+    prompt: str, prompt_index: int, candidates: list[str], sampler: dict
+) -> dict:
+    """Build one self-validating, ordered candidate group."""
+    sampler = _validate_sampler(sampler)
+    if len(candidates) != sampler["n"] or not all(
+        isinstance(candidate, str) for candidate in candidates
+    ):
+        raise ValueError("sampled candidates do not match the sampler specification")
+    prompt_id = _sha({"prompt_index": prompt_index, "prompt": prompt})
+    candidate_records = [
+        {"index": index, "text": text, "sha256": _sha(text.encode("utf-8"))}
+        for index, text in enumerate(candidates)
+    ]
+    core = {
+        "prompt_index": prompt_index,
+        "prompt_id": prompt_id,
+        "prompt_sha256": _sha(prompt.encode("utf-8")),
+        "prompt": prompt,
+        "candidates": candidate_records,
+        "sampler": sampler,
+    }
+    return {**core, "group_digest": _sha(core)}
+
+
+def candidate_artifact_text(groups: list[dict], sampler: dict) -> str:
+    sampler = _validate_sampler(sampler)
+    header = {
+        "_best_of_n_candidates": {
+            "schema": _CANDIDATE_SCHEMA,
+            "prompt_count": len(groups),
+            "sampler": sampler,
+        }
+    }
+    return "".join(
+        json.dumps(row, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
+        for row in [header, *groups]
+    )
+
+
+def _read_regular(path: str, field: str) -> bytes:
+    enforce_under_cwd_and_no_symlink(path, field)
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_BINARY", 0)
+    fd = os.open(path, flags)
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            raise ValueError(f"{field} must be a regular file")
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(fd, 1024 * 1024)
+            if not chunk:
+                return b"".join(chunks)
+            chunks.append(chunk)
+    finally:
+        os.close(fd)
+
+
+def _jsonl(data: bytes, field: str) -> list[dict]:
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"{field} must be UTF-8") from exc
+    rows = []
+    for line_number, raw in enumerate(text.splitlines(), 1):
+        if not raw.strip():
+            continue
+        try:
+            row = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{field} has invalid JSON on line {line_number}") from exc
+        if not isinstance(row, dict):
+            raise ValueError(f"{field} line {line_number} must be an object")
+        rows.append(row)
+    return rows
+
+
+def load_candidate_artifact(path: str) -> tuple[list[dict], dict, str]:
+    """Authenticate every group and return groups, public sampler spec, file hash."""
+    data = _read_regular(path, "--candidate-artifact path")
+    rows = _jsonl(data, "candidate artifact")
+    if not rows:
+        raise ValueError("candidate artifact is empty")
+    header = rows[0].get("_best_of_n_candidates")
+    if not isinstance(header, dict) or header.get("schema") != _CANDIDATE_SCHEMA:
+        raise ValueError("candidate artifact header or schema is invalid")
+    sampler = _validate_sampler(header.get("sampler"))
+    groups = rows[1:]
+    if not isinstance(sampler, dict) or header.get("prompt_count") != len(groups):
+        raise ValueError("candidate artifact header does not match its groups")
+    if not groups:
+        raise ValueError("candidate artifact contains no prompt groups")
+    seen_ids: set[str] = set()
+    for index, group in enumerate(groups):
+        if group.get("prompt_index") != index or not isinstance(group.get("prompt"), str):
+            raise ValueError("candidate groups must be sequential")
+        prompt = group["prompt"]
+        expected_id = _sha({"prompt_index": index, "prompt": prompt})
+        if group.get("prompt_id") != expected_id or expected_id in seen_ids:
+            raise ValueError(f"candidate group {index} has an invalid prompt id")
+        seen_ids.add(expected_id)
+        if group.get("prompt_sha256") != _sha(prompt.encode("utf-8")):
+            raise ValueError(f"candidate group {index} has a prompt digest mismatch")
+        candidates = group.get("candidates")
+        if not isinstance(candidates, list) or len(candidates) != sampler["n"]:
+            raise ValueError(f"candidate group {index} has the wrong candidate count")
+        for candidate_index, candidate in enumerate(candidates):
+            if not isinstance(candidate, dict) or candidate.get("index") != candidate_index:
+                raise ValueError(f"candidate group {index} has unordered candidates")
+            text = candidate.get("text")
+            if not isinstance(text, str) or candidate.get("sha256") != _sha(text.encode("utf-8")):
+                raise ValueError(f"candidate group {index} has a candidate digest mismatch")
+        core = {key: value for key, value in group.items() if key != "group_digest"}
+        if group.get("sampler") != sampler or group.get("group_digest") != _sha(core):
+            raise ValueError(f"candidate group {index} has a group digest mismatch")
+    return groups, sampler, _sha(data)
+
+
+def _verifier(value: Any, index: int) -> dict[str, str]:
+    if not isinstance(value, dict) or "name" not in value:
+        raise ValueError(f"judgment {index} needs verifier.name")
+    if set(value) - {"name", "version", "method"}:
+        raise ValueError(f"judgment {index} has unsupported verifier fields")
+    clean: dict[str, str] = {}
+    for key, item in value.items():
+        if not isinstance(item, str) or not _VERIFIER_VALUE.fullmatch(item):
+            raise ValueError(f"judgment {index} has an invalid verifier {key}")
+        clean[key] = item
+    return clean
+
+
+def load_judgments(path: str, groups: list[dict]) -> tuple[list[dict], str]:
+    """Validate complete one-to-one judgments against exact candidate groups."""
+    data = _read_regular(path, "--judgments path")
+    rows = _jsonl(data, "judgments")
+    by_prompt: dict[str, dict] = {}
+    for index, row in enumerate(rows):
+        prompt_id = row.get("prompt_id")
+        if not isinstance(prompt_id, str) or prompt_id in by_prompt:
+            raise ValueError("judgments contain a missing or duplicate prompt_id")
+        by_prompt[prompt_id] = row
+    if set(by_prompt) != {group["prompt_id"] for group in groups}:
+        raise ValueError("judgments must cover every candidate group exactly once")
+
+    validated = []
+    for index, group in enumerate(groups):
+        row = by_prompt[group["prompt_id"]]
+        if row.get("group_digest") != group["group_digest"]:
+            raise ValueError(f"judgment {index} has a candidate digest mismatch")
+        winner_idx = row.get("winner_idx")
+        candidates = group["candidates"]
+        if isinstance(winner_idx, bool) or not isinstance(winner_idx, int):
+            raise ValueError(f"judgment {index} winner_idx must be an integer")
+        if not 0 <= winner_idx < len(candidates):
+            raise ValueError(f"judgment {index} winner_idx is out of range")
+        scores = row.get("scores")
+        if not isinstance(scores, list) or len(scores) != len(candidates):
+            raise ValueError(f"judgment {index} scores must match candidate count")
+        clean_scores = []
+        for score in scores:
+            if isinstance(score, bool) or not isinstance(score, (int, float)):
+                raise ValueError(f"judgment {index} scores must be numeric")
+            number = float(score)
+            if not math.isfinite(number):
+                raise ValueError(f"judgment {index} scores must be finite")
+            clean_scores.append(number)
+        expected_winner = max(range(len(clean_scores)), key=clean_scores.__getitem__)
+        if winner_idx != expected_winner:
+            raise ValueError(f"judgment {index} winner_idx does not match its scores")
+        validated.append(
+            {
+                "prompt_id": group["prompt_id"],
+                "group_digest": group["group_digest"],
+                "winner_idx": winner_idx,
+                "scores": clean_scores,
+                "verifier": _verifier(row.get("verifier"), index),
+            }
+        )
+    return validated, _sha(data)
+
+
+def materialize_rows(
+    groups: list[dict],
+    judgments: list[dict],
+    *,
+    sampler: dict,
+    candidate_artifact_sha256: str,
+    judgments_sha256: str,
+) -> tuple[list[dict], list[dict]]:
+    """Produce byte-stable SFT and DPO rows from authenticated offline inputs."""
+    sft_rows = []
+    dpo_rows = []
+    for group, judgment in zip(groups, judgments):
+        candidates = group["candidates"]
+        winner_idx = judgment["winner_idx"]
+        loser_idx = min(range(len(candidates)), key=judgment["scores"].__getitem__)
+        provenance = {
+            "mode": "offline",
+            "n": len(candidates),
+            "winner_idx": winner_idx,
+            "scores": judgment["scores"],
+            "prompt_id": group["prompt_id"],
+            "candidate_group_digest": group["group_digest"],
+            "candidate_artifact_sha256": candidate_artifact_sha256,
+            "judgments_sha256": judgments_sha256,
+            "sampler": sampler,
+            "verifier": judgment["verifier"],
+        }
+        prompt = group["prompt"]
+        winner = candidates[winner_idx]["text"]
+        sft_rows.append(
+            {
+                "messages": [
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": winner},
+                ],
+                "_best_of_n": provenance,
+            }
+        )
+        if loser_idx != winner_idx:
+            dpo_rows.append(
+                {
+                    "prompt": prompt,
+                    "chosen": winner,
+                    "rejected": candidates[loser_idx]["text"],
+                    "_best_of_n": provenance,
+                }
+            )
+    return sft_rows, dpo_rows
+
+
+def stable_jsonl(rows: list[dict]) -> str:
+    return "".join(
+        json.dumps(row, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
+        for row in rows
+    )

--- a/src/soup_cli/utils/best_of_n_artifact.py
+++ b/src/soup_cli/utils/best_of_n_artifact.py
@@ -258,7 +258,10 @@ def load_judgments(path: str, groups: list[dict]) -> tuple[list[dict], str]:
         for score in scores:
             if isinstance(score, bool) or not isinstance(score, (int, float)):
                 raise ValueError(f"judgment {index} scores must be numeric")
-            number = float(score)
+            try:
+                number = float(score)
+            except (OverflowError, ValueError) as exc:
+                raise ValueError(f"judgment {index} scores must be finite") from exc
             if not math.isfinite(number):
                 raise ValueError(f"judgment {index} scores must be finite")
             clean_scores.append(number)

--- a/src/soup_cli/utils/best_of_n_artifact.py
+++ b/src/soup_cli/utils/best_of_n_artifact.py
@@ -98,10 +98,21 @@ def _validate_sampler(sampler: Any) -> dict:
 
 
 def build_candidate_group(
-    prompt: str, prompt_index: int, candidates: list[str], sampler: dict
+    prompt: str,
+    prompt_index: int,
+    candidates: list[str],
+    sampler: dict,
+    *,
+    source_line: int,
 ) -> dict:
     """Build one self-validating, ordered candidate group."""
     sampler = _validate_sampler(sampler)
+    if (
+        isinstance(source_line, bool)
+        or not isinstance(source_line, int)
+        or source_line < 1
+    ):
+        raise ValueError("candidate source line must be a positive integer")
     if len(candidates) != sampler["n"] or not all(
         isinstance(candidate, str) for candidate in candidates
     ):
@@ -113,6 +124,7 @@ def build_candidate_group(
     ]
     core = {
         "prompt_index": prompt_index,
+        "source_line": source_line,
         "prompt_id": prompt_id,
         "prompt_sha256": _sha(prompt.encode("utf-8")),
         "prompt": prompt,
@@ -192,6 +204,13 @@ def load_candidate_artifact(path: str) -> tuple[list[dict], dict, str]:
     for index, group in enumerate(groups):
         if group.get("prompt_index") != index or not isinstance(group.get("prompt"), str):
             raise ValueError("candidate groups must be sequential")
+        source_line = group.get("source_line")
+        if (
+            isinstance(source_line, bool)
+            or not isinstance(source_line, int)
+            or source_line < 1
+        ):
+            raise ValueError(f"candidate group {index} has an invalid source line")
         prompt = group["prompt"]
         expected_id = _sha({"prompt_index": index, "prompt": prompt})
         if group.get("prompt_id") != expected_id or expected_id in seen_ids:
@@ -298,6 +317,7 @@ def materialize_rows(
         provenance = {
             "mode": "offline",
             "n": len(candidates),
+            "source_line": group["source_line"],
             "winner_idx": winner_idx,
             "scores": judgment["scores"],
             "prompt_id": group["prompt_id"],

--- a/src/soup_cli/utils/paths.py
+++ b/src/soup_cli/utils/paths.py
@@ -149,3 +149,105 @@ def atomic_write_bytes(
             except OSError:
                 pass
     return os.path.realpath(output_path)
+
+
+def atomic_write_bytes_group(outputs: list[tuple[bytes, str, str]]) -> list[str]:
+    """Publish a group of byte outputs atomically as one logical generation.
+
+    Every payload is staged before an existing target is moved aside. If any
+    replacement fails, newly published targets are removed and every previous
+    target is restored. This gives multi-file commands an all-new-or-all-old
+    result instead of exposing a partial generation.
+    """
+    if not isinstance(outputs, list) or not outputs:
+        raise ValueError("outputs must be a non-empty list")
+
+    prepared: list[tuple[bytes, str, str]] = []
+    identities: set[str] = set()
+    for item in outputs:
+        if not isinstance(item, tuple) or len(item) != 3:
+            raise TypeError("each output must be a (data, path, field) tuple")
+        data, output_path, field = item
+        if not isinstance(data, (bytes, bytearray)):
+            raise TypeError("output data must be bytes")
+        enforce_under_cwd_and_no_symlink(output_path, field)
+        identity = os.path.normcase(os.path.realpath(output_path))
+        if identity in identities:
+            raise ValueError("output paths must be distinct")
+        identities.add(identity)
+        prepared.append((bytes(data), output_path, field))
+
+    staged: dict[str, str] = {}
+    backups: dict[str, str] = {}
+    committed: set[str] = set()
+    try:
+        for data, output_path, _field in prepared:
+            parent = os.path.dirname(os.path.abspath(output_path)) or "."
+            os.makedirs(parent, exist_ok=True)
+            fd, tmp_path = tempfile.mkstemp(
+                prefix=".soup.group.", suffix=".tmp", dir=parent
+            )
+            try:
+                with os.fdopen(fd, "wb") as fh:
+                    fh.write(data)
+            except Exception:
+                if os.path.exists(tmp_path):
+                    os.unlink(tmp_path)
+                raise
+            staged[output_path] = tmp_path
+
+        for _data, output_path, field in prepared:
+            if not os.path.lexists(output_path):
+                continue
+            st = os.lstat(output_path)
+            if not stat.S_ISREG(st.st_mode):
+                raise ValueError(f"{field} must be a regular file")
+            parent = os.path.dirname(os.path.abspath(output_path)) or "."
+            fd, backup_path = tempfile.mkstemp(
+                prefix=".soup.backup.", suffix=".tmp", dir=parent
+            )
+            os.close(fd)
+            try:
+                os.replace(output_path, backup_path)
+            except Exception:
+                os.unlink(backup_path)
+                raise
+            backups[output_path] = backup_path
+
+        for _data, output_path, _field in prepared:
+            os.replace(staged[output_path], output_path)
+            committed.add(output_path)
+            del staged[output_path]
+    except Exception as exc:
+        rollback_failed = False
+        for output_path in committed:
+            if output_path in backups:
+                continue
+            try:
+                os.unlink(output_path)
+            except FileNotFoundError:
+                pass
+            except OSError:
+                rollback_failed = True
+        for output_path, backup_path in backups.items():
+            try:
+                os.replace(backup_path, output_path)
+            except OSError:
+                rollback_failed = True
+        if rollback_failed:
+            raise OSError("failed to restore a previous output generation") from exc
+        raise
+    finally:
+        for tmp_path in staged.values():
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+
+    for backup_path in backups.values():
+        try:
+            os.unlink(backup_path)
+        except FileNotFoundError:
+            pass
+
+    return [os.path.realpath(output_path) for _data, output_path, _field in prepared]

--- a/tests/test_issue550_bon_offline.py
+++ b/tests/test_issue550_bon_offline.py
@@ -162,6 +162,7 @@ def test_offline_materialization_never_constructs_sampler_or_judge_and_is_stable
         ("duplicate", "missing or duplicate"),
         ("out-of-range", "out of range"),
         ("non-finite", "finite"),
+        ("integer-overflow", "finite"),
         ("digest", "candidate digest mismatch"),
     ],
 )
@@ -182,6 +183,8 @@ def test_invalid_offline_judgments_fail_before_publication(
         rows[0]["winner_idx"] = 2
     elif mutation == "non-finite":
         rows[0]["scores"][0] = float("nan")
+    elif mutation == "integer-overflow":
+        rows[0]["scores"][0] = 10**4000
     elif mutation == "digest":
         rows[0]["group_digest"] = "0" * 64
     judgment_path.write_text(
@@ -205,6 +208,58 @@ def test_invalid_offline_judgments_fail_before_publication(
     assert result.exit_code == 2, (result.output, repr(result.exception))
     assert match in result.output
     assert not output.exists()
+
+
+@pytest.mark.parametrize("preexisting", [False, True])
+def test_dpo_write_failure_rolls_back_the_complete_publication(
+    tmp_path, monkeypatch, preexisting
+):
+    from soup_cli.commands.data import app
+
+    artifact, _calls = _export_candidates(tmp_path, monkeypatch)
+    groups = _artifact_groups(artifact)
+    judgments = tmp_path / "judgments.jsonl"
+    _write_judgments(judgments, groups)
+    sft = tmp_path / "sft.jsonl"
+    dpo = tmp_path / "dpo.jsonl"
+    if preexisting:
+        sft.write_bytes(b"previous-sft\n")
+        dpo.write_bytes(b"previous-dpo\n")
+
+    real_replace = __import__("os").replace
+    failed = False
+
+    def fail_first_dpo_commit(source, destination):
+        nonlocal failed
+        if not failed and destination == str(dpo):
+            failed = True
+            raise OSError("injected DPO publication failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr("os.replace", fail_first_dpo_commit)
+    result = CliRunner().invoke(
+        app,
+        [
+            "best-of-n",
+            "--candidate-artifact",
+            str(artifact),
+            "--judgments",
+            str(judgments),
+            "--output",
+            str(sft),
+            "--emit-pairs",
+            str(dpo),
+        ],
+    )
+
+    assert result.exit_code == 1, (result.output, repr(result.exception))
+    assert "Failed to write output" in result.output
+    if preexisting:
+        assert sft.read_bytes() == b"previous-sft\n"
+        assert dpo.read_bytes() == b"previous-dpo\n"
+    else:
+        assert not sft.exists()
+        assert not dpo.exists()
 
 
 def test_local_export_records_revision_and_seed_without_exposing_local_path(

--- a/tests/test_issue550_bon_offline.py
+++ b/tests/test_issue550_bon_offline.py
@@ -270,6 +270,59 @@ def test_online_workflow_still_requires_judge(tmp_path, monkeypatch):
     assert "--judge is required" in result.output
 
 
+def test_offline_mode_rejects_irrelevant_sampling_overrides(tmp_path, monkeypatch):
+    from soup_cli.commands.data import app
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(
+        app,
+        [
+            "best-of-n",
+            "--candidate-artifact",
+            str(tmp_path / "candidates.jsonl"),
+            "--judgments",
+            str(tmp_path / "judgments.jsonl"),
+            "--output",
+            str(tmp_path / "sft.jsonl"),
+            "--n",
+            "9",
+        ],
+    )
+    assert result.exit_code == 2
+    assert "does not accept sampling" in result.output
+    assert "Invalid offline artifact" not in result.output
+
+
+def test_two_phase_artifacts_use_exact_utf8_byte_writes(tmp_path, monkeypatch):
+    from soup_cli.commands.data import app
+
+    monkeypatch.setattr(
+        "soup_cli.utils.paths.atomic_write_text",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("Best-of-N JSONL must use exact UTF-8 byte writes")
+        ),
+    )
+    artifact, _calls = _export_candidates(tmp_path, monkeypatch)
+    groups = _artifact_groups(artifact)
+    judgments = tmp_path / "judgments.jsonl"
+    _write_judgments(judgments, groups)
+    result = CliRunner().invoke(
+        app,
+        [
+            "best-of-n",
+            "--candidate-artifact",
+            str(artifact),
+            "--judgments",
+            str(judgments),
+            "--output",
+            str(tmp_path / "sft.jsonl"),
+            "--emit-pairs",
+            str(tmp_path / "dpo.jsonl"),
+        ],
+    )
+    assert result.exit_code == 0, (result.output, repr(result.exception))
+
+
 def test_candidate_text_tampering_is_detected_before_publication(tmp_path, monkeypatch):
     from soup_cli.commands.data import app
 

--- a/tests/test_issue550_bon_offline.py
+++ b/tests/test_issue550_bon_offline.py
@@ -1,0 +1,299 @@
+"""Regression tests for #550: artifact-mediated offline Best-of-N."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+
+def _export_candidates(tmp_path, monkeypatch, prompts=("question one", "question two")):
+    from soup_cli.commands.data import app
+
+    monkeypatch.chdir(tmp_path)
+    prompt_path = tmp_path / "prompts.jsonl"
+    prompt_path.write_text(
+        "".join(json.dumps({"prompt": prompt}) + "\n" for prompt in prompts),
+        encoding="utf-8",
+    )
+    calls = []
+
+    def factory(*_args, **_kwargs):
+        def generate(prompt):
+            calls.append(prompt)
+            return f"candidate-{len(calls)}"
+
+        return generate
+
+    monkeypatch.setattr("soup_cli.utils.magpie.make_magpie_generate_fn", factory)
+    monkeypatch.setattr(
+        "soup_cli.commands.data._load_bon_model",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("provider export must not load a local model")
+        ),
+    )
+    artifact = tmp_path / "candidates.jsonl"
+    result = CliRunner().invoke(
+        app,
+        [
+            "best-of-n",
+            "--provider",
+            "ollama",
+            "--model",
+            "sampler-model",
+            "--base-url",
+            "http://localhost:11434/private-route",
+            "--prompts",
+            str(prompt_path),
+            "--n",
+            "2",
+            "--export-candidates",
+            str(artifact),
+        ],
+    )
+    assert result.exit_code == 0, (result.output, repr(result.exception))
+    return artifact, calls
+
+
+def _artifact_groups(artifact):
+    return [json.loads(line) for line in artifact.read_text().splitlines()][1:]
+
+
+def _write_judgments(path, groups):
+    rows = [
+        {
+            "prompt_id": group["prompt_id"],
+            "group_digest": group["group_digest"],
+            "winner_idx": 1,
+            "scores": [0.25, 0.75],
+            "verifier": {"name": "Codex", "version": "offline-v1"},
+        }
+        for group in groups
+    ]
+    path.write_text(
+        "".join(json.dumps(row, allow_nan=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+    return rows
+
+
+def test_candidate_export_needs_no_judge_and_preserves_order_and_digests(
+    tmp_path, monkeypatch
+):
+    artifact, calls = _export_candidates(tmp_path, monkeypatch)
+    assert calls == ["question one", "question one", "question two", "question two"]
+    records = [json.loads(line) for line in artifact.read_text().splitlines()]
+    header = records[0]["_best_of_n_candidates"]
+    assert header["schema"] == "soup.best_of_n.candidates.v1"
+    assert header["sampler"] == {
+        "kind": "provider",
+        "provider": "ollama",
+        "model": "sampler-model",
+        "n": 2,
+        "temperature": 1.0,
+        "max_new_tokens": 256,
+    }
+    assert [candidate["index"] for candidate in records[1]["candidates"]] == [0, 1]
+    assert [candidate["text"] for candidate in records[1]["candidates"]] == [
+        "candidate-1",
+        "candidate-2",
+    ]
+    text = artifact.read_text()
+    assert "base_url" not in text
+    assert str(tmp_path) not in text
+
+
+def test_offline_materialization_never_constructs_sampler_or_judge_and_is_stable(
+    tmp_path, monkeypatch
+):
+    from soup_cli.commands.data import app
+
+    artifact, _calls = _export_candidates(tmp_path, monkeypatch)
+    groups = _artifact_groups(artifact)
+    judgments = tmp_path / "judgments.jsonl"
+    _write_judgments(judgments, groups)
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("offline materialization attempted model or network setup")
+
+    monkeypatch.setattr("soup_cli.commands.data._load_bon_model", forbidden)
+    monkeypatch.setattr("soup_cli.eval.judge.JudgeEvaluator", forbidden)
+    monkeypatch.setattr("soup_cli.utils.magpie.make_magpie_generate_fn", forbidden)
+
+    outputs = []
+    for suffix in ("a", "b"):
+        sft = tmp_path / f"sft-{suffix}.jsonl"
+        dpo = tmp_path / f"dpo-{suffix}.jsonl"
+        result = CliRunner().invoke(
+            app,
+            [
+                "best-of-n",
+                "--candidate-artifact",
+                str(artifact),
+                "--judgments",
+                str(judgments),
+                "--output",
+                str(sft),
+                "--emit-pairs",
+                str(dpo),
+            ],
+        )
+        assert result.exit_code == 0, (result.output, repr(result.exception))
+        outputs.append((sft.read_bytes(), dpo.read_bytes()))
+    assert outputs[0] == outputs[1]
+
+    sft_row = json.loads(outputs[0][0].splitlines()[0])
+    dpo_row = json.loads(outputs[0][1].splitlines()[0])
+    provenance = sft_row["_best_of_n"]
+    assert provenance["mode"] == "offline"
+    assert provenance["sampler"]["model"] == "sampler-model"
+    assert provenance["verifier"] == {"name": "Codex", "version": "offline-v1"}
+    assert len(provenance["candidate_artifact_sha256"]) == 64
+    assert len(provenance["judgments_sha256"]) == 64
+    assert dpo_row["_best_of_n"] == provenance
+    assert str(tmp_path) not in outputs[0][0].decode()
+
+
+@pytest.mark.parametrize(
+    "mutation,match",
+    [
+        ("missing", "cover every candidate group"),
+        ("duplicate", "missing or duplicate"),
+        ("out-of-range", "out of range"),
+        ("non-finite", "finite"),
+        ("digest", "candidate digest mismatch"),
+    ],
+)
+def test_invalid_offline_judgments_fail_before_publication(
+    tmp_path, monkeypatch, mutation, match
+):
+    from soup_cli.commands.data import app
+
+    artifact, _calls = _export_candidates(tmp_path, monkeypatch)
+    groups = _artifact_groups(artifact)
+    judgment_path = tmp_path / "judgments.jsonl"
+    rows = _write_judgments(judgment_path, groups)
+    if mutation == "missing":
+        rows = rows[:-1]
+    elif mutation == "duplicate":
+        rows.append(dict(rows[0]))
+    elif mutation == "out-of-range":
+        rows[0]["winner_idx"] = 2
+    elif mutation == "non-finite":
+        rows[0]["scores"][0] = float("nan")
+    elif mutation == "digest":
+        rows[0]["group_digest"] = "0" * 64
+    judgment_path.write_text(
+        "".join(json.dumps(row, allow_nan=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+    output = tmp_path / "must-not-exist.jsonl"
+    result = CliRunner().invoke(
+        app,
+        [
+            "best-of-n",
+            "--candidate-artifact",
+            str(artifact),
+            "--judgments",
+            str(judgment_path),
+            "--output",
+            str(output),
+        ],
+    )
+    assert result.exit_code == 2, (result.output, repr(result.exception))
+    assert match in result.output
+    assert not output.exists()
+
+
+def test_local_export_records_revision_and_seed_without_exposing_local_path(
+    tmp_path, monkeypatch
+):
+    from soup_cli.commands.data import app
+
+    monkeypatch.chdir(tmp_path)
+    model_dir = tmp_path / "private-user-model"
+    model_dir.mkdir()
+    prompts = tmp_path / "prompts.jsonl"
+    prompts.write_text('{"prompt":"q"}\n', encoding="utf-8")
+    load_calls = []
+    monkeypatch.setattr(
+        "soup_cli.commands.data._load_bon_model",
+        lambda *args, **kwargs: (load_calls.append((args, kwargs)) or (object(), object())),
+    )
+    monkeypatch.setattr(
+        "soup_cli.utils.best_of_n.sample_candidates",
+        lambda *_args, **_kwargs: ["a", "b"],
+    )
+    artifact = tmp_path / "local-candidates.jsonl"
+    result = CliRunner().invoke(
+        app,
+        [
+            "best-of-n",
+            "--base",
+            str(model_dir),
+            "--revision",
+            "abc123",
+            "--seed",
+            "42",
+            "--prompts",
+            str(prompts),
+            "--n",
+            "2",
+            "--export-candidates",
+            str(artifact),
+        ],
+    )
+    assert result.exit_code == 0, (result.output, repr(result.exception))
+    assert load_calls[0][1] == {"revision": "abc123"}
+    sampler = json.loads(artifact.read_text().splitlines()[0])[
+        "_best_of_n_candidates"
+    ]["sampler"]
+    assert sampler["model"] == "<local-model>"
+    assert sampler["revision"] == "abc123"
+    assert sampler["seed"] == 42
+    assert str(tmp_path) not in artifact.read_text()
+
+
+def test_online_workflow_still_requires_judge(tmp_path, monkeypatch):
+    from soup_cli.commands.data import app
+
+    monkeypatch.chdir(tmp_path)
+    prompts = tmp_path / "prompts.jsonl"
+    prompts.write_text('{"prompt":"q"}\n', encoding="utf-8")
+    result = CliRunner().invoke(
+        app,
+        ["best-of-n", "--base", "model", "--prompts", str(prompts), "--plan-only"],
+    )
+    assert result.exit_code == 2
+    assert "--judge is required" in result.output
+
+
+def test_candidate_text_tampering_is_detected_before_publication(tmp_path, monkeypatch):
+    from soup_cli.commands.data import app
+
+    artifact, _calls = _export_candidates(tmp_path, monkeypatch)
+    groups = _artifact_groups(artifact)
+    judgments = tmp_path / "judgments.jsonl"
+    _write_judgments(judgments, groups)
+    artifact.write_text(
+        artifact.read_text().replace("candidate-1", "tampered-candidate"),
+        encoding="utf-8",
+    )
+    output = tmp_path / "must-not-exist.jsonl"
+    result = CliRunner().invoke(
+        app,
+        [
+            "best-of-n",
+            "--candidate-artifact",
+            str(artifact),
+            "--judgments",
+            str(judgments),
+            "--output",
+            str(output),
+        ],
+    )
+    assert result.exit_code == 2, (result.output, repr(result.exception))
+    assert "candidate digest mismatch" in result.output
+    assert not output.exists()

--- a/tests/test_issue550_bon_offline.py
+++ b/tests/test_issue550_bon_offline.py
@@ -99,6 +99,7 @@ def test_candidate_export_needs_no_judge_and_preserves_order_and_digests(
         "candidate-1",
         "candidate-2",
     ]
+    assert [group["source_line"] for group in records[1:]] == [1, 2]
     text = artifact.read_text()
     assert "base_url" not in text
     assert str(tmp_path) not in text
@@ -147,6 +148,7 @@ def test_offline_materialization_never_constructs_sampler_or_judge_and_is_stable
     dpo_row = json.loads(outputs[0][1].splitlines()[0])
     provenance = sft_row["_best_of_n"]
     assert provenance["mode"] == "offline"
+    assert provenance["source_line"] == 1
     assert provenance["sampler"]["model"] == "sampler-model"
     assert provenance["verifier"] == {"name": "Codex", "version": "offline-v1"}
     assert len(provenance["candidate_artifact_sha256"]) == 64

--- a/tests/test_issue550_bon_offline.py
+++ b/tests/test_issue550_bon_offline.py
@@ -105,6 +105,23 @@ def test_candidate_export_needs_no_judge_and_preserves_order_and_digests(
     assert str(tmp_path) not in text
 
 
+def test_sampler_temperature_integer_overflow_is_a_controlled_validation_error(
+    tmp_path, monkeypatch
+):
+    from soup_cli.utils.best_of_n_artifact import load_candidate_artifact
+
+    artifact, _calls = _export_candidates(tmp_path, monkeypatch)
+    records = [json.loads(line) for line in artifact.read_text().splitlines()]
+    records[0]["_best_of_n_candidates"]["sampler"]["temperature"] = 10**4000
+    artifact.write_text(
+        "".join(json.dumps(record) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="candidate sampler temperature is invalid"):
+        load_candidate_artifact(str(artifact))
+
+
 def test_offline_materialization_never_constructs_sampler_or_judge_and_is_stable(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary

- add sampling-only `--export-candidates` mode that never constructs a judge
- preserve every ordered candidate with prompt/candidate/group digests and a bounded public sampler specification
- add `--candidate-artifact` + `--judgments` materialization that never constructs a sampler, loads a model, or makes a network call
- fail closed before publication on missing/duplicate judgments, changed bindings, invalid indexes, score-count drift, non-finite scores, and winner/score disagreement
- retain candidate-artifact and judgment-file hashes plus sampler/verifier provenance in both SFT and DPO rows
- exclude endpoint URLs and local model paths from artifacts/provenance and make identical offline inputs byte-stable
- preserve the existing one-command online workflow

## Validation

- `PYTHONPATH=src pytest tests/ -q --no-cov --tb=short` (18,942 passed, 82 skipped, 5 deselected)
- focused offline-contract and changelog tests (27 passed)
- `ruff check src/soup_cli/ tests/`
- `git diff --check`
- new module passes mypy; the command module retains only its two pre-existing baseline findings

## Merge order

This is independently based on `main`, but should be merged after #551, #552, and #553. I will rebase it after those predecessors land so the online finite-score, strict-prompt, and checkpoint paths are composed cleanly.

Fixes #550
