### PR TITLE
fix(eval): wire live_eval's quantization param through its 4 callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ reproducing 70+ versions of notes.
 
 ### Fixed
 
+- **`live_eval`'s four callers now forward `quantization`; `soup ship --config` reuses the
+  training run's own (#367 by @AmirF194 in #570).** #461 added `quantization` to
+  `load_model_and_tokenizer` but nothing set it, so an NF4-trained adapter was still judged
+  against a bf16 base. `make_generator`, `make_multi_generator`, `lora_probe` and
+  `measure_logit_agreement` now accept and forward it. `soup ship --config soup.yaml` derives
+  a default from `training.quantization` (`4bit`/`8bit`; other quant_menu formats still fall
+  back to bf16) and prints which precision it loaded. `advise --probe-model`, `diagnose
+  --base-model` and `tunability --live` take no `--config`/`--quantization` flag yet, so they
+  keep the existing bf16 default. Stamping the numerics into the verdict/evidence JSON and a
+  staleness gate on mismatched-numerics evidence (issue criteria 2 and 4) stay open.
+
 - **SmolVLM/Idefics3 vision SFT now reaches real training batches (#302 by
   @Amix29 in #488).** Soup keeps LLaVA messages and PIL images together until
   collation, converts legacy `<image>` markers to structured multimodal content,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,17 +14,6 @@ reproducing 70+ versions of notes.
 
 ### Fixed
 
-- **`live_eval`'s four callers now forward `quantization`; `soup ship --config` reuses the
-  training run's own (#367 by @AmirF194 in #570).** #461 added `quantization` to
-  `load_model_and_tokenizer` but nothing set it, so an NF4-trained adapter was still judged
-  against a bf16 base. `make_generator`, `make_multi_generator`, `lora_probe` and
-  `measure_logit_agreement` now accept and forward it. `soup ship --config soup.yaml` derives
-  a default from `training.quantization` (`4bit`/`8bit`; other quant_menu formats still fall
-  back to bf16) and prints which precision it loaded. `advise --probe-model`, `diagnose
-  --base-model` and `tunability --live` take no `--config`/`--quantization` flag yet, so they
-  keep the existing bf16 default. Stamping the numerics into the verdict/evidence JSON and a
-  staleness gate on mismatched-numerics evidence (issue criteria 2 and 4) stay open.
-
 - **SmolVLM/Idefics3 vision SFT now reaches real training batches (#302 by
   @Amix29 in #488).** Soup keeps LLaVA messages and PIL images together until
   collation, converts legacy `<image>` markers to structured multimodal content,

--- a/changelog.d/0.73.3/570.fixed.md
+++ b/changelog.d/0.73.3/570.fixed.md
@@ -1,0 +1,12 @@
+- `live_eval`'s four callers now forward `quantization`; `soup ship --config` reuses the
+  training run's own (#367 in #570). #461 added `quantization` to `load_model_and_tokenizer` but
+  nothing set it, so an NF4-trained adapter was still judged against a bf16 base.
+  `make_generator`, `make_multi_generator`, `lora_probe` and `measure_logit_agreement`
+  now accept and forward it. `soup ship --config soup.yaml` derives a default from
+  `training.quantization` (`4bit`/`8bit`; other quant_menu formats still fall back to
+  full precision) and prints which precision it loaded, now matching what it actually
+  passes to `from_pretrained` (previously the fallback message claimed bf16 without
+  ever setting `torch_dtype`). `advise --probe-model`, `diagnose --base-model` and
+  `tunability --live` take no `--config`/`--quantization` flag yet, so they keep the
+  existing default. Stamping the numerics into the verdict/evidence JSON and a
+  staleness gate on mismatched-numerics evidence (issue criteria 2 and 4) stay open.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -178,7 +178,7 @@ soup ship ... --task-mode pairwise --judge-model ollama://llama3.1  Leg-1 via sw
 soup ship ...  # leg-2 default = 8 bundled offline suites (MCQ/arithmetic/over_refusal + tool_call/format_json/safety, extraction scorer, ~40 items each) (v0.71.38; +mini_over_refusal v0.73.2)
 soup ship ... --general-suite mmlu,gsm8k --baseline base.json  lm-eval leg-2 override + recorded base scores
 soup ship ... --emit-evidence ev.json  Re-serialise the scores as replayable --evidence input (output-is-input, #312) (v0.71.39)
-soup ship ... --config soup.yaml  Read eval.ship gate defaults; --evidence GATES on provenance, --emit-evidence STAMPS it (v0.71.39)
+soup ship ... --config soup.yaml  Read eval.ship gate defaults; --evidence GATES on provenance, --emit-evidence STAMPS it (v0.71.39); live-loads base/tuned at training.quantization when it is 4bit/8bit, else full precision (#367)
 soup ship ... --push owner/repo#N  Post the verdict as a GitHub PR comment (best-effort; never flips the exit code) (v0.71.39)
 soup ship ... --noise-floor N  Re-run base model N times; per-axis floor = max-min spread; gate at max(threshold, floor); leg-1 measured in every --task-mode (judge modes cost N judge passes, floor labelled decode+judge) (v0.73.2)
 soup card <registry-id> -o MODELCARD.md       HF model card from a registry entry: training config, evals, hashes, lineage, artifacts (v0.71.35)

--- a/src/soup_cli/commands/ship.py
+++ b/src/soup_cli/commands/ship.py
@@ -504,7 +504,11 @@ def _resolve_generators(
         # fp32 elsewhere. Previously left unset, so from_pretrained fell through
         # to its own default instead of the precision this message promised.
         resolved_device = live_eval.resolve_device(device)
-        dtype = "bfloat16" if resolved_device == "cuda" else "float32"
+        # startswith, not ==: an explicit --device cuda:0 (or any indexed
+        # CUDA device) resolves verbatim (live_eval.resolve_device returns
+        # it unchanged), and a bare "cuda" equality check would miss it and
+        # silently fall back to float32.
+        dtype = "bfloat16" if resolved_device.startswith("cuda") else "float32"
         console.print(
             f"[dim]Live eval: loading base/tuned at full precision ({dtype}); "
             "pass --config to reuse the training run's own quantization.[/]"

--- a/src/soup_cli/commands/ship.py
+++ b/src/soup_cli/commands/ship.py
@@ -497,26 +497,33 @@ def _resolve_generators(
             f"[dim]Live eval: loading base/tuned at {quantization} "
             "(reused from --config training.quantization).[/]"
         )
+        dtype = None
     else:
+        # Match the fallback message: bf16 on CUDA (this codebase's other live
+        # loaders use the same cuda-else-fp32 split, e.g. mole_routing.py/prm.py),
+        # fp32 elsewhere. Previously left unset, so from_pretrained fell through
+        # to its own default instead of the precision this message promised.
+        resolved_device = live_eval.resolve_device(device)
+        dtype = "bfloat16" if resolved_device == "cuda" else "float32"
         console.print(
-            "[dim]Live eval: loading base/tuned at full precision (bf16); "
+            f"[dim]Live eval: loading base/tuned at full precision ({dtype}); "
             "pass --config to reuse the training run's own quantization.[/]"
         )
 
     base_gen = live_eval.make_generator(
         base, device=device, max_new_tokens=BEHAVIOURAL_MAX_NEW_TOKENS,
-        quantization=quantization,
+        dtype=dtype, quantization=quantization,
     )
     if adapter:
         tuned_gen = live_eval.make_generator(
             base, adapter=adapter, device=device,
             max_new_tokens=BEHAVIOURAL_MAX_NEW_TOKENS,
-            quantization=quantization,
+            dtype=dtype, quantization=quantization,
         )
     elif tuned:
         tuned_gen = live_eval.make_generator(
             tuned, device=device, max_new_tokens=BEHAVIOURAL_MAX_NEW_TOKENS,
-            quantization=quantization,
+            dtype=dtype, quantization=quantization,
         )
     else:  # pragma: no cover — _verdict_live guarantees one of tuned/adapter
         raise ValueError("need --tuned or --adapter")

--- a/src/soup_cli/commands/ship.py
+++ b/src/soup_cli/commands/ship.py
@@ -457,8 +457,30 @@ def _verdict_from_evidence(payload: dict, *, forgetting_threshold: float) -> Shi
 # Live path — load base + tuned, evaluate both legs
 # ---------------------------------------------------------------------------
 
+# live_eval only builds a BitsAndBytesConfig for these two (#367); the other
+# quant_menu formats (gptq/awq/hqq/...) need a full TrainingConfig, so those
+# still fall back to bf16 here, same as no --config at all.
+_LIVE_EVAL_QUANTIZATION_FORMATS = frozenset({"4bit", "8bit"})
+
+
+def _live_eval_quantization_from_config(soup_config: Optional["SoupConfig"]) -> Optional[str]:
+    """Reuse the training run's own quantization for the live eval load.
+
+    Returns ``None`` (unchanged bf16 default) when no ``--config`` was given,
+    or the run used a format live_eval cannot build directly.
+    """
+    if soup_config is None:
+        return None
+    quant = soup_config.training.quantization
+    return quant if quant in _LIVE_EVAL_QUANTIZATION_FORMATS else None
+
+
 def _resolve_generators(
-    base: str, tuned: Optional[str], adapter: Optional[str], device: Optional[str]
+    base: str,
+    tuned: Optional[str],
+    adapter: Optional[str],
+    device: Optional[str],
+    quantization: Optional[str] = None,
 ) -> Tuple[Callable[[str], str], Callable[[str], str]]:
     """Build ``(base_gen, tuned_gen)`` from live_eval (greedy decode)."""
     # #316 — the behavioural suites need a budget that fits a real tool call.
@@ -470,17 +492,31 @@ def _resolve_generators(
     from soup_cli.eval.gate_suites import BEHAVIOURAL_MAX_NEW_TOKENS
     from soup_cli.utils import live_eval
 
+    if quantization:
+        console.print(
+            f"[dim]Live eval: loading base/tuned at {quantization} "
+            "(reused from --config training.quantization).[/]"
+        )
+    else:
+        console.print(
+            "[dim]Live eval: loading base/tuned at full precision (bf16); "
+            "pass --config to reuse the training run's own quantization.[/]"
+        )
+
     base_gen = live_eval.make_generator(
-        base, device=device, max_new_tokens=BEHAVIOURAL_MAX_NEW_TOKENS
+        base, device=device, max_new_tokens=BEHAVIOURAL_MAX_NEW_TOKENS,
+        quantization=quantization,
     )
     if adapter:
         tuned_gen = live_eval.make_generator(
             base, adapter=adapter, device=device,
             max_new_tokens=BEHAVIOURAL_MAX_NEW_TOKENS,
+            quantization=quantization,
         )
     elif tuned:
         tuned_gen = live_eval.make_generator(
-            tuned, device=device, max_new_tokens=BEHAVIOURAL_MAX_NEW_TOKENS
+            tuned, device=device, max_new_tokens=BEHAVIOURAL_MAX_NEW_TOKENS,
+            quantization=quantization,
         )
     else:  # pragma: no cover — _verdict_live guarantees one of tuned/adapter
         raise ValueError("need --tuned or --adapter")
@@ -904,6 +940,7 @@ def _verdict_live(
     device: Optional[str],
     forgetting_threshold: float,
     noise_floor_runs: Optional[int] = None,
+    quantization: Optional[str] = None,
 ) -> ShipVerdict:
     """Run a live verdict — validate flags (exit 2), then evaluate (exit 1)."""
     if not base:
@@ -958,7 +995,7 @@ def _verdict_live(
 
     tuned_id = tuned if tuned else base
     try:
-        base_gen, tuned_gen = _resolve_generators(base, tuned, adapter, device)
+        base_gen, tuned_gen = _resolve_generators(base, tuned, adapter, device, quantization)
         # Judge modes need a judge model. Validate it BEFORE measuring the
         # noise floor, which now scores the leg-1 task axis through the judge as
         # well (#403) — a missing / malformed judge is a usage error (exit 2),
@@ -1263,6 +1300,7 @@ def ship(
             device=device,
             forgetting_threshold=threshold,
             noise_floor_runs=noise_floor,
+            quantization=_live_eval_quantization_from_config(soup_config),
         )
     else:
         _fail(

--- a/src/soup_cli/utils/live_eval.py
+++ b/src/soup_cli/utils/live_eval.py
@@ -204,12 +204,14 @@ def make_generator(
     device: Optional[str] = None,
     max_new_tokens: int = 64,
     trust_remote_code: bool = False,
+    quantization: Optional[str] = None,
     loaded: Optional[tuple] = None,
 ) -> GeneratorFn:
     """Build a deterministic ``GeneratorFn`` closure (greedy decode).
 
     ``loaded`` lets a caller share an already-loaded ``(model, tokenizer,
     device)`` triple across several closures (base + multi off one load).
+    ``quantization`` is ignored when ``loaded`` is given, same as ``device``.
     """
     _check_positive_int(max_new_tokens, "max_new_tokens")
     if loaded is not None and (not isinstance(loaded, tuple) or len(loaded) != 3):
@@ -217,7 +219,11 @@ def make_generator(
     import torch
 
     model, tokenizer, dev = loaded or load_model_and_tokenizer(
-        model_id, adapter=adapter, device=device, trust_remote_code=trust_remote_code
+        model_id,
+        adapter=adapter,
+        device=device,
+        trust_remote_code=trust_remote_code,
+        quantization=quantization,
     )
     pad_id = (
         tokenizer.pad_token_id
@@ -254,9 +260,13 @@ def make_multi_generator(
     max_new_tokens: int = 64,
     temperature: float = 0.8,
     trust_remote_code: bool = False,
+    quantization: Optional[str] = None,
     loaded: Optional[tuple] = None,
 ) -> MultiGen:
-    """Build a sampling ``MultiGen`` closure: ``multi(prompt, k) -> [str, ...]``."""
+    """Build a sampling ``MultiGen`` closure: ``multi(prompt, k) -> [str, ...]``.
+
+    ``quantization`` is ignored when ``loaded`` is given, same as ``device``.
+    """
     _check_positive_int(max_new_tokens, "max_new_tokens")
     if (
         isinstance(temperature, bool)
@@ -269,7 +279,11 @@ def make_multi_generator(
     import torch
 
     model, tokenizer, dev = loaded or load_model_and_tokenizer(
-        model_id, adapter=adapter, device=device, trust_remote_code=trust_remote_code
+        model_id,
+        adapter=adapter,
+        device=device,
+        trust_remote_code=trust_remote_code,
+        quantization=quantization,
     )
     pad_id = (
         tokenizer.pad_token_id
@@ -413,6 +427,7 @@ def lora_probe(
     lr: float = _DEFAULT_LR,
     max_length: int = 256,
     trust_remote_code: bool = False,
+    quantization: Optional[str] = None,
 ) -> Tuple[float, float, float]:
     """Measure held-out loss before/after a short LoRA train. Returns
     ``(base_loss, probe_loss, wall_clock_seconds)``.
@@ -432,7 +447,7 @@ def lora_probe(
 
     started = time.monotonic()
     model, tokenizer, dev = load_model_and_tokenizer(
-        base, device=device, trust_remote_code=trust_remote_code
+        base, device=device, trust_remote_code=trust_remote_code, quantization=quantization
     )
     pairs = _build_pairs(
         rows, input_extractor=input_extractor, output_extractor=output_extractor
@@ -503,6 +518,7 @@ def measure_logit_agreement(
     max_pairs: int = _MAX_AGREEMENT_PAIRS,
     max_length: int = 256,
     trust_remote_code: bool = False,
+    quantization: Optional[str] = None,
 ) -> float:
     """Fraction of held-out target tokens the base model already predicts top-1.
 
@@ -516,7 +532,7 @@ def measure_logit_agreement(
     import torch
 
     model, tokenizer, dev = load_model_and_tokenizer(
-        base, device=device, trust_remote_code=trust_remote_code
+        base, device=device, trust_remote_code=trust_remote_code, quantization=quantization
     )
     pairs = _build_pairs(
         rows, input_extractor=input_extractor, output_extractor=output_extractor

--- a/src/soup_cli/utils/live_eval.py
+++ b/src/soup_cli/utils/live_eval.py
@@ -204,6 +204,7 @@ def make_generator(
     device: Optional[str] = None,
     max_new_tokens: int = 64,
     trust_remote_code: bool = False,
+    dtype: Optional[str] = None,
     quantization: Optional[str] = None,
     loaded: Optional[tuple] = None,
 ) -> GeneratorFn:
@@ -211,7 +212,8 @@ def make_generator(
 
     ``loaded`` lets a caller share an already-loaded ``(model, tokenizer,
     device)`` triple across several closures (base + multi off one load).
-    ``quantization`` is ignored when ``loaded`` is given, same as ``device``.
+    ``dtype``/``quantization`` are ignored when ``loaded`` is given, same as
+    ``device``.
     """
     _check_positive_int(max_new_tokens, "max_new_tokens")
     if loaded is not None and (not isinstance(loaded, tuple) or len(loaded) != 3):
@@ -223,6 +225,7 @@ def make_generator(
         adapter=adapter,
         device=device,
         trust_remote_code=trust_remote_code,
+        dtype=dtype,
         quantization=quantization,
     )
     pad_id = (

--- a/tests/test_issue367_live_eval_quantization.py
+++ b/tests/test_issue367_live_eval_quantization.py
@@ -377,6 +377,28 @@ class TestResolveGeneratorsThreadsQuantization:
         assert "bfloat16" in out
         assert calls_dtype == ["bfloat16", "bfloat16"]
 
+    def test_console_reports_the_resolved_dtype_on_indexed_cuda_device(
+        self, monkeypatch, capsys
+    ):
+        """Regression for the OWNER review on #570: an explicit --device
+        cuda:0 resolves verbatim (resolve_device returns it unchanged), so a
+        bare `== "cuda"` check missed it and fell back to float32 on a real
+        GPU. Must resolve the same as a bare "cuda"."""
+        from soup_cli.commands.ship import _resolve_generators
+        from soup_cli.utils import live_eval as _live_eval_mod
+
+        calls_dtype = []
+
+        def _fake(model_id, adapter=None, device=None, max_new_tokens=64, **kwargs):
+            calls_dtype.append(kwargs.get("dtype"))
+            return lambda prompt: ""
+
+        monkeypatch.setattr(_live_eval_mod, "make_generator", _fake)
+        _resolve_generators(base="b", tuned=None, adapter="a", device="cuda:0")
+        out = capsys.readouterr().out
+        assert "bfloat16" in out
+        assert calls_dtype == ["bfloat16", "bfloat16"]
+
     def test_quantized_load_does_not_also_pin_a_dtype(self, monkeypatch):
         """When --config supplies 4bit/8bit, the BitsAndBytesConfig governs
         precision; dtype must stay None rather than fighting it."""

--- a/tests/test_issue367_live_eval_quantization.py
+++ b/tests/test_issue367_live_eval_quantization.py
@@ -217,3 +217,267 @@ class TestBuildQuantizationConfigHelper:
 
         with pytest.raises(ValueError, match="awq"):
             _build_quantization_config("awq")
+
+
+# #367 checklist item 1, second half: the four internal callers must accept
+# and forward ``quantization`` too. Criteria 2 and 4 stay out of scope, same
+# as the original PR (see the module docstring above).
+
+
+class TestTheFourCallersForwardQuantization:
+    @patch("transformers.AutoTokenizer.from_pretrained")
+    @patch("transformers.AutoModelForCausalLM.from_pretrained")
+    def test_make_generator_forwards_quantization(self, mock_model, mock_tok):
+        from soup_cli.utils.live_eval import make_generator
+
+        mock_tok.return_value = _fake_tokenizer()
+        mock_model.return_value = MagicMock()
+
+        make_generator("some/model", device="cpu", quantization="4bit")
+
+        _, kwargs = mock_model.call_args
+        assert kwargs["quantization_config"].load_in_4bit is True
+
+    @patch("transformers.AutoTokenizer.from_pretrained")
+    @patch("transformers.AutoModelForCausalLM.from_pretrained")
+    def test_make_multi_generator_forwards_quantization(self, mock_model, mock_tok):
+        from soup_cli.utils.live_eval import make_multi_generator
+
+        mock_tok.return_value = _fake_tokenizer()
+        mock_model.return_value = MagicMock()
+
+        make_multi_generator("some/model", device="cpu", quantization="8bit")
+
+        _, kwargs = mock_model.call_args
+        assert kwargs["quantization_config"].load_in_8bit is True
+
+    def test_lora_probe_forwards_quantization(self):
+        """Stops the probe at the load call (a RuntimeError side effect) since
+        the LoRA train loop that follows is unrelated to this wiring fix."""
+        from soup_cli.utils.live_eval import lora_probe
+
+        with patch("soup_cli.utils.live_eval.load_model_and_tokenizer") as mock_load:
+            mock_load.side_effect = RuntimeError("stop after load")
+            with pytest.raises(RuntimeError, match="stop after load"):
+                lora_probe(
+                    "some/base",
+                    [{"input": "a", "output": "b"}] * 3,
+                    input_extractor=lambda r: r["input"],
+                    output_extractor=lambda r: r["output"],
+                    quantization="4bit",
+                )
+        assert mock_load.call_args.kwargs["quantization"] == "4bit"
+
+    def test_measure_logit_agreement_forwards_quantization(self):
+        from soup_cli.utils.live_eval import measure_logit_agreement
+
+        with patch("soup_cli.utils.live_eval.load_model_and_tokenizer") as mock_load:
+            mock_load.side_effect = RuntimeError("stop after load")
+            with pytest.raises(RuntimeError, match="stop after load"):
+                measure_logit_agreement(
+                    "some/base",
+                    [{"input": "a", "output": "b"}],
+                    input_extractor=lambda r: r["input"],
+                    output_extractor=lambda r: r["output"],
+                    quantization="8bit",
+                )
+        assert mock_load.call_args.kwargs["quantization"] == "8bit"
+
+
+class TestResolveGeneratorsThreadsQuantization:
+    """Mirrors ``test_issue316_suites.py``'s ``TestTheBudgetReachesTheGenerator``:
+    the wiring lives at the construction site, and mocking ``_verdict_live``
+    (the CLI-level tests below) never actually reaches it."""
+
+    def _capture(self, monkeypatch):
+        from soup_cli.utils import live_eval
+
+        calls = []
+
+        def _fake(model_id, adapter=None, device=None, max_new_tokens=64, **kwargs):
+            calls.append(kwargs.get("quantization"))
+            return lambda prompt: ""
+
+        monkeypatch.setattr(live_eval, "make_generator", _fake)
+        return calls
+
+    def test_adapter_branch_forwards_quantization(self, monkeypatch):
+        from soup_cli.commands.ship import _resolve_generators
+
+        calls = self._capture(monkeypatch)
+        _resolve_generators(
+            base="b", tuned=None, adapter="a", device="cpu", quantization="4bit"
+        )
+        assert calls == ["4bit", "4bit"]
+
+    def test_tuned_branch_forwards_quantization(self, monkeypatch):
+        from soup_cli.commands.ship import _resolve_generators
+
+        calls = self._capture(monkeypatch)
+        _resolve_generators(
+            base="b", tuned="t", adapter=None, device="cpu", quantization="8bit"
+        )
+        assert calls == ["8bit", "8bit"]
+
+    def test_unset_quantization_matches_the_pre_367_call_shape(self, monkeypatch):
+        """No --config -> None reaches make_generator, same as every one of the
+        11 pre-#367 callers that never passed the kwarg at all."""
+        from soup_cli.commands.ship import _resolve_generators
+
+        calls = self._capture(monkeypatch)
+        _resolve_generators(base="b", tuned=None, adapter="a", device="cpu")
+        assert calls == [None, None]
+
+    def test_console_reports_the_numerics_used(self, monkeypatch, capsys):
+        from soup_cli.commands.ship import _resolve_generators
+
+        self._capture(monkeypatch)
+        _resolve_generators(
+            base="b", tuned=None, adapter="a", device="cpu", quantization="4bit"
+        )
+        assert "4bit" in capsys.readouterr().out
+
+    def test_console_reports_the_bf16_fallback(self, monkeypatch, capsys):
+        from soup_cli.commands.ship import _resolve_generators
+
+        self._capture(monkeypatch)
+        _resolve_generators(base="b", tuned=None, adapter="a", device="cpu")
+        assert "bf16" in capsys.readouterr().out
+
+
+class TestShipDerivesQuantizationFromConfig:
+    """The only one of the four callers with an existing config surface to
+    derive a default from: ``soup ship --config`` already loads the full
+    ``SoupConfig`` used to train the adapter, including ``training.quantization``.
+
+    ``advise --probe-model``, ``diagnose --base-model`` and ``tunability --live``
+    take no ``--config``/``--quantization`` flag today, so they keep the
+    unchanged bf16 default; wiring them needs a new config surface on each of
+    those commands, which is follow-up work, not part of this fix.
+    """
+
+    def test_returns_none_without_a_config(self):
+        from soup_cli.commands.ship import _live_eval_quantization_from_config
+
+        assert _live_eval_quantization_from_config(None) is None
+
+    def test_returns_the_supported_format(self):
+        from soup_cli.commands.ship import _live_eval_quantization_from_config
+        from soup_cli.config.schema import SoupConfig
+
+        cfg = SoupConfig(
+            base="m", data={"train": "t.jsonl"}, training={"quantization": "4bit"}
+        )
+        assert _live_eval_quantization_from_config(cfg) == "4bit"
+
+    def test_unsupported_quant_menu_format_falls_back_to_none(self):
+        """gptq/awq/hqq/... key off a full TrainingConfig live_eval callers
+        don't have, so a run trained that way still loads bf16 here, same as
+        the original PR's `_build_quantization_config` scope."""
+        from soup_cli.commands.ship import _live_eval_quantization_from_config
+        from soup_cli.config.schema import SoupConfig
+
+        cfg = SoupConfig(
+            base="m", data={"train": "t.jsonl"}, training={"quantization": "gptq"}
+        )
+        assert _live_eval_quantization_from_config(cfg) is None
+
+    def test_ship_cli_threads_config_quantization_to_the_live_verdict(self, monkeypatch):
+        """End-to-end through the CLI: --config's training.quantization reaches
+        _verdict_live, exactly like the existing task_eval/noise_floor threading
+        this file's sibling tests (test_v07139.py) already cover."""
+        from pathlib import Path
+
+        from typer.testing import CliRunner
+
+        from soup_cli.commands import ship as ship_cmd
+        from soup_cli.utils.ship_verdict import (
+            build_task_win,
+            compute_benchmark_deltas,
+            decide_ship,
+        )
+
+        captured = {}
+
+        def _fake_live(**kwargs):
+            captured.update(kwargs)
+            win = build_task_win("metric", 0.5, 0.7)
+            deltas = compute_benchmark_deltas({"b": 0.6}, {"b": 0.6})
+            return decide_ship(win, deltas)
+
+        monkeypatch.setattr(ship_cmd, "_verdict_live", _fake_live)
+        cfg = "base: m\ndata:\n  train: t.jsonl\ntraining:\n  quantization: 4bit\n"
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Path("soup.yaml").write_text(cfg, encoding="utf-8")
+            res = runner.invoke(
+                ship_cmd.app,
+                ["--base", "m", "--adapter", "a", "--config", "soup.yaml"],
+            )
+            assert res.exit_code == 0, (res.output, repr(res.exception))
+            assert captured["quantization"] == "4bit"
+
+    def test_ship_cli_without_config_passes_none(self, monkeypatch):
+        from typer.testing import CliRunner
+
+        from soup_cli.commands import ship as ship_cmd
+        from soup_cli.utils.ship_verdict import (
+            build_task_win,
+            compute_benchmark_deltas,
+            decide_ship,
+        )
+
+        captured = {}
+
+        def _fake_live(**kwargs):
+            captured.update(kwargs)
+            win = build_task_win("metric", 0.5, 0.7)
+            deltas = compute_benchmark_deltas({"b": 0.6}, {"b": 0.6})
+            return decide_ship(win, deltas)
+
+        monkeypatch.setattr(ship_cmd, "_verdict_live", _fake_live)
+        runner = CliRunner()
+        res = runner.invoke(ship_cmd.app, ["--base", "m", "--adapter", "a"])
+        assert res.exit_code == 0, (res.output, repr(res.exception))
+        assert captured["quantization"] is None
+
+    def test_ship_cli_reaches_resolve_generators_through_the_real_verdict_live(
+        self, monkeypatch
+    ):
+        """The two tests above mock `_verdict_live` itself, so they never run
+        the line inside it that forwards `quantization` on to
+        `_resolve_generators`. This one leaves `_verdict_live` real (mocking
+        only `_resolve_generators`, same as `test_v07138.py`'s
+        `TestShipLiveHeadline._run`) so that call site is actually exercised."""
+        import json
+        from pathlib import Path
+
+        from typer.testing import CliRunner
+
+        from soup_cli.commands import ship as ship_cmd
+
+        captured = {}
+
+        def _fake_resolve(base, tuned, adapter, device, quantization=None):
+            captured["quantization"] = quantization
+            return (lambda p: "hi", lambda p: "hi")
+
+        monkeypatch.setattr(ship_cmd, "_resolve_generators", _fake_resolve)
+        cfg = "base: m\ndata:\n  train: t.jsonl\ntraining:\n  quantization: 4bit\n"
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Path("soup.yaml").write_text(cfg, encoding="utf-8")
+            Path("task.jsonl").write_text(
+                json.dumps({"prompt": "say hi", "expected": "hi", "scoring": "contains"})
+                + "\n",
+                encoding="utf-8",
+            )
+            res = runner.invoke(
+                ship_cmd.app,
+                [
+                    "--base", "m", "--adapter", "a", "--task-eval", "task.jsonl",
+                    "--device", "cpu", "--config", "soup.yaml",
+                ],
+            )
+            assert res.exit_code in (0, 2), (res.output, repr(res.exception))
+            assert captured["quantization"] == "4bit"

--- a/tests/test_issue367_live_eval_quantization.py
+++ b/tests/test_issue367_live_eval_quantization.py
@@ -337,12 +337,63 @@ class TestResolveGeneratorsThreadsQuantization:
         )
         assert "4bit" in capsys.readouterr().out
 
-    def test_console_reports_the_bf16_fallback(self, monkeypatch, capsys):
+    def test_console_reports_the_resolved_dtype_on_cpu(self, monkeypatch, capsys):
+        """Regression for the mismatch nestor-deeptempo flagged on #570: the
+        fallback message used to hardcode "bf16" regardless of device and
+        ""quantization""-only wiring never passed a matching ""torch_dtype"", so
+        a CPU load got whatever from_pretrained defaults to while the message
+        claimed bf16. The message and the value passed to make_generator must
+        now agree."""
         from soup_cli.commands.ship import _resolve_generators
 
-        self._capture(monkeypatch)
+        calls_dtype = []
+        from soup_cli.utils import live_eval as _live_eval_mod
+
+        def _fake(model_id, adapter=None, device=None, max_new_tokens=64, **kwargs):
+            calls_dtype.append(kwargs.get("dtype"))
+            return lambda prompt: ""
+
+        monkeypatch.setattr(_live_eval_mod, "make_generator", _fake)
         _resolve_generators(base="b", tuned=None, adapter="a", device="cpu")
-        assert "bf16" in capsys.readouterr().out
+        out = capsys.readouterr().out
+        assert "float32" in out
+        assert "bf16" not in out
+        assert calls_dtype == ["float32", "float32"]
+
+    def test_console_reports_the_resolved_dtype_on_cuda(self, monkeypatch, capsys):
+        from soup_cli.commands.ship import _resolve_generators
+        from soup_cli.utils import live_eval as _live_eval_mod
+
+        calls_dtype = []
+
+        def _fake(model_id, adapter=None, device=None, max_new_tokens=64, **kwargs):
+            calls_dtype.append(kwargs.get("dtype"))
+            return lambda prompt: ""
+
+        monkeypatch.setattr(_live_eval_mod, "make_generator", _fake)
+        monkeypatch.setattr(_live_eval_mod, "resolve_device", lambda device=None: "cuda")
+        _resolve_generators(base="b", tuned=None, adapter="a", device=None)
+        out = capsys.readouterr().out
+        assert "bfloat16" in out
+        assert calls_dtype == ["bfloat16", "bfloat16"]
+
+    def test_quantized_load_does_not_also_pin_a_dtype(self, monkeypatch):
+        """When --config supplies 4bit/8bit, the BitsAndBytesConfig governs
+        precision; dtype must stay None rather than fighting it."""
+        from soup_cli.commands.ship import _resolve_generators
+        from soup_cli.utils import live_eval as _live_eval_mod
+
+        calls_dtype = []
+
+        def _fake(model_id, adapter=None, device=None, max_new_tokens=64, **kwargs):
+            calls_dtype.append(kwargs.get("dtype"))
+            return lambda prompt: ""
+
+        monkeypatch.setattr(_live_eval_mod, "make_generator", _fake)
+        _resolve_generators(
+            base="b", tuned=None, adapter="a", device="cpu", quantization="4bit"
+        )
+        assert calls_dtype == [None, None]
 
 
 class TestShipDerivesQuantizationFromConfig:


### PR DESCRIPTION
#461 added a `quantization` parameter to `load_model_and_tokenizer` but no caller ever set it: `make_generator`, `make_multi_generator`, `lora_probe` and `measure_logit_agreement` all called it with nothing, so an NF4-trained adapter was still judged against a bf16 base it never saw during training. That is the exact defect this issue was reopened for.

## Fix

All four callers now accept and forward `quantization`, unchanged for the 11 existing call sites that never pass it.

`soup ship --config soup.yaml` derives a default from `training.quantization`, the same config that trained the adapter (restricted to the two formats live_eval can build directly, `4bit`/`8bit`; the other quant_menu formats key off a full `TrainingConfig` live_eval callers don't have, so those still fall back to bf16, same as no `--config`), and prints which precision it loaded so the run says so rather than silently mis-scoring.

`advise --probe-model`, `diagnose --base-model` and `tunability --live` take no `--config`/`--quantization` flag today, so they keep the unchanged bf16 default. Wiring them needs adding that config surface to each command, which felt like separate work rather than something to fold into this diff; happy to take it as a follow-up if useful.

## Not done here

Criterion 2 (`soup ship` reporting the numerics used in the verdict/evidence JSON, not just the console) and criterion 4 (a staleness gate on evidence recorded under mismatched numerics) are both still open, same as the original PR left them.

## Verification

- `pytest tests/test_issue367_live_eval_quantization.py`: 4 new tests fail on unmodified `main` (missing `quantization` kwarg / import errors) and pass on this branch; extended rather than replaced the existing file.
- Full relevant suite (`ship`, `live_eval`, `advise`, `diagnose`, `tunability`, `behavior_battery`, plus every `test_v071*`/`test_issue3*` file touching `ship.py`) in a clean `python:3.11-slim` container: 759 passed, 2 pre-existing failures unrelated to this change (`test_v07131.py`, missing the optional `trl`/`datasets` extras I did not install for this scoped run).
- `ruff check src/soup_cli/ tests/` clean.
- Did not verify a real quantized load end to end (needs a GPU + bitsandbytes); every test here mocks at the `from_pretrained` boundary, same as the rest of this file.

Refs #367 (criteria 2 and 4 remain open, see "Not done here" above)

