### PR TITLE
fix(data): stream and resume two-phase Best-of-N

### DIFF
--- a/changelog.d/0.73.3/555.fixed.md
+++ b/changelog.d/0.73.3/555.fixed.md
@@ -1,3 +1,5 @@
 - Fixed #555: two-phase Best-of-N candidate export now resumes from durable,
   authenticated per-prompt checkpoints, while offline validation and output
-  materialization stream through bounded-memory disk staging.
+  materialization stream through bounded-memory disk staging. Resume binds
+  prompt source lines and exact local-model content, and streamed SFT/DPO
+  publication rolls back as one set on failure.

--- a/changelog.d/0.73.3/555.fixed.md
+++ b/changelog.d/0.73.3/555.fixed.md
@@ -2,4 +2,6 @@
   authenticated per-prompt checkpoints, while offline validation and output
   materialization stream through bounded-memory disk staging. Resume binds
   prompt source lines and exact local-model content, and streamed SFT/DPO
-  publication rolls back as one set on failure.
+  publication rolls back as one set on failure. Candidate export now seeds each
+  prompt independently so resumed runs reproduce the same candidates; this
+  changes the output of existing `--export-candidates --seed N` runs.

--- a/changelog.d/0.73.3/555.fixed.md
+++ b/changelog.d/0.73.3/555.fixed.md
@@ -1,0 +1,3 @@
+- Fixed #555: two-phase Best-of-N candidate export now resumes from durable,
+  authenticated per-prompt checkpoints, while offline validation and output
+  materialization stream through bounded-memory disk staging.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -302,7 +302,7 @@ soup build <manifest.yaml> [--dry-run] [--output-dir <dir>]  dbt-for-SFT DAG: va
 soup expect <data.jsonl> <suite.yaml>         Expectations suite: PII / token-length / refusal / judge (v0.69.0)
 soup data gen-magpie --base <m> --provider ollama|vllm --target N --output <jsonl> [--base-url <url>] [--quality-filter]  Magpie synthetic generator — live (v0.69.0; live v0.71.6)
 soup data best-of-n (--base <m> | --provider ollama|vllm --model <m> [--base-url <url>]) --prompts <jsonl> --n 8 --judge <url> -o <sft.jsonl> [--emit-pairs <dpo.jsonl>] [--resume] [--checkpoint <journal.jsonl>] [--manifest <manifest.json>]  Best-of-N rejection sampling with durable per-prompt recovery and manifest-last publication
-soup data best-of-n (--base <m> [--revision <rev>] | --provider ollama|vllm --model <m>) --prompts <jsonl> --n 8 --export-candidates <jsonl>  Sampling-only phase; no judge is constructed
+soup data best-of-n (--base <m> [--revision <rev>] | --provider ollama|vllm --model <m>) --prompts <jsonl> --n 8 --export-candidates <jsonl> [--checkpoint <jsonl>] [--resume]  Resumable sampling-only phase; no judge is constructed
 soup data best-of-n --candidate-artifact <jsonl> --judgments <jsonl> -o <sft.jsonl> [--emit-pairs <dpo.jsonl>] [--manifest <json>]  Validate offline judgments and materialize byte-stable training rows; a final manifest binds the requested output set
 soup data evolve --input <seeds.jsonl> --provider ollama|vllm --model <m> --strategy depth|breadth --rounds N -o <jsonl>  Evol-Instruct (WizardLM) instruction evolution (v0.71.31)
 soup data persona-mix --prompts <jsonl> --n N --output <jsonl>  Persona-Hub diversity sampler (v0.69.0)

--- a/docs/data.md
+++ b/docs/data.md
@@ -260,6 +260,13 @@ lists. They must never discover training inputs by globbing neighboring JSONL
 files: an unlisted sidecar, including an older DPO stored elsewhere, is not part
 of the committed generation.
 
+Candidate export durably checkpoints each completed prompt group at
+`<artifact>.checkpoint.jsonl`. If sampling stops, rerun the same command with
+`--resume`; Soup authenticates the checkpoint against the prompts and sampler
+before continuing at the first incomplete group. Candidate and judgment inputs
+are validated through a temporary disk index, and final SFT/DPO files are staged
+incrementally, so memory does not grow with the complete artifact size.
+
 ### Custom Transforms
 
 Use a dotted-path string (`module.path:function_name`) as the ``transform``

--- a/docs/data.md
+++ b/docs/data.md
@@ -266,6 +266,13 @@ Candidate export durably checkpoints each completed prompt group at
 before continuing at the first incomplete group. Candidate and judgment inputs
 are validated through a temporary disk index, and final SFT/DPO files are staged
 incrementally, so memory does not grow with the complete artifact size.
+For a local model directory, the checkpoint binds the exact regular-file names,
+sizes, and contents through a privacy-safe fingerprint; replacing weights at the
+same path therefore invalidates resume before the model is loaded. Prompt source
+lines and provider endpoints are bound as well without exposing private paths or
+URLs. Streamed SFT/DPO replacements are committed as one rollback-protected set,
+and an SFT-only replacement retires a prior manifest-bound DPO in that same
+transaction.
 
 ### Custom Transforms
 

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -3035,7 +3035,9 @@ def best_of_n(
         "", "--emit-pairs", help="Also write winner/loser DPO pairs to this JSONL"
     ),
     checkpoint: str = typer.Option(
-        "", "--checkpoint", help="Recovery journal (default: <output>.checkpoint.jsonl)"
+        "",
+        "--checkpoint",
+        help="Recovery journal (default: <output-or-artifact>.checkpoint.jsonl)",
     ),
     manifest: str = typer.Option(
         "", "--manifest", help="Commit manifest (default: <output>.manifest.json)"
@@ -3079,7 +3081,6 @@ def best_of_n(
     from soup_cli.utils.magpie import make_magpie_generate_fn
     from soup_cli.utils.paths import (
         atomic_write_bytes,
-        atomic_write_bytes_group,
         enforce_under_cwd_and_no_symlink,
     )
     from soup_cli.utils.trust_remote import (
@@ -3104,6 +3105,8 @@ def best_of_n(
         console.print("[red]offline materialization and --export-candidates are exclusive[/]")
         raise typer.Exit(2)
     if offline_mode:
+        from soup_cli.utils import best_of_n_stream as bon_stream
+
         if not candidate_artifact or not judgments:
             console.print("[red]provide both --candidate-artifact and --judgments[/]")
             raise typer.Exit(2)
@@ -3125,6 +3128,8 @@ def best_of_n(
                 revision,
                 trust_remote_code,
                 seed != 0,
+                checkpoint,
+                resume,
                 n != 8,
                 temperature != 1.0,
                 max_new_tokens != 256,
@@ -3151,66 +3156,60 @@ def best_of_n(
                 paths.append(manifest_path)
             if len({os.path.normcase(os.path.realpath(path)) for path in paths}) != len(paths):
                 raise ValueError("offline input and output paths must be distinct")
-            groups, sampler_spec, candidate_sha = bon_artifact.load_candidate_artifact(
-                candidate_artifact
-            )
-            verified, judgments_sha = bon_artifact.load_judgments(judgments, groups)
-            sft_rows, dpo_rows = bon_artifact.materialize_rows(
-                groups,
-                verified,
-                sampler=sampler_spec,
-                candidate_artifact_sha256=candidate_sha,
-                judgments_sha256=judgments_sha,
-            )
         except (FileNotFoundError, OSError, TypeError, ValueError) as exc:
             console.print(f"[red]Invalid offline artifact: {_escape(str(exc))}[/]")
             raise typer.Exit(2) from exc
-        console.print(
-            Panel(
-                f"Candidate groups: [bold]{len(groups)}[/]\n"
-                f"Verified rows:    [bold]{len(verified)}[/]\n"
-                "Network/model:    [bold]disabled[/]",
-                title="soup data best-of-n — offline plan",
-            )
-        )
-        if plan_only:
-            return
-        sft_bytes = bon_artifact.stable_jsonl(sft_rows).encode("utf-8")
-        dpo_bytes = (
-            bon_artifact.stable_jsonl(dpo_rows).encode("utf-8") if emit_pairs else b""
-        )
+        publication_started = False
         try:
-            stale_dpo = ""
-            if not emit_pairs and os.path.lexists(manifest_path):
-                stale_dpo = bon_artifact.find_committed_sibling_dpo(
-                    manifest_path, sft_path=output
+            with bon_stream.index_offline_artifacts(
+                candidate_artifact, judgments
+            ) as offline_index:
+                offline_index.validate_all()
+                console.print(
+                    Panel(
+                        f"Candidate groups: [bold]{offline_index.group_count}[/]\n"
+                        f"Verified rows:    [bold]{offline_index.group_count}[/]\n"
+                        "Network/model:    [bold]disabled[/]",
+                        title="soup data best-of-n — offline plan",
+                    )
                 )
-            manifest_bytes = bon_artifact.offline_manifest_text(
-                candidate_artifact_sha256=candidate_sha,
-                judgments_sha256=judgments_sha,
-                sft_path=output,
-                sft_bytes=sft_bytes,
-                sft_count=len(sft_rows),
-                dpo_path=emit_pairs,
-                dpo_bytes=dpo_bytes,
-                dpo_count=len(dpo_rows) if emit_pairs else 0,
-            ).encode("utf-8")
-            publication = [(sft_bytes, output, "output")]
-            if emit_pairs:
-                publication.append((dpo_bytes, emit_pairs, "emit-pairs"))
-            publication.append((manifest_bytes, manifest_path, "manifest"))
-            removals = [(stale_dpo, "prior DPO output")] if stale_dpo else None
-            atomic_write_bytes_group(publication, removals=removals)
-        except (OSError, TypeError, ValueError) as exc:
-            console.print(f"[red]Failed to write output: {_escape(str(exc))}[/]")
+                if plan_only:
+                    return
+                publication_started = True
+                staged = bon_stream.stage_offline_datasets(
+                    offline_index, output, emit_pairs
+                )
+                try:
+                    manifest_bytes = bon_artifact.offline_manifest_from_digests(
+                        candidate_artifact_sha256=offline_index.candidate_sha256,
+                        judgments_sha256=offline_index.judgments_sha256,
+                        sft_path=output,
+                        sft_sha256=staged.sft_sha256,
+                        sft_count=staged.sft_count,
+                        dpo_path=emit_pairs,
+                        dpo_sha256=staged.dpo_sha256,
+                        dpo_count=staged.dpo_count,
+                    ).encode("utf-8")
+                    bon_artifact.invalidate_offline_manifest(manifest_path)
+                    bon_stream.publish_staged_datasets(staged, output, emit_pairs)
+                    atomic_write_bytes(manifest_bytes, manifest_path, field="manifest")
+                finally:
+                    staged.cleanup()
+                sft_count = staged.sft_count
+                dpo_count = staged.dpo_count
+        except (FileNotFoundError, OSError, TypeError, ValueError) as exc:
+            if not publication_started:
+                console.print(f"[red]Invalid offline artifact: {_escape(str(exc))}[/]")
+                raise typer.Exit(2) from exc
+            console.print(f"[red]Offline materialization failed: {_escape(str(exc))}[/]")
             raise typer.Exit(1) from exc
         body = (
-            f"SFT rows:   [bold]{len(sft_rows)}[/]\n"
+            f"SFT rows:   [bold]{sft_count}[/]\n"
             f"Output:     [bold]{_escape(os.path.relpath(output))}[/]"
         )
         if emit_pairs:
             body += (
-                f"\nDPO pairs:  [bold]{len(dpo_rows)}[/]\n"
+                f"\nDPO pairs:  [bold]{dpo_count}[/]\n"
                 f"Pairs out:  [bold]{_escape(os.path.relpath(emit_pairs))}[/]"
             )
         body += f"\nManifest:   [bold]{_escape(os.path.relpath(manifest_path))}[/]"
@@ -3218,10 +3217,9 @@ def best_of_n(
         return
 
     if export_mode:
-        if judge or output or emit_pairs or checkpoint or manifest or resume:
+        if judge or output or emit_pairs or manifest:
             console.print(
-                "[red]--export-candidates cannot be combined with judge, final-output, "
-                "or online-recovery options[/]"
+                "[red]--export-candidates cannot be combined with judge or final outputs[/]"
             )
             raise typer.Exit(2)
     elif not judge:
@@ -3267,6 +3265,12 @@ def best_of_n(
             enforce_under_cwd_and_no_symlink(
                 export_candidates, "--export-candidates path"
             )
+            checkpoint_path = checkpoint or f"{export_candidates}.checkpoint.jsonl"
+            enforce_under_cwd_and_no_symlink(checkpoint_path, "--checkpoint path")
+            if os.path.normcase(os.path.realpath(checkpoint_path)) == os.path.normcase(
+                os.path.realpath(export_candidates)
+            ):
+                raise ValueError("candidate artifact and checkpoint paths must be distinct")
     except (FileNotFoundError, TypeError, ValueError) as exc:
         console.print(f"[red]{_escape(str(exc))}[/]")
         raise typer.Exit(2) from exc
@@ -3274,7 +3278,7 @@ def best_of_n(
         console.print("[red]--prompts produced no usable rows[/]")
         raise typer.Exit(2)
     prompt_list = [prompt for prompt, _source_line in prompt_records]
-    if resume and not output:
+    if resume and not export_mode and not output:
         console.print("[red]--resume requires --output[/]")
         raise typer.Exit(2)
 
@@ -3390,29 +3394,96 @@ def best_of_n(
         console.print("[red]--output is required unless --plan-only is set.[/]")
         raise typer.Exit(2)
 
-    completed_entries = []
-    if not export_mode:
+    dev = device or None
+    if export_mode:
+        from soup_cli.utils import best_of_n_stream as bon_stream
+
+        checkpoint_path = checkpoint or f"{export_candidates}.checkpoint.jsonl"
+        completed = 0
         try:
-            targets = [output, checkpoint_path, manifest_path]
-            if emit_pairs:
-                targets.append(emit_pairs)
-            if len({os.path.normcase(os.path.realpath(path)) for path in targets}) != len(
-                targets
-            ):
-                raise ValueError(
-                    "output, pairs, checkpoint, and manifest paths must be distinct"
+            completed = bon_stream.prepare_candidate_checkpoint(
+                checkpoint_path, prompt_list, sampler_spec, resume=resume
+            )
+            local_model = None
+            tokenizer = None
+            local_torch = None
+            if generate_fn is None and completed < len(prompt_list):
+                import torch
+
+                local_torch = torch
+                if revision:
+                    local_model, tokenizer = _load_bon_model(
+                        base, device, trust, revision=revision
+                    )
+                else:
+                    local_model, tokenizer = _load_bon_model(base, device, trust)
+            for index in range(completed, len(prompt_records)):
+                prompt, source_line = prompt_records[index]
+                if local_torch is not None:
+                    local_torch.manual_seed(bon_checkpoint.prompt_seed(seed, index))
+                candidates = bon.sample_candidates(
+                    local_model,
+                    tokenizer,
+                    prompt,
+                    n=n,
+                    temperature=temperature,
+                    max_new_tokens=max_new_tokens,
+                    device=dev,
+                    generate_fn=generate_fn,
                 )
-            if resume:
-                completed_entries = bon_checkpoint.load_checkpoint(
-                    checkpoint_path, digest=digest, total=len(prompt_list)
+                group = bon_artifact.build_candidate_group(
+                    prompt,
+                    index,
+                    candidates,
+                    sampler_spec,
+                    source_line=source_line,
                 )
-            else:
-                bon_checkpoint.initialise_checkpoint(
-                    checkpoint_path, digest=digest, total=len(prompt_list)
-                )
-        except (FileNotFoundError, OSError, TypeError, ValueError) as exc:
-            console.print(f"[red]Invalid checkpoint: {_escape(str(exc))}[/]")
-            raise typer.Exit(2) from exc
+                bon_stream.append_candidate_group(checkpoint_path, group)
+                completed = index + 1
+            bon_stream.publish_candidate_checkpoint(
+                checkpoint_path, export_candidates, prompt_list, sampler_spec
+            )
+        except Exception as exc:
+            console.print(
+                "[red]Candidate export failed before publication.[/]\n"
+                f"Reason:           [bold]{_escape(str(exc))}[/]\n"
+                f"Completed groups: [bold]{completed}/{len(prompt_list)}[/]\n"
+                f"Resume with: [bold]--resume --checkpoint "
+                f"{_escape(os.path.relpath(checkpoint_path))}[/]"
+            )
+            raise typer.Exit(1) from exc
+        console.print(
+            Panel(
+                f"Candidate groups: [bold]{completed}[/]\n"
+                f"Output:           [bold]{_escape(os.path.relpath(export_candidates))}[/]\n"
+                f"Checkpoint:       [bold]{_escape(os.path.relpath(checkpoint_path))}[/]",
+                title="soup data best-of-n — candidates exported",
+            )
+        )
+        return
+
+    completed_entries = []
+    try:
+        targets = [output, checkpoint_path, manifest_path]
+        if emit_pairs:
+            targets.append(emit_pairs)
+        if len({os.path.normcase(os.path.realpath(path)) for path in targets}) != len(
+            targets
+        ):
+            raise ValueError(
+                "output, pairs, checkpoint, and manifest paths must be distinct"
+            )
+        if resume:
+            completed_entries = bon_checkpoint.load_checkpoint(
+                checkpoint_path, digest=digest, total=len(prompt_list)
+            )
+        else:
+            bon_checkpoint.initialise_checkpoint(
+                checkpoint_path, digest=digest, total=len(prompt_list)
+            )
+    except (FileNotFoundError, OSError, TypeError, ValueError) as exc:
+        console.print(f"[red]Invalid checkpoint: {_escape(str(exc))}[/]")
+        raise typer.Exit(2) from exc
 
     local_model = None
     tokenizer = None
@@ -3431,49 +3502,6 @@ def best_of_n(
             )
         else:
             local_model, tokenizer = _load_bon_model(base, device, trust)
-
-    dev = device or None
-    if export_mode:
-        groups = []
-        try:
-            for index, (prompt, source_line) in enumerate(prompt_records):
-                candidates = bon.sample_candidates(
-                    local_model,
-                    tokenizer,
-                    prompt,
-                    n=n,
-                    temperature=temperature,
-                    max_new_tokens=max_new_tokens,
-                    device=dev,
-                    generate_fn=generate_fn,
-                )
-                groups.append(
-                    bon_artifact.build_candidate_group(
-                        prompt,
-                        index,
-                        candidates,
-                        sampler_spec,
-                        source_line=source_line,
-                    )
-                )
-            atomic_write_bytes(
-                bon_artifact.candidate_artifact_text(groups, sampler_spec).encode(
-                    "utf-8"
-                ),
-                export_candidates,
-                field="export-candidates",
-            )
-        except Exception as exc:
-            console.print("[red]Candidate export failed before publication.[/]")
-            raise typer.Exit(1) from exc
-        console.print(
-            Panel(
-                f"Candidate groups: [bold]{len(groups)}[/]\n"
-                f"Output:           [bold]{_escape(os.path.relpath(export_candidates))}[/]",
-                title="soup data best-of-n — candidates exported",
-            )
-        )
-        return
 
     sft_rows = [entry[0] for entry in completed_entries]
     pair_rows = [entry[1] for entry in completed_entries if entry[1] is not None]

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -3164,21 +3164,26 @@ def best_of_n(
             with bon_stream.index_offline_artifacts(
                 candidate_artifact, judgments
             ) as offline_index:
-                offline_index.validate_all()
                 console.print(
                     Panel(
                         f"Candidate groups: [bold]{offline_index.group_count}[/]\n"
-                        f"Verified rows:    [bold]{offline_index.group_count}[/]\n"
+                        f"Matched rows:     [bold]{offline_index.group_count}[/]\n"
                         "Network/model:    [bold]disabled[/]",
                         title="soup data best-of-n — offline plan",
                     )
                 )
                 if plan_only:
+                    offline_index.validate_all()
                     return
-                publication_started = True
                 staged = bon_stream.stage_offline_datasets(
                     offline_index, output, emit_pairs
                 )
+                if staged.sft_count != offline_index.group_count:
+                    staged.cleanup()
+                    raise ValueError(
+                        "judgments must cover every candidate group exactly once"
+                    )
+                publication_started = True
                 try:
                     manifest_bytes = bon_artifact.offline_manifest_from_digests(
                         candidate_artifact_sha256=offline_index.candidate_sha256,
@@ -3333,10 +3338,17 @@ def best_of_n(
 
     sampler_label = f"{sampling_provider}:{model}" if generate_fn is not None else base
     if generate_fn is not None:
+        default_endpoint = {
+            "ollama": "http://localhost:11434",
+            "vllm": "http://localhost:8000",
+        }[sampling_provider]
         sampler_spec = {
             "kind": "provider",
             "provider": sampling_provider,
             "model": model,
+            "endpoint_fingerprint": bon_artifact.sampler_identity_fingerprint(
+                "provider-endpoint", base_url or default_endpoint
+            ),
             "n": n,
             "temperature": temperature,
             "max_new_tokens": max_new_tokens,
@@ -3344,9 +3356,13 @@ def best_of_n(
     else:
         is_local_path = os.path.exists(base) or os.path.isabs(base) or ntpath.isabs(base)
         public_model = "<local-model>" if is_local_path else base
+        model_identity = os.path.realpath(base) if is_local_path else base
         sampler_spec = {
             "kind": "local",
             "model": public_model,
+            "model_fingerprint": bon_artifact.sampler_identity_fingerprint(
+                "local-model", model_identity, revision or "unspecified"
+            ),
             "revision": revision or "unspecified",
             "n": n,
             "temperature": temperature,
@@ -3488,14 +3504,10 @@ def best_of_n(
     local_model = None
     tokenizer = None
     local_torch = None
-    if generate_fn is None and (
-        export_mode or len(completed_entries) < len(prompt_list)
-    ):
+    if generate_fn is None and len(completed_entries) < len(prompt_list):
         import torch
 
         local_torch = torch
-        if export_mode:
-            torch.manual_seed(seed)
         if revision:
             local_model, tokenizer = _load_bon_model(
                 base, device, trust, revision=revision

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -3357,13 +3357,13 @@ def best_of_n(
             "kind": "provider",
             "provider": sampling_provider,
             "model": model,
-            "endpoint_fingerprint": bon_artifact.sampler_identity_fingerprint(
-                "provider-endpoint", base_url or default_endpoint
-            ),
             "n": n,
             "temperature": temperature,
             "max_new_tokens": max_new_tokens,
         }
+        sampler_identity = bon_artifact.sampler_identity_fingerprint(
+            "provider-endpoint", base_url or default_endpoint
+        )
     else:
         is_local_path = os.path.exists(base) or os.path.isabs(base) or ntpath.isabs(base)
         public_model = "<local-model>" if is_local_path else base
@@ -3380,9 +3380,6 @@ def best_of_n(
         sampler_spec = {
             "kind": "local",
             "model": public_model,
-            "model_fingerprint": bon_artifact.sampler_identity_fingerprint(
-                *model_fingerprint_parts
-            ),
             "revision": revision or "unspecified",
             "n": n,
             "temperature": temperature,
@@ -3391,6 +3388,9 @@ def best_of_n(
             "seed": seed,
             "trust_remote_code": trust,
         }
+        sampler_identity = bon_artifact.sampler_identity_fingerprint(
+            *model_fingerprint_parts
+        )
 
     digest = ""
     if not export_mode:
@@ -3438,7 +3438,11 @@ def best_of_n(
         completed = 0
         try:
             completed = bon_stream.prepare_candidate_checkpoint(
-                checkpoint_path, prompt_records, sampler_spec, resume=resume
+                checkpoint_path,
+                prompt_records,
+                sampler_spec,
+                sampler_identity,
+                resume=resume,
             )
             local_model = None
             tokenizer = None
@@ -3477,7 +3481,11 @@ def best_of_n(
                 bon_stream.append_candidate_group(checkpoint_path, group)
                 completed = index + 1
             bon_stream.publish_candidate_checkpoint(
-                checkpoint_path, export_candidates, prompt_records, sampler_spec
+                checkpoint_path,
+                export_candidates,
+                prompt_records,
+                sampler_spec,
+                sampler_identity,
             )
         except Exception as exc:
             console.print(

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -3185,6 +3185,11 @@ def best_of_n(
                     )
                 publication_started = True
                 try:
+                    stale_dpo = ""
+                    if not emit_pairs and os.path.lexists(manifest_path):
+                        stale_dpo = bon_artifact.find_committed_sibling_dpo(
+                            manifest_path, sft_path=output
+                        )
                     manifest_bytes = bon_artifact.offline_manifest_from_digests(
                         candidate_artifact_sha256=offline_index.candidate_sha256,
                         judgments_sha256=offline_index.judgments_sha256,
@@ -3196,7 +3201,15 @@ def best_of_n(
                         dpo_count=staged.dpo_count,
                     ).encode("utf-8")
                     bon_artifact.invalidate_offline_manifest(manifest_path)
-                    bon_stream.publish_staged_datasets(staged, output, emit_pairs)
+                    if stale_dpo:
+                        bon_stream.publish_staged_datasets(
+                            staged,
+                            output,
+                            emit_pairs,
+                            stale_dpo_path=stale_dpo,
+                        )
+                    else:
+                        bon_stream.publish_staged_datasets(staged, output, emit_pairs)
                     atomic_write_bytes(manifest_bytes, manifest_path, field="manifest")
                 finally:
                     staged.cleanup()
@@ -3206,7 +3219,7 @@ def best_of_n(
             if not publication_started:
                 console.print(f"[red]Invalid offline artifact: {_escape(str(exc))}[/]")
                 raise typer.Exit(2) from exc
-            console.print(f"[red]Offline materialization failed: {_escape(str(exc))}[/]")
+            console.print(f"[red]Failed to write output: {_escape(str(exc))}[/]")
             raise typer.Exit(1) from exc
         body = (
             f"SFT rows:   [bold]{sft_count}[/]\n"
@@ -3357,11 +3370,20 @@ def best_of_n(
         is_local_path = os.path.exists(base) or os.path.isabs(base) or ntpath.isabs(base)
         public_model = "<local-model>" if is_local_path else base
         model_identity = os.path.realpath(base) if is_local_path else base
+        model_fingerprint_parts = [
+            "local-model",
+            model_identity,
+            revision or "unspecified",
+        ]
+        if is_local_path and export_mode:
+            model_fingerprint_parts.append(
+                bon_artifact.local_model_content_fingerprint(base)
+            )
         sampler_spec = {
             "kind": "local",
             "model": public_model,
             "model_fingerprint": bon_artifact.sampler_identity_fingerprint(
-                "local-model", model_identity, revision or "unspecified"
+                *model_fingerprint_parts
             ),
             "revision": revision or "unspecified",
             "n": n,
@@ -3418,7 +3440,7 @@ def best_of_n(
         completed = 0
         try:
             completed = bon_stream.prepare_candidate_checkpoint(
-                checkpoint_path, prompt_list, sampler_spec, resume=resume
+                checkpoint_path, prompt_records, sampler_spec, resume=resume
             )
             local_model = None
             tokenizer = None
@@ -3457,7 +3479,7 @@ def best_of_n(
                 bon_stream.append_candidate_group(checkpoint_path, group)
                 completed = index + 1
             bon_stream.publish_candidate_checkpoint(
-                checkpoint_path, export_candidates, prompt_list, sampler_spec
+                checkpoint_path, export_candidates, prompt_records, sampler_spec
             )
         except Exception as exc:
             console.print(

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -3079,10 +3079,7 @@ def best_of_n(
     from soup_cli.utils import best_of_n_artifact as bon_artifact
     from soup_cli.utils import best_of_n_checkpoint as bon_checkpoint
     from soup_cli.utils.magpie import make_magpie_generate_fn
-    from soup_cli.utils.paths import (
-        atomic_write_bytes,
-        enforce_under_cwd_and_no_symlink,
-    )
+    from soup_cli.utils.paths import enforce_under_cwd_and_no_symlink
     from soup_cli.utils.trust_remote import (
         model_requires_trust_remote_code,
         resolve_trust_remote_code,
@@ -3200,17 +3197,14 @@ def best_of_n(
                         dpo_sha256=staged.dpo_sha256,
                         dpo_count=staged.dpo_count,
                     ).encode("utf-8")
-                    bon_artifact.invalidate_offline_manifest(manifest_path)
-                    if stale_dpo:
-                        bon_stream.publish_staged_datasets(
-                            staged,
-                            output,
-                            emit_pairs,
-                            stale_dpo_path=stale_dpo,
-                        )
-                    else:
-                        bon_stream.publish_staged_datasets(staged, output, emit_pairs)
-                    atomic_write_bytes(manifest_bytes, manifest_path, field="manifest")
+                    bon_stream.publish_staged_datasets(
+                        staged,
+                        output,
+                        emit_pairs,
+                        manifest_path=manifest_path,
+                        manifest_bytes=manifest_bytes,
+                        stale_dpo_path=stale_dpo,
+                    )
                 finally:
                     staged.cleanup()
                 sft_count = staged.sft_count
@@ -3285,10 +3279,14 @@ def best_of_n(
             )
             checkpoint_path = checkpoint or f"{export_candidates}.checkpoint.jsonl"
             enforce_under_cwd_and_no_symlink(checkpoint_path, "--checkpoint path")
-            if os.path.normcase(os.path.realpath(checkpoint_path)) == os.path.normcase(
-                os.path.realpath(export_candidates)
-            ):
-                raise ValueError("candidate artifact and checkpoint paths must be distinct")
+            export_paths = [prompts, export_candidates, checkpoint_path]
+            if len(
+                {os.path.normcase(os.path.realpath(path)) for path in export_paths}
+            ) != len(export_paths):
+                raise ValueError(
+                    "prompt source, candidate artifact, and checkpoint paths "
+                    "must be distinct"
+                )
     except (FileNotFoundError, TypeError, ValueError) as exc:
         console.print(f"[red]{_escape(str(exc))}[/]")
         raise typer.Exit(2) from exc

--- a/src/soup_cli/utils/best_of_n_artifact.py
+++ b/src/soup_cli/utils/best_of_n_artifact.py
@@ -107,10 +107,9 @@ def _validate_sampler(sampler: Any) -> dict:
     kind = sampler.get("kind")
     common = {"kind", "model", "n", "temperature", "max_new_tokens"}
     expected = (
-        common | {"provider", "endpoint_fingerprint"}
+        common | {"provider"}
         if kind == "provider"
-        else common
-        | {"revision", "device", "seed", "trust_remote_code", "model_fingerprint"}
+        else common | {"revision", "device", "seed", "trust_remote_code"}
     )
     if kind not in {"provider", "local"} or set(sampler) != expected:
         raise ValueError("candidate sampler specification has unsupported fields")
@@ -147,10 +146,6 @@ def _validate_sampler(sampler: Any) -> dict:
     if kind == "provider":
         if sampler.get("provider") not in {"ollama", "vllm"}:
             raise ValueError("candidate sampler provider is invalid")
-        if not isinstance(sampler.get("endpoint_fingerprint"), str) or not (
-            _SHA256_VALUE.fullmatch(sampler["endpoint_fingerprint"])
-        ):
-            raise ValueError("candidate sampler endpoint fingerprint is invalid")
     else:
         revision = sampler.get("revision")
         if (
@@ -173,10 +168,6 @@ def _validate_sampler(sampler: Any) -> dict:
             raise ValueError("candidate sampler seed is invalid")
         if not isinstance(sampler.get("trust_remote_code"), bool):
             raise ValueError("candidate sampler trust flag is invalid")
-        if not isinstance(sampler.get("model_fingerprint"), str) or not (
-            _SHA256_VALUE.fullmatch(sampler["model_fingerprint"])
-        ):
-            raise ValueError("candidate sampler model fingerprint is invalid")
     return sampler
 
 

--- a/src/soup_cli/utils/best_of_n_artifact.py
+++ b/src/soup_cli/utils/best_of_n_artifact.py
@@ -37,10 +37,68 @@ def sampler_identity_fingerprint(*parts: str) -> str:
     return _sha({"identity": list(parts)})
 
 
-def prompt_seed(seed: int, index: int) -> int:
-    """Derive a stable torch seed for one prompt, independent of resume position."""
-    encoded = f"{seed}:{index}".encode("ascii")
-    return int.from_bytes(hashlib.sha256(encoded).digest()[:8], "big") & ((1 << 63) - 1)
+def local_model_content_fingerprint(path: str) -> str:
+    """Hash the exact regular-file content of a local model source.
+
+    Logical relative names and bytes are included so replacing a file in the
+    same directory cannot reuse an authenticated candidate checkpoint. Paths
+    themselves are never returned or written to the public artifact.
+    """
+    if not isinstance(path, str) or not path:
+        raise ValueError("local model path must be a non-empty string")
+    root = os.path.realpath(path)
+    files: list[tuple[str, str]] = []
+    if os.path.isfile(root):
+        files.append((os.path.basename(root), root))
+    elif os.path.isdir(root):
+        for directory, dirnames, filenames in os.walk(root, followlinks=False):
+            dirnames.sort()
+            filenames.sort()
+            for dirname in dirnames:
+                if os.path.islink(os.path.join(directory, dirname)):
+                    raise ValueError("local model path contains a symlinked directory")
+            for filename in filenames:
+                logical = os.path.relpath(os.path.join(directory, filename), root)
+                files.append((logical.replace(os.sep, "/"), os.path.join(directory, filename)))
+    else:
+        raise ValueError("local model path must be a regular file or directory")
+
+    digest = hashlib.sha256(b"soup.local-model-content.v1\0")
+    for logical, source in files:
+        resolved = os.path.realpath(source)
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_BINARY", 0)
+        fd = os.open(resolved, flags)
+        try:
+            before = os.fstat(fd)
+            if not stat.S_ISREG(before.st_mode):
+                raise ValueError("local model content must contain only regular files")
+            name = logical.encode("utf-8")
+            digest.update(len(name).to_bytes(8, "big"))
+            digest.update(name)
+            digest.update(before.st_size.to_bytes(16, "big"))
+            while True:
+                chunk = os.read(fd, 1024 * 1024)
+                if not chunk:
+                    break
+                digest.update(chunk)
+            after = os.fstat(fd)
+            identity_before = (
+                before.st_dev,
+                before.st_ino,
+                before.st_size,
+                before.st_mtime_ns,
+            )
+            identity_after = (
+                after.st_dev,
+                after.st_ino,
+                after.st_size,
+                after.st_mtime_ns,
+            )
+            if identity_before != identity_after:
+                raise ValueError("local model content changed while it was fingerprinted")
+        finally:
+            os.close(fd)
+    return digest.hexdigest()
 
 
 def _validate_sampler(sampler: Any) -> dict:
@@ -233,6 +291,7 @@ def validate_candidate_group(
     sampler: dict,
     *,
     expected_prompt: str | None = None,
+    expected_source_line: int | None = None,
 ) -> str:
     """Authenticate one candidate group and return its prompt id."""
     if not isinstance(group, dict):
@@ -246,6 +305,8 @@ def validate_candidate_group(
         or source_line < 1
     ):
         raise ValueError(f"candidate group {index} has an invalid source line")
+    if expected_source_line is not None and source_line != expected_source_line:
+        raise ValueError(f"candidate group {index} does not match its source line")
     prompt = group["prompt"]
     if expected_prompt is not None and prompt != expected_prompt:
         raise ValueError(f"candidate group {index} does not match its source prompt")

--- a/src/soup_cli/utils/best_of_n_artifact.py
+++ b/src/soup_cli/utils/best_of_n_artifact.py
@@ -30,15 +30,29 @@ def _sha(value: Any) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
+def sampler_identity_fingerprint(*parts: str) -> str:
+    """Return a privacy-safe identity pin for a sampler source or endpoint."""
+    if not parts or not all(isinstance(part, str) and part for part in parts):
+        raise ValueError("sampler identity parts must be non-empty strings")
+    return _sha({"identity": list(parts)})
+
+
+def prompt_seed(seed: int, index: int) -> int:
+    """Derive a stable torch seed for one prompt, independent of resume position."""
+    encoded = f"{seed}:{index}".encode("ascii")
+    return int.from_bytes(hashlib.sha256(encoded).digest()[:8], "big") & ((1 << 63) - 1)
+
+
 def _validate_sampler(sampler: Any) -> dict:
     if not isinstance(sampler, dict):
         raise ValueError("candidate sampler specification must be an object")
     kind = sampler.get("kind")
     common = {"kind", "model", "n", "temperature", "max_new_tokens"}
     expected = (
-        common | {"provider"}
+        common | {"provider", "endpoint_fingerprint"}
         if kind == "provider"
-        else common | {"revision", "device", "seed", "trust_remote_code"}
+        else common
+        | {"revision", "device", "seed", "trust_remote_code", "model_fingerprint"}
     )
     if kind not in {"provider", "local"} or set(sampler) != expected:
         raise ValueError("candidate sampler specification has unsupported fields")
@@ -75,6 +89,10 @@ def _validate_sampler(sampler: Any) -> dict:
     if kind == "provider":
         if sampler.get("provider") not in {"ollama", "vllm"}:
             raise ValueError("candidate sampler provider is invalid")
+        if not isinstance(sampler.get("endpoint_fingerprint"), str) or not (
+            _SHA256_VALUE.fullmatch(sampler["endpoint_fingerprint"])
+        ):
+            raise ValueError("candidate sampler endpoint fingerprint is invalid")
     else:
         revision = sampler.get("revision")
         if (
@@ -97,6 +115,10 @@ def _validate_sampler(sampler: Any) -> dict:
             raise ValueError("candidate sampler seed is invalid")
         if not isinstance(sampler.get("trust_remote_code"), bool):
             raise ValueError("candidate sampler trust flag is invalid")
+        if not isinstance(sampler.get("model_fingerprint"), str) or not (
+            _SHA256_VALUE.fullmatch(sampler["model_fingerprint"])
+        ):
+            raise ValueError("candidate sampler model fingerprint is invalid")
     return sampler
 
 

--- a/src/soup_cli/utils/best_of_n_artifact.py
+++ b/src/soup_cli/utils/best_of_n_artifact.py
@@ -100,6 +100,11 @@ def _validate_sampler(sampler: Any) -> dict:
     return sampler
 
 
+def validate_sampler_spec(sampler: Any) -> dict:
+    """Validate and return one public sampler specification."""
+    return _validate_sampler(sampler)
+
+
 def build_candidate_group(
     prompt: str,
     prompt_index: int,
@@ -137,15 +142,27 @@ def build_candidate_group(
     return {**core, "group_digest": _sha(core)}
 
 
-def candidate_artifact_text(groups: list[dict], sampler: dict) -> str:
+def candidate_artifact_header(prompt_count: int, sampler: dict) -> dict:
+    """Build the authenticated candidate-artifact header."""
     sampler = _validate_sampler(sampler)
-    header = {
+    if isinstance(prompt_count, bool) or not isinstance(prompt_count, int) or prompt_count < 1:
+        raise ValueError("candidate artifact prompt count is invalid")
+    return {
         "_best_of_n_candidates": {
             "schema": _CANDIDATE_SCHEMA,
-            "prompt_count": len(groups),
+            "prompt_count": prompt_count,
             "sampler": sampler,
         }
     }
+
+
+def stable_json_line(row: dict) -> bytes:
+    """Encode one canonical JSONL record as exact UTF-8 bytes."""
+    return _canonical(row) + b"\n"
+
+
+def candidate_artifact_text(groups: list[dict], sampler: dict) -> str:
+    header = candidate_artifact_header(len(groups), sampler)
     return "".join(
         json.dumps(row, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
         for row in [header, *groups]
@@ -188,6 +205,48 @@ def _jsonl(data: bytes, field: str) -> list[dict]:
     return rows
 
 
+def validate_candidate_group(
+    group: Any,
+    index: int,
+    sampler: dict,
+    *,
+    expected_prompt: str | None = None,
+) -> str:
+    """Authenticate one candidate group and return its prompt id."""
+    if not isinstance(group, dict):
+        raise ValueError(f"candidate group {index} must be an object")
+    if group.get("prompt_index") != index or not isinstance(group.get("prompt"), str):
+        raise ValueError("candidate groups must be sequential")
+    source_line = group.get("source_line")
+    if (
+        isinstance(source_line, bool)
+        or not isinstance(source_line, int)
+        or source_line < 1
+    ):
+        raise ValueError(f"candidate group {index} has an invalid source line")
+    prompt = group["prompt"]
+    if expected_prompt is not None and prompt != expected_prompt:
+        raise ValueError(f"candidate group {index} does not match its source prompt")
+    expected_id = _sha({"prompt_index": index, "prompt": prompt})
+    if group.get("prompt_id") != expected_id:
+        raise ValueError(f"candidate group {index} has an invalid prompt id")
+    if group.get("prompt_sha256") != _sha(prompt.encode("utf-8")):
+        raise ValueError(f"candidate group {index} has a prompt digest mismatch")
+    candidates = group.get("candidates")
+    if not isinstance(candidates, list) or len(candidates) != sampler["n"]:
+        raise ValueError(f"candidate group {index} has the wrong candidate count")
+    for candidate_index, candidate in enumerate(candidates):
+        if not isinstance(candidate, dict) or candidate.get("index") != candidate_index:
+            raise ValueError(f"candidate group {index} has unordered candidates")
+        text = candidate.get("text")
+        if not isinstance(text, str) or candidate.get("sha256") != _sha(text.encode("utf-8")):
+            raise ValueError(f"candidate group {index} has a candidate digest mismatch")
+    core = {key: value for key, value in group.items() if key != "group_digest"}
+    if group.get("sampler") != sampler or group.get("group_digest") != _sha(core):
+        raise ValueError(f"candidate group {index} has a group digest mismatch")
+    return expected_id
+
+
 def load_candidate_artifact(path: str) -> tuple[list[dict], dict, str]:
     """Authenticate every group and return groups, public sampler spec, file hash."""
     data = _read_regular(path, "--candidate-artifact path")
@@ -205,34 +264,10 @@ def load_candidate_artifact(path: str) -> tuple[list[dict], dict, str]:
         raise ValueError("candidate artifact contains no prompt groups")
     seen_ids: set[str] = set()
     for index, group in enumerate(groups):
-        if group.get("prompt_index") != index or not isinstance(group.get("prompt"), str):
-            raise ValueError("candidate groups must be sequential")
-        source_line = group.get("source_line")
-        if (
-            isinstance(source_line, bool)
-            or not isinstance(source_line, int)
-            or source_line < 1
-        ):
-            raise ValueError(f"candidate group {index} has an invalid source line")
-        prompt = group["prompt"]
-        expected_id = _sha({"prompt_index": index, "prompt": prompt})
-        if group.get("prompt_id") != expected_id or expected_id in seen_ids:
+        prompt_id = validate_candidate_group(group, index, sampler)
+        if prompt_id in seen_ids:
             raise ValueError(f"candidate group {index} has an invalid prompt id")
-        seen_ids.add(expected_id)
-        if group.get("prompt_sha256") != _sha(prompt.encode("utf-8")):
-            raise ValueError(f"candidate group {index} has a prompt digest mismatch")
-        candidates = group.get("candidates")
-        if not isinstance(candidates, list) or len(candidates) != sampler["n"]:
-            raise ValueError(f"candidate group {index} has the wrong candidate count")
-        for candidate_index, candidate in enumerate(candidates):
-            if not isinstance(candidate, dict) or candidate.get("index") != candidate_index:
-                raise ValueError(f"candidate group {index} has unordered candidates")
-            text = candidate.get("text")
-            if not isinstance(text, str) or candidate.get("sha256") != _sha(text.encode("utf-8")):
-                raise ValueError(f"candidate group {index} has a candidate digest mismatch")
-        core = {key: value for key, value in group.items() if key != "group_digest"}
-        if group.get("sampler") != sampler or group.get("group_digest") != _sha(core):
-            raise ValueError(f"candidate group {index} has a group digest mismatch")
+        seen_ids.add(prompt_id)
     return groups, sampler, _sha(data)
 
 
@@ -249,12 +284,52 @@ def _verifier(value: Any, index: int) -> dict[str, str]:
     return clean
 
 
+def validate_judgment(row: Any, group: dict, index: int) -> dict:
+    """Validate one judgment against its exact candidate group."""
+    if not isinstance(row, dict):
+        raise ValueError(f"judgment {index} must be an object")
+    if row.get("prompt_id") != group["prompt_id"]:
+        raise ValueError(f"judgment {index} has a prompt id mismatch")
+    if row.get("group_digest") != group["group_digest"]:
+        raise ValueError(f"judgment {index} has a candidate digest mismatch")
+    winner_idx = row.get("winner_idx")
+    candidates = group["candidates"]
+    if isinstance(winner_idx, bool) or not isinstance(winner_idx, int):
+        raise ValueError(f"judgment {index} winner_idx must be an integer")
+    if not 0 <= winner_idx < len(candidates):
+        raise ValueError(f"judgment {index} winner_idx is out of range")
+    scores = row.get("scores")
+    if not isinstance(scores, list) or len(scores) != len(candidates):
+        raise ValueError(f"judgment {index} scores must match candidate count")
+    clean_scores = []
+    for score in scores:
+        if isinstance(score, bool) or not isinstance(score, (int, float)):
+            raise ValueError(f"judgment {index} scores must be numeric")
+        try:
+            number = float(score)
+        except (OverflowError, ValueError) as exc:
+            raise ValueError(f"judgment {index} scores must be finite") from exc
+        if not math.isfinite(number):
+            raise ValueError(f"judgment {index} scores must be finite")
+        clean_scores.append(number)
+    expected_winner = max(range(len(clean_scores)), key=clean_scores.__getitem__)
+    if winner_idx != expected_winner:
+        raise ValueError(f"judgment {index} winner_idx does not match its scores")
+    return {
+        "prompt_id": group["prompt_id"],
+        "group_digest": group["group_digest"],
+        "winner_idx": winner_idx,
+        "scores": clean_scores,
+        "verifier": _verifier(row.get("verifier"), index),
+    }
+
+
 def load_judgments(path: str, groups: list[dict]) -> tuple[list[dict], str]:
     """Validate complete one-to-one judgments against exact candidate groups."""
     data = _read_regular(path, "--judgments path")
     rows = _jsonl(data, "judgments")
     by_prompt: dict[str, dict] = {}
-    for index, row in enumerate(rows):
+    for row in rows:
         prompt_id = row.get("prompt_id")
         if not isinstance(prompt_id, str) or prompt_id in by_prompt:
             raise ValueError("judgments contain a missing or duplicate prompt_id")
@@ -265,41 +340,53 @@ def load_judgments(path: str, groups: list[dict]) -> tuple[list[dict], str]:
     validated = []
     for index, group in enumerate(groups):
         row = by_prompt[group["prompt_id"]]
-        if row.get("group_digest") != group["group_digest"]:
-            raise ValueError(f"judgment {index} has a candidate digest mismatch")
-        winner_idx = row.get("winner_idx")
-        candidates = group["candidates"]
-        if isinstance(winner_idx, bool) or not isinstance(winner_idx, int):
-            raise ValueError(f"judgment {index} winner_idx must be an integer")
-        if not 0 <= winner_idx < len(candidates):
-            raise ValueError(f"judgment {index} winner_idx is out of range")
-        scores = row.get("scores")
-        if not isinstance(scores, list) or len(scores) != len(candidates):
-            raise ValueError(f"judgment {index} scores must match candidate count")
-        clean_scores = []
-        for score in scores:
-            if isinstance(score, bool) or not isinstance(score, (int, float)):
-                raise ValueError(f"judgment {index} scores must be numeric")
-            try:
-                number = float(score)
-            except (OverflowError, ValueError) as exc:
-                raise ValueError(f"judgment {index} scores must be finite") from exc
-            if not math.isfinite(number):
-                raise ValueError(f"judgment {index} scores must be finite")
-            clean_scores.append(number)
-        expected_winner = max(range(len(clean_scores)), key=clean_scores.__getitem__)
-        if winner_idx != expected_winner:
-            raise ValueError(f"judgment {index} winner_idx does not match its scores")
-        validated.append(
-            {
-                "prompt_id": group["prompt_id"],
-                "group_digest": group["group_digest"],
-                "winner_idx": winner_idx,
-                "scores": clean_scores,
-                "verifier": _verifier(row.get("verifier"), index),
-            }
-        )
+        validated.append(validate_judgment(row, group, index))
     return validated, _sha(data)
+
+
+def materialize_group(
+    group: dict,
+    judgment: dict,
+    *,
+    sampler: dict,
+    candidate_artifact_sha256: str,
+    judgments_sha256: str,
+) -> tuple[dict, dict | None]:
+    """Produce one SFT row and optional DPO row from authenticated records."""
+    candidates = group["candidates"]
+    winner_idx = judgment["winner_idx"]
+    loser_idx = min(range(len(candidates)), key=judgment["scores"].__getitem__)
+    provenance = {
+        "mode": "offline",
+        "n": len(candidates),
+        "source_line": group["source_line"],
+        "winner_idx": winner_idx,
+        "scores": judgment["scores"],
+        "prompt_id": group["prompt_id"],
+        "candidate_group_digest": group["group_digest"],
+        "candidate_artifact_sha256": candidate_artifact_sha256,
+        "judgments_sha256": judgments_sha256,
+        "sampler": sampler,
+        "verifier": judgment["verifier"],
+    }
+    prompt = group["prompt"]
+    winner = candidates[winner_idx]["text"]
+    sft = {
+        "messages": [
+            {"role": "user", "content": prompt},
+            {"role": "assistant", "content": winner},
+        ],
+        "_best_of_n": provenance,
+    }
+    dpo = None
+    if loser_idx != winner_idx:
+        dpo = {
+            "prompt": prompt,
+            "chosen": winner,
+            "rejected": candidates[loser_idx]["text"],
+            "_best_of_n": provenance,
+        }
+    return sft, dpo
 
 
 def materialize_rows(
@@ -314,42 +401,16 @@ def materialize_rows(
     sft_rows = []
     dpo_rows = []
     for group, judgment in zip(groups, judgments):
-        candidates = group["candidates"]
-        winner_idx = judgment["winner_idx"]
-        loser_idx = min(range(len(candidates)), key=judgment["scores"].__getitem__)
-        provenance = {
-            "mode": "offline",
-            "n": len(candidates),
-            "source_line": group["source_line"],
-            "winner_idx": winner_idx,
-            "scores": judgment["scores"],
-            "prompt_id": group["prompt_id"],
-            "candidate_group_digest": group["group_digest"],
-            "candidate_artifact_sha256": candidate_artifact_sha256,
-            "judgments_sha256": judgments_sha256,
-            "sampler": sampler,
-            "verifier": judgment["verifier"],
-        }
-        prompt = group["prompt"]
-        winner = candidates[winner_idx]["text"]
-        sft_rows.append(
-            {
-                "messages": [
-                    {"role": "user", "content": prompt},
-                    {"role": "assistant", "content": winner},
-                ],
-                "_best_of_n": provenance,
-            }
+        sft, dpo = materialize_group(
+            group,
+            judgment,
+            sampler=sampler,
+            candidate_artifact_sha256=candidate_artifact_sha256,
+            judgments_sha256=judgments_sha256,
         )
-        if loser_idx != winner_idx:
-            dpo_rows.append(
-                {
-                    "prompt": prompt,
-                    "chosen": winner,
-                    "rejected": candidates[loser_idx]["text"],
-                    "_best_of_n": provenance,
-                }
-            )
+        sft_rows.append(sft)
+        if dpo is not None:
+            dpo_rows.append(dpo)
     return sft_rows, dpo_rows
 
 
@@ -372,16 +433,44 @@ def offline_manifest_text(
     dpo_count: int,
 ) -> str:
     """Build the final commit marker for one offline materialization."""
+    if not isinstance(sft_bytes, bytes) or not isinstance(dpo_bytes, bytes):
+        raise TypeError("offline dataset payloads must be bytes")
+    return offline_manifest_from_digests(
+        candidate_artifact_sha256=candidate_artifact_sha256,
+        judgments_sha256=judgments_sha256,
+        sft_path=sft_path,
+        sft_sha256=_sha(sft_bytes),
+        sft_count=sft_count,
+        dpo_path=dpo_path,
+        dpo_sha256=_sha(dpo_bytes),
+        dpo_count=dpo_count,
+    )
+
+
+def offline_manifest_from_digests(
+    *,
+    candidate_artifact_sha256: str,
+    judgments_sha256: str,
+    sft_path: str,
+    sft_sha256: str,
+    sft_count: int,
+    dpo_path: str,
+    dpo_sha256: str,
+    dpo_count: int,
+) -> str:
+    """Build an offline commit marker from incrementally computed digests."""
     if not _SHA256_VALUE.fullmatch(candidate_artifact_sha256):
         raise ValueError("candidate artifact SHA-256 is invalid")
     if not _SHA256_VALUE.fullmatch(judgments_sha256):
         raise ValueError("judgments SHA-256 is invalid")
+    if not _SHA256_VALUE.fullmatch(sft_sha256):
+        raise ValueError("SFT SHA-256 is invalid")
+    if not _SHA256_VALUE.fullmatch(dpo_sha256):
+        raise ValueError("DPO SHA-256 is invalid")
     if isinstance(sft_count, bool) or not isinstance(sft_count, int) or sft_count < 0:
         raise ValueError("SFT row count is invalid")
     if isinstance(dpo_count, bool) or not isinstance(dpo_count, int) or dpo_count < 0:
         raise ValueError("DPO row count is invalid")
-    if not isinstance(sft_bytes, bytes) or not isinstance(dpo_bytes, bytes):
-        raise TypeError("offline dataset payloads must be bytes")
     dpo_requested = bool(dpo_path)
     manifest = {
         "schema": _OFFLINE_MANIFEST_SCHEMA,
@@ -391,13 +480,13 @@ def offline_manifest_text(
         "sft": {
             "file": os.path.basename(sft_path),
             "rows": sft_count,
-            "sha256": _sha(sft_bytes),
+            "sha256": sft_sha256,
         },
         "dpo": (
             {
                 "file": os.path.basename(dpo_path),
                 "rows": dpo_count,
-                "sha256": _sha(dpo_bytes),
+                "sha256": dpo_sha256,
             }
             if dpo_requested
             else None

--- a/src/soup_cli/utils/best_of_n_stream.py
+++ b/src/soup_cli/utils/best_of_n_stream.py
@@ -76,6 +76,38 @@ def _checkpoint_header(prompts: list[str], sampler: dict) -> dict:
     }
 
 
+def _discard_incomplete_checkpoint_tail(path: str) -> None:
+    """Discard a final record that never reached its newline commit boundary."""
+    enforce_under_cwd_and_no_symlink(path, "--checkpoint path")
+    flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_BINARY", 0)
+    fd = os.open(path, flags)
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            raise ValueError("--checkpoint path must be a regular file")
+        size = os.lseek(fd, 0, os.SEEK_END)
+        if size == 0:
+            return
+        os.lseek(fd, size - 1, os.SEEK_SET)
+        if os.read(fd, 1) == b"\n":
+            return
+
+        cursor = size
+        truncate_at = 0
+        while cursor:
+            chunk_start = max(0, cursor - 8192)
+            os.lseek(fd, chunk_start, os.SEEK_SET)
+            chunk = os.read(fd, cursor - chunk_start)
+            newline = chunk.rfind(b"\n")
+            if newline >= 0:
+                truncate_at = chunk_start + newline + 1
+                break
+            cursor = chunk_start
+        os.ftruncate(fd, truncate_at)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
 def prepare_candidate_checkpoint(
     path: str, prompts: list[str], sampler: dict, *, resume: bool
 ) -> int:
@@ -100,6 +132,7 @@ def prepare_candidate_checkpoint(
     if not resume:
         raise ValueError("candidate checkpoint already exists; pass --resume to continue")
 
+    _discard_incomplete_checkpoint_tail(path)
     completed = 0
     saw_header = False
     with _regular_binary_lines(path, "--checkpoint path") as lines:

--- a/src/soup_cli/utils/best_of_n_stream.py
+++ b/src/soup_cli/utils/best_of_n_stream.py
@@ -16,6 +16,7 @@ from soup_cli.utils import best_of_n_artifact as artifact
 from soup_cli.utils.paths import enforce_under_cwd_and_no_symlink
 
 _CHECKPOINT_SCHEMA = "soup.best_of_n.candidate_checkpoint.v1"
+PromptRecord = tuple[str, int]
 
 
 def _write_all(fd: int, data: bytes) -> None:
@@ -28,8 +29,35 @@ def _write_all(fd: int, data: bytes) -> None:
         view = view[written:]
 
 
-def _run_digest(prompts: list[str], sampler: dict) -> str:
-    payload = {"prompts": prompts, "sampler": sampler}
+def _normalise_prompt_records(prompts: list[str] | list[PromptRecord]) -> list[PromptRecord]:
+    records: list[PromptRecord] = []
+    for index, value in enumerate(prompts):
+        if isinstance(value, str):
+            record = (value, index + 1)
+        elif (
+            isinstance(value, tuple)
+            and len(value) == 2
+            and isinstance(value[0], str)
+            and isinstance(value[1], int)
+            and not isinstance(value[1], bool)
+            and value[1] > 0
+        ):
+            record = value
+        else:
+            raise ValueError("candidate checkpoint prompts are invalid")
+        records.append(record)
+    return records
+
+
+def _run_digest(prompts: list[str] | list[PromptRecord], sampler: dict) -> str:
+    records = _normalise_prompt_records(prompts)
+    payload = {
+        "prompts": [
+            {"prompt": prompt, "source_line": source_line}
+            for prompt, source_line in records
+        ],
+        "sampler": sampler,
+    }
     data = json.dumps(
         payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
     ).encode("utf-8")
@@ -65,12 +93,13 @@ def _regular_binary_lines(path: str, field: str) -> Iterator[Iterator[tuple[int,
             os.close(fd)
 
 
-def _checkpoint_header(prompts: list[str], sampler: dict) -> dict:
+def _checkpoint_header(prompts: list[str] | list[PromptRecord], sampler: dict) -> dict:
+    records = _normalise_prompt_records(prompts)
     return {
         "_best_of_n_checkpoint": {
             "schema": _CHECKPOINT_SCHEMA,
-            "run_digest": _run_digest(prompts, sampler),
-            "prompt_count": len(prompts),
+            "run_digest": _run_digest(records, sampler),
+            "prompt_count": len(records),
             "sampler": sampler,
         }
     }
@@ -109,12 +138,17 @@ def _discard_incomplete_checkpoint_tail(path: str) -> None:
 
 
 def prepare_candidate_checkpoint(
-    path: str, prompts: list[str], sampler: dict, *, resume: bool
+    path: str,
+    prompts: list[str] | list[PromptRecord],
+    sampler: dict,
+    *,
+    resume: bool,
 ) -> int:
     """Create or authenticate a checkpoint and return completed group count."""
     sampler = artifact.validate_sampler_spec(sampler)
     enforce_under_cwd_and_no_symlink(path, "--checkpoint path")
-    expected_header = _checkpoint_header(prompts, sampler)
+    records = _normalise_prompt_records(prompts)
+    expected_header = _checkpoint_header(records, sampler)
     exists = os.path.lexists(path)
     if not exists:
         if resume:
@@ -145,10 +179,15 @@ def prepare_candidate_checkpoint(
                     raise ValueError("candidate checkpoint does not match this run")
                 saw_header = True
                 continue
-            if completed >= len(prompts):
+            if completed >= len(records):
                 raise ValueError("candidate checkpoint has too many groups")
+            expected_prompt, expected_source_line = records[completed]
             artifact.validate_candidate_group(
-                row, completed, sampler, expected_prompt=prompts[completed]
+                row,
+                completed,
+                sampler,
+                expected_prompt=expected_prompt,
+                expected_source_line=expected_source_line,
             )
             completed += 1
     if not saw_header:
@@ -178,20 +217,21 @@ def append_candidate_group(path: str, group: dict) -> None:
 def publish_candidate_checkpoint(
     checkpoint: str,
     output: str,
-    prompts: list[str],
+    prompts: list[str] | list[PromptRecord],
     sampler: dict,
 ) -> None:
     """Stream a complete checkpoint into one atomically published artifact."""
     enforce_under_cwd_and_no_symlink(output, "--export-candidates path")
     parent = os.path.dirname(os.path.abspath(output)) or "."
     os.makedirs(parent, exist_ok=True)
+    records = _normalise_prompt_records(prompts)
     fd, staging = tempfile.mkstemp(prefix=".soup-bon-candidates.", dir=parent)
     try:
         with os.fdopen(fd, "wb") as target:
             fd = -1
             target.write(
                 artifact.stable_json_line(
-                    artifact.candidate_artifact_header(len(prompts), sampler)
+                    artifact.candidate_artifact_header(len(records), sampler)
                 )
             )
             completed = 0
@@ -202,18 +242,23 @@ def publish_candidate_checkpoint(
                         continue
                     row = _parse_line(raw, "candidate checkpoint", line_number)
                     if not saw_header:
-                        if row != _checkpoint_header(prompts, sampler):
+                        if row != _checkpoint_header(records, sampler):
                             raise ValueError("candidate checkpoint does not match this run")
                         saw_header = True
                         continue
-                    if completed >= len(prompts):
+                    if completed >= len(records):
                         raise ValueError("candidate checkpoint has too many groups")
+                    expected_prompt, expected_source_line = records[completed]
                     artifact.validate_candidate_group(
-                        row, completed, sampler, expected_prompt=prompts[completed]
+                        row,
+                        completed,
+                        sampler,
+                        expected_prompt=expected_prompt,
+                        expected_source_line=expected_source_line,
                     )
                     target.write(artifact.stable_json_line(row))
                     completed += 1
-            if not saw_header or completed != len(prompts):
+            if not saw_header or completed != len(records):
                 raise ValueError("candidate checkpoint is incomplete")
             target.flush()
             os.fsync(target.fileno())
@@ -442,13 +487,92 @@ def stage_offline_datasets(
 
 
 def publish_staged_datasets(
-    staged: StagedDatasets, sft_path: str, dpo_path: str
+    staged: StagedDatasets,
+    sft_path: str,
+    dpo_path: str,
+    *,
+    stale_dpo_path: str = "",
 ) -> None:
-    """Replace the requested outputs with already validated staging files."""
-    enforce_under_cwd_and_no_symlink(sft_path, "--output path")
-    os.replace(staged.sft_temp, sft_path)
-    staged.sft_temp = ""
+    """Publish staged outputs as one rollback-protected generation.
+
+    Existing SFT/DPO files are moved aside before either replacement. A failed
+    second replacement restores every previous file and removes a newly
+    published first file. ``stale_dpo_path`` participates in the same
+    transaction for a later SFT-only generation.
+    """
+    publications = [("sft_temp", staged.sft_temp, sft_path, "--output path")]
     if dpo_path:
-        enforce_under_cwd_and_no_symlink(dpo_path, "--emit-pairs path")
-        os.replace(staged.dpo_temp, dpo_path)
-        staged.dpo_temp = ""
+        publications.append(
+            ("dpo_temp", staged.dpo_temp, dpo_path, "--emit-pairs path")
+        )
+    removals = (
+        [(stale_dpo_path, "previous DPO path")] if stale_dpo_path else []
+    )
+    identities: set[str] = set()
+    destinations: list[tuple[str, str]] = []
+    for _attribute, staging, destination, field in publications:
+        if not staging or not os.path.isfile(staging):
+            raise ValueError(f"{field} staging file is missing")
+        enforce_under_cwd_and_no_symlink(destination, field)
+        identity = os.path.normcase(os.path.realpath(destination))
+        if identity in identities:
+            raise ValueError("offline publication paths must be distinct")
+        identities.add(identity)
+        destinations.append((destination, field))
+    for destination, field in removals:
+        enforce_under_cwd_and_no_symlink(destination, field)
+        identity = os.path.normcase(os.path.realpath(destination))
+        if identity in identities:
+            raise ValueError("offline publication paths must be distinct")
+        identities.add(identity)
+        destinations.append((destination, field))
+
+    backups: dict[str, str] = {}
+    committed: set[str] = set()
+    try:
+        for destination, field in destinations:
+            if not os.path.lexists(destination):
+                continue
+            if not stat.S_ISREG(os.lstat(destination).st_mode):
+                raise ValueError(f"{field} must be a regular file")
+            parent = os.path.dirname(os.path.abspath(destination)) or "."
+            fd, backup = tempfile.mkstemp(
+                prefix=".soup-bon-backup.", suffix=".tmp", dir=parent
+            )
+            os.close(fd)
+            try:
+                os.replace(destination, backup)
+            except Exception:
+                os.unlink(backup)
+                raise
+            backups[destination] = backup
+
+        for attribute, staging, destination, _field in publications:
+            os.replace(staging, destination)
+            setattr(staged, attribute, "")
+            committed.add(destination)
+    except Exception as exc:
+        rollback_failed = False
+        for destination in committed:
+            if destination in backups:
+                continue
+            try:
+                os.unlink(destination)
+            except FileNotFoundError:
+                pass
+            except OSError:
+                rollback_failed = True
+        for destination, backup in backups.items():
+            try:
+                os.replace(backup, destination)
+            except OSError:
+                rollback_failed = True
+        if rollback_failed:
+            raise OSError("failed to restore a previous offline generation") from exc
+        raise
+    finally:
+        for backup in backups.values():
+            try:
+                os.unlink(backup)
+            except FileNotFoundError:
+                pass

--- a/src/soup_cli/utils/best_of_n_stream.py
+++ b/src/soup_cli/utils/best_of_n_stream.py
@@ -491,16 +491,22 @@ def publish_staged_datasets(
     sft_path: str,
     dpo_path: str,
     *,
+    manifest_path: str,
+    manifest_bytes: bytes,
     stale_dpo_path: str = "",
 ) -> None:
     """Publish staged outputs as one rollback-protected generation.
 
-    Existing SFT/DPO files are moved aside before either replacement. A failed
-    second replacement restores every previous file and removes a newly
-    published first file. ``stale_dpo_path`` participates in the same
-    transaction for a later SFT-only generation.
+    Existing SFT/DPO/manifest files are moved aside before any replacement. A
+    failed replacement restores every previous file and removes newly
+    published files. ``stale_dpo_path`` participates in the same transaction
+    for a later SFT-only generation. The manifest is always published last.
     """
-    publications = [("sft_temp", staged.sft_temp, sft_path, "--output path")]
+    if not isinstance(manifest_bytes, (bytes, bytearray)):
+        raise TypeError("manifest data must be bytes")
+    publications: list[tuple[str, str, str, str]] = [
+        ("sft_temp", staged.sft_temp, sft_path, "--output path")
+    ]
     if dpo_path:
         publications.append(
             ("dpo_temp", staged.dpo_temp, dpo_path, "--emit-pairs path")
@@ -527,6 +533,34 @@ def publish_staged_datasets(
         identities.add(identity)
         destinations.append((destination, field))
 
+    enforce_under_cwd_and_no_symlink(manifest_path, "--manifest path")
+    manifest_identity = os.path.normcase(os.path.realpath(manifest_path))
+    if manifest_identity in identities:
+        raise ValueError("offline publication paths must be distinct")
+    identities.add(manifest_identity)
+    destinations.append((manifest_path, "--manifest path"))
+
+    manifest_parent = os.path.dirname(os.path.abspath(manifest_path)) or "."
+    os.makedirs(manifest_parent, exist_ok=True)
+    manifest_fd, manifest_temp = tempfile.mkstemp(
+        prefix=".soup-bon-manifest.", suffix=".tmp", dir=manifest_parent
+    )
+    try:
+        with os.fdopen(manifest_fd, "wb") as manifest_handle:
+            manifest_fd = -1
+            manifest_handle.write(bytes(manifest_bytes))
+            manifest_handle.flush()
+            os.fsync(manifest_handle.fileno())
+    except Exception:
+        if manifest_fd >= 0:
+            os.close(manifest_fd)
+        try:
+            os.unlink(manifest_temp)
+        except FileNotFoundError:
+            pass
+        raise
+    publications.append(("", manifest_temp, manifest_path, "--manifest path"))
+
     backups: dict[str, str] = {}
     committed: set[str] = set()
     try:
@@ -549,7 +583,10 @@ def publish_staged_datasets(
 
         for attribute, staging, destination, _field in publications:
             os.replace(staging, destination)
-            setattr(staged, attribute, "")
+            if attribute:
+                setattr(staged, attribute, "")
+            else:
+                manifest_temp = ""
             committed.add(destination)
     except Exception as exc:
         rollback_failed = False
@@ -570,9 +607,15 @@ def publish_staged_datasets(
         if rollback_failed:
             raise OSError("failed to restore a previous offline generation") from exc
         raise
-    finally:
+    else:
         for backup in backups.values():
             try:
                 os.unlink(backup)
+            except FileNotFoundError:
+                pass
+    finally:
+        if manifest_temp:
+            try:
+                os.unlink(manifest_temp)
             except FileNotFoundError:
                 pass

--- a/src/soup_cli/utils/best_of_n_stream.py
+++ b/src/soup_cli/utils/best_of_n_stream.py
@@ -10,7 +10,7 @@ import stat
 import tempfile
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Iterator
+from typing import Iterator, cast
 
 from soup_cli.utils import best_of_n_artifact as artifact
 from soup_cli.utils.paths import enforce_under_cwd_and_no_symlink
@@ -42,7 +42,7 @@ def _normalise_prompt_records(prompts: list[str] | list[PromptRecord]) -> list[P
             and not isinstance(value[1], bool)
             and value[1] > 0
         ):
-            record = value
+            record = cast(PromptRecord, value)
         else:
             raise ValueError("candidate checkpoint prompts are invalid")
         records.append(record)

--- a/src/soup_cli/utils/best_of_n_stream.py
+++ b/src/soup_cli/utils/best_of_n_stream.py
@@ -1,0 +1,421 @@
+"""Bounded-memory persistence for two-phase Best-of-N workflows."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import stat
+import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Iterator
+
+from soup_cli.utils import best_of_n_artifact as artifact
+from soup_cli.utils.paths import enforce_under_cwd_and_no_symlink
+
+_CHECKPOINT_SCHEMA = "soup.best_of_n.candidate_checkpoint.v1"
+
+
+def _write_all(fd: int, data: bytes) -> None:
+    """Write one checkpoint record completely before it can be fsynced."""
+    view = memoryview(data)
+    while view:
+        written = os.write(fd, view)
+        if written <= 0:
+            raise OSError("candidate checkpoint write made no progress")
+        view = view[written:]
+
+
+def _run_digest(prompts: list[str], sampler: dict) -> str:
+    payload = {"prompts": prompts, "sampler": sampler}
+    data = json.dumps(
+        payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(data).hexdigest()
+
+
+def _parse_line(raw: bytes, field: str, line_number: int) -> dict:
+    try:
+        row = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{field} has invalid UTF-8 JSON on line {line_number}") from exc
+    if not isinstance(row, dict):
+        raise ValueError(f"{field} line {line_number} must be an object")
+    return row
+
+
+@contextmanager
+def _regular_binary_lines(path: str, field: str) -> Iterator[Iterator[tuple[int, bytes]]]:
+    enforce_under_cwd_and_no_symlink(path, field)
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_BINARY", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError as exc:
+        raise ValueError(f"{field} could not be opened safely: {exc}") from exc
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            raise ValueError(f"{field} must be a regular file")
+        with os.fdopen(fd, "rb") as handle:
+            fd = -1
+            yield enumerate(handle, 1)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+
+def _checkpoint_header(prompts: list[str], sampler: dict) -> dict:
+    return {
+        "_best_of_n_checkpoint": {
+            "schema": _CHECKPOINT_SCHEMA,
+            "run_digest": _run_digest(prompts, sampler),
+            "prompt_count": len(prompts),
+            "sampler": sampler,
+        }
+    }
+
+
+def prepare_candidate_checkpoint(
+    path: str, prompts: list[str], sampler: dict, *, resume: bool
+) -> int:
+    """Create or authenticate a checkpoint and return completed group count."""
+    sampler = artifact.validate_sampler_spec(sampler)
+    enforce_under_cwd_and_no_symlink(path, "--checkpoint path")
+    expected_header = _checkpoint_header(prompts, sampler)
+    exists = os.path.lexists(path)
+    if not exists:
+        if resume:
+            raise ValueError("--resume requires an existing candidate checkpoint")
+        parent = os.path.dirname(os.path.abspath(path)) or "."
+        os.makedirs(parent, exist_ok=True)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0)
+        fd = os.open(path, flags, 0o600)
+        try:
+            _write_all(fd, artifact.stable_json_line(expected_header))
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        return 0
+    if not resume:
+        raise ValueError("candidate checkpoint already exists; pass --resume to continue")
+
+    completed = 0
+    saw_header = False
+    with _regular_binary_lines(path, "--checkpoint path") as lines:
+        for line_number, raw in lines:
+            if not raw.strip():
+                continue
+            row = _parse_line(raw, "candidate checkpoint", line_number)
+            if not saw_header:
+                if row != expected_header:
+                    raise ValueError("candidate checkpoint does not match this run")
+                saw_header = True
+                continue
+            if completed >= len(prompts):
+                raise ValueError("candidate checkpoint has too many groups")
+            artifact.validate_candidate_group(
+                row, completed, sampler, expected_prompt=prompts[completed]
+            )
+            completed += 1
+    if not saw_header:
+        raise ValueError("candidate checkpoint header is missing")
+    return completed
+
+
+def append_candidate_group(path: str, group: dict) -> None:
+    """Durably append one complete candidate group."""
+    enforce_under_cwd_and_no_symlink(path, "--checkpoint path")
+    flags = (
+        os.O_WRONLY
+        | os.O_APPEND
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_BINARY", 0)
+    )
+    fd = os.open(path, flags)
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            raise ValueError("--checkpoint path must be a regular file")
+        _write_all(fd, artifact.stable_json_line(group))
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def publish_candidate_checkpoint(
+    checkpoint: str,
+    output: str,
+    prompts: list[str],
+    sampler: dict,
+) -> None:
+    """Stream a complete checkpoint into one atomically published artifact."""
+    enforce_under_cwd_and_no_symlink(output, "--export-candidates path")
+    parent = os.path.dirname(os.path.abspath(output)) or "."
+    os.makedirs(parent, exist_ok=True)
+    fd, staging = tempfile.mkstemp(prefix=".soup-bon-candidates.", dir=parent)
+    try:
+        with os.fdopen(fd, "wb") as target:
+            fd = -1
+            target.write(
+                artifact.stable_json_line(
+                    artifact.candidate_artifact_header(len(prompts), sampler)
+                )
+            )
+            completed = 0
+            saw_header = False
+            with _regular_binary_lines(checkpoint, "--checkpoint path") as lines:
+                for line_number, raw in lines:
+                    if not raw.strip():
+                        continue
+                    row = _parse_line(raw, "candidate checkpoint", line_number)
+                    if not saw_header:
+                        if row != _checkpoint_header(prompts, sampler):
+                            raise ValueError("candidate checkpoint does not match this run")
+                        saw_header = True
+                        continue
+                    if completed >= len(prompts):
+                        raise ValueError("candidate checkpoint has too many groups")
+                    artifact.validate_candidate_group(
+                        row, completed, sampler, expected_prompt=prompts[completed]
+                    )
+                    target.write(artifact.stable_json_line(row))
+                    completed += 1
+            if not saw_header or completed != len(prompts):
+                raise ValueError("candidate checkpoint is incomplete")
+            target.flush()
+            os.fsync(target.fileno())
+        enforce_under_cwd_and_no_symlink(output, "--export-candidates path")
+        os.replace(staging, output)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        if os.path.exists(staging):
+            os.unlink(staging)
+
+
+@dataclass
+class OfflineArtifactIndex:
+    """Disk-backed authenticated mapping of groups to judgments."""
+
+    connection: sqlite3.Connection
+    sampler: dict
+    candidate_sha256: str
+    judgments_sha256: str
+    group_count: int
+
+    def iter_rows(self) -> Iterator[tuple[dict, dict | None]]:
+        query = """
+            SELECT groups.position, groups.payload, judgments.payload
+            FROM groups JOIN judgments USING (prompt_id)
+            ORDER BY groups.position
+        """
+        for position, group_raw, judgment_raw in self.connection.execute(query):
+            group = json.loads(group_raw)
+            judgment = artifact.validate_judgment(
+                json.loads(judgment_raw), group, position
+            )
+            yield artifact.materialize_group(
+                group,
+                judgment,
+                sampler=self.sampler,
+                candidate_artifact_sha256=self.candidate_sha256,
+                judgments_sha256=self.judgments_sha256,
+            )
+
+    def validate_all(self) -> None:
+        count = sum(1 for _ in self.iter_rows())
+        if count != self.group_count:
+            raise ValueError("judgments must cover every candidate group exactly once")
+
+
+def _index_candidates(connection: sqlite3.Connection, path: str) -> tuple[dict, str, int]:
+    digest = hashlib.sha256()
+    header = None
+    sampler = None
+    count = 0
+    with _regular_binary_lines(path, "--candidate-artifact path") as lines:
+        for line_number, raw in lines:
+            digest.update(raw)
+            if not raw.strip():
+                continue
+            row = _parse_line(raw, "candidate artifact", line_number)
+            if header is None:
+                header = row.get("_best_of_n_candidates")
+                if not isinstance(header, dict) or header.get("schema") != (
+                    "soup.best_of_n.candidates.v1"
+                ):
+                    raise ValueError("candidate artifact header or schema is invalid")
+                sampler = artifact.validate_sampler_spec(header.get("sampler"))
+                continue
+            assert sampler is not None
+            prompt_id = artifact.validate_candidate_group(row, count, sampler)
+            try:
+                connection.execute(
+                    "INSERT INTO groups(position, prompt_id, payload) VALUES (?, ?, ?)",
+                    (count, prompt_id, artifact.stable_json_line(row).decode("utf-8")),
+                )
+            except sqlite3.IntegrityError as exc:
+                raise ValueError(f"candidate group {count} has an invalid prompt id") from exc
+            count += 1
+    if header is None or sampler is None:
+        raise ValueError("candidate artifact is empty")
+    if not count:
+        raise ValueError("candidate artifact contains no prompt groups")
+    if header.get("prompt_count") != count:
+        raise ValueError("candidate artifact header does not match its groups")
+    return sampler, digest.hexdigest(), count
+
+
+def _index_judgments(connection: sqlite3.Connection, path: str) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    count = 0
+    with _regular_binary_lines(path, "--judgments path") as lines:
+        for line_number, raw in lines:
+            digest.update(raw)
+            if not raw.strip():
+                continue
+            row = _parse_line(raw, "judgments", line_number)
+            prompt_id = row.get("prompt_id")
+            if not isinstance(prompt_id, str):
+                raise ValueError("judgments contain a missing or duplicate prompt_id")
+            try:
+                connection.execute(
+                    "INSERT INTO judgments(prompt_id, payload) VALUES (?, ?)",
+                    (prompt_id, artifact.stable_json_line(row).decode("utf-8")),
+                )
+            except sqlite3.IntegrityError as exc:
+                raise ValueError(
+                    "judgments contain a missing or duplicate prompt_id"
+                ) from exc
+            count += 1
+    return digest.hexdigest(), count
+
+
+@contextmanager
+def index_offline_artifacts(
+    candidate_path: str, judgments_path: str
+) -> Iterator[OfflineArtifactIndex]:
+    """Authenticate large offline artifacts through a temporary disk index."""
+    with tempfile.TemporaryDirectory(prefix=".soup-bon-index.", dir=os.getcwd()) as temp:
+        database = os.path.join(temp, "index.sqlite3")
+        connection = sqlite3.connect(database)
+        try:
+            connection.execute(
+                "CREATE TABLE groups(position INTEGER PRIMARY KEY, "
+                "prompt_id TEXT NOT NULL UNIQUE, payload TEXT NOT NULL)"
+            )
+            connection.execute(
+                "CREATE TABLE judgments(prompt_id TEXT PRIMARY KEY, payload TEXT NOT NULL)"
+            )
+            sampler, candidate_sha, group_count = _index_candidates(
+                connection, candidate_path
+            )
+            judgments_sha, judgment_count = _index_judgments(connection, judgments_path)
+            connection.commit()
+            matched = connection.execute(
+                "SELECT COUNT(*) FROM groups JOIN judgments USING (prompt_id)"
+            ).fetchone()[0]
+            if judgment_count != group_count or matched != group_count:
+                raise ValueError("judgments must cover every candidate group exactly once")
+            yield OfflineArtifactIndex(
+                connection=connection,
+                sampler=sampler,
+                candidate_sha256=candidate_sha,
+                judgments_sha256=judgments_sha,
+                group_count=group_count,
+            )
+        finally:
+            connection.close()
+
+
+@dataclass
+class StagedDatasets:
+    sft_temp: str
+    dpo_temp: str
+    sft_sha256: str
+    dpo_sha256: str
+    sft_count: int
+    dpo_count: int
+
+    def cleanup(self) -> None:
+        for path in (self.sft_temp, self.dpo_temp):
+            if path and os.path.exists(path):
+                os.unlink(path)
+
+
+def _staging_file(output: str, field: str) -> tuple[int, str]:
+    enforce_under_cwd_and_no_symlink(output, field)
+    parent = os.path.dirname(os.path.abspath(output)) or "."
+    os.makedirs(parent, exist_ok=True)
+    return tempfile.mkstemp(prefix=".soup-bon-output.", dir=parent)
+
+
+def stage_offline_datasets(
+    index: OfflineArtifactIndex, sft_path: str, dpo_path: str
+) -> StagedDatasets:
+    """Stream authenticated rows to unpublished files and compute exact digests."""
+    sft_fd, sft_temp = _staging_file(sft_path, "--output path")
+    dpo_fd = -1
+    dpo_temp = ""
+    sft_hash = hashlib.sha256()
+    dpo_hash = hashlib.sha256()
+    sft_count = 0
+    dpo_count = 0
+    try:
+        if dpo_path:
+            dpo_fd, dpo_temp = _staging_file(dpo_path, "--emit-pairs path")
+        with os.fdopen(sft_fd, "wb") as sft_handle:
+            sft_fd = -1
+            dpo_handle = os.fdopen(dpo_fd, "wb") if dpo_fd >= 0 else None
+            if dpo_handle is not None:
+                dpo_fd = -1
+            try:
+                for sft, dpo in index.iter_rows():
+                    sft_line = artifact.stable_json_line(sft)
+                    sft_handle.write(sft_line)
+                    sft_hash.update(sft_line)
+                    sft_count += 1
+                    if dpo_handle is not None and dpo is not None:
+                        dpo_line = artifact.stable_json_line(dpo)
+                        dpo_handle.write(dpo_line)
+                        dpo_hash.update(dpo_line)
+                        dpo_count += 1
+                sft_handle.flush()
+                os.fsync(sft_handle.fileno())
+                if dpo_handle is not None:
+                    dpo_handle.flush()
+                    os.fsync(dpo_handle.fileno())
+            finally:
+                if dpo_handle is not None:
+                    dpo_handle.close()
+        return StagedDatasets(
+            sft_temp=sft_temp,
+            dpo_temp=dpo_temp,
+            sft_sha256=sft_hash.hexdigest(),
+            dpo_sha256=dpo_hash.hexdigest(),
+            sft_count=sft_count,
+            dpo_count=dpo_count,
+        )
+    except Exception:
+        for path in (sft_temp, dpo_temp):
+            if path and os.path.exists(path):
+                os.unlink(path)
+        raise
+    finally:
+        if sft_fd >= 0:
+            os.close(sft_fd)
+        if dpo_fd >= 0:
+            os.close(dpo_fd)
+
+
+def publish_staged_datasets(
+    staged: StagedDatasets, sft_path: str, dpo_path: str
+) -> None:
+    """Replace the requested outputs with already validated staging files."""
+    enforce_under_cwd_and_no_symlink(sft_path, "--output path")
+    os.replace(staged.sft_temp, sft_path)
+    staged.sft_temp = ""
+    if dpo_path:
+        enforce_under_cwd_and_no_symlink(dpo_path, "--emit-pairs path")
+        os.replace(staged.dpo_temp, dpo_path)
+        staged.dpo_temp = ""

--- a/src/soup_cli/utils/best_of_n_stream.py
+++ b/src/soup_cli/utils/best_of_n_stream.py
@@ -49,7 +49,21 @@ def _normalise_prompt_records(prompts: list[str] | list[PromptRecord]) -> list[P
     return records
 
 
-def _run_digest(prompts: list[str] | list[PromptRecord], sampler: dict) -> str:
+def _validate_identity_fingerprint(value: str) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise ValueError("candidate checkpoint identity fingerprint is invalid")
+    return value
+
+
+def _run_digest(
+    prompts: list[str] | list[PromptRecord],
+    sampler: dict,
+    identity_fingerprint: str,
+) -> str:
     records = _normalise_prompt_records(prompts)
     payload = {
         "prompts": [
@@ -57,6 +71,7 @@ def _run_digest(prompts: list[str] | list[PromptRecord], sampler: dict) -> str:
             for prompt, source_line in records
         ],
         "sampler": sampler,
+        "identity_fingerprint": _validate_identity_fingerprint(identity_fingerprint),
     }
     data = json.dumps(
         payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
@@ -93,14 +108,21 @@ def _regular_binary_lines(path: str, field: str) -> Iterator[Iterator[tuple[int,
             os.close(fd)
 
 
-def _checkpoint_header(prompts: list[str] | list[PromptRecord], sampler: dict) -> dict:
+def _checkpoint_header(
+    prompts: list[str] | list[PromptRecord],
+    sampler: dict,
+    identity_fingerprint: str,
+) -> dict:
     records = _normalise_prompt_records(prompts)
     return {
         "_best_of_n_checkpoint": {
             "schema": _CHECKPOINT_SCHEMA,
-            "run_digest": _run_digest(records, sampler),
+            "run_digest": _run_digest(records, sampler, identity_fingerprint),
             "prompt_count": len(records),
             "sampler": sampler,
+            "identity_fingerprint": _validate_identity_fingerprint(
+                identity_fingerprint
+            ),
         }
     }
 
@@ -141,6 +163,7 @@ def prepare_candidate_checkpoint(
     path: str,
     prompts: list[str] | list[PromptRecord],
     sampler: dict,
+    identity_fingerprint: str,
     *,
     resume: bool,
 ) -> int:
@@ -148,7 +171,7 @@ def prepare_candidate_checkpoint(
     sampler = artifact.validate_sampler_spec(sampler)
     enforce_under_cwd_and_no_symlink(path, "--checkpoint path")
     records = _normalise_prompt_records(prompts)
-    expected_header = _checkpoint_header(records, sampler)
+    expected_header = _checkpoint_header(records, sampler, identity_fingerprint)
     exists = os.path.lexists(path)
     if not exists:
         if resume:
@@ -219,6 +242,7 @@ def publish_candidate_checkpoint(
     output: str,
     prompts: list[str] | list[PromptRecord],
     sampler: dict,
+    identity_fingerprint: str,
 ) -> None:
     """Stream a complete checkpoint into one atomically published artifact."""
     enforce_under_cwd_and_no_symlink(output, "--export-candidates path")
@@ -242,7 +266,9 @@ def publish_candidate_checkpoint(
                         continue
                     row = _parse_line(raw, "candidate checkpoint", line_number)
                     if not saw_header:
-                        if row != _checkpoint_header(records, sampler):
+                        if row != _checkpoint_header(
+                            records, sampler, identity_fingerprint
+                        ):
                             raise ValueError("candidate checkpoint does not match this run")
                         saw_header = True
                         continue
@@ -425,7 +451,7 @@ def _staging_file(output: str, field: str) -> tuple[int, str]:
     enforce_under_cwd_and_no_symlink(output, field)
     parent = os.path.dirname(os.path.abspath(output)) or "."
     os.makedirs(parent, exist_ok=True)
-    return tempfile.mkstemp(prefix=".soup-bon-output.", dir=parent)
+    return tempfile.mkstemp(prefix=".soup.group.", suffix=".tmp", dir=parent)
 
 
 def stage_offline_datasets(

--- a/tests/test_issue550_bon_offline.py
+++ b/tests/test_issue550_bon_offline.py
@@ -81,8 +81,6 @@ def _write_judgments(path, groups):
 def test_candidate_export_needs_no_judge_and_preserves_order_and_digests(
     tmp_path, monkeypatch
 ):
-    from soup_cli.utils.best_of_n_artifact import sampler_identity_fingerprint
-
     artifact, calls = _export_candidates(tmp_path, monkeypatch)
     assert calls == ["question one", "question one", "question two", "question two"]
     records = [json.loads(line) for line in artifact.read_text().splitlines()]
@@ -92,9 +90,6 @@ def test_candidate_export_needs_no_judge_and_preserves_order_and_digests(
         "kind": "provider",
         "provider": "ollama",
         "model": "sampler-model",
-        "endpoint_fingerprint": sampler_identity_fingerprint(
-            "provider-endpoint", "http://localhost:11434/private-route"
-        ),
         "n": 2,
         "temperature": 1.0,
         "max_new_tokens": 256,
@@ -307,16 +302,17 @@ def test_failed_dpo_replacement_restores_previous_generation(tmp_path, monkeypat
     assert manifest_path.exists()
     previous = (sft.read_bytes(), dpo.read_bytes(), manifest_path.read_bytes())
 
-    def fail_dpo(staged, sft_path, _dpo_path):
-        import os
+    real_replace = __import__("os").replace
+    failed_once = False
 
-        os.replace(staged.sft_temp, sft_path)
-        staged.sft_temp = ""
-        raise OSError("simulated DPO publication failure")
+    def fail_dpo(source, destination):
+        nonlocal failed_once
+        if not failed_once and destination == str(dpo):
+            failed_once = True
+            raise OSError("simulated DPO publication failure")
+        return real_replace(source, destination)
 
-    monkeypatch.setattr(
-        "soup_cli.utils.best_of_n_stream.publish_staged_datasets", fail_dpo
-    )
+    monkeypatch.setattr("os.replace", fail_dpo)
     failed = CliRunner().invoke(app, args)
     assert failed.exit_code == 1
     assert (sft.read_bytes(), dpo.read_bytes(), manifest_path.read_bytes()) == previous
@@ -363,7 +359,11 @@ def test_failed_sft_only_replacement_restores_manifest_bound_dpo(
 
     def fail_sft(source, destination):
         nonlocal failed_once
-        if not failed_once and destination == str(sft):
+        if (
+            not failed_once
+            and destination == str(sft)
+            and ".soup.group." in str(source)
+        ):
             failed_once = True
             raise OSError("simulated SFT publication failure")
         return real_replace(source, destination)

--- a/tests/test_issue550_bon_offline.py
+++ b/tests/test_issue550_bon_offline.py
@@ -81,6 +81,8 @@ def _write_judgments(path, groups):
 def test_candidate_export_needs_no_judge_and_preserves_order_and_digests(
     tmp_path, monkeypatch
 ):
+    from soup_cli.utils.best_of_n_artifact import sampler_identity_fingerprint
+
     artifact, calls = _export_candidates(tmp_path, monkeypatch)
     assert calls == ["question one", "question one", "question two", "question two"]
     records = [json.loads(line) for line in artifact.read_text().splitlines()]
@@ -90,6 +92,9 @@ def test_candidate_export_needs_no_judge_and_preserves_order_and_digests(
         "kind": "provider",
         "provider": "ollama",
         "model": "sampler-model",
+        "endpoint_fingerprint": sampler_identity_fingerprint(
+            "provider-endpoint", "http://localhost:11434/private-route"
+        ),
         "n": 2,
         "temperature": 1.0,
         "max_new_tokens": 256,

--- a/tests/test_issue550_bon_offline.py
+++ b/tests/test_issue550_bon_offline.py
@@ -302,17 +302,16 @@ def test_failed_dpo_replacement_restores_previous_generation(tmp_path, monkeypat
     assert manifest_path.exists()
     previous = (sft.read_bytes(), dpo.read_bytes(), manifest_path.read_bytes())
 
-    real_replace = __import__("os").replace
-    failed_once = False
+    def fail_dpo(staged, sft_path, _dpo_path):
+        import os
 
-    def fail_dpo(source, destination):
-        nonlocal failed_once
-        if not failed_once and destination == str(dpo):
-            failed_once = True
-            raise OSError("simulated DPO publication failure")
-        return real_replace(source, destination)
+        os.replace(staged.sft_temp, sft_path)
+        staged.sft_temp = ""
+        raise OSError("simulated DPO publication failure")
 
-    monkeypatch.setattr("os.replace", fail_dpo)
+    monkeypatch.setattr(
+        "soup_cli.utils.best_of_n_stream.publish_staged_datasets", fail_dpo
+    )
     failed = CliRunner().invoke(app, args)
     assert failed.exit_code == 1
     assert (sft.read_bytes(), dpo.read_bytes(), manifest_path.read_bytes()) == previous

--- a/tests/test_issue550_bon_offline.py
+++ b/tests/test_issue550_bon_offline.py
@@ -363,11 +363,7 @@ def test_failed_sft_only_replacement_restores_manifest_bound_dpo(
 
     def fail_sft(source, destination):
         nonlocal failed_once
-        if (
-            not failed_once
-            and destination == str(sft)
-            and ".soup.group." in str(source)
-        ):
+        if not failed_once and destination == str(sft):
             failed_once = True
             raise OSError("simulated SFT publication failure")
         return real_replace(source, destination)

--- a/tests/test_issue555_bon_stream_resume.py
+++ b/tests/test_issue555_bon_stream_resume.py
@@ -179,7 +179,6 @@ def test_offline_large_artifacts_bypass_whole_file_materializers(tmp_path, monke
         "kind": "provider",
         "provider": "ollama",
         "model": "sampler-model",
-        "endpoint_fingerprint": _FINGERPRINT,
         "n": 2,
         "temperature": 1.0,
         "max_new_tokens": 256,
@@ -272,7 +271,6 @@ def test_streaming_candidate_structure_failures_never_commit_manifest(
         "kind": "provider",
         "provider": "ollama",
         "model": "sampler-model",
-        "endpoint_fingerprint": _FINGERPRINT,
         "n": 2,
         "temperature": 1.0,
         "max_new_tokens": 256,
@@ -322,7 +320,6 @@ def test_resume_discards_an_uncommitted_candidate_tail(tmp_path, monkeypatch):
         "kind": "provider",
         "provider": "ollama",
         "model": "sampler-model",
-        "endpoint_fingerprint": _FINGERPRINT,
         "n": 2,
         "temperature": 1.0,
         "max_new_tokens": 256,
@@ -330,7 +327,7 @@ def test_resume_discards_an_uncommitted_candidate_tail(tmp_path, monkeypatch):
     prompts = ["q1", "q2"]
     checkpoint = tmp_path / "checkpoint.jsonl"
     assert prepare_candidate_checkpoint(
-        str(checkpoint), prompts, sampler, resume=False
+        str(checkpoint), prompts, sampler, _FINGERPRINT, resume=False
     ) == 0
     append_candidate_group(
         str(checkpoint),
@@ -340,11 +337,37 @@ def test_resume_discards_an_uncommitted_candidate_tail(tmp_path, monkeypatch):
         handle.write(b'{"prompt_index":1,"prompt":')
 
     completed = prepare_candidate_checkpoint(
-        str(checkpoint), prompts, sampler, resume=True
+        str(checkpoint), prompts, sampler, _FINGERPRINT, resume=True
     )
 
     assert completed == 1
     assert checkpoint.read_bytes().endswith(b"\n")
+
+
+def test_checkpoint_identity_is_private_and_not_published(tmp_path, monkeypatch):
+    from soup_cli.commands.data import app
+    from soup_cli.utils.best_of_n_artifact import sampler_identity_fingerprint
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "prompts.jsonl").write_text('{"prompt":"q"}\n', encoding="utf-8")
+    monkeypatch.setattr(
+        "soup_cli.utils.magpie.make_magpie_generate_fn",
+        lambda *_args, **_kwargs: lambda _prompt: "candidate",
+    )
+
+    result = CliRunner().invoke(app, _args(tmp_path))
+
+    assert result.exit_code == 0, (result.output, repr(result.exception))
+    identity = sampler_identity_fingerprint(
+        "provider-endpoint", "http://localhost:11434"
+    )
+    checkpoint = (tmp_path / "candidates.jsonl.checkpoint.jsonl").read_text(
+        encoding="utf-8"
+    )
+    artifact = (tmp_path / "candidates.jsonl").read_text(encoding="utf-8")
+    assert identity in checkpoint
+    assert identity not in artifact
+    assert "endpoint_fingerprint" not in artifact
 
 
 def test_resume_rejects_provider_endpoint_drift(tmp_path, monkeypatch):
@@ -480,3 +503,78 @@ def test_local_resume_reuses_the_same_prompt_seed(tmp_path, monkeypatch):
 
     assert resumed.exit_code == 0, (resumed.output, repr(resumed.exception))
     assert sampled[-1] == ("second", interrupted)
+
+
+def test_streamed_publication_restores_changed_generation_on_dpo_failure(
+    tmp_path, monkeypatch
+):
+    import os
+
+    from soup_cli.utils.best_of_n_stream import StagedDatasets, publish_staged_datasets
+
+    monkeypatch.chdir(tmp_path)
+    sft = tmp_path / "sft.jsonl"
+    dpo = tmp_path / "dpo.jsonl"
+    manifest = tmp_path / "manifest.json"
+    old = (b"old-sft\n", b"old-dpo\n", b'{"generation":"old"}\n')
+    for path, content in zip((sft, dpo, manifest), old):
+        path.write_bytes(content)
+
+    sft_temp = tmp_path / ".soup.group.new-sft.tmp"
+    dpo_temp = tmp_path / ".soup.group.new-dpo.tmp"
+    sft_temp.write_bytes(b"new-sft\n")
+    dpo_temp.write_bytes(b"new-dpo\n")
+    staged = StagedDatasets(
+        sft_temp=str(sft_temp),
+        dpo_temp=str(dpo_temp),
+        sft_sha256="1" * 64,
+        dpo_sha256="2" * 64,
+        sft_count=1,
+        dpo_count=1,
+    )
+    real_replace = os.replace
+
+    def fail_new_dpo(source, destination):
+        if source == str(dpo_temp) and destination == str(dpo):
+            raise OSError("simulated DPO publication failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(os, "replace", fail_new_dpo)
+    with pytest.raises(OSError, match="simulated DPO publication failure"):
+        publish_staged_datasets(
+            staged,
+            str(sft),
+            str(dpo),
+            manifest_path=str(manifest),
+            manifest_bytes=b'{"generation":"new"}\n',
+        )
+
+    assert (sft.read_bytes(), dpo.read_bytes(), manifest.read_bytes()) == old
+    assert not list(tmp_path.glob(".soup-bon-backup.*"))
+    staged.cleanup()
+
+
+def test_atomic_group_removal_validation_is_directly_covered(tmp_path, monkeypatch):
+    from soup_cli.utils.paths import atomic_write_bytes_group
+
+    monkeypatch.chdir(tmp_path)
+    output = str(tmp_path / "output.jsonl")
+
+    with pytest.raises(TypeError, match="removals must be a list"):
+        atomic_write_bytes_group([(b"new", output, "output")], removals=())
+    with pytest.raises(TypeError, match="each removal"):
+        atomic_write_bytes_group(
+            [(b"new", output, "output")], removals=[(output,)]
+        )
+    with pytest.raises(ValueError, match="must be distinct"):
+        atomic_write_bytes_group(
+            [(b"new", output, "output")], removals=[(output, "stale output")]
+        )
+
+    removal_directory = tmp_path / "stale-directory"
+    removal_directory.mkdir()
+    with pytest.raises(ValueError, match="must be a regular file"):
+        atomic_write_bytes_group(
+            [(b"new", output, "output")],
+            removals=[(str(removal_directory), "stale output")],
+        )

--- a/tests/test_issue555_bon_stream_resume.py
+++ b/tests/test_issue555_bon_stream_resume.py
@@ -554,6 +554,48 @@ def test_streamed_publication_restores_changed_generation_on_dpo_failure(
     staged.cleanup()
 
 
+def test_streamed_publication_commits_manifest_last(tmp_path, monkeypatch):
+    import os
+
+    from soup_cli.utils.best_of_n_stream import StagedDatasets, publish_staged_datasets
+
+    monkeypatch.chdir(tmp_path)
+    sft = tmp_path / "sft.jsonl"
+    dpo = tmp_path / "dpo.jsonl"
+    manifest = tmp_path / "manifest.json"
+    sft_temp = tmp_path / ".soup.group.sft.tmp"
+    dpo_temp = tmp_path / ".soup.group.dpo.tmp"
+    sft_temp.write_bytes(b"sft\n")
+    dpo_temp.write_bytes(b"dpo\n")
+    staged = StagedDatasets(
+        sft_temp=str(sft_temp),
+        dpo_temp=str(dpo_temp),
+        sft_sha256="1" * 64,
+        dpo_sha256="2" * 64,
+        sft_count=1,
+        dpo_count=1,
+    )
+    destinations = {str(sft), str(dpo), str(manifest)}
+    publication_order = []
+    real_replace = os.replace
+
+    def record_publication(source, destination):
+        if destination in destinations:
+            publication_order.append(destination)
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(os, "replace", record_publication)
+    publish_staged_datasets(
+        staged,
+        str(sft),
+        str(dpo),
+        manifest_path=str(manifest),
+        manifest_bytes=b'{"generation":"new"}\n',
+    )
+
+    assert publication_order == [str(sft), str(dpo), str(manifest)]
+
+
 def test_atomic_group_removal_validation_is_directly_covered(tmp_path, monkeypatch):
     from soup_cli.utils.paths import atomic_write_bytes_group
 

--- a/tests/test_issue555_bon_stream_resume.py
+++ b/tests/test_issue555_bon_stream_resume.py
@@ -43,6 +43,30 @@ def _local_args(tmp_path, model_path, *extra):
     ]
 
 
+def test_candidate_export_rejects_prompt_destination_collision(tmp_path, monkeypatch):
+    from soup_cli.commands.data import app
+
+    monkeypatch.chdir(tmp_path)
+    prompts = tmp_path / "prompts.jsonl"
+    original = b'{"prompt":"must survive"}\n'
+    prompts.write_bytes(original)
+    calls = []
+    monkeypatch.setattr(
+        "soup_cli.utils.magpie.make_magpie_generate_fn",
+        lambda *_args, **_kwargs: lambda prompt: calls.append(prompt) or "candidate",
+    )
+
+    args = _args(tmp_path)
+    args[args.index(str(tmp_path / "candidates.jsonl"))] = str(prompts)
+    result = CliRunner().invoke(app, args)
+
+    assert result.exit_code == 2
+    assert "must be distinct" in result.output
+    assert prompts.read_bytes() == original
+    assert calls == []
+    assert not (tmp_path / "prompts.jsonl.checkpoint.jsonl").exists()
+
+
 def test_late_candidate_failure_resumes_without_replaying_completed_groups(
     tmp_path, monkeypatch
 ):

--- a/tests/test_issue555_bon_stream_resume.py
+++ b/tests/test_issue555_bon_stream_resume.py
@@ -7,6 +7,8 @@ import json
 import pytest
 from typer.testing import CliRunner
 
+_FINGERPRINT = "0" * 64
+
 
 def _args(tmp_path):
     return [
@@ -21,6 +23,23 @@ def _args(tmp_path):
         "2",
         "--export-candidates",
         str(tmp_path / "candidates.jsonl"),
+    ]
+
+
+def _local_args(tmp_path, model_path, *extra):
+    return [
+        "best-of-n",
+        "--base",
+        str(model_path),
+        "--prompts",
+        str(tmp_path / "prompts.jsonl"),
+        "--n",
+        "2",
+        "--seed",
+        "23",
+        "--export-candidates",
+        str(tmp_path / "candidates.jsonl"),
+        *extra,
     ]
 
 
@@ -110,6 +129,7 @@ def test_offline_large_artifacts_bypass_whole_file_materializers(tmp_path, monke
         "kind": "provider",
         "provider": "ollama",
         "model": "sampler-model",
+        "endpoint_fingerprint": _FINGERPRINT,
         "n": 2,
         "temperature": 1.0,
         "max_new_tokens": 256,
@@ -145,6 +165,16 @@ def test_offline_large_artifacts_bypass_whole_file_materializers(tmp_path, monke
     monkeypatch.setattr("soup_cli.utils.best_of_n_artifact.load_judgments", forbidden)
     monkeypatch.setattr("soup_cli.utils.best_of_n_artifact.materialize_rows", forbidden)
     monkeypatch.setattr("soup_cli.utils.best_of_n_artifact.stable_jsonl", forbidden)
+    from soup_cli.utils.best_of_n_stream import OfflineArtifactIndex
+
+    real_iter_rows = OfflineArtifactIndex.iter_rows
+    iteration_count = {"value": 0}
+
+    def counted_iter_rows(self):
+        iteration_count["value"] += 1
+        yield from real_iter_rows(self)
+
+    monkeypatch.setattr(OfflineArtifactIndex, "iter_rows", counted_iter_rows)
     sft = tmp_path / "sft.jsonl"
     dpo = tmp_path / "dpo.jsonl"
     result = CliRunner().invoke(
@@ -164,6 +194,7 @@ def test_offline_large_artifacts_bypass_whole_file_materializers(tmp_path, monke
     assert result.exit_code == 0, (result.output, repr(result.exception))
     assert sum(1 for _ in sft.open(encoding="utf-8")) == count
     assert sum(1 for _ in dpo.open(encoding="utf-8")) == count
+    assert iteration_count["value"] == 1
     verify_offline_manifest(
         str(tmp_path / "sft.jsonl.manifest.json"),
         sft_path=str(sft),
@@ -187,6 +218,7 @@ def test_streaming_candidate_structure_failures_never_commit_manifest(
         "kind": "provider",
         "provider": "ollama",
         "model": "sampler-model",
+        "endpoint_fingerprint": _FINGERPRINT,
         "n": 2,
         "temperature": 1.0,
         "max_new_tokens": 256,
@@ -220,3 +252,134 @@ def test_streaming_candidate_structure_failures_never_commit_manifest(
     assert result.exit_code == 2
     assert not output.exists()
     assert not (tmp_path / "sft.jsonl.manifest.json").exists()
+
+
+def test_resume_discards_an_uncommitted_candidate_tail(tmp_path, monkeypatch):
+    from soup_cli.utils.best_of_n_artifact import build_candidate_group
+    from soup_cli.utils.best_of_n_stream import (
+        append_candidate_group,
+        prepare_candidate_checkpoint,
+    )
+
+    monkeypatch.chdir(tmp_path)
+    sampler = {
+        "kind": "provider",
+        "provider": "ollama",
+        "model": "sampler-model",
+        "endpoint_fingerprint": _FINGERPRINT,
+        "n": 2,
+        "temperature": 1.0,
+        "max_new_tokens": 256,
+    }
+    prompts = ["q1", "q2"]
+    checkpoint = tmp_path / "checkpoint.jsonl"
+    assert prepare_candidate_checkpoint(
+        str(checkpoint), prompts, sampler, resume=False
+    ) == 0
+    append_candidate_group(
+        str(checkpoint), build_candidate_group("q1", 0, ["a", "b"], sampler)
+    )
+    with checkpoint.open("ab") as handle:
+        handle.write(b'{"prompt_index":1,"prompt":')
+
+    completed = prepare_candidate_checkpoint(
+        str(checkpoint), prompts, sampler, resume=True
+    )
+
+    assert completed == 1
+    assert checkpoint.read_bytes().endswith(b"\n")
+
+
+def test_resume_rejects_provider_endpoint_drift(tmp_path, monkeypatch):
+    from soup_cli.commands.data import app
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "prompts.jsonl").write_text('{"prompt":"q"}\n', encoding="utf-8")
+    monkeypatch.setattr(
+        "soup_cli.utils.magpie.make_magpie_generate_fn",
+        lambda *_args, **_kwargs: lambda _prompt: "candidate",
+    )
+    first = CliRunner().invoke(app, _args(tmp_path))
+    assert first.exit_code == 0, (first.output, repr(first.exception))
+
+    changed = [*_args(tmp_path), "--resume", "--base-url", "http://localhost:11435"]
+    resumed = CliRunner().invoke(app, changed)
+
+    assert resumed.exit_code == 1
+    assert "does not match this run" in resumed.output
+
+
+def test_resume_rejects_a_different_private_local_model(tmp_path, monkeypatch):
+    from soup_cli.commands.data import app
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "prompts.jsonl").write_text('{"prompt":"q"}\n', encoding="utf-8")
+    model_a = tmp_path / "model-a"
+    model_b = tmp_path / "model-b"
+    model_a.mkdir()
+    model_b.mkdir()
+    monkeypatch.setattr(
+        "soup_cli.utils.trust_remote.model_requires_trust_remote_code",
+        lambda _model: False,
+    )
+    monkeypatch.setattr(
+        "soup_cli.commands.data._load_bon_model", lambda *_args, **_kwargs: (object(), object())
+    )
+    monkeypatch.setattr(
+        "soup_cli.utils.best_of_n.sample_candidates",
+        lambda *_args, n, **_kwargs: [f"candidate-{i}" for i in range(n)],
+    )
+
+    first = CliRunner().invoke(app, _local_args(tmp_path, model_a))
+    assert first.exit_code == 0, (first.output, repr(first.exception))
+    resumed = CliRunner().invoke(
+        app, _local_args(tmp_path, model_b, "--resume")
+    )
+
+    assert resumed.exit_code == 1
+    assert "does not match this run" in resumed.output
+    artifact_text = (tmp_path / "candidates.jsonl").read_text(encoding="utf-8")
+    assert str(model_a) not in artifact_text
+    assert str(model_b) not in artifact_text
+
+
+def test_local_resume_reuses_the_same_prompt_seed(tmp_path, monkeypatch):
+    import torch
+
+    from soup_cli.commands.data import app
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "prompts.jsonl").write_text(
+        '{"prompt":"first"}\n{"prompt":"second"}\n', encoding="utf-8"
+    )
+    model = tmp_path / "model"
+    model.mkdir()
+    monkeypatch.setattr(
+        "soup_cli.utils.trust_remote.model_requires_trust_remote_code",
+        lambda _model: False,
+    )
+    monkeypatch.setattr(
+        "soup_cli.commands.data._load_bon_model", lambda *_args, **_kwargs: (object(), object())
+    )
+    sampled = []
+    fail_second = {"value": True}
+
+    def sample_candidates(_model, _tokenizer, prompt, *, n, **_kwargs):
+        values = [f"{torch.rand(1).item():.12f}" for _ in range(n)]
+        sampled.append((prompt, values))
+        if prompt == "second" and fail_second["value"]:
+            raise RuntimeError("simulated interruption")
+        return values
+
+    monkeypatch.setattr(
+        "soup_cli.utils.best_of_n.sample_candidates", sample_candidates
+    )
+    first = CliRunner().invoke(app, _local_args(tmp_path, model))
+    assert first.exit_code == 1, (first.output, repr(first.exception))
+    interrupted = sampled[-1][1]
+
+    fail_second["value"] = False
+    resumed = CliRunner().invoke(app, _local_args(tmp_path, model, "--resume"))
+
+    assert resumed.exit_code == 0, (resumed.output, repr(resumed.exception))
+    assert sampled[-1] == ("second", interrupted)

--- a/tests/test_issue555_bon_stream_resume.py
+++ b/tests/test_issue555_bon_stream_resume.py
@@ -115,6 +115,32 @@ def test_resume_rejects_changed_prompt_contract_before_sampling(tmp_path, monkey
     assert calls == []
 
 
+def test_resume_rejects_changed_prompt_source_line_before_sampling(tmp_path, monkeypatch):
+    from soup_cli.commands.data import app
+
+    monkeypatch.chdir(tmp_path)
+    prompts = tmp_path / "prompts.jsonl"
+    prompts.write_text('{"prompt":"same"}\n', encoding="utf-8")
+    monkeypatch.setattr(
+        "soup_cli.utils.magpie.make_magpie_generate_fn",
+        lambda *_args, **_kwargs: lambda _prompt: "candidate",
+    )
+    first = CliRunner().invoke(app, _args(tmp_path))
+    assert first.exit_code == 0, (first.output, repr(first.exception))
+
+    prompts.write_text('\n{"prompt":"same"}\n', encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(
+        "soup_cli.utils.magpie.make_magpie_generate_fn",
+        lambda *_args, **_kwargs: lambda prompt: calls.append(prompt) or "unexpected",
+    )
+    resumed = CliRunner().invoke(app, [*_args(tmp_path), "--resume"])
+
+    assert resumed.exit_code == 1
+    assert "does not match this run" in resumed.output
+    assert calls == []
+
+
 def test_offline_large_artifacts_bypass_whole_file_materializers(tmp_path, monkeypatch):
     from soup_cli.commands.data import app
     from soup_cli.utils.best_of_n_artifact import (
@@ -143,7 +169,11 @@ def test_offline_large_artifacts_bypass_whole_file_materializers(tmp_path, monke
         candidate_file.write(stable_json_line(candidate_artifact_header(count, sampler)))
         for index in range(count):
             group = build_candidate_group(
-                f"prompt-{index}", index, [f"loser-{index}", f"winner-{index}"], sampler
+                f"prompt-{index}",
+                index,
+                [f"loser-{index}", f"winner-{index}"],
+                sampler,
+                source_line=index + 1,
             )
             candidate_file.write(stable_json_line(group))
             judgment_file.write(
@@ -224,7 +254,9 @@ def test_streaming_candidate_structure_failures_never_commit_manifest(
         "max_new_tokens": 256,
     }
     groups = [
-        build_candidate_group(f"q{index}", index, ["a", "b"], sampler)
+        build_candidate_group(
+            f"q{index}", index, ["a", "b"], sampler, source_line=index + 1
+        )
         for index in range(2)
     ]
     records = [candidate_artifact_header(2, sampler), *groups]
@@ -277,7 +309,8 @@ def test_resume_discards_an_uncommitted_candidate_tail(tmp_path, monkeypatch):
         str(checkpoint), prompts, sampler, resume=False
     ) == 0
     append_candidate_group(
-        str(checkpoint), build_candidate_group("q1", 0, ["a", "b"], sampler)
+        str(checkpoint),
+        build_candidate_group("q1", 0, ["a", "b"], sampler, source_line=1),
     )
     with checkpoint.open("ab") as handle:
         handle.write(b'{"prompt_index":1,"prompt":')
@@ -341,6 +374,46 @@ def test_resume_rejects_a_different_private_local_model(tmp_path, monkeypatch):
     artifact_text = (tmp_path / "candidates.jsonl").read_text(encoding="utf-8")
     assert str(model_a) not in artifact_text
     assert str(model_b) not in artifact_text
+
+
+def test_resume_rejects_replaced_content_at_the_same_local_model_path(
+    tmp_path, monkeypatch
+):
+    from soup_cli.commands.data import app
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "prompts.jsonl").write_text('{"prompt":"q"}\n', encoding="utf-8")
+    model = tmp_path / "model"
+    model.mkdir()
+    weights = model / "weights.bin"
+    weights.write_bytes(b"first-content")
+    load_calls = []
+    monkeypatch.setattr(
+        "soup_cli.utils.trust_remote.model_requires_trust_remote_code",
+        lambda _model: False,
+    )
+    monkeypatch.setattr(
+        "soup_cli.commands.data._load_bon_model",
+        lambda *_args, **_kwargs: (
+            load_calls.append(True) or (object(), object())
+        ),
+    )
+    monkeypatch.setattr(
+        "soup_cli.utils.best_of_n.sample_candidates",
+        lambda *_args, n, **_kwargs: [f"candidate-{index}" for index in range(n)],
+    )
+
+    first = CliRunner().invoke(app, _local_args(tmp_path, model))
+    assert first.exit_code == 0, (first.output, repr(first.exception))
+    assert load_calls == [True]
+
+    weights.write_bytes(b"other-content")
+    load_calls.clear()
+    resumed = CliRunner().invoke(app, _local_args(tmp_path, model, "--resume"))
+
+    assert resumed.exit_code == 1
+    assert "does not match this run" in resumed.output
+    assert load_calls == []
 
 
 def test_local_resume_reuses_the_same_prompt_seed(tmp_path, monkeypatch):

--- a/tests/test_issue555_bon_stream_resume.py
+++ b/tests/test_issue555_bon_stream_resume.py
@@ -1,0 +1,222 @@
+"""Regression tests for #555: resumable and bounded two-phase Best-of-N."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+
+def _args(tmp_path):
+    return [
+        "best-of-n",
+        "--provider",
+        "ollama",
+        "--model",
+        "sampler-model",
+        "--prompts",
+        str(tmp_path / "prompts.jsonl"),
+        "--n",
+        "2",
+        "--export-candidates",
+        str(tmp_path / "candidates.jsonl"),
+    ]
+
+
+def test_late_candidate_failure_resumes_without_replaying_completed_groups(
+    tmp_path, monkeypatch
+):
+    from soup_cli.commands.data import app
+    from soup_cli.utils.best_of_n_artifact import load_candidate_artifact
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "prompts.jsonl").write_text(
+        ''.join(json.dumps({"prompt": prompt}) + "\n" for prompt in ("q1", "q2", "q3")),
+        encoding="utf-8",
+    )
+    first_calls = []
+
+    def failing_factory(*_args, **_kwargs):
+        def generate(prompt):
+            first_calls.append(prompt)
+            if prompt == "q2":
+                raise RuntimeError("simulated sampler interruption")
+            return f"first-{prompt}-{len(first_calls)}"
+
+        return generate
+
+    monkeypatch.setattr("soup_cli.utils.magpie.make_magpie_generate_fn", failing_factory)
+    failed = CliRunner().invoke(app, _args(tmp_path))
+    assert failed.exit_code == 1
+    assert "Completed groups: 1/3" in failed.output
+    assert not (tmp_path / "candidates.jsonl").exists()
+    checkpoint = tmp_path / "candidates.jsonl.checkpoint.jsonl"
+    assert len(checkpoint.read_bytes().splitlines()) == 2
+
+    resumed_calls = []
+
+    def resumed_factory(*_args, **_kwargs):
+        def generate(prompt):
+            resumed_calls.append(prompt)
+            return f"resumed-{prompt}-{len(resumed_calls)}"
+
+        return generate
+
+    monkeypatch.setattr("soup_cli.utils.magpie.make_magpie_generate_fn", resumed_factory)
+    resumed = CliRunner().invoke(app, [*_args(tmp_path), "--resume"])
+    assert resumed.exit_code == 0, (resumed.output, repr(resumed.exception))
+    assert resumed_calls == ["q2", "q2", "q3", "q3"]
+    groups, sampler, _digest = load_candidate_artifact(str(tmp_path / "candidates.jsonl"))
+    assert [group["prompt"] for group in groups] == ["q1", "q2", "q3"]
+    assert sampler["model"] == "sampler-model"
+
+
+def test_resume_rejects_changed_prompt_contract_before_sampling(tmp_path, monkeypatch):
+    from soup_cli.commands.data import app
+
+    monkeypatch.chdir(tmp_path)
+    prompts = tmp_path / "prompts.jsonl"
+    prompts.write_text('{"prompt":"original"}\n', encoding="utf-8")
+    monkeypatch.setattr(
+        "soup_cli.utils.magpie.make_magpie_generate_fn",
+        lambda *_args, **_kwargs: lambda _prompt: "candidate",
+    )
+    first = CliRunner().invoke(app, _args(tmp_path))
+    assert first.exit_code == 0, (first.output, repr(first.exception))
+    prompts.write_text('{"prompt":"changed"}\n', encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(
+        "soup_cli.utils.magpie.make_magpie_generate_fn",
+        lambda *_args, **_kwargs: lambda prompt: calls.append(prompt) or "unexpected",
+    )
+    resumed = CliRunner().invoke(app, [*_args(tmp_path), "--resume"])
+    assert resumed.exit_code == 1
+    assert "does not match this run" in resumed.output
+    assert calls == []
+
+
+def test_offline_large_artifacts_bypass_whole_file_materializers(tmp_path, monkeypatch):
+    from soup_cli.commands.data import app
+    from soup_cli.utils.best_of_n_artifact import (
+        build_candidate_group,
+        candidate_artifact_header,
+        stable_json_line,
+        verify_offline_manifest,
+    )
+
+    monkeypatch.chdir(tmp_path)
+    sampler = {
+        "kind": "provider",
+        "provider": "ollama",
+        "model": "sampler-model",
+        "n": 2,
+        "temperature": 1.0,
+        "max_new_tokens": 256,
+    }
+    count = 1500
+    candidate_path = tmp_path / "large-candidates.jsonl"
+    judgment_path = tmp_path / "large-judgments.jsonl"
+    with candidate_path.open("wb") as candidate_file, judgment_path.open(
+        "wb"
+    ) as judgment_file:
+        candidate_file.write(stable_json_line(candidate_artifact_header(count, sampler)))
+        for index in range(count):
+            group = build_candidate_group(
+                f"prompt-{index}", index, [f"loser-{index}", f"winner-{index}"], sampler
+            )
+            candidate_file.write(stable_json_line(group))
+            judgment_file.write(
+                stable_json_line(
+                    {
+                        "prompt_id": group["prompt_id"],
+                        "group_digest": group["group_digest"],
+                        "winner_idx": 1,
+                        "scores": [0.0, 1.0],
+                        "verifier": {"name": "Codex", "version": "offline-v1"},
+                    }
+                )
+            )
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("whole-artifact materializer must not be used")
+
+    monkeypatch.setattr("soup_cli.utils.best_of_n_artifact.load_candidate_artifact", forbidden)
+    monkeypatch.setattr("soup_cli.utils.best_of_n_artifact.load_judgments", forbidden)
+    monkeypatch.setattr("soup_cli.utils.best_of_n_artifact.materialize_rows", forbidden)
+    monkeypatch.setattr("soup_cli.utils.best_of_n_artifact.stable_jsonl", forbidden)
+    sft = tmp_path / "sft.jsonl"
+    dpo = tmp_path / "dpo.jsonl"
+    result = CliRunner().invoke(
+        app,
+        [
+            "best-of-n",
+            "--candidate-artifact",
+            str(candidate_path),
+            "--judgments",
+            str(judgment_path),
+            "--output",
+            str(sft),
+            "--emit-pairs",
+            str(dpo),
+        ],
+    )
+    assert result.exit_code == 0, (result.output, repr(result.exception))
+    assert sum(1 for _ in sft.open(encoding="utf-8")) == count
+    assert sum(1 for _ in dpo.open(encoding="utf-8")) == count
+    verify_offline_manifest(
+        str(tmp_path / "sft.jsonl.manifest.json"),
+        sft_path=str(sft),
+        dpo_path=str(dpo),
+    )
+
+
+@pytest.mark.parametrize("mutation", ["reordered", "truncated"])
+def test_streaming_candidate_structure_failures_never_commit_manifest(
+    tmp_path, monkeypatch, mutation
+):
+    from soup_cli.commands.data import app
+    from soup_cli.utils.best_of_n_artifact import (
+        build_candidate_group,
+        candidate_artifact_header,
+        stable_json_line,
+    )
+
+    monkeypatch.chdir(tmp_path)
+    sampler = {
+        "kind": "provider",
+        "provider": "ollama",
+        "model": "sampler-model",
+        "n": 2,
+        "temperature": 1.0,
+        "max_new_tokens": 256,
+    }
+    groups = [
+        build_candidate_group(f"q{index}", index, ["a", "b"], sampler)
+        for index in range(2)
+    ]
+    records = [candidate_artifact_header(2, sampler), *groups]
+    if mutation == "reordered":
+        records[1:] = reversed(records[1:])
+    else:
+        records.pop()
+    candidate_path = tmp_path / "candidates.jsonl"
+    candidate_path.write_bytes(b"".join(stable_json_line(row) for row in records))
+    judgments = tmp_path / "judgments.jsonl"
+    judgments.write_text("", encoding="utf-8")
+    output = tmp_path / "sft.jsonl"
+    result = CliRunner().invoke(
+        app,
+        [
+            "best-of-n",
+            "--candidate-artifact",
+            str(candidate_path),
+            "--judgments",
+            str(judgments),
+            "--output",
+            str(output),
+        ],
+    )
+    assert result.exit_code == 2
+    assert not output.exists()
+    assert not (tmp_path / "sft.jsonl.manifest.json").exists()


### PR DESCRIPTION
## Summary

Closes #555.

- stream candidate export through a durable, per-prompt checkpoint and resume from the first incomplete group;
- authenticate resume against prompt text, source-line provenance, sampler settings, provider endpoint identity, and exact local-model file names/sizes/content;
- keep private endpoint/model identities in the recovery journal instead of changing or leaking them through the public `candidates.v1` artifact;
- discard only an incomplete final checkpoint record, preserve deterministic per-prompt RNG on local resume, and reject changed inputs before loading the model;
- validate candidate/judgment artifacts through a bounded-memory disk index and stage SFT/DPO incrementally;
- publish streamed SFT, optional DPO retirement, and the manifest as one rollback-protected generation, with the manifest committed last;
- reject collisions among prompt, candidate, checkpoint, output, DPO, judgment, and manifest paths before sampling or publication.

## Rebase and scope

This branch is rebased onto current `main` after #557 merged. The PR diff now contains only the #555 streaming/resume implementation, its tests, documentation, and `555.fixed.md`; `556.fixed.md`, the #557 offline test additions, and the shared `paths.py` removal transaction are supplied by `main` and no longer appear in this PR.

Two non-blocking #557 follow-ups that directly exercise this path were folded in:

- direct coverage for the shared atomic-group removal validation branches;
- changed-generation rollback coverage plus an explicit SFT -> DPO -> manifest publication-order assertion.

## Validation

- `ruff check src/soup_cli/ scripts/ tests/` — passed
- `mypy src/soup_cli/utils/best_of_n_stream.py` — passed
- focused Best-of-N and changelog suite — **77 passed**
- full local suite on the rebased implementation — **19,164 passed, 74 skipped, 5 deselected, 18 failed; 82.64% coverage**
- the same exact 18 failures reproduce **18/18** on pristine `main` at `0d98183`; they are restricted-environment failures, not branch regressions:
  - `test_doctor.py::test_doctor_nccl_mocked_success` (process/socket or local Torch environment)
  - three `test_issue144_gguf_export.py` cases (registry database cannot be opened)
  - two `test_issue296_network_transport.py::TestSseEndToEnd` cases (loopback bind denied)
  - one `test_part_f_hardening.py` and two `test_rlvr.py` code-exec cases (subprocess sandbox denied)
  - two `test_v0402_part_b.py` data-registry cases (home-directory write denied)
  - two `test_v0537.py` recipe code-node cases (sandbox execution denied)
  - `test_v0540.py::TestCLI::test_explain_no_prior_verdict` (home-directory unlink denied)
  - `test_v07110.py::TestSteeringArtifactRoundtrip::test_resolve_unknown_raises` (registry database cannot be opened)
  - three `test_v07118.py` sandbox-eval cases (`sandbox-exec` denied)

Mutation checks:

- removing the private sampler identity from the checkpoint made the endpoint-drift, local-content-drift, and identity-privacy regressions fail (**3 failures**);
- committing the manifest before the streamed data made `test_streamed_publication_commits_manifest_last` fail by name (**1 failure**).

The PR remains draft until the fresh GitHub Actions matrix for this rebased head is green.
