### PR TITLE
fix(trainer): scale multipack bin cap by batch_size in flat mode

### DIFF
--- a/changelog.d/0.73.3/562.fixed.md
+++ b/changelog.d/0.73.3/562.fixed.md
@@ -1,0 +1,3 @@
+- Live multipack training now packs each bin to `training.batch_size * data.max_length`
+  instead of `data.max_length` alone, so the configured batch size actually affects
+  packing density again (#562).

--- a/src/soup_cli/utils/multipack_trainer.py
+++ b/src/soup_cli/utils/multipack_trainer.py
@@ -208,7 +208,10 @@ def make_multipack_trainer_class(base_cls: type) -> type:
 
             sampler = MultipackBatchSampler(
                 lengths=list(lengths),
-                batch_max_len=int(max_seq),
+                # real_batches=False packs each bin to batch_size * max_seq_length
+                # (multipack.py's own flat-mode branch), not bare max_seq_length, or
+                # training.batch_size has no effect on the packing density here.
+                batch_max_len=int(max_seq) * int(batch_size),
                 batch_size=int(batch_size),
                 real_batches=False,  # yield list[int] per pack — DataLoader-compatible
                 seed=int(seed),

--- a/tests/test_v0404_part_b.py
+++ b/tests/test_v0404_part_b.py
@@ -121,6 +121,52 @@ class TestGetTrainDataloaderReturnsMultipackDataloader:
         assert all(isinstance(x, int) for x in first_pack)
 
 
+class TestGetTrainDataloaderScalesBinCapByBatchSize:
+    """training.batch_size must reach the packer's bin cap (multipack.py's own
+    ``build_multipack_sampler_for_lengths`` branch: ``batch_max_len =
+    batch_size * max_seq_length`` for the flat, real_batches=False mode)."""
+
+    def test_batch_max_len_scales_with_batch_size(self):
+        try:
+            from torch.utils.data import Dataset
+        except ImportError:
+            pytest.skip("torch not installed")
+
+        class TinyDataset(Dataset):
+            def __init__(self, n):
+                self.n = n
+
+            def __len__(self):
+                return self.n
+
+            def __getitem__(self, idx):
+                return {"x": idx}
+
+        class Base:
+            def __init__(self):
+                self.train_dataset = TinyDataset(10)
+                self.data_collator = None
+                self.args = MagicMock(
+                    dataloader_num_workers=0, dataloader_pin_memory=False,
+                )
+
+            def get_train_dataloader(self):
+                return "should-not-be-called"
+
+        sub = make_multipack_trainer_class(Base)
+        instance = sub()
+        attach_multipack_state(
+            instance,
+            lengths=[10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
+            max_seq_len=128,
+            batch_size=4,
+            seed=42,
+        )
+
+        dl = instance.get_train_dataloader()
+        assert dl.batch_sampler._batch_max_len == 128 * 4
+
+
 class TestGetTrainDataloaderForwardsDropLast:
     """v0.40.4 H3 — `args.dataloader_drop_last` must reach the
     MultipackBatchSampler; v0.40.4 first-cut hardcoded `drop_last=False`.


### PR DESCRIPTION
## What does this PR do?

Fixes #561: the live multipack `DataLoader` wiring ignores `training.batch_size`.

`get_train_dataloader` (`make_multipack_trainer_class`, `src/soup_cli/utils/multipack_trainer.py`) builds the FFD sampler with `batch_max_len=int(max_seq)`, so every packed bin is capped at the raw sequence length regardless of `training.batch_size`. `src/soup_cli/utils/multipack.py`'s own `build_multipack_sampler_for_lengths` already implements the correct flat-mode branch (`batch_max_len = batch_size * max_seq_length` when `real_batches=False`), the live wiring just never applies it.

Root cause: `6fdf7e2` (v0.40.4 Part B) flipped the sampler from `real_batches=True` to `real_batches=False` to fix a `Sampler[int]` vs `list[list[int]]` shape mismatch, but left `batch_max_len=int(max_seq)` unchanged, carrying the `real_batches=True`-era value into the branch where the semantics differ. Nothing has touched that line since, so this reads as an unintentional regression from that refactor rather than a design decision.

Fix: `batch_max_len=int(max_seq) * int(batch_size)`, matching `multipack.py`'s own pattern.

## Type of change

- [x] Bug fix

## Verification

- New test `test_batch_max_len_scales_with_batch_size` (`tests/test_v0404_part_b.py`) fails on main (`_batch_max_len == 128`, expected `512`) and passes on this branch.
- `tests/test_v0404_part_b.py` and `tests/test_multipack_sampler.py` pass in full (42 passed, 1 pre-existing skip that needs a real `transformers` install).
- `ruff check src/soup_cli/utils/multipack_trainer.py tests/test_v0404_part_b.py` is clean.
- Not run: the full suite and CI's `pip install -e ".[dev]"` matrix (torch/transformers/trl/peft/accelerate/bitsandbytes), and an end-to-end training run comparing throughput before/after. Verified the sampler wiring directly instead, with `torch.utils.data.{Dataset,DataLoader}` stubbed to their minimal shape so the fix could be exercised without installing the training stack.

## Checklist

- [x] `ruff check src/soup_cli/ scripts/ tests/` passes (scoped to the changed files, see above)
- [x] `pytest tests/ -v` passes (scoped to the two files exercising this code path, see above)
- [ ] Updated relevant docs
- [x] Added a changelog fragment
