### PR TITLE
fix(grpo): preserve reward metadata through data loading

### DIFF
--- a/changelog.d/0.73.3/566.fixed.md
+++ b/changelog.d/0.73.3/566.fixed.md
@@ -1,0 +1,2 @@
+- Preserve reward metadata from local GRPO datasets and keep earlier assistant turns when
+  separating a final reference answer from multi-turn conversations (#566).

--- a/docs/training.md
+++ b/docs/training.md
@@ -1014,6 +1014,17 @@ soup train --config soup.yaml
 - `accuracy` — checks if the final answer matches expected (supports `####` and `\boxed{}` formats)
 - `format` — checks for structured `<think>...</think>` reasoning blocks
 
+For GRPO, Soup preserves source dataset columns and TRL passes them to reward functions as
+keyword arguments. An Alpaca `output` or the final assistant turn in ShareGPT/ChatML is also
+exposed as `answer`; an explicit `answer` column takes precedence. Gold-dependent built-ins
+validate their inputs before generation:
+
+| Reward | Required source metadata |
+|---|---|
+| `accuracy` or verifiable `math` | `answer`, or an assistant reference response |
+| verifiable `code` | `expected` or `answer` |
+| verifiable `json_schema` | `schema` |
+
 **Custom reward functions** — point to a Python file:
 ```python
 # my_reward.py
@@ -1025,6 +1036,10 @@ def reward_fn(completions, **kwargs):
 training:
   reward_fn: ./my_reward.py
 ```
+
+Custom rewards can read any preserved source column through `kwargs`. They must return exactly
+one finite numeric score per completion; Soup checks this contract and reports the reward name
+and count before TRL attempts to build a reward tensor.
 
 **Reward ensembles** — list several rewards, comma-separated, and they combine (GRPO only).
 This also unlocks the `rm_ensemble` reward-hack detector, which needs ≥ 2 rewards:

--- a/src/soup_cli/commands/sweep.py
+++ b/src/soup_cli/commands/sweep.py
@@ -351,7 +351,10 @@ def _run_single(base_cfg, params: dict, run_name: str, config_path: Path) -> dic
     gpu_info = get_gpu_info()
 
     # Load data
-    dataset = load_dataset(cfg.data)
+    dataset = load_dataset(
+        cfg.data,
+        preserve_source_columns=cfg.task == "grpo",
+    )
     console.print(f"[dim]Loaded {len(dataset['train'])} train samples[/]")
 
     # Start tracking

--- a/src/soup_cli/commands/train.py
+++ b/src/soup_cli/commands/train.py
@@ -1207,7 +1207,10 @@ def train(
 
     if dry_run:
         console.print("[yellow]Dry run - validating data...[/]")
-        dataset = load_dataset(cfg.data)
+        dataset = load_dataset(
+            cfg.data,
+            preserve_source_columns=cfg.task == "grpo",
+        )
         console.print(f"[green]Data OK:[/] {len(dataset['train'])} train samples")
         if "val" in dataset:
             console.print(f"[green]Val:[/] {len(dataset['val'])} samples")
@@ -1216,7 +1219,10 @@ def train(
 
     # Load data
     console.print("[dim]Loading dataset...[/]")
-    dataset = load_dataset(cfg.data)
+    dataset = load_dataset(
+        cfg.data,
+        preserve_source_columns=cfg.task == "grpo",
+    )
     console.print(f"[green]Loaded:[/] {len(dataset['train'])} train samples")
 
     # Capture the --tracker CLI value BEFORE the local ExperimentTracker

--- a/src/soup_cli/data/loader.py
+++ b/src/soup_cli/data/loader.py
@@ -153,7 +153,37 @@ def _load_txt(path: Path) -> list[dict]:
     return [{"text": line} for line in lines]
 
 
-def _load_replay_rows(data_config: DataConfig) -> list[dict]:
+def _format_rows(
+    raw_data: list[dict],
+    fmt: str,
+    *,
+    preserve_source_columns: bool = False,
+) -> list[dict]:
+    """Normalize rows, optionally retaining columns used by GRPO rewards.
+
+    TRL forwards every non-prompt dataset column to custom reward functions.
+    Soup's normalizers intentionally return only task-specific columns, which
+    is correct for supervised and preference trainers but would discard GRPO
+    references such as ``answer``, ``expected``, ``schema``, or custom
+    metadata.  The opt-in keeps the default loader contract byte-for-byte
+    unchanged for every other task.
+    """
+    formatted: list[dict] = []
+    for raw_row in raw_data:
+        normalized = format_to_messages(raw_row, fmt)
+        if normalized is None:
+            continue
+        if preserve_source_columns:
+            normalized = {**raw_row, **normalized}
+        formatted.append(normalized)
+    return formatted
+
+
+def _load_replay_rows(
+    data_config: DataConfig,
+    *,
+    preserve_source_columns: bool = False,
+) -> list[dict]:
     """Load + normalize the replay file with its OWN format detection.
 
     The old dataset may be alpaca while the new one is sharegpt, so the
@@ -179,8 +209,11 @@ def _load_replay_rows(data_config: DataConfig) -> list[dict]:
         )
     raw = load_raw_data(replay_path)
     fmt = detect_format(raw)
-    rows = [format_to_messages(row, fmt) for row in raw]
-    rows = [row for row in rows if row is not None]
+    rows = _format_rows(
+        raw,
+        fmt,
+        preserve_source_columns=preserve_source_columns,
+    )
 
     if is_vision_format(fmt):
         image_dir = (
@@ -204,6 +237,7 @@ def _finalize(
     data_config: DataConfig,
     *,
     val: list[dict] | None = None,
+    preserve_source_columns: bool = False,
 ) -> dict:
     """Split train/val, then mix replay into train ONLY.
 
@@ -227,7 +261,10 @@ def _finalize(
     if getattr(data_config, "replay", None):
         from soup_cli.utils.rehearsal import mix_replay
 
-        replay_rows = _load_replay_rows(data_config)
+        replay_rows = _load_replay_rows(
+            data_config,
+            preserve_source_columns=preserve_source_columns,
+        )
         mixed, report = mix_replay(
             result["train"],
             replay_rows,
@@ -281,7 +318,11 @@ def _classify_train_entry(value: str) -> str:
     return "hub"
 
 
-def load_dataset(data_config: DataConfig) -> dict:
+def load_dataset(
+    data_config: DataConfig,
+    *,
+    preserve_source_columns: bool = False,
+) -> dict:
     """Load dataset for training. Returns dict with 'train' and optionally 'val' keys.
 
     Supports:
@@ -301,8 +342,16 @@ def load_dataset(data_config: DataConfig) -> dict:
     if isinstance(train_path, list):
         kinds = {_classify_train_entry(p) for p in train_path}
         if kinds == {"hub"}:
-            return _load_interleaved_hub_datasets(train_path, data_config)
-        return _load_interleaved_local_datasets(train_path, data_config)
+            return _load_interleaved_hub_datasets(
+                train_path,
+                data_config,
+                preserve_source_columns=preserve_source_columns,
+            )
+        return _load_interleaved_local_datasets(
+            train_path,
+            data_config,
+            preserve_source_columns=preserve_source_columns,
+        )
 
     # v0.53.8 #85 — fsspec live remote loader. Schema accepts these URIs
     # since v0.42.0; live loader lands here. Lazy-imports fsspec + the
@@ -310,11 +359,19 @@ def load_dataset(data_config: DataConfig) -> dict:
     # friendly Rich panel naming the pip install when the driver is
     # missing.
     if _looks_like_remote_uri(train_path):
-        return _load_remote_dataset(train_path, data_config)
+        return _load_remote_dataset(
+            train_path,
+            data_config,
+            preserve_source_columns=preserve_source_columns,
+        )
 
     # Check if it's a HuggingFace dataset
     if not Path(train_path).suffix:
-        return _load_hf_dataset(train_path, data_config)
+        return _load_hf_dataset(
+            train_path,
+            data_config,
+            preserve_source_columns=preserve_source_columns,
+        )
 
     # Local file
     path = Path(train_path)
@@ -327,8 +384,11 @@ def load_dataset(data_config: DataConfig) -> dict:
         console.print(f"[dim]Auto-detected format: {fmt}[/]")
 
     # Convert to standard message format
-    formatted = [format_to_messages(row, fmt) for row in raw_data]
-    formatted = [r for r in formatted if r is not None]  # filter failed rows
+    formatted = _format_rows(
+        raw_data,
+        fmt,
+        preserve_source_columns=preserve_source_columns,
+    )
 
     # Validate image paths for vision formats
     if is_vision_format(fmt):
@@ -341,10 +401,19 @@ def load_dataset(data_config: DataConfig) -> dict:
         formatted = _validate_audio_files(formatted, audio_dir)
 
     # Split into train/val, then mix replay into train (v0.71.36).
-    return _finalize(formatted, data_config)
+    return _finalize(
+        formatted,
+        data_config,
+        preserve_source_columns=preserve_source_columns,
+    )
 
 
-def _load_one_local_dataset(train_path: str, data_config: DataConfig) -> list[dict]:
+def _load_one_local_dataset(
+    train_path: str,
+    data_config: DataConfig,
+    *,
+    preserve_source_columns: bool = False,
+) -> list[dict]:
     """Load + format one local file — the same per-file pipeline the
     single-path branch of load_dataset() runs above, factored out so
     #443's interleave path (below) reuses it rather than re-deriving it.
@@ -360,8 +429,11 @@ def _load_one_local_dataset(train_path: str, data_config: DataConfig) -> list[di
         fmt = detect_format(raw_data)
         console.print(f"[dim]Auto-detected format ({train_path}): {fmt}[/]")
 
-    formatted = [format_to_messages(row, fmt) for row in raw_data]
-    formatted = [r for r in formatted if r is not None]
+    formatted = _format_rows(
+        raw_data,
+        fmt,
+        preserve_source_columns=preserve_source_columns,
+    )
 
     if is_vision_format(fmt):
         image_dir = Path(data_config.image_dir) if data_config.image_dir else path.parent
@@ -442,7 +514,12 @@ def _combine_interleaved(per_dataset_rows: list[list[dict]], spec) -> list[dict]
     raise AssertionError(f"unreachable interleave strategy {spec.strategy!r}")
 
 
-def _load_interleaved_local_datasets(train_paths: list[str], data_config: DataConfig) -> dict:
+def _load_interleaved_local_datasets(
+    train_paths: list[str],
+    data_config: DataConfig,
+    *,
+    preserve_source_columns: bool = False,
+) -> dict:
     """#443 — load + combine every local dataset in a list-shaped
     data.train per data.interleave, then hand the combined rows to the
     existing, unmodified _finalize() — same seam every other loader uses.
@@ -468,19 +545,39 @@ def _load_interleaved_local_datasets(train_paths: list[str], data_config: DataCo
         raise ValueError("data.train is a list but data.interleave is not set")
 
     if data_config.streaming:
-        return _load_interleaved_streaming_datasets(train_paths, data_config, spec)
+        return _load_interleaved_streaming_datasets(
+            train_paths,
+            data_config,
+            spec,
+            preserve_source_columns=preserve_source_columns,
+        )
 
-    per_dataset_rows = [_load_one_local_dataset(p, data_config) for p in train_paths]
+    per_dataset_rows = [
+        _load_one_local_dataset(
+            p,
+            data_config,
+            preserve_source_columns=preserve_source_columns,
+        )
+        for p in train_paths
+    ]
     combined = _combine_interleaved(per_dataset_rows, spec)
     console.print(
         f"[dim]Interleaved {len(train_paths)} datasets "
         f"(strategy={spec.strategy}) -> {len(combined)} rows[/]"
     )
-    return _finalize(combined, data_config)
+    return _finalize(
+        combined,
+        data_config,
+        preserve_source_columns=preserve_source_columns,
+    )
 
 
 def _load_interleaved_streaming_datasets(
-    train_paths: list[str], data_config: DataConfig, spec
+    train_paths: list[str],
+    data_config: DataConfig,
+    spec,
+    *,
+    preserve_source_columns: bool = False,
 ) -> dict:
     """#459 — data.interleave + data.streaming=true: delegate combining to
     HF ``datasets.interleave_datasets`` / ``concatenate_datasets`` instead
@@ -595,14 +692,21 @@ def _load_interleaved_streaming_datasets(
         fmt = detect_format(raw_data)
         console.print(f"[dim]Auto-detected format: {fmt}[/]")
 
-    formatted = [format_to_messages(row, fmt) for row in raw_data]
-    formatted = [r for r in formatted if r is not None]
+    formatted = _format_rows(
+        raw_data,
+        fmt,
+        preserve_source_columns=preserve_source_columns,
+    )
 
     console.print(
         f"[dim]Streaming-interleaved {len(train_paths)} datasets "
         f"(strategy={spec.strategy}) -> {len(formatted)} rows[/]"
     )
-    return _finalize(formatted, data_config)
+    return _finalize(
+        formatted,
+        data_config,
+        preserve_source_columns=preserve_source_columns,
+    )
 
 
 def _validate_vision_images(data: list[dict], image_dir: Path) -> list[dict]:
@@ -696,7 +800,12 @@ def _looks_like_remote_uri(value: str) -> bool:
     return isinstance(value, str) and "://" in value
 
 
-def _load_remote_dataset(train_path: str, data_config: DataConfig) -> dict:
+def _load_remote_dataset(
+    train_path: str,
+    data_config: DataConfig,
+    *,
+    preserve_source_columns: bool = False,
+) -> dict:
     """Load JSONL from a remote fsspec URI (s3 / gs / az / oci / etc.).
 
     Validates the URI via the v0.42.0 ``validate_remote_uri`` allowlist
@@ -791,14 +900,24 @@ def _load_remote_dataset(train_path: str, data_config: DataConfig) -> dict:
         fmt = detect_format(raw_data)
         console.print(f"[dim]Auto-detected format: {fmt}[/]")
 
-    formatted = [format_to_messages(row, fmt) for row in raw_data]
-    formatted = [r for r in formatted if r is not None]
+    formatted = _format_rows(
+        raw_data,
+        fmt,
+        preserve_source_columns=preserve_source_columns,
+    )
 
-    return _finalize(formatted, data_config)
+    return _finalize(
+        formatted,
+        data_config,
+        preserve_source_columns=preserve_source_columns,
+    )
 
 
 def _load_one_hub_dataset(
-    name: str, data_config: DataConfig
+    name: str,
+    data_config: DataConfig,
+    *,
+    preserve_source_columns: bool = False,
 ) -> tuple[list[dict], list[dict] | None]:
     """Load + format one HF-hub dataset name's 'train' (+ optional
     'validation') split. Factored out of _load_hf_dataset (#459) — same
@@ -823,30 +942,60 @@ def _load_one_hub_dataset(
     if fmt == "auto":
         fmt = detect_format(raw_data)
 
-    formatted = [format_to_messages(row, fmt) for row in raw_data]
-    formatted = [r for r in formatted if r is not None]
+    formatted = _format_rows(
+        raw_data,
+        fmt,
+        preserve_source_columns=preserve_source_columns,
+    )
 
     if "validation" in ds:
         val_data = [dict(row) for row in ds["validation"]]
-        val_formatted = [format_to_messages(row, fmt) for row in val_data]
-        return formatted, [r for r in val_formatted if r is not None]
+        val_formatted = _format_rows(
+            val_data,
+            fmt,
+            preserve_source_columns=preserve_source_columns,
+        )
+        return formatted, val_formatted
 
     return formatted, None
 
 
-def _load_hf_dataset(name: str, data_config: DataConfig) -> dict:
+def _load_hf_dataset(
+    name: str,
+    data_config: DataConfig,
+    *,
+    preserve_source_columns: bool = False,
+) -> dict:
     """Load a dataset from HuggingFace Hub.
 
     The hub split wins over val_split; passing it through as _finalize's
     ``val=`` means _finalize does not re-derive one from the train rows.
     """
-    formatted, val_formatted = _load_one_hub_dataset(name, data_config)
+    formatted, val_formatted = _load_one_hub_dataset(
+        name,
+        data_config,
+        preserve_source_columns=preserve_source_columns,
+    )
     if val_formatted is not None:
-        return _finalize(formatted, data_config, val=val_formatted)
-    return _finalize(formatted, data_config)
+        return _finalize(
+            formatted,
+            data_config,
+            val=val_formatted,
+            preserve_source_columns=preserve_source_columns,
+        )
+    return _finalize(
+        formatted,
+        data_config,
+        preserve_source_columns=preserve_source_columns,
+    )
 
 
-def _load_interleaved_hub_datasets(train_names: list[str], data_config: DataConfig) -> dict:
+def _load_interleaved_hub_datasets(
+    train_names: list[str],
+    data_config: DataConfig,
+    *,
+    preserve_source_columns: bool = False,
+) -> dict:
     """#459 — data.train is a list of HF-hub dataset names combined via
     data.interleave. Reuses the SAME _combine_interleaved the local-file
     path (#443) uses — this is what makes the strategy names mean the same
@@ -875,7 +1024,11 @@ def _load_interleaved_hub_datasets(train_names: list[str], data_config: DataConf
     per_dataset_train: list[list[dict]] = []
     per_dataset_val: list[list[dict] | None] = []
     for name in train_names:
-        train_rows, val_rows = _load_one_hub_dataset(name, data_config)
+        train_rows, val_rows = _load_one_hub_dataset(
+            name,
+            data_config,
+            preserve_source_columns=preserve_source_columns,
+        )
         per_dataset_train.append(train_rows)
         per_dataset_val.append(val_rows)
 
@@ -886,7 +1039,12 @@ def _load_interleaved_hub_datasets(train_names: list[str], data_config: DataConf
         combined_val = _combine_interleaved(
             [v for v in per_dataset_val if v is not None], spec
         )
-        result = _finalize(combined_train, data_config, val=combined_val)
+        result = _finalize(
+            combined_train,
+            data_config,
+            val=combined_val,
+            preserve_source_columns=preserve_source_columns,
+        )
     else:
         if any(has_val):
             missing = [
@@ -898,7 +1056,11 @@ def _load_interleaved_hub_datasets(train_names: list[str], data_config: DataConf
                 "every hub validation split and applying data.val_split to "
                 "the combined train rows instead.[/]"
             )
-        result = _finalize(combined_train, data_config)
+        result = _finalize(
+            combined_train,
+            data_config,
+            preserve_source_columns=preserve_source_columns,
+        )
 
     console.print(
         f"[dim]Interleaved {len(train_names)} HF-hub datasets "

--- a/src/soup_cli/trainer/grpo.py
+++ b/src/soup_cli/trainer/grpo.py
@@ -696,16 +696,18 @@ def _prepare_grpo_dataset(data: list[dict]) -> list[dict]:
             _copy_grpo_metadata(row, entry)
             prepared.append(entry)
         elif "messages" in row:
-            # Messages format — use the user message(s) as prompt
+            # Messages format — the final assistant turn may be a reference
+            # answer. Earlier assistant turns are part of the conversation and
+            # must remain in the prompt for multi-turn GRPO (#565).
             messages = row["messages"]
-            prompt_msgs = [msg for msg in messages if msg["role"] != "assistant"]
+            has_reference_turn = bool(
+                messages and messages[-1].get("role") == "assistant"
+            )
+            prompt_msgs = messages[:-1] if has_reference_turn else messages
             entry = {"prompt": prompt_msgs}
             _copy_grpo_metadata(row, entry)
-            assistant_messages = [
-                msg for msg in messages if msg.get("role") == "assistant"
-            ]
-            if assistant_messages:
-                entry.setdefault("answer", assistant_messages[-1].get("content"))
+            if has_reference_turn:
+                entry.setdefault("answer", messages[-1].get("content"))
             prepared.append(entry)
         elif "prompt" in row and isinstance(row["prompt"], list):
             # Already in message list format

--- a/src/soup_cli/trainer/grpo.py
+++ b/src/soup_cli/trainer/grpo.py
@@ -282,6 +282,11 @@ class GRPOTrainerWrapper:
 
             reward_fn = apply_reward_shaping(reward_fn, tcfg)
             self._rl_buffer = RLSignalBuffer()
+
+        from soup_cli.trainer.rewards import validate_reward_funcs
+
+        reward_fn = validate_reward_funcs(reward_fn)
+        if self._rl_buffer is not None:
             reward_fn = wrap_reward_funcs(reward_fn, self._rl_buffer)
 
         if use_unsloth:
@@ -330,6 +335,7 @@ class GRPOTrainerWrapper:
         # --- Dataset ---
         # GRPO expects prompts — extract from messages or use prompt field
         train_data = _prepare_grpo_dataset(dataset["train"])
+        _validate_grpo_reward_metadata(train_data, tcfg, split="train")
 
         # v0.71.21 #125 — multi-turn agent rollout backend. The backend
         # receives the dataset prompts as seeds; its rows REPLACE the
@@ -346,6 +352,7 @@ class GRPOTrainerWrapper:
                 reward_fn=reward_fn,
             )
             train_data = _prepare_grpo_dataset([dict(row) for row in rollout_result.rows])
+            _validate_grpo_reward_metadata(train_data, tcfg, split="rollout")
             console.print(
                 f"[green]Rollout backend '{tcfg.rollout_backend}':[/] "
                 f"{len(train_data)} prompts collected "
@@ -356,6 +363,7 @@ class GRPOTrainerWrapper:
         eval_ds = None
         if "val" in dataset and dataset["val"]:
             eval_data = _prepare_grpo_dataset(dataset["val"])
+            _validate_grpo_reward_metadata(eval_data, tcfg, split="validation")
             eval_ds = Dataset.from_list(eval_data)
 
         # --- Output dir ---
@@ -685,27 +693,74 @@ def _prepare_grpo_dataset(data: list[dict]) -> list[dict]:
         if "prompt" in row and isinstance(row["prompt"], str):
             # DPO or plain prompt format — convert to message list
             entry = {"prompt": [{"role": "user", "content": row["prompt"]}]}
-            # Preserve 'answer' field if present (for accuracy reward)
-            if "answer" in row:
-                entry["answer"] = row["answer"]
+            _copy_grpo_metadata(row, entry)
             prepared.append(entry)
         elif "messages" in row:
             # Messages format — use the user message(s) as prompt
             messages = row["messages"]
             prompt_msgs = [msg for msg in messages if msg["role"] != "assistant"]
             entry = {"prompt": prompt_msgs}
+            _copy_grpo_metadata(row, entry)
+            assistant_messages = [
+                msg for msg in messages if msg.get("role") == "assistant"
+            ]
+            if assistant_messages:
+                entry.setdefault("answer", assistant_messages[-1].get("content"))
             prepared.append(entry)
         elif "prompt" in row and isinstance(row["prompt"], list):
             # Already in message list format
             entry = {"prompt": row["prompt"]}
-            if "answer" in row:
-                entry["answer"] = row["answer"]
+            _copy_grpo_metadata(row, entry)
             prepared.append(entry)
         else:
             # Fallback: treat any 'instruction' field as prompt
             instruction = row.get("instruction", row.get("input", ""))
             entry = {"prompt": [{"role": "user", "content": str(instruction)}]}
+            _copy_grpo_metadata(row, entry)
             if "output" in row:
-                entry["answer"] = row["output"]
+                entry.setdefault("answer", row["output"])
             prepared.append(entry)
     return prepared
+
+
+def _copy_grpo_metadata(row: dict, entry: dict) -> None:
+    """Copy non-prompt columns that TRL forwards to reward functions."""
+    for key, value in row.items():
+        if key not in {"messages", "prompt"}:
+            entry[key] = value
+
+
+def _validate_grpo_reward_metadata(
+    data: list[dict],
+    tcfg: TrainingConfig,
+    *,
+    split: str,
+) -> None:
+    """Fail before generation when a built-in reward lacks required data."""
+    if tcfg.prm_reward is not None:
+        return
+
+    requirements: list[tuple[str, tuple[str, ...]]] = []
+    for reward_spec in (part.strip() for part in (tcfg.reward_fn or "").split(",")):
+        if reward_spec == "accuracy":
+            requirements.append(("accuracy", ("answer",)))
+        elif reward_spec == "verifiable":
+            domain = tcfg.verifiable_domain
+            if domain == "math":
+                requirements.append(("verifiable/math", ("answer",)))
+            elif domain == "code":
+                requirements.append(("verifiable/code", ("expected", "answer")))
+            elif domain == "json_schema":
+                requirements.append(("verifiable/json_schema", ("schema",)))
+
+    for row_index, row in enumerate(data):
+        for reward_name, alternatives in requirements:
+            if any(row.get(field) is not None for field in alternatives):
+                continue
+            fields = " or ".join(repr(field) for field in alternatives)
+            raise ValueError(
+                f"GRPO {split} row {row_index} is missing {fields}, required "
+                f"by reward {reward_name!r}. Preserve that column in the source "
+                "dataset or include an assistant response that Soup can use as "
+                "'answer'."
+            )

--- a/src/soup_cli/trainer/grpo.py
+++ b/src/soup_cli/trainer/grpo.py
@@ -757,12 +757,21 @@ def _validate_grpo_reward_metadata(
 
     for row_index, row in enumerate(data):
         for reward_name, alternatives in requirements:
-            if any(row.get(field) is not None for field in alternatives):
+            if any(_has_grpo_reward_metadata(row.get(field)) for field in alternatives):
                 continue
             fields = " or ".join(repr(field) for field in alternatives)
             raise ValueError(
-                f"GRPO {split} row {row_index} is missing {fields}, required "
+                f"GRPO {split} row {row_index} is missing or empty {fields}, required "
                 f"by reward {reward_name!r}. Preserve that column in the source "
                 "dataset or include an assistant response that Soup can use as "
                 "'answer'."
             )
+
+
+def _has_grpo_reward_metadata(value: object) -> bool:
+    """Return whether a reward metadata value is usable as a gold target."""
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    return True

--- a/src/soup_cli/trainer/rewards.py
+++ b/src/soup_cli/trainer/rewards.py
@@ -177,10 +177,14 @@ def accuracy_reward(completions: list[list[dict]], **kwargs) -> list[float]:
     rewards = []
     for completion, expected in zip(completions, answers):
         content = completion[-1]["content"] if completion else ""
+        expected_text = "" if expected is None else str(expected).strip()
+        if not expected_text:
+            rewards.append(0.0)
+            continue
         predicted = _extract_answer(content)
-        if predicted is not None and predicted.strip() == str(expected).strip():
+        if predicted is not None and predicted.strip() == expected_text:
             rewards.append(1.0)
-        elif str(expected).strip().lower() in content.lower():
+        elif expected_text.lower() in content.lower():
             rewards.append(0.5)
         else:
             rewards.append(0.0)

--- a/src/soup_cli/trainer/rewards.py
+++ b/src/soup_cli/trainer/rewards.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import math
 import os
 import re
 import shutil as _shutil
@@ -20,7 +21,9 @@ import subprocess
 import sys
 import tempfile
 from collections.abc import Callable
+from functools import wraps
 from pathlib import Path
+from typing import Any
 
 from rich.console import Console
 from rich.panel import Panel
@@ -491,6 +494,64 @@ VERIFIABLE_DOMAINS: dict[str, Callable] = {
     "code": code_exec_reward,
     "json_schema": json_schema_reward,
 }
+
+
+def _validated_reward_fn(reward_fn: Callable) -> Callable:
+    """Wrap one reward function with TRL's one-score-per-completion contract."""
+    reward_name = getattr(reward_fn, "__name__", "reward_fn")
+
+    @wraps(reward_fn)
+    def checked(*args: Any, **kwargs: Any) -> Any:
+        rewards = reward_fn(*args, **kwargs)
+        completions = kwargs.get("completions")
+        if completions is None:
+            if len(args) >= 2:
+                completions = args[1]
+            elif args:
+                completions = args[0]
+        if completions is None:
+            raise ValueError(
+                f"Reward function {reward_name!r} was called without completions"
+            )
+        try:
+            reward_count = len(rewards)
+        except TypeError as exc:
+            raise ValueError(
+                f"Reward function {reward_name!r} must return one finite score "
+                "per completion"
+            ) from exc
+        completion_count = len(completions)
+        if reward_count != completion_count:
+            raise ValueError(
+                f"Reward function {reward_name!r} returned {reward_count} scores "
+                f"for {completion_count} completions; return exactly one finite "
+                "score per completion and verify the required dataset columns"
+            )
+        for index, reward in enumerate(rewards):
+            if isinstance(reward, bool):
+                raise ValueError(
+                    f"Reward function {reward_name!r} returned boolean score at "
+                    f"index {index}; scores must be finite numbers"
+                )
+            try:
+                finite = math.isfinite(float(reward))
+            except (TypeError, ValueError, OverflowError):
+                finite = False
+            if not finite:
+                raise ValueError(
+                    f"Reward function {reward_name!r} returned non-finite or "
+                    f"non-numeric score {reward!r} at index {index}"
+                )
+        return rewards
+
+    return checked
+
+
+def validate_reward_funcs(reward_funcs: Any) -> Any:
+    """Validate one reward callable or an ensemble without changing its shape."""
+    if isinstance(reward_funcs, (list, tuple)):
+        return [_validated_reward_fn(reward_fn) for reward_fn in reward_funcs]
+    return _validated_reward_fn(reward_funcs)
 
 
 def load_reward_fn(

--- a/tests/test_grpo.py
+++ b/tests/test_grpo.py
@@ -305,10 +305,39 @@ class TestPrepareGRPODataset:
         ]
         result = _prepare_grpo_dataset(data)
         assert len(result) == 1
-        # Should only include non-assistant messages as prompt
+        # The final assistant reference is removed from the prompt.
         assert len(result[0]["prompt"]) == 2
         assert result[0]["prompt"][0]["role"] == "system"
         assert result[0]["prompt"][1]["role"] == "user"
+
+    def test_multi_turn_prompt_preserves_earlier_assistant_turns(self):
+        from soup_cli.trainer.grpo import _prepare_grpo_dataset
+
+        messages = [
+            {"role": "user", "content": "First question"},
+            {"role": "assistant", "content": "First answer"},
+            {"role": "user", "content": "Follow-up"},
+            {"role": "assistant", "content": "Reference answer"},
+        ]
+
+        result = _prepare_grpo_dataset([{"messages": messages}])
+
+        assert result[0]["prompt"] == messages[:-1]
+        assert result[0]["answer"] == "Reference answer"
+
+    def test_trailing_user_is_not_misread_as_an_answer_pair(self):
+        from soup_cli.trainer.grpo import _prepare_grpo_dataset
+
+        messages = [
+            {"role": "user", "content": "First question"},
+            {"role": "assistant", "content": "First answer"},
+            {"role": "user", "content": "Still waiting"},
+        ]
+
+        result = _prepare_grpo_dataset([{"messages": messages}])
+
+        assert result[0]["prompt"] == messages
+        assert "answer" not in result[0]
 
     def test_from_prompt_message_list(self):
         from soup_cli.trainer.grpo import _prepare_grpo_dataset

--- a/tests/test_issue565_grpo_reward_metadata.py
+++ b/tests/test_issue565_grpo_reward_metadata.py
@@ -1,0 +1,163 @@
+"""Regression tests for #565: preserve GRPO reward metadata end to end."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from soup_cli.config.schema import DataConfig, TrainingConfig
+from soup_cli.data.loader import load_dataset
+from soup_cli.trainer.grpo import (
+    _prepare_grpo_dataset,
+    _validate_grpo_reward_metadata,
+)
+from soup_cli.trainer.rewards import validate_reward_funcs
+
+
+def _write_jsonl(tmp_path, rows: list[dict]):
+    path = tmp_path / "train.jsonl"
+    path.write_text(
+        "".join(json.dumps(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_grpo_local_alpaca_preserves_metadata_and_derives_answer(tmp_path):
+    schema = {"type": "object", "required": ["result"]}
+    path = _write_jsonl(
+        tmp_path,
+        [
+            {
+                "instruction": "Return 2.",
+                "input": "",
+                "output": "2",
+                "expected": "2",
+                "schema": schema,
+                "difficulty": "easy",
+            }
+        ],
+    )
+    cfg = DataConfig(train=str(path), format="alpaca", val_split=0)
+
+    loaded = load_dataset(cfg, preserve_source_columns=True)
+    prepared = _prepare_grpo_dataset(loaded["train"])
+
+    assert prepared == [
+        {
+            "prompt": [{"role": "user", "content": "Return 2."}],
+            "instruction": "Return 2.",
+            "input": "",
+            "output": "2",
+            "expected": "2",
+            "schema": schema,
+            "difficulty": "easy",
+            "answer": "2",
+        }
+    ]
+
+
+def test_default_loader_contract_still_drops_unrelated_source_columns(tmp_path):
+    path = _write_jsonl(
+        tmp_path,
+        [
+            {
+                "instruction": "Return 2.",
+                "output": "2",
+                "private_reward_metadata": "must not leak into SFT",
+            }
+        ],
+    )
+    cfg = DataConfig(train=str(path), format="alpaca", val_split=0)
+
+    loaded = load_dataset(cfg)
+
+    assert loaded["train"] == [
+        {
+            "messages": [
+                {"role": "user", "content": "Return 2."},
+                {"role": "assistant", "content": "2"},
+            ]
+        }
+    ]
+
+
+def test_explicit_answer_wins_over_assistant_reference():
+    prepared = _prepare_grpo_dataset(
+        [
+            {
+                "messages": [
+                    {"role": "user", "content": "Question"},
+                    {"role": "assistant", "content": "assistant gold"},
+                ],
+                "answer": "explicit gold",
+                "source_id": "row-1",
+            }
+        ]
+    )
+
+    assert prepared[0]["answer"] == "explicit gold"
+    assert prepared[0]["source_id"] == "row-1"
+
+
+@pytest.mark.parametrize(
+    ("reward_fn", "domain", "row"),
+    [
+        ("accuracy", None, {"prompt": "question"}),
+        ("verifiable", "math", {"prompt": "question"}),
+        ("verifiable", "code", {"prompt": "question"}),
+        ("verifiable", "json_schema", {"prompt": "question"}),
+    ],
+)
+def test_gold_dependent_rewards_fail_before_generation(reward_fn, domain, row):
+    config = TrainingConfig(reward_fn=reward_fn, verifiable_domain=domain)
+
+    with pytest.raises(ValueError, match=r"GRPO train row 0 is missing"):
+        _validate_grpo_reward_metadata([row], config, split="train")
+
+
+def test_code_reward_accepts_expected_without_answer():
+    config = TrainingConfig(reward_fn="verifiable", verifiable_domain="code")
+
+    _validate_grpo_reward_metadata(
+        [{"prompt": "question", "expected": "stdout"}],
+        config,
+        split="train",
+    )
+
+
+def test_reward_contract_rejects_wrong_score_count():
+    def bad_reward(completions, **kwargs):
+        return []
+
+    checked = validate_reward_funcs(bad_reward)
+
+    with pytest.raises(ValueError, match=r"returned 0 scores for 2 completions"):
+        checked(completions=[[{"content": "a"}], [{"content": "b"}]])
+
+
+def test_reward_contract_rejects_non_finite_score():
+    def bad_reward(completions, **kwargs):
+        return [float("nan") for _ in completions]
+
+    checked = validate_reward_funcs(bad_reward)
+
+    with pytest.raises(ValueError, match="non-finite"):
+        checked(completions=[[{"content": "a"}]])
+
+
+def test_reward_contract_preserves_ensemble_shape_and_valid_scores():
+    def reward_a(completions, **kwargs):
+        return [0.0 for _ in completions]
+
+    def reward_b(completions, **kwargs):
+        return [1.0 for _ in completions]
+
+    checked = validate_reward_funcs([reward_a, reward_b])
+
+    assert isinstance(checked, list)
+    assert [reward(completions=[[{"content": "a"}]]) for reward in checked] == [
+        [0.0],
+        [1.0],
+    ]

--- a/tests/test_issue565_grpo_reward_metadata.py
+++ b/tests/test_issue565_grpo_reward_metadata.py
@@ -12,7 +12,7 @@ from soup_cli.trainer.grpo import (
     _prepare_grpo_dataset,
     _validate_grpo_reward_metadata,
 )
-from soup_cli.trainer.rewards import validate_reward_funcs
+from soup_cli.trainer.rewards import accuracy_reward, validate_reward_funcs
 
 
 def _write_jsonl(tmp_path, rows: list[dict]):
@@ -139,6 +139,30 @@ def test_code_reward_accepts_expected_without_answer():
         config,
         split="train",
     )
+
+
+def test_empty_gold_fails_normal_loader_to_grpo_setup_path(tmp_path):
+    path = _write_jsonl(
+        tmp_path,
+        [{"instruction": "Return 2.", "input": "", "output": "   "}],
+    )
+    cfg = DataConfig(train=str(path), format="alpaca", val_split=0)
+    loaded = load_dataset(cfg, preserve_source_columns=True)
+    prepared = _prepare_grpo_dataset(loaded["train"])
+
+    with pytest.raises(ValueError, match=r"GRPO train row 0 is missing or empty 'answer'"):
+        _validate_grpo_reward_metadata(
+            prepared,
+            TrainingConfig(reward_fn="accuracy"),
+            split="train",
+        )
+
+
+@pytest.mark.parametrize("answer", ["", "   ", "\n\t"])
+def test_accuracy_reward_never_awards_empty_gold(answer):
+    completions = [[{"role": "assistant", "content": "unrelated completion"}]]
+
+    assert accuracy_reward(completions, answer=[answer]) == [0.0]
 
 
 def test_reward_contract_rejects_wrong_score_count():

--- a/tests/test_issue565_grpo_reward_metadata.py
+++ b/tests/test_issue565_grpo_reward_metadata.py
@@ -101,6 +101,20 @@ def test_explicit_answer_wins_over_assistant_reference():
     assert prepared[0]["source_id"] == "row-1"
 
 
+def test_multi_turn_history_reaches_grpo_with_only_final_reference_removed():
+    messages = [
+        {"role": "user", "content": "Question one"},
+        {"role": "assistant", "content": "Answer one"},
+        {"role": "user", "content": "Question two"},
+        {"role": "assistant", "content": "Answer two"},
+    ]
+
+    prepared = _prepare_grpo_dataset([{"messages": messages}])
+
+    assert prepared[0]["prompt"] == messages[:-1]
+    assert prepared[0]["answer"] == "Answer two"
+
+
 @pytest.mark.parametrize(
     ("reward_fn", "domain", "row"),
     [


### PR DESCRIPTION
## Summary

- preserve source dataset columns only for GRPO, across local, replay, streaming, remote, and Hugging Face Hub loading paths
- carry arbitrary reward metadata into TRL and derive `answer` from the final assistant reference when no explicit answer is present
- validate built-in reward metadata before generation and enforce one finite score per completion for built-in and custom rewards
- document the GRPO/RLVR data contract and its required fields

## Why

Soup normalized documented Alpaca and ShareGPT GRPO inputs to `messages` and discarded the columns that TRL forwards to reward functions. The assistant reference was then removed while building the prompt without being recovered as `answer`. Gold-dependent rewards consequently returned an empty list, and TRL failed later with an opaque tensor-shape error.

The preservation path is opt-in from the GRPO command and sweep paths, so SFT and preference-task loader output remains unchanged.

## Validation

- `ruff check src/soup_cli/ tests/`
- `18,943 passed, 82 skipped, 5 deselected` in the full non-smoke test suite
- 138 focused GRPO, RLVR, loader, local interleave, and Hub/streaming interleave tests
- Apple Silicon MPS hardware reproduction with `HuggingFaceTB/SmolLM2-135M-Instruct`: the formerly failing two-row Alpaca/verifiable-math job completed one GRPO step and saved a LoRA adapter

Fixes #565
