### PR TITLE
fix(grpo): enable runtime-probed MPS BF16

### DIFF
--- a/changelog.d/0.73.3/568.fixed.md
+++ b/changelog.d/0.73.3/568.fixed.md
@@ -1,0 +1,5 @@
+- [#568](https://github.com/MakazhanAlpamys/Soup/pull/568) enables runtime-probed
+  BF16 autocast for local Transformers GRPO/RLVR on capable Apple Silicon MPS
+  runtimes. Unsupported MPS remains FP32, local generation avoids the CUDA-only
+  vLLM path, and an Apple Silicon train/save/reload smoke covers deterministic
+  RLVR with LoRA.

--- a/docs/backends-and-ops.md
+++ b/docs/backends-and-ops.md
@@ -119,18 +119,21 @@ MLX backend supports SFT. `backend: mlx` with `task: dpo` or `task: grpo` is ref
 
 The regular `backend: transformers` path can run more than MLX's SFT-only
 surface. On a live MPS runtime that accepts bfloat16, Soup enables BF16 autocast
-for the hardware-validated text trainers: SFT, DPO, reward modelling, and PRM.
+for the hardware-validated text trainers: SFT, DPO, GRPO/RLVR, reward modelling,
+and PRM.
 The decision comes from a live MPS allocation probe rather than a macOS version
 guess. CPU and an unavailable or older MPS runtime remain in FP32; FP16 is not
 selected on MPS.
 
-For BF16 checkpoints, resident SFT, DPO, and reward-model runs preserve the
-frozen base weights in BF16 while keeping LoRA parameters in FP32. PRM uses BF16
-autocast but deliberately retains FP32 master weights: loading its trainable
-base in BF16 makes the Metal optimizer abort because its accumulator and
-destination matrix dtypes differ. This policy was validated with one-step runs
-on Apple Silicon for all four tasks. Other Transformers trainers remain FP32 on
-MPS until their task-specific kernels receive equivalent hardware coverage.
+For BF16 checkpoints, resident SFT, DPO, GRPO, and reward-model runs preserve
+the frozen base weights in BF16 while keeping LoRA parameters in FP32. PRM uses
+BF16 autocast but deliberately retains FP32 master weights: loading its
+trainable base in BF16 makes the Metal optimizer abort because its accumulator
+and destination matrix dtypes differ. This policy was validated with one-step
+runs on Apple Silicon for all five tasks. GRPO validation uses local
+Transformers generation (`use_vllm: false`) and deterministic RLVR; vLLM remains
+a CUDA-oriented optional path. Other Transformers trainers remain FP32 on MPS
+until their task-specific kernels receive equivalent hardware coverage.
 
 
 ## Unsloth Backend (2-5x Faster Training)

--- a/docs/performance-and-quantization.md
+++ b/docs/performance-and-quantization.md
@@ -272,9 +272,10 @@ made yet that streaming fits a larger model or runs faster than resident MPS tra
 `stream_layers`.
 
 Resident Transformers training shares the same live MPS BF16 capability probe.
-SFT, DPO, reward modelling, and PRM use BF16 autocast on a capable runtime; the
-remaining trainers retain the conservative FP32 policy until they have
-task-specific Apple Silicon validation. PRM keeps FP32 master weights even when
+SFT, DPO, GRPO/RLVR, reward modelling, and PRM use BF16 autocast on a capable
+runtime; the remaining trainers retain the conservative FP32 policy until they
+have task-specific Apple Silicon validation. GRPO uses local Transformers
+generation rather than vLLM on MPS. PRM keeps FP32 master weights even when
 autocast is BF16 because a BF16 trainable base currently triggers a fatal Metal
 optimizer dtype mismatch.
 

--- a/src/soup_cli/trainer/grpo.py
+++ b/src/soup_cli/trainer/grpo.py
@@ -207,11 +207,10 @@ class GRPOTrainerWrapper:
         """Resolve fp16/bf16 kwargs for GRPOConfig (v0.53.3 #128).
 
         Priority:
-        - Non-CUDA device (CPU / MPS / XPU) → no mixed precision (both
-          False). HF Trainer's fp16/bf16 kwargs are CUDA-specific; non-CUDA
-          backends must use their own mixed-precision path (MPS Metal,
-          XPU IPEX). Documented explicitly so future MPS work doesn't
-          regress this branch silently.
+        - MPS → BF16 only when the live runtime accepts a BF16 allocation;
+          otherwise FP32. This is the same hardware-probed policy used by
+          Soup's other validated text trainers.
+        - Other non-CUDA devices (CPU / XPU) → no mixed precision.
         - ``grpo_fp16=True`` (CUDA) → ``fp16=True, bf16=False`` (unsloth
           parity).
         - Default CUDA → bf16 when the card supports it, fp16 when it does
@@ -225,7 +224,14 @@ class GRPOTrainerWrapper:
         when only ``auto_mixed_precision`` is set, the v0.32.0 picker runs
         elsewhere in the training loop and overrides this default.
         """
-        if self.device != "cuda":
+        device_name = str(self.device).lower()
+        if device_name.startswith("mps"):
+            bf16, fp16 = bf16_fp16_flags(
+                self.device,
+                allow_mps_bf16=True,
+            )
+            return {"fp16": fp16, "bf16": bf16}
+        if not device_name.startswith("cuda"):
             return {"fp16": False, "bf16": False}
         # grpo_fp16 is a Pydantic field with default=False; direct attribute
         # access (no getattr fallback) so a typo would fail loudly.

--- a/tests/test_issue563_mps_bf16_training.py
+++ b/tests/test_issue563_mps_bf16_training.py
@@ -113,7 +113,7 @@ class TestPrecisionPolicy:
         import soup_cli.trainer as trainer_package
 
         root = Path(trainer_package.__file__).parent
-        expected = {"sft.py", "dpo.py", "reward_model.py", "prm.py"}
+        expected = {"sft.py", "dpo.py", "grpo.py", "reward_model.py", "prm.py"}
         opted_in = {
             path.name
             for path in root.glob("*.py")

--- a/tests/test_issue567_grpo_mps_bf16.py
+++ b/tests/test_issue567_grpo_mps_bf16.py
@@ -1,0 +1,56 @@
+"""Regression coverage for #567: runtime-probed MPS BF16 in GRPO."""
+
+from __future__ import annotations
+
+from soup_cli.config.loader import load_config_from_string
+from soup_cli.trainer.grpo import GRPOTrainerWrapper
+
+
+def _config(*, grpo_fp16: bool = False):
+    return load_config_from_string(
+        f"""
+base: HuggingFaceTB/SmolLM2-135M-Instruct
+task: grpo
+backend: transformers
+data:
+  train: train.jsonl
+  format: alpaca
+training:
+  reward_fn: accuracy
+  num_generations: 2
+  grpo_fp16: {str(grpo_fp16).lower()}
+"""
+    )
+
+
+def test_grpo_enables_bf16_when_live_mps_probe_succeeds(monkeypatch):
+    from soup_cli.utils import gpu
+
+    monkeypatch.setattr(gpu, "mps_supports_bf16", lambda: True)
+    wrapper = GRPOTrainerWrapper(_config(), device="mps")
+
+    assert wrapper._build_precision_kwargs() == {"fp16": False, "bf16": True}
+
+
+def test_grpo_falls_back_to_fp32_when_live_mps_probe_fails(monkeypatch):
+    from soup_cli.utils import gpu
+
+    monkeypatch.setattr(gpu, "mps_supports_bf16", lambda: False)
+    wrapper = GRPOTrainerWrapper(_config(), device="mps:0")
+
+    assert wrapper._build_precision_kwargs() == {"fp16": False, "bf16": False}
+
+
+def test_cuda_only_grpo_fp16_override_does_not_force_fp16_on_mps(monkeypatch):
+    from soup_cli.utils import gpu
+
+    monkeypatch.setattr(gpu, "mps_supports_bf16", lambda: True)
+    wrapper = GRPOTrainerWrapper(_config(grpo_fp16=True), device="mps")
+
+    assert wrapper._build_precision_kwargs() == {"fp16": False, "bf16": True}
+
+
+def test_cpu_precision_policy_is_unchanged():
+    wrapper = GRPOTrainerWrapper(_config(), device="cpu")
+
+    assert wrapper._build_precision_kwargs() == {"fp16": False, "bf16": False}

--- a/tests/test_v0533.py
+++ b/tests/test_v0533.py
@@ -393,10 +393,14 @@ class TestReviewFixes:
         monkeypatch.setattr(torch, "cuda", _Cuda())
         assert wrapper._build_precision_kwargs() == {"fp16": False, "bf16": True}
 
-    def test_precision_kwargs_mps_device(self) -> None:
-        """tdd-review HIGH — non-CUDA / non-CPU device (MPS) returns no-MP."""
+    def test_precision_kwargs_mps_falls_back_when_bf16_is_unavailable(
+        self, monkeypatch
+    ) -> None:
+        """#567 — MPS remains FP32 when its live runtime rejects BF16."""
         from soup_cli.trainer.grpo import GRPOTrainerWrapper
+        from soup_cli.utils import gpu
 
+        monkeypatch.setattr(gpu, "mps_supports_bf16", lambda: False)
         cfg = load_config_from_string(_minimal_grpo_yaml())
         wrapper = GRPOTrainerWrapper(cfg, device="mps")
         assert wrapper._build_precision_kwargs() == {"fp16": False, "bf16": False}


### PR DESCRIPTION
## Dependencies

Draft until both prerequisite PRs merge:

- #564 provides the shared runtime-probed MPS BF16 policy and validates it in the resident text trainers.
- #566 fixes the GRPO data/reward contract needed for the documented local Alpaca/RLVR path to reach training.

The focused change for this PR is commit `a095405`. I will rebase it onto `main` after both dependencies merge.

## Summary

- opt local Transformers GRPO/RLVR into BF16 only when the live MPS runtime accepts BF16
- retain the existing FP32 fallback for unsupported MPS runtimes and leave CPU/CUDA behavior unchanged
- keep MPS on local Transformers generation (`use_vllm: false`)
- document the newly hardware-validated surface and cover capability success, capability failure, `mps:0`, CPU, and the CUDA-only `grpo_fp16` override

## Apple Silicon hardware evidence

Tested offline with PyTorch 2.12.1, Transformers 5.12.1, TRL 0.29.1, and `HuggingFaceTB/SmolLM2-135M-Instruct`:

- local Transformers GRPO, LoRA rank 4, two generations, deterministic math RLVR
- process started with `PYTORCH_ENABLE_MPS_FALLBACK=0` before Torch import; Accelerate later rewrites the environment variable to `1`, but the MPS runtime was initialized with fallback disabled
- `bf16=true`, `fp16=false`, `use_vllm=false`
- 134,515,008 frozen base parameters in BF16; 230,400 trainable LoRA parameters in FP32
- one training step completed in 1.445 seconds (`train_runtime=1.573s`)
- finite loss `0.0001353885`, gradient norm `0.00201798`, KL `0.00135388`, and entropy `1.75193`
- MPS current allocation: 270,973,696 -> 296,548,864 bytes; driver allocation: 1,166,508,032 -> 1,222,524,928 bytes
- adapter save completed; reload found 120 finite LoRA tensors / 230,400 parameters
- a reloaded BF16 forward produced finite BF16 logits on `mps:0` with shape `[1, 7, 49152]`

This is a compatibility smoke, not a quality or throughput benchmark; the two generated samples scored zero reward, which is expected to be noisy for an untrained 135M model.

## Validation

- `ruff check src/soup_cli/ tests/`
- `18,957 passed, 82 skipped, 5 deselected` in the full non-smoke test suite
- 141 focused MPS precision, GRPO, RLVR, reward-metadata, and existing GRPO compatibility tests
- hardware train/save/reload/forward smoke described above

Fixes #567
