### PR TITLE
fix(data): commit offline Best-of-N generations

### DIFF
--- a/changelog.d/0.73.3/556.fixed.md
+++ b/changelog.d/0.73.3/556.fixed.md
@@ -1,2 +1,3 @@
 - Fixed #556: offline Best-of-N now commits SFT and optional DPO outputs through a
-  final verifiable manifest, so interrupted or mismatched generations fail closed.
+  final verifiable manifest, rejects unsupported online recovery options, and
+  makes interrupted or mismatched generations fail closed.

--- a/changelog.d/0.73.3/556.fixed.md
+++ b/changelog.d/0.73.3/556.fixed.md
@@ -1,0 +1,2 @@
+- Fixed #556: offline Best-of-N now commits SFT and optional DPO outputs through a
+  final verifiable manifest, so interrupted or mismatched generations fail closed.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -345,9 +345,10 @@ local data such as a non-finite judge score remains a validation failure rather
 than being presented as a recoverable backend outage.
 
 For offline Best-of-N, the candidate and judgment artifacts are the recovery
-checkpoint. There is no offline `--resume`: rerun the exact materialization
-command after a late failure. The final manifest is written last and is the only
-commit marker; consumers must verify it and use only the SFT/DPO files it lists.
+checkpoint. Offline materialization rejects `--resume` and `--checkpoint`; rerun
+the exact materialization command after a late failure. The final manifest is
+written last and is the only commit marker; consumers must verify it and use only
+the SFT/DPO files it lists.
 
 ## Fine-tune from your coding agent (MCP)
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -303,7 +303,7 @@ soup expect <data.jsonl> <suite.yaml>         Expectations suite: PII / token-le
 soup data gen-magpie --base <m> --provider ollama|vllm --target N --output <jsonl> [--base-url <url>] [--quality-filter]  Magpie synthetic generator — live (v0.69.0; live v0.71.6)
 soup data best-of-n (--base <m> | --provider ollama|vllm --model <m> [--base-url <url>]) --prompts <jsonl> --n 8 --judge <url> -o <sft.jsonl> [--emit-pairs <dpo.jsonl>] [--resume] [--checkpoint <journal.jsonl>] [--manifest <manifest.json>]  Best-of-N rejection sampling with durable per-prompt recovery and manifest-last publication
 soup data best-of-n (--base <m> [--revision <rev>] | --provider ollama|vllm --model <m>) --prompts <jsonl> --n 8 --export-candidates <jsonl>  Sampling-only phase; no judge is constructed
-soup data best-of-n --candidate-artifact <jsonl> --judgments <jsonl> -o <sft.jsonl> [--emit-pairs <dpo.jsonl>]  Validate offline judgments and materialize byte-stable training rows without a model or network
+soup data best-of-n --candidate-artifact <jsonl> --judgments <jsonl> -o <sft.jsonl> [--emit-pairs <dpo.jsonl>] [--manifest <json>]  Validate offline judgments and materialize byte-stable training rows; a final manifest binds the requested output set
 soup data evolve --input <seeds.jsonl> --provider ollama|vllm --model <m> --strategy depth|breadth --rounds N -o <jsonl>  Evol-Instruct (WizardLM) instruction evolution (v0.71.31)
 soup data persona-mix --prompts <jsonl> --n N --output <jsonl>  Persona-Hub diversity sampler (v0.69.0)
 soup data brain-rot <data.jsonl> [--strict]   Brain-rot detector — arXiv 2510.13928 (v0.69.0)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -344,6 +344,11 @@ treat only files listed by that final manifest as committed output. Invalid
 local data such as a non-finite judge score remains a validation failure rather
 than being presented as a recoverable backend outage.
 
+For offline Best-of-N, the candidate and judgment artifacts are the recovery
+checkpoint. There is no offline `--resume`: rerun the exact materialization
+command after a late failure. The final manifest is written last and is the only
+commit marker; consumers must verify it and use only the SFT/DPO files it lists.
+
 ## Fine-tune from your coding agent (MCP)
 
 `soup mcp serve` runs a [Model Context Protocol](https://modelcontextprotocol.io)

--- a/docs/data.md
+++ b/docs/data.md
@@ -241,7 +241,11 @@ closed. It does not construct a sampler or judge. SFT and DPO rows retain the
 candidate-artifact and judgment-file digests, group id, public sampler settings,
 and bounded verifier identity. Endpoint URLs and local model paths are never
 copied into those artifacts. Reusing the same two input files produces identical
-training-row bytes.
+training-row bytes. The offline command writes `<output>.manifest.json` last (or
+the explicit `--manifest` path) and binds the exact SFT/DPO hashes, row counts,
+candidate artifact, judgment file, and whether DPO output was requested. Treat
+the manifest as the commit marker: missing or mismatched manifests identify an
+interrupted or replaced generation.
 
 ### Custom Transforms
 

--- a/docs/data.md
+++ b/docs/data.md
@@ -249,11 +249,11 @@ interrupted or replaced generation.
 
 The candidate artifact and verified judgment file are the durable recovery
 boundary for offline materialization. This phase performs no sampling, so it has
-no progress checkpoint and `--resume` does not apply: after any late write
-failure, keep those two inputs and rerun the exact offline command. Soup removes
-the previous manifest before replacing outputs and publishes the new manifest
-last. A prior, manifest-authenticated DPO beside the manifest is removed when the
-replacement run requests SFT only.
+no progress checkpoint: `--resume` and `--checkpoint` are rejected. After any
+late write failure, keep those two inputs and rerun the exact offline command.
+Soup removes the previous manifest before replacing outputs and publishes the
+new manifest last. A prior, manifest-authenticated DPO beside the manifest is
+removed when the replacement run requests SFT only.
 
 Consumers must verify the final manifest and open exactly the SFT/DPO files it
 lists. They must never discover training inputs by globbing neighboring JSONL

--- a/docs/data.md
+++ b/docs/data.md
@@ -247,6 +247,19 @@ candidate artifact, judgment file, and whether DPO output was requested. Treat
 the manifest as the commit marker: missing or mismatched manifests identify an
 interrupted or replaced generation.
 
+The candidate artifact and verified judgment file are the durable recovery
+boundary for offline materialization. This phase performs no sampling, so it has
+no progress checkpoint and `--resume` does not apply: after any late write
+failure, keep those two inputs and rerun the exact offline command. Soup removes
+the previous manifest before replacing outputs and publishes the new manifest
+last. A prior, manifest-authenticated DPO beside the manifest is removed when the
+replacement run requests SFT only.
+
+Consumers must verify the final manifest and open exactly the SFT/DPO files it
+lists. They must never discover training inputs by globbing neighboring JSONL
+files: an unlisted sidecar, including an older DPO stored elsewhere, is not part
+of the committed generation.
+
 ### Custom Transforms
 
 Use a dotted-path string (`module.path:function_name`) as the ``transform``

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -3361,6 +3361,7 @@ def best_of_n(
                 "temperature": temperature,
                 "max_new_tokens": max_new_tokens,
                 "device": device,
+                "revision": revision,
                 "seed": seed,
                 "trust_remote_code": trust,
                 "judge": judge,

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -3195,14 +3195,12 @@ def best_of_n(
                 dpo_bytes=dpo_bytes,
                 dpo_count=len(dpo_rows) if emit_pairs else 0,
             ).encode("utf-8")
-            bon_artifact.invalidate_offline_manifest(manifest_path)
-            if stale_dpo:
-                os.unlink(stale_dpo)
             publication = [(sft_bytes, output, "output")]
             if emit_pairs:
                 publication.append((dpo_bytes, emit_pairs, "emit-pairs"))
-            atomic_write_bytes_group(publication)
-            atomic_write_bytes(manifest_bytes, manifest_path, field="manifest")
+            publication.append((manifest_bytes, manifest_path, "manifest"))
+            removals = [(stale_dpo, "prior DPO output")] if stale_dpo else None
+            atomic_write_bytes_group(publication, removals=removals)
         except (OSError, TypeError, ValueError) as exc:
             console.print(f"[red]Failed to write output: {_escape(str(exc))}[/]")
             raise typer.Exit(1) from exc

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -3050,6 +3050,9 @@ def best_of_n(
     judgments: str = typer.Option(
         "", "--judgments", help="Offline verified judgments JSONL"
     ),
+    manifest: str = typer.Option(
+        "", "--manifest", help="Offline commit manifest (default: <output>.manifest.json)"
+    ),
     temperature: float = typer.Option(1.0, "--temperature", help="Sampling temp [0, 2]"),
     max_new_tokens: int = typer.Option(
         256, "--max-new-tokens", help="Max new tokens per candidate [1, 4096]"
@@ -3131,6 +3134,7 @@ def best_of_n(
         if not output and not plan_only:
             console.print("[red]--output is required unless --plan-only is set.[/]")
             raise typer.Exit(2)
+        manifest_path = manifest or (f"{output}.manifest.json" if output else "")
         try:
             paths = [candidate_artifact, judgments]
             if output:
@@ -3139,6 +3143,9 @@ def best_of_n(
             if emit_pairs:
                 enforce_under_cwd_and_no_symlink(emit_pairs, "--emit-pairs path")
                 paths.append(emit_pairs)
+            if manifest_path:
+                enforce_under_cwd_and_no_symlink(manifest_path, "--manifest path")
+                paths.append(manifest_path)
             if len({os.path.normcase(os.path.realpath(path)) for path in paths}) != len(paths):
                 raise ValueError("offline input and output paths must be distinct")
             groups, sampler_spec, candidate_sha = bon_artifact.load_candidate_artifact(
@@ -3165,23 +3172,27 @@ def best_of_n(
         )
         if plan_only:
             return
+        sft_bytes = bon_artifact.stable_jsonl(sft_rows).encode("utf-8")
+        dpo_bytes = (
+            bon_artifact.stable_jsonl(dpo_rows).encode("utf-8") if emit_pairs else b""
+        )
         try:
-            publication = [
-                (
-                    bon_artifact.stable_jsonl(sft_rows).encode("utf-8"),
-                    output,
-                    "output",
-                )
-            ]
+            manifest_bytes = bon_artifact.offline_manifest_text(
+                candidate_artifact_sha256=candidate_sha,
+                judgments_sha256=judgments_sha,
+                sft_path=output,
+                sft_bytes=sft_bytes,
+                sft_count=len(sft_rows),
+                dpo_path=emit_pairs,
+                dpo_bytes=dpo_bytes,
+                dpo_count=len(dpo_rows) if emit_pairs else 0,
+            ).encode("utf-8")
+            bon_artifact.invalidate_offline_manifest(manifest_path)
+            publication = [(sft_bytes, output, "output")]
             if emit_pairs:
-                publication.append(
-                    (
-                        bon_artifact.stable_jsonl(dpo_rows).encode("utf-8"),
-                        emit_pairs,
-                        "emit-pairs",
-                    )
-                )
+                publication.append((dpo_bytes, emit_pairs, "emit-pairs"))
             atomic_write_bytes_group(publication)
+            atomic_write_bytes(manifest_bytes, manifest_path, field="manifest")
         except (OSError, TypeError, ValueError) as exc:
             console.print(f"[red]Failed to write output: {_escape(str(exc))}[/]")
             raise typer.Exit(1) from exc
@@ -3194,9 +3205,13 @@ def best_of_n(
                 f"\nDPO pairs:  [bold]{len(dpo_rows)}[/]\n"
                 f"Pairs out:  [bold]{_escape(os.path.relpath(emit_pairs))}[/]"
             )
+        body += f"\nManifest:   [bold]{_escape(os.path.relpath(manifest_path))}[/]"
         console.print(Panel(body, title="soup data best-of-n — offline done"))
         return
 
+    if manifest:
+        console.print("[red]--manifest applies only to offline materialization[/]")
+        raise typer.Exit(2)
     if export_mode:
         if judge or output or emit_pairs or checkpoint or manifest or resume:
             console.print(

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -3038,7 +3038,7 @@ def best_of_n(
         "", "--checkpoint", help="Recovery journal (default: <output>.checkpoint.jsonl)"
     ),
     manifest: str = typer.Option(
-        "", "--manifest", help="Final consistency manifest (default: <output>.manifest.json)"
+        "", "--manifest", help="Commit manifest (default: <output>.manifest.json)"
     ),
     resume: bool = typer.Option(False, "--resume", help="Resume a matching checkpoint"),
     export_candidates: str = typer.Option(
@@ -3049,9 +3049,6 @@ def best_of_n(
     ),
     judgments: str = typer.Option(
         "", "--judgments", help="Offline verified judgments JSONL"
-    ),
-    manifest: str = typer.Option(
-        "", "--manifest", help="Offline commit manifest (default: <output>.manifest.json)"
     ),
     temperature: float = typer.Option(1.0, "--temperature", help="Sampling temp [0, 2]"),
     max_new_tokens: int = typer.Option(
@@ -3177,6 +3174,11 @@ def best_of_n(
             bon_artifact.stable_jsonl(dpo_rows).encode("utf-8") if emit_pairs else b""
         )
         try:
+            stale_dpo = ""
+            if not emit_pairs and os.path.lexists(manifest_path):
+                stale_dpo = bon_artifact.find_committed_sibling_dpo(
+                    manifest_path, sft_path=output
+                )
             manifest_bytes = bon_artifact.offline_manifest_text(
                 candidate_artifact_sha256=candidate_sha,
                 judgments_sha256=judgments_sha,
@@ -3188,6 +3190,8 @@ def best_of_n(
                 dpo_count=len(dpo_rows) if emit_pairs else 0,
             ).encode("utf-8")
             bon_artifact.invalidate_offline_manifest(manifest_path)
+            if stale_dpo:
+                os.unlink(stale_dpo)
             publication = [(sft_bytes, output, "output")]
             if emit_pairs:
                 publication.append((dpo_bytes, emit_pairs, "emit-pairs"))
@@ -3209,9 +3213,6 @@ def best_of_n(
         console.print(Panel(body, title="soup data best-of-n — offline done"))
         return
 
-    if manifest:
-        console.print("[red]--manifest applies only to offline materialization[/]")
-        raise typer.Exit(2)
     if export_mode:
         if judge or output or emit_pairs or checkpoint or manifest or resume:
             console.print(

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -3107,6 +3107,12 @@ def best_of_n(
         if not candidate_artifact or not judgments:
             console.print("[red]provide both --candidate-artifact and --judgments[/]")
             raise typer.Exit(2)
+        if resume or checkpoint:
+            console.print(
+                "[red]offline materialization does not support --resume or --checkpoint; "
+                "rerun with the same candidate and judgment artifacts[/]"
+            )
+            raise typer.Exit(2)
         if any(
             (
                 base,

--- a/src/soup_cli/utils/best_of_n_artifact.py
+++ b/src/soup_cli/utils/best_of_n_artifact.py
@@ -456,11 +456,8 @@ def _regular_sha_and_rows(path: str, field: str) -> tuple[str, int]:
     return digest.hexdigest(), rows
 
 
-def verify_offline_manifest(
-    path: str, *, sft_path: str, dpo_path: str = ""
-) -> dict:
-    """Verify the final marker against exact SFT/DPO file bytes and counts."""
-    data = _read_regular(path, "--manifest path")
+def _parse_offline_manifest(data: bytes) -> dict:
+    """Parse and validate the bounded manifest envelope."""
     try:
         manifest = json.loads(data)
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
@@ -483,6 +480,14 @@ def verify_offline_manifest(
             raise ValueError(f"offline manifest {field} is invalid")
     if not isinstance(manifest["dpo_requested"], bool):
         raise ValueError("offline manifest dpo_requested must be a bool")
+    return manifest
+
+
+def verify_offline_manifest(
+    path: str, *, sft_path: str, dpo_path: str = ""
+) -> dict:
+    """Verify the final marker against exact SFT/DPO file bytes and counts."""
+    manifest = _parse_offline_manifest(_read_regular(path, "--manifest path"))
     _validate_manifest_dataset(manifest["sft"], label="SFT", path=sft_path, required=True)
     _validate_manifest_dataset(
         manifest["dpo"],
@@ -491,6 +496,35 @@ def verify_offline_manifest(
         required=manifest["dpo_requested"],
     )
     return manifest
+
+
+def find_committed_sibling_dpo(path: str, *, sft_path: str) -> str:
+    """Return an authenticated prior DPO that sits beside ``path``.
+
+    Offline manifests intentionally record public basenames rather than local
+    absolute paths. A later SFT-only generation can therefore retire a prior
+    DPO only when that exact, hash-bound file is beside the manifest. Outputs
+    elsewhere remain unlisted and must not be inferred by consumers.
+    """
+    manifest = _parse_offline_manifest(_read_regular(path, "--manifest path"))
+    if manifest.get("dpo_requested") is False:
+        verify_offline_manifest(path, sft_path=sft_path)
+        return ""
+    record = manifest.get("dpo")
+    if not isinstance(record, dict) or set(record) != {"file", "rows", "sha256"}:
+        raise ValueError("offline manifest DPO record is invalid")
+    filename = record.get("file")
+    if (
+        not isinstance(filename, str)
+        or not filename
+        or os.path.basename(filename) != filename
+    ):
+        raise ValueError("offline manifest DPO filename is invalid")
+    sibling = os.path.join(os.path.dirname(os.path.abspath(path)), filename)
+    if not os.path.lexists(sibling):
+        return ""
+    verify_offline_manifest(path, sft_path=sft_path, dpo_path=sibling)
+    return sibling
 
 
 def invalidate_offline_manifest(path: str) -> None:

--- a/src/soup_cli/utils/best_of_n_artifact.py
+++ b/src/soup_cli/utils/best_of_n_artifact.py
@@ -14,7 +14,9 @@ from typing import Any
 from soup_cli.utils.paths import enforce_under_cwd_and_no_symlink
 
 _CANDIDATE_SCHEMA = "soup.best_of_n.candidates.v1"
+_OFFLINE_MANIFEST_SCHEMA = "soup.best_of_n.offline_manifest.v1"
 _VERIFIER_VALUE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 ._-]{0,127}$")
+_SHA256_VALUE = re.compile(r"^[0-9a-f]{64}$")
 
 
 def _canonical(value: Any) -> bytes:
@@ -356,3 +358,147 @@ def stable_jsonl(rows: list[dict]) -> str:
         json.dumps(row, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
         for row in rows
     )
+
+
+def offline_manifest_text(
+    *,
+    candidate_artifact_sha256: str,
+    judgments_sha256: str,
+    sft_path: str,
+    sft_bytes: bytes,
+    sft_count: int,
+    dpo_path: str,
+    dpo_bytes: bytes,
+    dpo_count: int,
+) -> str:
+    """Build the final commit marker for one offline materialization."""
+    if not _SHA256_VALUE.fullmatch(candidate_artifact_sha256):
+        raise ValueError("candidate artifact SHA-256 is invalid")
+    if not _SHA256_VALUE.fullmatch(judgments_sha256):
+        raise ValueError("judgments SHA-256 is invalid")
+    if isinstance(sft_count, bool) or not isinstance(sft_count, int) or sft_count < 0:
+        raise ValueError("SFT row count is invalid")
+    if isinstance(dpo_count, bool) or not isinstance(dpo_count, int) or dpo_count < 0:
+        raise ValueError("DPO row count is invalid")
+    if not isinstance(sft_bytes, bytes) or not isinstance(dpo_bytes, bytes):
+        raise TypeError("offline dataset payloads must be bytes")
+    dpo_requested = bool(dpo_path)
+    manifest = {
+        "schema": _OFFLINE_MANIFEST_SCHEMA,
+        "candidate_artifact_sha256": candidate_artifact_sha256,
+        "judgments_sha256": judgments_sha256,
+        "dpo_requested": dpo_requested,
+        "sft": {
+            "file": os.path.basename(sft_path),
+            "rows": sft_count,
+            "sha256": _sha(sft_bytes),
+        },
+        "dpo": (
+            {
+                "file": os.path.basename(dpo_path),
+                "rows": dpo_count,
+                "sha256": _sha(dpo_bytes),
+            }
+            if dpo_requested
+            else None
+        ),
+    }
+    return json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def _validate_manifest_dataset(
+    record: Any, *, label: str, path: str, required: bool
+) -> None:
+    if not required:
+        if record is not None or path:
+            raise ValueError(f"offline manifest unexpectedly records {label}")
+        return
+    if not path:
+        raise ValueError(f"offline manifest requires the {label} path")
+    if not isinstance(record, dict) or set(record) != {"file", "rows", "sha256"}:
+        raise ValueError(f"offline manifest {label} record is invalid")
+    if record["file"] != os.path.basename(path):
+        raise ValueError(f"offline manifest {label} filename does not match")
+    rows = record["rows"]
+    if isinstance(rows, bool) or not isinstance(rows, int) or rows < 0:
+        raise ValueError(f"offline manifest {label} row count is invalid")
+    if not isinstance(record["sha256"], str) or not _SHA256_VALUE.fullmatch(
+        record["sha256"]
+    ):
+        raise ValueError(f"offline manifest {label} SHA-256 is invalid")
+    actual_sha, actual_rows = _regular_sha_and_rows(path, f"{label} path")
+    if record["sha256"] != actual_sha or rows != actual_rows:
+        raise ValueError(f"offline manifest {label} content does not match")
+
+
+def _regular_sha_and_rows(path: str, field: str) -> tuple[str, int]:
+    """Hash and count non-empty JSONL records without buffering the dataset."""
+    enforce_under_cwd_and_no_symlink(path, field)
+    try:
+        fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    except OSError as exc:
+        raise ValueError(f"{field} could not be opened safely: {exc}") from exc
+    digest = hashlib.sha256()
+    rows = 0
+    try:
+        mode = os.fstat(fd).st_mode
+        if not stat.S_ISREG(mode):
+            raise ValueError(f"{field} must be a regular file")
+        with os.fdopen(fd, "rb") as handle:
+            fd = -1
+            for line in handle:
+                digest.update(line)
+                if line.strip():
+                    rows += 1
+    finally:
+        if fd >= 0:
+            os.close(fd)
+    return digest.hexdigest(), rows
+
+
+def verify_offline_manifest(
+    path: str, *, sft_path: str, dpo_path: str = ""
+) -> dict:
+    """Verify the final marker against exact SFT/DPO file bytes and counts."""
+    data = _read_regular(path, "--manifest path")
+    try:
+        manifest = json.loads(data)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("offline manifest is not valid UTF-8 JSON") from exc
+    expected = {
+        "schema",
+        "candidate_artifact_sha256",
+        "judgments_sha256",
+        "dpo_requested",
+        "sft",
+        "dpo",
+    }
+    if not isinstance(manifest, dict) or set(manifest) != expected:
+        raise ValueError("offline manifest fields are invalid")
+    if manifest["schema"] != _OFFLINE_MANIFEST_SCHEMA:
+        raise ValueError("offline manifest schema is unsupported")
+    for field in ("candidate_artifact_sha256", "judgments_sha256"):
+        value = manifest[field]
+        if not isinstance(value, str) or not _SHA256_VALUE.fullmatch(value):
+            raise ValueError(f"offline manifest {field} is invalid")
+    if not isinstance(manifest["dpo_requested"], bool):
+        raise ValueError("offline manifest dpo_requested must be a bool")
+    _validate_manifest_dataset(manifest["sft"], label="SFT", path=sft_path, required=True)
+    _validate_manifest_dataset(
+        manifest["dpo"],
+        label="DPO",
+        path=dpo_path,
+        required=manifest["dpo_requested"],
+    )
+    return manifest
+
+
+def invalidate_offline_manifest(path: str) -> None:
+    """Remove an old commit marker before replacing any bound output."""
+    enforce_under_cwd_and_no_symlink(path, "--manifest path")
+    if not os.path.lexists(path):
+        return
+    mode = os.lstat(path).st_mode
+    if not stat.S_ISREG(mode):
+        raise ValueError("--manifest path must be a regular file")
+    os.unlink(path)

--- a/src/soup_cli/utils/best_of_n_artifact.py
+++ b/src/soup_cli/utils/best_of_n_artifact.py
@@ -525,14 +525,3 @@ def find_committed_sibling_dpo(path: str, *, sft_path: str) -> str:
         return ""
     verify_offline_manifest(path, sft_path=sft_path, dpo_path=sibling)
     return sibling
-
-
-def invalidate_offline_manifest(path: str) -> None:
-    """Remove an old commit marker before replacing any bound output."""
-    enforce_under_cwd_and_no_symlink(path, "--manifest path")
-    if not os.path.lexists(path):
-        return
-    mode = os.lstat(path).st_mode
-    if not stat.S_ISREG(mode):
-        raise ValueError("--manifest path must be a regular file")
-    os.unlink(path)

--- a/src/soup_cli/utils/paths.py
+++ b/src/soup_cli/utils/paths.py
@@ -151,13 +151,19 @@ def atomic_write_bytes(
     return os.path.realpath(output_path)
 
 
-def atomic_write_bytes_group(outputs: list[tuple[bytes, str, str]]) -> list[str]:
+def atomic_write_bytes_group(
+    outputs: list[tuple[bytes, str, str]],
+    *,
+    removals: list[tuple[str, str]] | None = None,
+) -> list[str]:
     """Publish a group of byte outputs atomically as one logical generation.
 
     Every payload is staged before an existing target is moved aside. If any
     replacement fails, newly published targets are removed and every previous
-    target is restored. This gives multi-file commands an all-new-or-all-old
-    result instead of exposing a partial generation.
+    target is restored. ``removals`` participate in the same transaction: they
+    disappear only after every replacement succeeds and are restored on
+    failure. This gives multi-file commands an all-new-or-all-old result
+    instead of exposing a partial generation.
     """
     if not isinstance(outputs, list) or not outputs:
         raise ValueError("outputs must be a non-empty list")
@@ -176,6 +182,20 @@ def atomic_write_bytes_group(outputs: list[tuple[bytes, str, str]]) -> list[str]
             raise ValueError("output paths must be distinct")
         identities.add(identity)
         prepared.append((bytes(data), output_path, field))
+
+    prepared_removals: list[tuple[str, str]] = []
+    if removals is not None and not isinstance(removals, list):
+        raise TypeError("removals must be a list")
+    for item in removals or []:
+        if not isinstance(item, tuple) or len(item) != 2:
+            raise TypeError("each removal must be a (path, field) tuple")
+        removal_path, field = item
+        enforce_under_cwd_and_no_symlink(removal_path, field)
+        identity = os.path.normcase(os.path.realpath(removal_path))
+        if identity in identities:
+            raise ValueError("output and removal paths must be distinct")
+        identities.add(identity)
+        prepared_removals.append((removal_path, field))
 
     staged: dict[str, str] = {}
     backups: dict[str, str] = {}
@@ -196,7 +216,10 @@ def atomic_write_bytes_group(outputs: list[tuple[bytes, str, str]]) -> list[str]
                 raise
             staged[output_path] = tmp_path
 
-        for _data, output_path, field in prepared:
+        existing = [
+            (output_path, field) for _data, output_path, field in prepared
+        ] + prepared_removals
+        for output_path, field in existing:
             if not os.path.lexists(output_path):
                 continue
             st = os.lstat(output_path)

--- a/tests/test_issue549_bon_resume.py
+++ b/tests/test_issue549_bon_resume.py
@@ -207,6 +207,52 @@ def test_resume_rejects_changed_run_before_sampling(tmp_path, monkeypatch):
     assert generate_calls == []
 
 
+def test_resume_rejects_changed_local_model_revision_before_loading(
+    tmp_path, monkeypatch
+):
+    from soup_cli.commands.data import app
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "prompts.jsonl").write_text('{"prompt":"one"}\n', encoding="utf-8")
+    load_calls = []
+    monkeypatch.setattr(
+        "soup_cli.commands.data._load_bon_model",
+        lambda *args, **kwargs: (
+            load_calls.append((args, kwargs)) or (object(), object())
+        ),
+    )
+    monkeypatch.setattr(
+        "soup_cli.utils.trust_remote.model_requires_trust_remote_code",
+        lambda _model: False,
+    )
+    monkeypatch.setattr(
+        "soup_cli.utils.best_of_n.sample_candidates",
+        lambda *_args, **_kwargs: ["candidate-a", "candidate-b"],
+    )
+    monkeypatch.setattr(
+        "soup_cli.eval.judge.JudgeEvaluator",
+        lambda **_kwargs: SimpleNamespace(
+            evaluate=lambda _prompt, response: SimpleNamespace(
+                weighted_score=float(len(response))
+            )
+        ),
+    )
+
+    first = CliRunner().invoke(app, _local_args(tmp_path, "--revision", "revision-a"))
+    assert first.exit_code == 0, (first.output, repr(first.exception))
+    assert load_calls[0][1] == {"revision": "revision-a"}
+    load_calls.clear()
+
+    resumed = CliRunner().invoke(
+        app,
+        _local_args(tmp_path, "--revision", "revision-b", "--resume"),
+    )
+
+    assert resumed.exit_code == 2, (resumed.output, repr(resumed.exception))
+    assert "does not match prompts or run configuration" in resumed.output
+    assert load_calls == []
+
+
 def test_final_datasets_use_exact_utf8_bytes_for_manifest_hashes(tmp_path, monkeypatch):
     from soup_cli.commands.data import app
     from soup_cli.utils.paths import atomic_write_text as real_text_write

--- a/tests/test_issue550_bon_offline.py
+++ b/tests/test_issue550_bon_offline.py
@@ -565,6 +565,41 @@ def test_offline_mode_rejects_irrelevant_sampling_overrides(tmp_path, monkeypatc
     assert "Invalid offline artifact" not in result.output
 
 
+@pytest.mark.parametrize("recovery_option", ["resume", "checkpoint"])
+def test_offline_mode_rejects_online_recovery_options_before_publication(
+    tmp_path, monkeypatch, recovery_option
+):
+    from soup_cli.commands.data import app
+
+    artifact, _calls = _export_candidates(tmp_path, monkeypatch, prompts=("question",))
+    judgments = tmp_path / "judgments.jsonl"
+    _write_judgments(judgments, _artifact_groups(artifact))
+    output = tmp_path / "sft.jsonl"
+    manifest = tmp_path / "manifest.json"
+    args = [
+        "best-of-n",
+        "--candidate-artifact",
+        str(artifact),
+        "--judgments",
+        str(judgments),
+        "--output",
+        str(output),
+        "--manifest",
+        str(manifest),
+    ]
+    if recovery_option == "resume":
+        args.append("--resume")
+    else:
+        args.extend(("--checkpoint", str(tmp_path / "checkpoint.jsonl")))
+
+    result = CliRunner().invoke(app, args)
+
+    assert result.exit_code == 2
+    assert "does not support --resume or --checkpoint" in result.output
+    assert not output.exists()
+    assert not manifest.exists()
+
+
 def test_two_phase_artifacts_use_exact_utf8_byte_writes(tmp_path, monkeypatch):
     from soup_cli.commands.data import app
 

--- a/tests/test_issue550_bon_offline.py
+++ b/tests/test_issue550_bon_offline.py
@@ -240,9 +240,44 @@ def test_sft_only_manifest_records_that_dpo_was_not_requested(tmp_path, monkeypa
     assert manifest["dpo"] is None
 
 
+def test_later_sft_only_generation_removes_prior_manifest_bound_dpo(
+    tmp_path, monkeypatch
+):
+    from soup_cli.commands.data import app
+    from soup_cli.utils.best_of_n_artifact import verify_offline_manifest
+
+    artifact, _calls = _export_candidates(tmp_path, monkeypatch, prompts=("question",))
+    judgments = tmp_path / "judgments.jsonl"
+    _write_judgments(judgments, _artifact_groups(artifact))
+    sft = tmp_path / "sft.jsonl"
+    dpo = tmp_path / "dpo.jsonl"
+    manifest_path = tmp_path / "commit.json"
+    common = [
+        "best-of-n",
+        "--candidate-artifact",
+        str(artifact),
+        "--judgments",
+        str(judgments),
+        "--output",
+        str(sft),
+        "--manifest",
+        str(manifest_path),
+    ]
+    first = CliRunner().invoke(app, [*common, "--emit-pairs", str(dpo)])
+    assert first.exit_code == 0, (first.output, repr(first.exception))
+    assert dpo.exists()
+
+    second = CliRunner().invoke(app, common)
+
+    assert second.exit_code == 0, (second.output, repr(second.exception))
+    assert not dpo.exists()
+    manifest = verify_offline_manifest(str(manifest_path), sft_path=str(sft))
+    assert manifest["dpo_requested"] is False
+    assert manifest["dpo"] is None
+
+
 def test_failed_dpo_replacement_invalidates_old_manifest(tmp_path, monkeypatch):
     from soup_cli.commands.data import app
-    from soup_cli.utils.paths import atomic_write_bytes as real_byte_write
 
     artifact, _calls = _export_candidates(tmp_path, monkeypatch)
     judgments = tmp_path / "judgments.jsonl"
@@ -265,12 +300,17 @@ def test_failed_dpo_replacement_invalidates_old_manifest(tmp_path, monkeypatch):
     manifest_path = tmp_path / "sft.jsonl.manifest.json"
     assert manifest_path.exists()
 
-    def fail_dpo(data, path, *, field):
-        if field == "emit-pairs":
-            raise OSError("simulated DPO publication failure")
-        return real_byte_write(data, path, field=field)
+    real_replace = __import__("os").replace
+    failed_once = False
 
-    monkeypatch.setattr("soup_cli.utils.paths.atomic_write_bytes", fail_dpo)
+    def fail_dpo(source, destination):
+        nonlocal failed_once
+        if not failed_once and destination == str(dpo):
+            failed_once = True
+            raise OSError("simulated DPO publication failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr("os.replace", fail_dpo)
     failed = CliRunner().invoke(app, args)
     assert failed.exit_code == 1
     assert sft.exists()

--- a/tests/test_issue550_bon_offline.py
+++ b/tests/test_issue550_bon_offline.py
@@ -174,6 +174,164 @@ def test_offline_materialization_never_constructs_sampler_or_judge_and_is_stable
     assert str(tmp_path) not in outputs[0][0].decode()
 
 
+def test_offline_manifest_commits_and_verifies_exact_output_set(tmp_path, monkeypatch):
+    from soup_cli.commands.data import app
+    from soup_cli.utils.best_of_n_artifact import verify_offline_manifest
+
+    artifact, _calls = _export_candidates(tmp_path, monkeypatch)
+    groups = _artifact_groups(artifact)
+    judgments = tmp_path / "judgments.jsonl"
+    _write_judgments(judgments, groups)
+    sft = tmp_path / "sft.jsonl"
+    dpo = tmp_path / "dpo.jsonl"
+    result = CliRunner().invoke(
+        app,
+        [
+            "best-of-n",
+            "--candidate-artifact",
+            str(artifact),
+            "--judgments",
+            str(judgments),
+            "--output",
+            str(sft),
+            "--emit-pairs",
+            str(dpo),
+        ],
+    )
+    assert result.exit_code == 0, (result.output, repr(result.exception))
+    manifest_path = tmp_path / "sft.jsonl.manifest.json"
+    manifest = verify_offline_manifest(
+        str(manifest_path), sft_path=str(sft), dpo_path=str(dpo)
+    )
+    assert manifest["schema"] == "soup.best_of_n.offline_manifest.v1"
+    assert manifest["dpo_requested"] is True
+    assert manifest["sft"]["rows"] == 2
+    assert manifest["dpo"]["rows"] == 2
+    assert len(manifest["candidate_artifact_sha256"]) == 64
+    assert len(manifest["judgments_sha256"]) == 64
+
+
+def test_sft_only_manifest_records_that_dpo_was_not_requested(tmp_path, monkeypatch):
+    from soup_cli.commands.data import app
+    from soup_cli.utils.best_of_n_artifact import verify_offline_manifest
+
+    artifact, _calls = _export_candidates(tmp_path, monkeypatch, prompts=("question",))
+    judgments = tmp_path / "judgments.jsonl"
+    _write_judgments(judgments, _artifact_groups(artifact))
+    sft = tmp_path / "sft.jsonl"
+    manifest_path = tmp_path / "commit.json"
+    result = CliRunner().invoke(
+        app,
+        [
+            "best-of-n",
+            "--candidate-artifact",
+            str(artifact),
+            "--judgments",
+            str(judgments),
+            "--output",
+            str(sft),
+            "--manifest",
+            str(manifest_path),
+        ],
+    )
+    assert result.exit_code == 0, (result.output, repr(result.exception))
+    manifest = verify_offline_manifest(str(manifest_path), sft_path=str(sft))
+    assert manifest["dpo_requested"] is False
+    assert manifest["dpo"] is None
+
+
+def test_failed_dpo_replacement_invalidates_old_manifest(tmp_path, monkeypatch):
+    from soup_cli.commands.data import app
+    from soup_cli.utils.paths import atomic_write_bytes as real_byte_write
+
+    artifact, _calls = _export_candidates(tmp_path, monkeypatch)
+    judgments = tmp_path / "judgments.jsonl"
+    _write_judgments(judgments, _artifact_groups(artifact))
+    sft = tmp_path / "sft.jsonl"
+    dpo = tmp_path / "dpo.jsonl"
+    args = [
+        "best-of-n",
+        "--candidate-artifact",
+        str(artifact),
+        "--judgments",
+        str(judgments),
+        "--output",
+        str(sft),
+        "--emit-pairs",
+        str(dpo),
+    ]
+    first = CliRunner().invoke(app, args)
+    assert first.exit_code == 0, (first.output, repr(first.exception))
+    manifest_path = tmp_path / "sft.jsonl.manifest.json"
+    assert manifest_path.exists()
+
+    def fail_dpo(data, path, *, field):
+        if field == "emit-pairs":
+            raise OSError("simulated DPO publication failure")
+        return real_byte_write(data, path, field=field)
+
+    monkeypatch.setattr("soup_cli.utils.paths.atomic_write_bytes", fail_dpo)
+    failed = CliRunner().invoke(app, args)
+    assert failed.exit_code == 1
+    assert sft.exists()
+    assert dpo.exists()
+    assert not manifest_path.exists()
+
+
+def test_manifest_verifier_rejects_replaced_output(tmp_path, monkeypatch):
+    from soup_cli.commands.data import app
+    from soup_cli.utils.best_of_n_artifact import verify_offline_manifest
+
+    artifact, _calls = _export_candidates(tmp_path, monkeypatch, prompts=("question",))
+    judgments = tmp_path / "judgments.jsonl"
+    _write_judgments(judgments, _artifact_groups(artifact))
+    sft = tmp_path / "sft.jsonl"
+    result = CliRunner().invoke(
+        app,
+        [
+            "best-of-n",
+            "--candidate-artifact",
+            str(artifact),
+            "--judgments",
+            str(judgments),
+            "--output",
+            str(sft),
+        ],
+    )
+    assert result.exit_code == 0, (result.output, repr(result.exception))
+    sft.write_bytes(sft.read_bytes() + b"{}\n")
+    with pytest.raises(ValueError, match="SFT content does not match"):
+        verify_offline_manifest(
+            str(tmp_path / "sft.jsonl.manifest.json"), sft_path=str(sft)
+        )
+
+
+def test_offline_manifest_path_must_be_distinct(tmp_path, monkeypatch):
+    from soup_cli.commands.data import app
+
+    artifact, _calls = _export_candidates(tmp_path, monkeypatch, prompts=("question",))
+    judgments = tmp_path / "judgments.jsonl"
+    _write_judgments(judgments, _artifact_groups(artifact))
+    sft = tmp_path / "sft.jsonl"
+    result = CliRunner().invoke(
+        app,
+        [
+            "best-of-n",
+            "--candidate-artifact",
+            str(artifact),
+            "--judgments",
+            str(judgments),
+            "--output",
+            str(sft),
+            "--manifest",
+            str(sft),
+        ],
+    )
+    assert result.exit_code == 2
+    assert "must be distinct" in result.output
+    assert not sft.exists()
+
+
 @pytest.mark.parametrize(
     "mutation,match",
     [

--- a/tests/test_issue550_bon_offline.py
+++ b/tests/test_issue550_bon_offline.py
@@ -276,8 +276,9 @@ def test_later_sft_only_generation_removes_prior_manifest_bound_dpo(
     assert manifest["dpo"] is None
 
 
-def test_failed_dpo_replacement_invalidates_old_manifest(tmp_path, monkeypatch):
+def test_failed_dpo_replacement_restores_previous_generation(tmp_path, monkeypatch):
     from soup_cli.commands.data import app
+    from soup_cli.utils.best_of_n_artifact import verify_offline_manifest
 
     artifact, _calls = _export_candidates(tmp_path, monkeypatch)
     judgments = tmp_path / "judgments.jsonl"
@@ -299,6 +300,7 @@ def test_failed_dpo_replacement_invalidates_old_manifest(tmp_path, monkeypatch):
     assert first.exit_code == 0, (first.output, repr(first.exception))
     manifest_path = tmp_path / "sft.jsonl.manifest.json"
     assert manifest_path.exists()
+    previous = (sft.read_bytes(), dpo.read_bytes(), manifest_path.read_bytes())
 
     real_replace = __import__("os").replace
     failed_once = False
@@ -313,9 +315,67 @@ def test_failed_dpo_replacement_invalidates_old_manifest(tmp_path, monkeypatch):
     monkeypatch.setattr("os.replace", fail_dpo)
     failed = CliRunner().invoke(app, args)
     assert failed.exit_code == 1
-    assert sft.exists()
-    assert dpo.exists()
-    assert not manifest_path.exists()
+    assert (sft.read_bytes(), dpo.read_bytes(), manifest_path.read_bytes()) == previous
+    verify_offline_manifest(
+        str(manifest_path), sft_path=str(sft), dpo_path=str(dpo)
+    )
+
+
+def test_failed_sft_only_replacement_restores_manifest_bound_dpo(
+    tmp_path, monkeypatch
+):
+    from soup_cli.commands.data import app
+    from soup_cli.utils.best_of_n_artifact import verify_offline_manifest
+
+    artifact, _calls = _export_candidates(tmp_path, monkeypatch, prompts=("question",))
+    judgments = tmp_path / "judgments.jsonl"
+    _write_judgments(judgments, _artifact_groups(artifact))
+    sft = tmp_path / "sft.jsonl"
+    dpo = tmp_path / "dpo.jsonl"
+    manifest_path = tmp_path / "commit.json"
+    common = [
+        "best-of-n",
+        "--candidate-artifact",
+        str(artifact),
+        "--judgments",
+        str(judgments),
+        "--output",
+        str(sft),
+        "--manifest",
+        str(manifest_path),
+    ]
+    first = CliRunner().invoke(app, [*common, "--emit-pairs", str(dpo)])
+    assert first.exit_code == 0, (first.output, repr(first.exception))
+    previous = (sft.read_bytes(), dpo.read_bytes(), manifest_path.read_bytes())
+    changed = _write_judgments(judgments, _artifact_groups(artifact))
+    changed[0]["winner_idx"] = 0
+    changed[0]["scores"] = [0.9, 0.1]
+    judgments.write_text(
+        "".join(json.dumps(row) + "\n" for row in changed), encoding="utf-8"
+    )
+
+    real_replace = __import__("os").replace
+    failed_once = False
+
+    def fail_sft(source, destination):
+        nonlocal failed_once
+        if (
+            not failed_once
+            and destination == str(sft)
+            and ".soup.group." in str(source)
+        ):
+            failed_once = True
+            raise OSError("simulated SFT publication failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr("os.replace", fail_sft)
+    failed = CliRunner().invoke(app, common)
+
+    assert failed.exit_code == 1
+    assert (sft.read_bytes(), dpo.read_bytes(), manifest_path.read_bytes()) == previous
+    verify_offline_manifest(
+        str(manifest_path), sft_path=str(sft), dpo_path=str(dpo)
+    )
 
 
 def test_manifest_verifier_rejects_replaced_output(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #556.

## Summary
- publish an offline Best-of-N manifest last as the generation commit marker
- bind exact candidate/judgment digests, SFT/DPO byte hashes, row counts, filenames, and whether DPO was requested
- invalidate any prior manifest before replacing bound outputs so interrupted writes fail closed
- remove a previously committed sibling DPO artifact when an SFT-only replacement is published
- verify dataset hashes and row counts incrementally without buffering the generated files
- bind the model revision into the Best-of-N resume identity and reject revision changes before model loading
- reject `--resume` and `--checkpoint` before offline artifact loading or publication
- reject manifest path collisions and document the offline publication contract

## Validation
- `PYTHONPATH=src pytest -q --no-cov tests/test_issue549_bon_resume.py tests/test_issue550_bon_offline.py tests/test_v07131.py` (141 passed)
- full local current-head suite: 19,148 passed, 74 skipped, 5 deselected; the same 18 sandbox-only failures previously reproduced on pristine `origin/main`
- `ruff check src/soup_cli/ scripts/ tests/`
- `git diff --check`
- all 13 fresh GitHub CI checks passed on Linux, Windows, and macOS
