### PR TITLE
fix(sft): only check the most recent value of each finite-state metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ reproducing 70+ versions of notes.
 
 ### Fixed
 
+- **`_assert_finite_training_state` no longer refuses a run over a self-corrected
+  transient metric (#546 by @AmirF194 in #560).** The log_history scan now checks only
+  the most recently logged value of each metric instead of raising on the first
+  non-finite value found at any step, so a GradScaler warm-up nan that recovers no
+  longer blocks the final save.
 - **SmolVLM/Idefics3 vision SFT now reaches real training batches (#302 by
   @Amix29 in #488).** Soup keeps LLaVA messages and PIL images together until
   collation, converts legacy `<image>` markers to structured multimodal content,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,6 @@ reproducing 70+ versions of notes.
 
 ### Fixed
 
-- **`_assert_finite_training_state` no longer refuses a run over a self-corrected
-  transient metric (#546 by @AmirF194 in #560).** The log_history scan now checks only
-  the most recently logged value of each metric instead of raising on the first
-  non-finite value found at any step, so a GradScaler warm-up nan that recovers no
-  longer blocks the final save.
 - **SmolVLM/Idefics3 vision SFT now reaches real training batches (#302 by
   @Amix29 in #488).** Soup keeps LLaVA messages and PIL images together until
   collation, converts legacy `<image>` markers to structured multimodal content,

--- a/changelog.d/0.73.3/560.fixed.md
+++ b/changelog.d/0.73.3/560.fixed.md
@@ -1,0 +1,5 @@
+- **`_assert_finite_training_state` no longer refuses a run over a self-corrected
+  transient metric (#546 by @AmirF194 in #560).** The log_history scan now checks only
+  the most recently logged value of each metric instead of raising on the first
+  non-finite value found at any step, so a GradScaler warm-up nan that recovers no
+  longer blocks the final save.

--- a/src/soup_cli/trainer/sft.py
+++ b/src/soup_cli/trainer/sft.py
@@ -60,20 +60,25 @@ _FINITE_TRAINING_METRICS = (
 def _assert_finite_training_state(
     log_history: list[dict[str, Any]], model: Any | None = None
 ) -> None:
-    """Refuse the final save when metrics or trainable weights are non-finite."""
-    for entry in log_history:
-        if not isinstance(entry, dict):
-            continue
-        for metric in _FINITE_TRAINING_METRICS:
-            if metric not in entry:
+    """Refuse the final save when metrics or trainable weights are non-finite.
+
+    Only the most recently logged value of each metric is checked. ``log_history``
+    accumulates one entry per log call over the whole run, and a metric that was
+    transiently non-finite earlier (e.g. a GradScaler warm-up nan) but recovered
+    says nothing about the final state; checking every past entry made a
+    self-corrected run indistinguishable from a genuinely corrupted one.
+    """
+    for metric in _FINITE_TRAINING_METRICS:
+        for entry in reversed(log_history):
+            if not isinstance(entry, dict) or metric not in entry:
                 continue
             value = entry[metric]
             try:
                 finite = math.isfinite(float(value))
             except (TypeError, ValueError):
-                continue
+                break
             if finite:
-                continue
+                break
             step = entry.get("step", "unknown")
             raise RuntimeError(
                 f"non-finite training metric {metric}={value} at step {step}; "

--- a/tests/test_issue546_transient_finite_metric.py
+++ b/tests/test_issue546_transient_finite_metric.py
@@ -1,0 +1,46 @@
+"""Regression coverage for issue #546's over-broad log_history finite-state gate."""
+
+from __future__ import annotations
+
+
+def test_self_corrected_transient_metric_is_accepted() -> None:
+    from soup_cli.trainer.sft import _assert_finite_training_state
+
+    _assert_finite_training_state(
+        [
+            {"loss": 0.0, "grad_norm": float("nan"), "step": 2},
+            {"loss": 0.4, "grad_norm": 0.089, "step": 9},
+        ]
+    )
+
+
+def test_non_finite_final_metric_is_still_rejected() -> None:
+    import pytest
+
+    from soup_cli.trainer.sft import _assert_finite_training_state
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"non-finite training metric grad_norm=nan.*step 9.*refusing to save",
+    ):
+        _assert_finite_training_state(
+            [
+                {"loss": 0.4, "grad_norm": 1.1, "step": 2},
+                {"loss": 0.0, "grad_norm": float("nan"), "step": 9},
+            ]
+        )
+
+
+def test_recovered_metric_checked_independently_per_metric() -> None:
+    """A self-corrected ``loss`` must not mask a still-broken ``grad_norm``."""
+    import pytest
+
+    from soup_cli.trainer.sft import _assert_finite_training_state
+
+    with pytest.raises(RuntimeError, match=r"grad_norm=nan.*step 9"):
+        _assert_finite_training_state(
+            [
+                {"loss": float("nan"), "grad_norm": 0.5, "step": 2},
+                {"loss": 0.4, "grad_norm": float("nan"), "step": 9},
+            ]
+        )


### PR DESCRIPTION
## What does this PR do?

`_assert_finite_training_state` (`src/soup_cli/trainer/sft.py`, added in #535) scans the
whole `log_history` and raises on the first non-finite metric it finds at any step. A run
whose GradScaler warm-up produced a transient nan that self-corrected is refused
identically to a genuinely corrupted one, and the loop never reaches the
`torch.isfinite` parameter check a few lines below it, which is the check that actually
reflects the final saved weights.

Fix: check only the most recently logged value of each metric in `_FINITE_TRAINING_METRICS`,
scanning `log_history` in reverse and stopping at the first entry that carries it. This
matches the function's own docstring ("refuse the final save... because its weights may be
corrupted") without changing anything for a run that is still non-finite at its last logged
step, which still raises exactly as before.

## Type of change

- [x] Bug fix

## How I verified it

- New regression tests in `tests/test_issue546_transient_finite_metric.py`: a transient nan
  that recovers by the next entry is now accepted; a metric still non-finite at the last
  entry still raises; two independently-tracked metrics (one recovered, one not) are each
  checked on their own trailing value.
- Ran both the new tests and the existing `test_issue532_supervised_token_guard.py` tests
  that exercise this function against unmodified `main` and against this branch, in a
  `python:3.11-slim` container: the two new discriminating tests fail on `main` and pass on
  the branch, and none of the pre-existing tests for this function changed outcome.
- `ruff check src/soup_cli/ tests/` passes on the changed files.
- What I did not check: the full CI matrix (macos/windows, real `torch`/`transformers`
  install). This environment is disk-constrained, so I verified only the pure-Python
  `log_history` path, which this fix and both call-site arguments are limited to.

Fixes #546.
