### PR TITLE
feat(models): scaffold Qwen4-Exp text LoRA support

### DIFF
--- a/.github/constraints/transformers-floor.txt
+++ b/.github/constraints/transformers-floor.txt
@@ -2,8 +2,10 @@
 # Qwen3.8-Flash-Next text loading establishes Transformers 5.16.1 as Soup's
 # declared training floor. trl 0.29 is the first release that does not import the
 # Transformers private availability helper whose v5 return type broke trl 0.28.
+# Torch 2.5.1 deliberately exercises Qwen4-Exp's legacy int64-only scatter path.
 # Plotext 6.0.0 is pinned here so one CI cell exercises the real Figure API rather
 # than relying only on the fake 5.x/6.x contract doubles in the unit suite.
+torch==2.5.1
 transformers==5.16.1
 trl==0.29.0
 peft==0.20.0

--- a/.github/constraints/transformers-floor.txt
+++ b/.github/constraints/transformers-floor.txt
@@ -1,10 +1,10 @@
-# #502/#503/#522 — exact pins for the dedicated dependency-floor CI job.
-# Qwen3.5/Qwen3.8 text loading establishes Transformers 5.12.1 as Soup's
+# #571 — exact pins for the dedicated dependency-floor CI job.
+# Qwen3.8-Flash-Next text loading establishes Transformers 5.16.1 as Soup's
 # declared training floor. trl 0.29 is the first release that does not import the
 # Transformers private availability helper whose v5 return type broke trl 0.28.
 # Plotext 6.0.0 is pinned here so one CI cell exercises the real Figure API rather
 # than relying only on the fake 5.x/6.x contract doubles in the unit suite.
-transformers==5.12.1
+transformers==5.16.1
 trl==0.29.0
 peft==0.20.0
 plotext==6.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,9 @@ jobs:
       - name: Run one-step MLX SFT through the real CLI
         run: pytest -o addopts= -m smoke -k mlx_sft_smoke -q tests/test_smoke_train.py
 
-  # #502/#503/#522: install the exact Transformers 5.12.1 / trl 0.29 /
-  # PEFT 0.20 support floor and Plotext 6.0.0 so pip cannot silently upgrade
-  # the cell, then assert every pinned compatibility boundary.
+  # #502/#503/#522/#571: install the exact Torch 2.5.1 / Transformers 5.16.1 /
+  # trl 0.29 / PEFT 0.20 support stack and Plotext 6.0.0 so pip cannot silently
+  # upgrade the cell, then assert every pinned compatibility boundary.
   transformers-floor:
     runs-on: ubuntu-latest
     env:
@@ -101,7 +101,7 @@ jobs:
           )
           expected = dict(pairs)
           assert len(expected) == len(pairs), "duplicate package pin in floor constraints"
-          for name in ("transformers", "trl", "peft", "plotext"):
+          for name in ("torch", "transformers", "trl", "peft", "plotext"):
               assert name in expected, f"floor constraints missing exact {name} pin"
               want = expected[name]
               got = md.version(name)
@@ -116,6 +116,7 @@ jobs:
         run: >
           pytest -o addopts= --no-cov -q
           tests/test_transformers_floor_compat.py
+          tests/test_issue571_qwen4_exp.py
           tests/test_plotext_compat.py
           tests/test_bugfixes.py::TestDiffModelLoading
 

--- a/changelog.d/0.73.3/572.added.md
+++ b/changelog.d/0.73.3/572.added.md
@@ -1,5 +1,7 @@
 - [#572](https://github.com/MakazhanAlpamys/Soup/pull/572) adds a weight-free
   Qwen3.8-Flash-Next text-LoRA compatibility scaffold on Transformers 5.16.1,
   including architecture-aware linear targets, MoE detection, and a tiny-config
-  forward/backward gate; real checkpoint, catalog, streaming, multimodal, and
-  routed-expert-parameter support remain explicitly unclaimed.
+  forward/backward gate. Legacy int64-only Torch scatter runtimes receive an
+  instance-local QSA index compatibility shim; real checkpoint, catalog,
+  streaming, multimodal, and routed-expert-parameter support remain explicitly
+  unclaimed.

--- a/changelog.d/0.73.3/572.added.md
+++ b/changelog.d/0.73.3/572.added.md
@@ -1,0 +1,5 @@
+- [#572](https://github.com/MakazhanAlpamys/Soup/pull/572) adds a weight-free
+  Qwen3.8-Flash-Next text-LoRA compatibility scaffold on Transformers 5.16.1,
+  including architecture-aware linear targets, MoE detection, and a tiny-config
+  forward/backward gate; real checkpoint, catalog, streaming, multimodal, and
+  routed-expert-parameter support remain explicitly unclaimed.

--- a/docs/backends-and-ops.md
+++ b/docs/backends-and-ops.md
@@ -85,7 +85,7 @@ pip install "soup-cli[mlx]"
 For SFT with local JSONL, JSON, or CSV data, `[mlx]` is sufficient on its own.
 It can also be installed with `[train]` when the same environment needs the
 PyTorch/TRL Transformers backend: both extras now share the supported
-`transformers>=5.12.1,<6` range (#502/#503). A Hugging Face `datasets` source or
+`transformers>=5.16.1,<6` range. A Hugging Face `datasets` source or
 streaming dataset still needs `datasets` because that data source owns the
 dependency; the local file path below does not.
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -37,7 +37,8 @@ architecture on the Hub, but Soup's catalog recipes are deliberately text-only.
 Their explicit `modality: text` selects `AutoModelForCausalLM`, which instantiates the
 language decoder without the visual tower. This is appropriate for text-only SFT,
 pre-training, and GRPO data; it is not a full multimodal fine-tune. The Transformers
-backend requires Transformers 5.12.1 or newer for the `qwen3_5` architecture.
+backend requires Transformers 5.16.1 or newer, which also supplies the
+`qwen4_exp` text decoder used by Qwen3.8-Flash-Next (#571).
 
 ### Vision Models (with `modality: vision`)
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -38,7 +38,10 @@ Their explicit `modality: text` selects `AutoModelForCausalLM`, which instantiat
 language decoder without the visual tower. This is appropriate for text-only SFT,
 pre-training, and GRPO data; it is not a full multimodal fine-tune. The Transformers
 backend requires Transformers 5.16.1 or newer, which also supplies the
-`qwen4_exp` text decoder used by Qwen3.8-Flash-Next (#571).
+`qwen4_exp` text decoder used by Qwen3.8-Flash-Next (#571). On Torch runtimes
+whose `scatter` operator still requires `int64` indices, Soup widens only the
+QSA indexer's local index tensors before LoRA injection; Torch and the upstream
+Transformers class remain unchanged.
 
 ### Vision Models (with `modality: vision`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,11 +52,11 @@ dependencies = [
 # These were core dependencies through v0.70.0.
 train = [
     "torch>=2.0.0",
-    # Qwen3.5 classes first ship in Transformers 5.2, but 5.12.1 is the first
-    # validated floor where an outer `qwen3_5` config selects the text-only
-    # Qwen3_5ForCausalLM correctly. The v5 range also makes `[train,mlx]`
-    # resolvable because mlx-lm requires Transformers 5.
-    "transformers>=5.12.1,<6.0.0",
+    # 5.16.1 is the validated Qwen4-Exp floor: an outer `qwen4_exp` config
+    # selects the text-only Qwen4ExpForCausalLM, and the patch release restores
+    # tensor-parallel compatibility needed by large-model training. The v5
+    # range also keeps `[train,mlx]` resolvable because mlx-lm requires v5.
+    "transformers>=5.16.1,<6.0.0",
     # 0.20 is the validated Transformers 5 adapter floor. It still needs Soup's
     # explicit qwen3_5_text target policy below the automatic PEFT mapping layer.
     "peft>=0.20.0,<1.0.0",
@@ -141,7 +141,7 @@ mlx = [
     "mlx-lm>=0.31.3",
     # mlx-lm imports transformers at runtime; keep the standalone contract from
     # depending on that transitive requirement remaining undeclared here.
-    "transformers>=5.12.1,<6.0.0",
+    "transformers>=5.16.1,<6.0.0",
 ]
 cce = ["cut-cross-entropy>=24.10.0"]
 tui = ["textual>=0.50.0"]

--- a/src/soup_cli/commands/doctor.py
+++ b/src/soup_cli/commands/doctor.py
@@ -17,7 +17,7 @@ console = Console()
 # Dependencies to check: (import_name, package_name, min_version, required)
 DEPS = [
     ("torch", "torch", "2.0.0", True),
-    ("transformers", "transformers", "5.12.1", True),
+    ("transformers", "transformers", "5.16.1", True),
     ("peft", "peft", "0.20.0", True),
     ("trl", "trl", "0.29.0", True),
     ("datasets", "datasets", "2.14.0", True),

--- a/src/soup_cli/utils/completions.py
+++ b/src/soup_cli/utils/completions.py
@@ -45,6 +45,32 @@ _LLAMA_SHAPE: Tuple[str, ...] = (
     "down_proj",
 )
 
+# Every nn.Linear suffix exposed by the Qwen4-Exp text decoder. This includes
+# QSA, Gated DeltaNet, shared-expert, PLE, and gated-residual projections. The
+# routed experts use raw 3-D parameters and therefore do not belong in a
+# target-*module* completer.
+_QWEN4_EXP_TEXT_SHAPE: Tuple[str, ...] = (
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "index_qk_proj",
+    "in_proj_qkv",
+    "in_proj_z",
+    "in_proj_b",
+    "in_proj_a",
+    "out_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj",
+    "shared_expert_gate",
+    "input_mix_weight_down",
+    "input_mix_weight_up",
+    "block_inject_weight",
+    "key_proj",
+    "value_proj",
+)
+
 # Per-``model_type`` LoRA target-module names (v0.71.1 #210). Keyed on the
 # HF config ``model_type`` so a ``base`` model's *actual* linear layers are
 # offered rather than the generic Llama default. Config-only (no torch /
@@ -58,6 +84,7 @@ _ARCH_TARGET_MODULES: Mapping[str, Tuple[str, ...]] = MappingProxyType({
     "qwen2_moe": _LLAMA_SHAPE,
     "qwen3": _LLAMA_SHAPE,
     "qwen3_moe": _LLAMA_SHAPE,
+    "qwen4_exp_text": _QWEN4_EXP_TEXT_SHAPE,
     "gemma": _LLAMA_SHAPE,
     "gemma2": _LLAMA_SHAPE,
     "gemma3": _LLAMA_SHAPE,
@@ -98,10 +125,15 @@ def _introspect_target_modules(base: str) -> Optional[Tuple[str, ...]]:
         cfg = AutoConfig.from_pretrained(base, local_files_only=True)
     except Exception:  # noqa: BLE001 — completer must never raise / hang
         return None
-    model_type = getattr(cfg, "model_type", None)
-    if not isinstance(model_type, str) or not model_type:
-        return None
-    return _ARCH_TARGET_MODULES.get(model_type.lower())
+    text_config = getattr(cfg, "text_config", None)
+    for candidate in (text_config, cfg):
+        model_type = getattr(candidate, "model_type", None)
+        if not isinstance(model_type, str) or not model_type:
+            continue
+        targets = _ARCH_TARGET_MODULES.get(model_type.lower())
+        if targets is not None:
+            return targets
+    return None
 
 
 def validate_shell(value: object) -> str:

--- a/src/soup_cli/utils/moe.py
+++ b/src/soup_cli/utils/moe.py
@@ -40,6 +40,7 @@ _MOE_MODEL_TYPES = {
     "qwen3_moe",
     "qwen3_5_moe",
     "qwen3_5_moe_text",
+    "qwen4_exp_text",
     "qwen2_moe",
     "dbrx",
     "deepseek_v2",

--- a/src/soup_cli/utils/peft_wiring.py
+++ b/src/soup_cli/utils/peft_wiring.py
@@ -72,9 +72,14 @@ def resolve_lora_target_modules(model: Any, configured: Any) -> Any:
 def apply_pre_lora_patches(model: Any, base: str) -> None:
     """Run pre-LoRA surgical patches (v0.39.0 Part D, multi-trainer in v0.40.6).
 
-    Currently: Gemma4 ``ClippableLinear`` -> ``nn.Linear`` swap. Gated by
-    ``is_gemma4_model(base)`` so the swap never runs on non-Gemma4 models.
+    Qwen4-Exp's compatibility patch is fail-closed because an unpatched legacy
+    Torch forward cannot train. Gemma4's best-effort ``ClippableLinear`` ->
+    ``nn.Linear`` swap remains gated by ``is_gemma4_model(base)``.
     """
+    from soup_cli.utils.qwen4_compat import apply_qwen4_exp_scatter_compat
+
+    apply_qwen4_exp_scatter_compat(model)
+
     from soup_cli.utils.peft_patches import apply_gemma4_clippable_patch, is_gemma4_model
 
     if not is_gemma4_model(base):

--- a/src/soup_cli/utils/peft_wiring.py
+++ b/src/soup_cli/utils/peft_wiring.py
@@ -29,6 +29,15 @@ QWEN35_TEXT_LORA_TARGETS = (
     "out_proj",
 )
 
+# Qwen4-Exp combines ordinary QSA projections, fused Gated DeltaNet
+# projections, shared experts, PLE projections, and gated-residual mixers.
+# PEFT has no qwen4_exp_text default mapping yet. A short suffix list would
+# silently omit one of those new paths, so ``all-linear`` is the deliberate
+# text-decoder policy. The routed experts themselves are 3-D nn.Parameters,
+# not nn.Linear modules; adapting those needs PEFT ``target_parameters`` and is
+# tracked separately from this safe linear-module baseline.
+QWEN4_EXP_TEXT_LORA_TARGETS = "all-linear"
+
 
 def resolve_lora_target_modules(model: Any, configured: Any) -> Any:
     """Resolve ``target_modules: auto`` for models PEFT does not know yet.
@@ -37,6 +46,7 @@ def resolve_lora_target_modules(model: Any, configured: Any) -> Any:
     Explicit user targets are returned unchanged. Qwen3.5 uses a wrapper
     config (``qwen3_5``) around ``qwen3_5_text`` and its MoE counterpart, so
     inspect both configs without importing Transformers or PEFT at module load.
+    Qwen4-Exp's causal-LM loader exposes ``qwen4_exp_text`` directly.
     """
     if configured != "auto" and configured != ["auto"]:
         return configured
@@ -54,6 +64,8 @@ def resolve_lora_target_modules(model: Any, configured: Any) -> Any:
         "qwen3_5_moe_text",
     }:
         return list(QWEN35_TEXT_LORA_TARGETS)
+    if "qwen4_exp_text" in model_types:
+        return QWEN4_EXP_TEXT_LORA_TARGETS
     return None
 
 

--- a/src/soup_cli/utils/qwen4_compat.py
+++ b/src/soup_cli/utils/qwen4_compat.py
@@ -1,0 +1,126 @@
+"""Narrow runtime compatibility fixes for the Transformers Qwen4-Exp decoder."""
+
+from __future__ import annotations
+
+from functools import update_wrapper
+from types import FunctionType, MethodType
+from typing import Any
+
+_INDEXER_CLASS = "Qwen4ExpTextQSAIndexer"
+_INDEXER_MODULE_PREFIX = "transformers.models.qwen4_exp."
+_PATCH_MARKER = "_soup_qwen4_long_scatter_indices"
+
+
+class _LongIndexTorchProxy:
+    """Delegate to Torch while exposing ``int32`` as ``int64`` to one function."""
+
+    def __init__(self, torch_module: Any) -> None:
+        self._torch = torch_module
+
+    @property
+    def int32(self) -> Any:
+        return self._torch.int64
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._torch, name)
+
+
+def _model_types(model: Any) -> set[Any]:
+    config = getattr(model, "config", None)
+    text_config = getattr(config, "text_config", None)
+    return {
+        getattr(config, "model_type", None),
+        getattr(text_config, "model_type", None),
+    }
+
+
+def _supports_int32_scatter(torch_module: Any, device: Any) -> bool:
+    """Probe the live operator instead of guessing from a Torch version."""
+    target = torch_module.zeros((1, 1), dtype=torch_module.bool, device=device)
+    index = torch_module.zeros((1, 1), dtype=torch_module.int32, device=device)
+    try:
+        target.scatter(-1, index, True)
+    except RuntimeError as exc:
+        if "Expected dtype int64 for index" in str(exc):
+            return False
+        raise
+    return True
+
+
+def _clone_forward_with_long_indices(module: Any, torch_module: Any) -> None:
+    """Bind the upstream forward to one instance with only integer indices widened."""
+    bound_forward = module.forward
+    original = getattr(bound_forward, "__func__", None)
+    if original is None:
+        raise RuntimeError("Qwen4-Exp QSA indexer has no patchable Python forward")
+    if getattr(original, _PATCH_MARKER, False):
+        return
+    if original.__globals__.get("torch") is not torch_module:
+        raise RuntimeError("Qwen4-Exp QSA indexer does not use the expected Torch module")
+
+    patched_globals = dict(original.__globals__)
+    patched_globals["torch"] = _LongIndexTorchProxy(torch_module)
+    patched = FunctionType(
+        original.__code__,
+        patched_globals,
+        name=original.__name__,
+        argdefs=original.__defaults__,
+        closure=original.__closure__,
+    )
+    patched.__kwdefaults__ = original.__kwdefaults__
+    update_wrapper(patched, original)
+    setattr(patched, _PATCH_MARKER, True)
+    module.forward = MethodType(patched, module)
+
+
+def apply_qwen4_exp_scatter_compat(model: Any) -> int:
+    """Use long QSA scatter indices when the installed Torch requires them.
+
+    Transformers 5.16.1 constructs Qwen4-Exp QSA indices as ``int32``. Torch
+    releases before the live operator gained ``int32`` support reject the
+    forward pass. Reusing the exact upstream code object with an instance-local
+    Torch proxy changes only those integer index factories; it does not mutate
+    Torch, the Transformers class, or other model instances.
+    """
+    if "qwen4_exp_text" not in _model_types(model):
+        return 0
+
+    import torch
+
+    indexers = []
+    for module in model.modules():
+        module_type = type(module)
+        if (
+            module_type.__name__ != _INDEXER_CLASS
+            or not module_type.__module__.startswith(_INDEXER_MODULE_PREFIX)
+        ):
+            continue
+        indexers.append(module)
+
+    if not indexers:
+        return 0
+
+    probe_devices = {torch.device("cpu")}
+    for module in indexers:
+        parameter = next(module.parameters(), None)
+        if parameter is not None and parameter.device.type != "meta":
+            probe_devices.add(parameter.device)
+    if all(_supports_int32_scatter(torch, device) for device in probe_devices):
+        return 0
+
+    patched = 0
+    already_patched = 0
+    for module in indexers:
+        forward_function = getattr(getattr(module, "forward", None), "__func__", None)
+        if getattr(forward_function, _PATCH_MARKER, False):
+            already_patched += 1
+            continue
+        _clone_forward_with_long_indices(module, torch)
+        patched += 1
+
+    if patched == 0 and already_patched == 0:
+        raise RuntimeError(
+            "Qwen4-Exp requires long QSA scatter indices on this Torch runtime, "
+            "but Soup could not locate the compatible Transformers indexer"
+        )
+    return patched

--- a/tests/test_issue502_qwen35_transformers5.py
+++ b/tests/test_issue502_qwen35_transformers5.py
@@ -41,7 +41,7 @@ def _single_bound(requirement: Requirement, operator: str) -> str:
 
 
 _RUNTIME_FLOORS = {
-    "transformers": "5.12.1",
+    "transformers": "5.16.1",
     "trl": "0.29.0",
     "peft": "0.20.0",
 }
@@ -61,8 +61,8 @@ def _missing_runtime_floors() -> list[str]:
 
 _MISSING_RUNTIME_FLOORS = _missing_runtime_floors()
 _RUNTIME_FLOOR_REASON = (
-    "requires the new #502 training floor; install soup-cli[train] with "
-    "transformers>=5.12.1, trl>=0.29.0, peft>=0.20.0; missing/outdated: "
+    "requires the validated training floor; install soup-cli[train] with "
+    "transformers>=5.16.1, trl>=0.29.0, peft>=0.20.0; missing/outdated: "
     + ", ".join(_MISSING_RUNTIME_FLOORS)
 )
 _REQUIRES_TRAINING_FLOOR = pytest.mark.skipif(
@@ -113,9 +113,9 @@ def test_training_and_mlx_extras_share_the_transformers5_range():
     mlx = _extra_requirement("mlx", "transformers")
 
     assert train.specifier == mlx.specifier
-    assert Version("5.12.1") in train.specifier
-    assert Version("5.12.0") not in train.specifier
-    assert Version("5.15.1") in train.specifier
+    assert Version("5.16.1") in train.specifier
+    assert Version("5.16.0") not in train.specifier
+    assert Version("5.15.1") not in train.specifier
     assert Version("6.0.0") not in train.specifier
 
 

--- a/tests/test_issue571_qwen4_exp.py
+++ b/tests/test_issue571_qwen4_exp.py
@@ -1,0 +1,157 @@
+"""#571 weight-free compatibility gates for Qwen3.8-Flash-Next's text decoder."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_qwen4_exp_text_auto_lora_covers_every_linear_family():
+    from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+
+    model = SimpleNamespace(config=SimpleNamespace(model_type="qwen4_exp_text"))
+
+    assert resolve_lora_target_modules(model, "auto") == "all-linear"
+    assert resolve_lora_target_modules(model, ["auto"]) == "all-linear"
+
+
+def test_qwen4_exp_explicit_lora_targets_are_not_overridden():
+    from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+
+    model = SimpleNamespace(config=SimpleNamespace(model_type="qwen4_exp_text"))
+    explicit = ["in_proj_qkv", "q_proj"]
+
+    assert resolve_lora_target_modules(model, explicit) is explicit
+
+
+def test_qwen4_exp_outer_config_completes_text_decoder_modules(monkeypatch):
+    from transformers import AutoConfig
+
+    from soup_cli.utils.completions import complete_target_modules
+
+    outer = SimpleNamespace(
+        model_type="qwen4_exp",
+        text_config=SimpleNamespace(model_type="qwen4_exp_text"),
+    )
+    monkeypatch.setattr(AutoConfig, "from_pretrained", lambda *_args, **_kwargs: outer)
+
+    targets = complete_target_modules("", base="Qwen/Qwen3.8-Flash-Next")
+
+    assert "q_proj" in targets
+    assert "index_qk_proj" in targets
+    assert "in_proj_qkv" in targets
+    assert "in_proj_z" in targets
+    assert "shared_expert_gate" in targets
+    assert "input_mix_weight_down" in targets
+    assert "key_proj" in targets
+
+
+def test_qwen4_exp_text_is_detected_as_moe_without_numeric_hints():
+    from soup_cli.utils.moe import detect_moe_model
+
+    model = SimpleNamespace(config=SimpleNamespace(model_type="qwen4_exp_text"))
+
+    assert detect_moe_model(model) is True
+
+
+def test_qwen4_exp_is_not_admitted_to_layer_streaming_by_name_only():
+    from soup_cli.utils.layer_stream import _STREAM_ARCH_ALIASES, SUPPORTED_STREAM_ARCHS
+
+    assert "qwen4_exp" not in SUPPORTED_STREAM_ARCHS
+    assert "qwen4_exp_text" not in SUPPORTED_STREAM_ARCHS
+    assert "qwen4_exp" not in _STREAM_ARCH_ALIASES
+    assert "qwen4_exp_text" not in _STREAM_ARCH_ALIASES
+
+
+def _tiny_qwen4_exp_config():
+    try:
+        from transformers import Qwen4ExpConfig, Qwen4ExpTextConfig
+    except ImportError:
+        pytest.skip("installed Transformers release does not include qwen4_exp yet")
+
+    text = Qwen4ExpTextConfig(
+        vocab_size=64,
+        hidden_size=16,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        linear_conv_kernel_dim=2,
+        linear_key_head_dim=4,
+        linear_value_head_dim=4,
+        linear_num_key_heads=2,
+        linear_num_value_heads=2,
+        moe_intermediate_size=8,
+        shared_expert_intermediate_size=8,
+        num_experts_per_tok=1,
+        num_experts=2,
+        layer_types=["linear_attention", "full_attention"],
+        max_position_embeddings=64,
+        hc_count=2,
+        hc_lowrank=4,
+        ple_layer_ids=[],
+        use_cache=False,
+        indexer_n_heads=1,
+        indexer_kv_heads=1,
+        indexer_head_dim=8,
+        indexer_budget=8,
+        indexer_compress_ratio=2,
+    )
+    return Qwen4ExpConfig(text_config=text.to_dict())
+
+
+def test_qwen4_exp_outer_config_builds_text_only_causal_lm_and_lora():
+    import torch
+    from peft import LoraConfig, TaskType, get_peft_model
+    from transformers import AutoModelForCausalLM
+
+    from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+
+    model = AutoModelForCausalLM.from_config(_tiny_qwen4_exp_config(), dtype=torch.float32)
+
+    assert type(model).__name__ == "Qwen4ExpForCausalLM"
+    assert model.config.model_type == "qwen4_exp_text"
+    assert not [
+        name
+        for name, _ in model.named_parameters()
+        if "vision" in name or "visual" in name
+    ]
+
+    targets = resolve_lora_target_modules(model, "auto")
+    model = get_peft_model(
+        model,
+        LoraConfig(
+            r=2,
+            lora_alpha=4,
+            target_modules=targets,
+            task_type=TaskType.CAUSAL_LM,
+        ),
+    )
+    batch = torch.tensor([[1, 2, 3, 4]])
+    loss = model(input_ids=batch, labels=batch).loss
+
+    assert torch.isfinite(loss).item()
+    loss.backward()
+    trainable = {
+        name: parameter
+        for name, parameter in model.named_parameters()
+        if parameter.requires_grad
+    }
+    assert trainable
+    for family in (
+        "linear_attn.in_proj_qkv",
+        "self_attn.q_proj",
+        "self_attn.indexer.index_qk_proj",
+        "mlp.shared_expert.gate_proj",
+        "attn_hyper_connection.input_mix_weight_down",
+    ):
+        assert any(family in name for name in trainable)
+    # The four-token probe is too short to activate QSA's compressed-block
+    # indexer, but every other selected text-decoder family must participate in
+    # backward. The indexer assertion above still proves adapter injection.
+    assert all(
+        parameter.grad is not None
+        for name, parameter in trainable.items()
+        if "self_attn.indexer.index_qk_proj" not in name
+    )

--- a/tests/test_issue571_qwen4_exp.py
+++ b/tests/test_issue571_qwen4_exp.py
@@ -106,7 +106,10 @@ def test_qwen4_exp_outer_config_builds_text_only_causal_lm_and_lora():
     from peft import LoraConfig, TaskType, get_peft_model
     from transformers import AutoModelForCausalLM
 
-    from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+    from soup_cli.utils.peft_wiring import (
+        apply_pre_lora_patches,
+        resolve_lora_target_modules,
+    )
 
     model = AutoModelForCausalLM.from_config(_tiny_qwen4_exp_config(), dtype=torch.float32)
 
@@ -119,6 +122,35 @@ def test_qwen4_exp_outer_config_builds_text_only_causal_lm_and_lora():
     ]
 
     targets = resolve_lora_target_modules(model, "auto")
+    torch_int32 = torch.int32
+    indexers = [
+        module
+        for module in model.modules()
+        if type(module).__name__ == "Qwen4ExpTextQSAIndexer"
+    ]
+    class_forward = type(indexers[0]).forward
+    apply_pre_lora_patches(model, "Qwen/Qwen3.8-Flash-Next")
+
+    # The compatibility shim must remain instance-local: neither Torch's dtype
+    # singleton nor the upstream Transformers class may be changed globally.
+    assert torch.int32 is torch_int32
+    assert type(indexers[0]).forward is class_forward
+    int32_scatter_supported = True
+    try:
+        torch.zeros((1, 1), dtype=torch.bool).scatter(
+            -1, torch.zeros((1, 1), dtype=torch.int32), True
+        )
+    except RuntimeError as exc:
+        assert "Expected dtype int64 for index" in str(exc)
+        int32_scatter_supported = False
+    if int32_scatter_supported:
+        assert indexers[0].forward.__func__ is class_forward
+    else:
+        assert indexers[0].forward.__func__ is not class_forward
+    patched_forward = indexers[0].forward.__func__
+    apply_pre_lora_patches(model, "Qwen/Qwen3.8-Flash-Next")
+    assert indexers[0].forward.__func__ is patched_forward
+
     model = get_peft_model(
         model,
         LoraConfig(

--- a/tests/test_transformers_floor_compat.py
+++ b/tests/test_transformers_floor_compat.py
@@ -1,6 +1,6 @@
 """Transformers floor policy and model-load keyword compatibility.
 
-#502 moves the declared floor to Transformers 5.12.1 and #503 moves TRL to 0.29.
+The declared floor is Transformers 5.16.1 for Qwen4-Exp; TRL remains at 0.29.
 The dedicated CI cell installs those exact versions so the normal newest-version
 matrix cannot hide a floor regression. The historical #478 static guard remains:
 Soup continues using the backward-compatible ``torch_dtype=`` spelling at model

--- a/tests/test_transformers_floor_compat.py
+++ b/tests/test_transformers_floor_compat.py
@@ -1,8 +1,8 @@
 """Transformers floor policy and model-load keyword compatibility.
 
-The declared floor is Transformers 5.16.1 for Qwen4-Exp; TRL remains at 0.29.
-The dedicated CI cell installs those exact versions so the normal newest-version
-matrix cannot hide a floor regression. The historical #478 static guard remains:
+The declared floor is Transformers 5.16.1 for Qwen4-Exp; the dedicated CI cell
+also pins Torch 2.5.1 and TRL 0.29 so the normal newest-version matrix cannot
+hide a floor regression. The historical #478 static guard remains:
 Soup continues using the backward-compatible ``torch_dtype=`` spelling at model
 load sites throughout the supported Transformers 5.x range.
 
@@ -282,6 +282,7 @@ class TestFloorConstraintAndWorkflowPins:
             text,
         )
         assert _version_key(pinned) >= _version_key(declared)
+        _constraint_pin(text, "torch")
         _constraint_pin(text, "trl")
         _constraint_pin(text, "peft")
         _constraint_pin(text, "plotext")
@@ -291,16 +292,20 @@ class TestFloorConstraintAndWorkflowPins:
         job = _transformers_floor_job_block(CI_WORKFLOW.read_text(encoding="utf-8"))
         assert "python -m pip check" in job
         assert "-c .github/constraints/transformers-floor.txt" in job
+        assert "tests/test_issue571_qwen4_exp.py" in job
         assert "tests/test_plotext_compat.py" in job
 
-    @pytest.mark.parametrize("package", ["transformers", "trl", "peft", "plotext"])
+    @pytest.mark.parametrize(
+        "package", ["torch", "transformers", "trl", "peft", "plotext"]
+    )
     def test_workflow_version_check_accepts_pins_and_rejects_mismatch(self, package: str):
         constraints = (
-            "transformers==8.8.8\ntrl==9.9.9\npeft==7.7.7\nplotext==6.6.6\n"
+            "torch==2.5.1\ntransformers==8.8.8\ntrl==9.9.9\n"
+            "peft==7.7.7\nplotext==6.6.6\n"
         )
         installed = {
             name: _constraint_pin(constraints, name)
-            for name in ("transformers", "trl", "peft", "plotext")
+            for name in ("torch", "transformers", "trl", "peft", "plotext")
         }
         _run_transformers_floor_version_check(installed, constraints)
 

--- a/tests/test_v0640_part_c.py
+++ b/tests/test_v0640_part_c.py
@@ -735,14 +735,14 @@ def test_cli_env_lock_null_byte_output_rejected(tmp_path, monkeypatch):
 # lists `transformers` only under `extra == "train"/"all"/"dev"`, so no un-gated
 # transformers row exists — see `_TRAIN_TRANSFORMERS` for the real shape and the
 # tests that cover #368 end to end.
-_UNGATED_TRANSFORMERS = ("transformers>=5.12.1,<6.0.0",)
+_UNGATED_TRANSFORMERS = ("transformers>=5.16.1,<6.0.0",)
 
 # The real shape: the `transformers` cap #368 was reported against, exactly as
 # metadata states it — gated behind the extras that pull it in.
 _TRAIN_TRANSFORMERS = (
-    'transformers>=5.12.1,<6.0.0; extra == "train"',
-    'transformers>=5.12.1,<6.0.0; extra == "all"',
-    'transformers>=5.12.1,<6.0.0; extra == "dev"',
+    'transformers>=5.16.1,<6.0.0; extra == "train"',
+    'transformers>=5.16.1,<6.0.0; extra == "all"',
+    'transformers>=5.16.1,<6.0.0; extra == "dev"',
 )
 
 
@@ -765,7 +765,7 @@ def test_check_declared_bounds_control_compliant_passes():
 
     # Control: an in-bounds environment passes, so the check cannot be
     # satisfied by always failing.
-    report = check_declared_bounds(_UNGATED_TRANSFORMERS, {"transformers": "5.15.1"})
+    report = check_declared_bounds(_UNGATED_TRANSFORMERS, {"transformers": "5.16.1"})
     assert report.ok
     assert report.violations == ()
 
@@ -816,10 +816,10 @@ def test_core_bound_counted_once_despite_extra_duplicates():
     from soup_cli.utils.env_lock import check_declared_bounds
 
     reqs = (
-        "transformers>=5.12.1,<6.0.0",
-        'transformers>=5.12.1,<6.0.0; extra == "all"',
-        'transformers>=5.12.1,<6.0.0; extra == "dev"',
-        'transformers>=5.12.1,<6.0.0; extra == "train"',
+        "transformers>=5.16.1,<6.0.0",
+        'transformers>=5.16.1,<6.0.0; extra == "all"',
+        'transformers>=5.16.1,<6.0.0; extra == "dev"',
+        'transformers>=5.16.1,<6.0.0; extra == "train"',
     )
     report = check_declared_bounds(reqs, {"transformers": "6.0.0"})
     assert report.violation_count == 1
@@ -860,8 +860,8 @@ def test_mlx_only_bound_on_tracked_package_is_enforced():
     # is now part of the ABI-sensitive bounds audit too.
     from soup_cli.utils.env_lock import check_declared_bounds
 
-    mlx_only = ('transformers>=5.12.1,<6.0.0; extra == "mlx"',)
-    assert check_declared_bounds(mlx_only, {"transformers": "5.15.1"}).ok
+    mlx_only = ('transformers>=5.16.1,<6.0.0; extra == "mlx"',)
+    assert check_declared_bounds(mlx_only, {"transformers": "5.16.1"}).ok
     assert not check_declared_bounds(mlx_only, {"transformers": "6.0.0"}).ok
 
     # The identical training/MLX bounds deduplicate to one violation.
@@ -917,7 +917,7 @@ def test_current_declared_bounds_check_real_path_detects_violation(monkeypatch):
 
     from soup_cli.utils import env_lock
 
-    monkeypatch.setattr(md, "requires", lambda dist: ["transformers>=5.12.1,<6.0.0"])
+    monkeypatch.setattr(md, "requires", lambda dist: ["transformers>=5.16.1,<6.0.0"])
     monkeypatch.setattr(
         env_lock,
         "_detect_package_version",
@@ -938,7 +938,7 @@ def test_cli_env_check_declared_bound_violation_exits_3(tmp_path, monkeypatch):
     violation = BoundViolation(
         name="transformers",
         installed="6.0.0",
-        specifier=">=5.12.1,<6.0.0",
+        specifier=">=5.16.1,<6.0.0",
         extra=None,
     )
     monkeypatch.setattr(
@@ -967,7 +967,7 @@ def test_cli_env_check_bound_violation_escapes_rich_markup(tmp_path, monkeypatch
     violation = BoundViolation(
         name="[bold]evil[/bold]",
         installed="6.0.0",
-        specifier=">=5.12.1,<6.0.0",
+        specifier=">=5.16.1,<6.0.0",
         extra=None,
     )
     monkeypatch.setattr(


### PR DESCRIPTION
Closes #571.

## Summary

- raise the shared `[train]` / `[mlx]` Transformers floor to 5.16.1, the first validated stable Qwen4-Exp release with the 5.16.1 tensor-parallel compatibility fix
- resolve `target_modules: auto` to PEFT `all-linear` for `qwen4_exp_text`, while preserving explicit targets
- complete the actual QSA, Gated DeltaNet, shared-expert, PLE, and gated-residual linear families from the nested text config
- recognize `qwen4_exp_text` as MoE
- add a real tiny-config gate proving outer `qwen4_exp` -> text-only `Qwen4ExpForCausalLM`, finite loss/backward, and LoRA injection across the new linear paths
- explicitly keep Qwen4-Exp outside layer streaming until architecture parity is demonstrated

## Validation

- `ruff check src/soup_cli/ tests/`
- focused mypy: 3 changed source files clean
- targeted compatibility suite: 156 passed
- full suite under Transformers 5.16.1: 18,965 passed, 82 skipped, 5 deselected; coverage 82.81%
- dependency/import check with Transformers 5.16.1, TRL 0.29.1, PEFT 0.20.0, MLX 0.31.2, and MLX-LM 0.31.3

## Deliberate limits

This is a weight-free compatibility scaffold, not a full checkpoint certification. It does not add a catalog recipe or claim a real-weight Apple-Silicon memory fit, multimodal fine-tuning, layer streaming, or routed-expert adaptation. Qwen4-Exp routed experts are raw 3-D parameters, so covering them needs separate PEFT `target_parameters` wiring and independent validation.

Official references:
- https://huggingface.co/Qwen/Qwen3.8-Flash-Next
- https://github.com/huggingface/transformers/pull/48337
- https://github.com/huggingface/transformers/releases/tag/v5.16.1