### PR TITLE
fix(train): enable BF16 on validated MPS trainers

### DIFF
--- a/changelog.d/0.73.3/564.fixed.md
+++ b/changelog.d/0.73.3/564.fixed.md
@@ -1,0 +1,5 @@
+- [#564](https://github.com/MakazhanAlpamys/Soup/pull/564) enables BF16 autocast for
+  hardware-validated resident SFT, DPO, reward-model, and PRM training on capable
+  Apple Silicon MPS runtimes. The live capability probe is shared with layer
+  streaming; CPU and unvalidated MPS trainers remain FP32, while PRM retains FP32
+  master weights to avoid a fatal Metal optimizer dtype mismatch.

--- a/docs/backends-and-ops.md
+++ b/docs/backends-and-ops.md
@@ -115,6 +115,23 @@ training:
 
 MLX backend supports SFT. `backend: mlx` with `task: dpo` or `task: grpo` is refused when the config is loaded, with an error naming the task — upstream `mlx-lm` ships no DPO/GRPO training helper, so those wrappers exist only as a backstop for callers that bypass config validation. Requires `mlx-lm >= 0.31.3`. Use `soup recipes search --tag mlx` for ready-made Apple Silicon configs.
 
+### Transformers on MPS
+
+The regular `backend: transformers` path can run more than MLX's SFT-only
+surface. On a live MPS runtime that accepts bfloat16, Soup enables BF16 autocast
+for the hardware-validated text trainers: SFT, DPO, reward modelling, and PRM.
+The decision comes from a live MPS allocation probe rather than a macOS version
+guess. CPU and an unavailable or older MPS runtime remain in FP32; FP16 is not
+selected on MPS.
+
+For BF16 checkpoints, resident SFT, DPO, and reward-model runs preserve the
+frozen base weights in BF16 while keeping LoRA parameters in FP32. PRM uses BF16
+autocast but deliberately retains FP32 master weights: loading its trainable
+base in BF16 makes the Metal optimizer abort because its accumulator and
+destination matrix dtypes differ. This policy was validated with one-step runs
+on Apple Silicon for all four tasks. Other Transformers trainers remain FP32 on
+MPS until their task-specific kernels receive equivalent hardware coverage.
+
 
 ## Unsloth Backend (2-5x Faster Training)
 

--- a/docs/performance-and-quantization.md
+++ b/docs/performance-and-quantization.md
@@ -271,6 +271,13 @@ made yet that streaming fits a larger model or runs faster than resident MPS tra
 `backend: mlx` remains a separate, incompatible model-loading path and is rejected with
 `stream_layers`.
 
+Resident Transformers training shares the same live MPS BF16 capability probe.
+SFT, DPO, reward modelling, and PRM use BF16 autocast on a capable runtime; the
+remaining trainers retain the conservative FP32 policy until they have
+task-specific Apple Silicon validation. PRM keeps FP32 master weights even when
+autocast is BF16 because a BF16 trainable base currently triggers a fatal Metal
+optimizer dtype mismatch.
+
 The tradeoff: **1.43× slower than resident training**, measured at 0.5B — the only apples-to-apples comparison available on the reference box, because 1.5B and above cannot run resident there at all.
 
 ### NF4 streaming (`quantization: 4bit`)

--- a/src/soup_cli/trainer/dpo.py
+++ b/src/soup_cli/trainer/dpo.py
@@ -163,7 +163,7 @@ class DPOTrainerWrapper(StreamingSetupMixin):
         # --- DPO config ---
         from soup_cli.utils.layer_stream import should_enable_hf_gradient_checkpointing
 
-        _bf16, _fp16 = bf16_fp16_flags(self.device)
+        _bf16, _fp16 = bf16_fp16_flags(self.device, allow_mps_bf16=True)
         dpo_config = DPOConfig(
             output_dir=str(output_dir),
             num_train_epochs=tcfg.epochs,

--- a/src/soup_cli/trainer/prm.py
+++ b/src/soup_cli/trainer/prm.py
@@ -24,6 +24,7 @@ from typing import Any, Optional
 from rich.console import Console
 
 from soup_cli.config.schema import SoupConfig
+from soup_cli.utils.gpu import bf16_fp16_flags
 from soup_cli.utils.mixed_precision import align_trainable_dtype_for_fp16
 from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
@@ -264,6 +265,11 @@ class PRMTrainerWrapper:
         base_model = AutoModelForCausalLM.from_pretrained(
             cfg.base,
             trust_remote_code=self._trust_remote_code,
+            # MPS PRM keeps fp32 master weights while TrainingArguments below
+            # autocasts the forward to bf16. Loading the trainable base itself
+            # as bf16 makes the Metal optimizer abort: its accumulator and
+            # destination matrix dtypes differ. CUDA retains its established
+            # bf16-parameter policy; CPU remains fp32.
             torch_dtype=torch.bfloat16 if self.device == "cuda" else torch.float32,
         )
         hidden_size = base_model.config.hidden_size
@@ -313,6 +319,7 @@ class PRMTrainerWrapper:
             bs = 1
         else:
             bs = tcfg.batch_size
+        use_bf16, use_fp16 = bf16_fp16_flags(self.device, allow_mps_bf16=True)
         args = TrainingArguments(
             output_dir=str(output_dir),
             num_train_epochs=tcfg.epochs,
@@ -322,6 +329,8 @@ class PRMTrainerWrapper:
             logging_steps=tcfg.logging_steps,
             save_steps=tcfg.save_steps,
             save_total_limit=3,
+            bf16=use_bf16,
+            fp16=use_fp16,
             report_to=self.report_to,
             remove_unused_columns=False,
             deepspeed=self.deepspeed_config,

--- a/src/soup_cli/trainer/reward_model.py
+++ b/src/soup_cli/trainer/reward_model.py
@@ -136,7 +136,7 @@ class RewardModelTrainerWrapper:
         warmup_steps = int(total_steps * tcfg.warmup_ratio)
 
         # --- Reward config ---
-        _bf16, _fp16 = bf16_fp16_flags(self.device)
+        _bf16, _fp16 = bf16_fp16_flags(self.device, allow_mps_bf16=True)
         reward_config = RewardConfig(
             output_dir=str(output_dir),
             num_train_epochs=tcfg.epochs,

--- a/src/soup_cli/trainer/sft.py
+++ b/src/soup_cli/trainer/sft.py
@@ -1186,10 +1186,13 @@ class SFTTrainerWrapper(StreamingSetupMixin):
         unchanged, and where it is not the previous behaviour was a crash.
         """
         if not getattr(tcfg, "auto_mixed_precision", False):
-            return bf16_fp16_flags(self.device)
+            return bf16_fp16_flags(self.device, allow_mps_bf16=True)
 
         if self.device != "cuda":
-            return (False, False)
+            # ``auto_mixed_precision`` predates MPS support and its model/CC
+            # heuristic is CUDA-specific.  Keep CPU disabled, but do not let
+            # enabling the option undo the validated MPS policy above.
+            return bf16_fp16_flags(self.device, allow_mps_bf16=True)
 
         try:
             import torch

--- a/src/soup_cli/utils/gpu.py
+++ b/src/soup_cli/utils/gpu.py
@@ -421,18 +421,51 @@ def cuda_supports_bf16() -> bool:
         return False
 
 
-def bf16_fp16_flags(device: str) -> tuple[bool, bool]:
+def mps_supports_bf16() -> bool:
+    """Return whether the live MPS runtime accepts native bfloat16 tensors.
+
+    PyTorch exposes no public ``is_bf16_supported`` equivalent for MPS.  Probe
+    the exact runtime instead of inferring support from a macOS or torch version:
+    this also covers builds compiled without MPS and older Metal runtimes.
+    """
+    try:
+        import torch
+
+        mps = getattr(torch.backends, "mps", None)
+        if mps is None or not mps.is_available():
+            return False
+        probe = torch.empty(1, dtype=torch.bfloat16, device="mps")
+        del probe
+        return True
+    except (
+        ImportError,
+        RuntimeError,
+        TypeError,
+        NotImplementedError,
+        AssertionError,
+        OSError,
+    ):
+        return False
+
+
+def bf16_fp16_flags(
+    device: str, *, allow_mps_bf16: bool = False
+) -> tuple[bool, bool]:
     """``(bf16, fp16)`` for ``TrainingArguments`` on ``device``.
 
-    bf16 where the card has it, fp16 where it does not, neither on CPU. Cannot
-    regress a working setup: on a bf16-capable card the answer is what every
-    wrapper hardcoded, and on the rest the previous answer was a crash.
+    bf16 where the card has it, fp16 where CUDA requires it, neither on CPU.
+    MPS is opt-in per trainer until that trainer has a real Apple Silicon smoke:
+    several audio/vision kernels have a different support surface from causal-LM
+    text training, so a successful scalar allocation cannot certify every task.
 
     A ``"cuda"`` string with no CUDA runtime behind it gets neither, rather than
     fp16 on a card that is not there — the run cannot proceed either way, and
     asking for mixed precision on a phantom device only obscures the real error.
     """
-    if not str(device).lower().startswith("cuda"):
+    device_name = str(device).lower()
+    if device_name.startswith("mps"):
+        return (allow_mps_bf16 and mps_supports_bf16(), False)
+    if not device_name.startswith("cuda"):
         return (False, False)
     try:
         import torch

--- a/src/soup_cli/utils/layer_stream.py
+++ b/src/soup_cli/utils/layer_stream.py
@@ -224,26 +224,9 @@ def resolve_stream_dtype(device: str = "cuda") -> str:
     """
     device_name = str(device).lower()
     if device_name.startswith("mps"):
-        try:
-            import torch
+        from soup_cli.utils.gpu import mps_supports_bf16
 
-            mps = getattr(torch.backends, "mps", None)
-            if mps is None or not mps.is_available():
-                return "float32"
-            # PyTorch rejects this before model state exists on macOS versions
-            # that predate MPS bfloat16 support.
-            probe = torch.empty(1, dtype=torch.bfloat16, device="mps")
-            del probe
-            return "bfloat16"
-        except (
-            ImportError,
-            RuntimeError,
-            TypeError,
-            NotImplementedError,
-            AssertionError,
-            OSError,
-        ):
-            return "float32"
+        return "bfloat16" if mps_supports_bf16() else "float32"
     if not device_name.startswith("cuda"):
         return "float32"
 

--- a/tests/test_issue563_mps_bf16_training.py
+++ b/tests/test_issue563_mps_bf16_training.py
@@ -1,0 +1,134 @@
+"""Regression coverage for #563: BF16-capable MPS text trainers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture()
+def fake_mps(monkeypatch):
+    import torch
+
+    probes = []
+
+    class _MPS:
+        available = True
+
+        def is_available(self):
+            return self.available
+
+    backend = _MPS()
+    monkeypatch.setattr(torch.backends, "mps", backend)
+
+    def apply(*, available=True, accepts_bf16=True):
+        backend.available = available
+        probes.clear()
+
+        def empty(size, *, dtype, device):
+            probes.append((size, dtype, device))
+            if not accepts_bf16:
+                raise TypeError("MPS runtime rejected bfloat16")
+            return object()
+
+        monkeypatch.setattr(torch, "empty", empty)
+        return probes
+
+    return apply
+
+
+class TestMPSBF16Capability:
+    def test_available_runtime_that_accepts_bf16_is_supported(self, fake_mps):
+        import torch
+
+        from soup_cli.utils.gpu import mps_supports_bf16
+
+        probes = fake_mps(available=True, accepts_bf16=True)
+
+        assert mps_supports_bf16() is True
+        assert probes == [(1, torch.bfloat16, "mps")]
+
+    def test_unavailable_runtime_does_not_probe_or_claim_bf16(self, fake_mps):
+        from soup_cli.utils.gpu import mps_supports_bf16
+
+        probes = fake_mps(available=False, accepts_bf16=True)
+
+        assert mps_supports_bf16() is False
+        assert probes == []
+
+    def test_runtime_rejection_falls_back_to_fp32(self, fake_mps):
+        from soup_cli.utils.gpu import mps_supports_bf16
+
+        fake_mps(available=True, accepts_bf16=False)
+
+        assert mps_supports_bf16() is False
+
+
+class TestPrecisionPolicy:
+    def test_verified_text_trainer_can_opt_into_mps_bf16(self, fake_mps):
+        from soup_cli.utils.gpu import bf16_fp16_flags
+
+        fake_mps(available=True, accepts_bf16=True)
+
+        assert bf16_fp16_flags("mps", allow_mps_bf16=True) == (True, False)
+
+    def test_mps_stays_fp32_without_per_trainer_opt_in(self, fake_mps):
+        from soup_cli.utils.gpu import bf16_fp16_flags
+
+        fake_mps(available=True, accepts_bf16=True)
+
+        assert bf16_fp16_flags("mps") == (False, False)
+
+    def test_cpu_stays_fp32_even_when_mps_is_available(self, fake_mps):
+        from soup_cli.utils.gpu import bf16_fp16_flags
+
+        fake_mps(available=True, accepts_bf16=True)
+
+        assert bf16_fp16_flags("cpu", allow_mps_bf16=True) == (False, False)
+
+    @pytest.mark.parametrize("auto_mixed_precision", [False, True])
+    def test_sft_requests_the_verified_mps_policy(
+        self, monkeypatch, auto_mixed_precision
+    ):
+        from soup_cli.trainer import sft
+
+        calls = []
+
+        def resolve(device, *, allow_mps_bf16=False):
+            calls.append((device, allow_mps_bf16))
+            return (True, False)
+
+        monkeypatch.setattr(sft, "bf16_fp16_flags", resolve)
+        wrapper = object.__new__(sft.SFTTrainerWrapper)
+        wrapper.device = "mps"
+
+        assert wrapper._resolve_mixed_precision(
+            SimpleNamespace(auto_mixed_precision=auto_mixed_precision), "model"
+        ) == (True, False)
+        assert calls == [("mps", True)]
+
+    def test_only_hardware_validated_text_trainers_opt_in(self):
+        import soup_cli.trainer as trainer_package
+
+        root = Path(trainer_package.__file__).parent
+        expected = {"sft.py", "dpo.py", "reward_model.py", "prm.py"}
+        opted_in = {
+            path.name
+            for path in root.glob("*.py")
+            if "allow_mps_bf16=True" in path.read_text(encoding="utf-8")
+        }
+
+        assert opted_in == expected
+
+
+def test_layer_streaming_uses_the_same_mps_capability(monkeypatch):
+    from soup_cli.utils import gpu
+    from soup_cli.utils.layer_stream import resolve_stream_dtype
+
+    monkeypatch.setattr(gpu, "mps_supports_bf16", lambda: True)
+    assert resolve_stream_dtype("mps") == "bfloat16"
+
+    monkeypatch.setattr(gpu, "mps_supports_bf16", lambda: False)
+    assert resolve_stream_dtype("mps") == "float32"


### PR DESCRIPTION
## Summary

- add a live MPS BF16 capability probe shared by resident training and layer streaming
- opt only the hardware-validated text trainers into MPS BF16: SFT, DPO, reward modelling, and PRM
- keep CPU and unvalidated MPS trainers on their existing FP32 path
- keep PRM master weights in FP32 while using BF16 autocast, avoiding a measured fatal Metal optimizer dtype mismatch
- document the MPS/Transformers precision policy and its boundary

Closes #563.

## Apple Silicon evidence

Validated on an Apple M4 Max with PyTorch 2.12.1 and Transformers 5.12.1.

Before this change, one-step SFT, DPO, reward-model, and PRM runs all completed on MPS with `bf16=false` and `fp16=false`.

After this change:

| Task | Precision policy | Storage evidence | One-step result |
| --- | --- | --- | --- |
| SFT LoRA | `bf16=true`, `fp16=false` | 134,515,008 frozen base parameters in BF16; 230,400 trainable LoRA parameters in FP32 | completed, loss 0.873974 |
| DPO LoRA | `bf16=true`, `fp16=false` | 134,515,008 frozen base parameters in BF16; 230,400 trainable LoRA parameters in FP32 | completed, loss 0.677233 |
| Reward model LoRA | `bf16=true`, `fp16=false` | 134,515,584 base parameters in BF16; 230,976 trainable parameters in FP32 | completed, loss 0.755024 |
| PRM | `bf16=true`, `fp16=false` | FP32 master parameters with BF16 autocast | completed, loss 1.386875 |

The first PRM attempt also loaded its trainable base in BF16. Metal aborted in matrix multiplication because the destination and accumulator dtypes differed. The submitted policy therefore preserves FP32 PRM master weights and enables only the hardware-validated BF16 autocast path. This PR makes no throughput claim from these single-step smokes.

## Validation

- `pytest -q tests/test_issue563_mps_bf16_training.py tests/test_issue385_stream_dtype.py tests/test_v0533.py tests/test_v05311.py --no-cov`: 152 passed, 4 skipped
- `pytest tests/ -q --tb=short --no-cov`: 18,942 passed, 82 skipped, 5 deselected
- `ruff check src/soup_cli/ tests/`
- `git diff --check`
