### PR TITLE
fix(mcp): correct execution-tool refusal message (#483)

### DIFF
--- a/changelog.d/0.73.3/574.fixed.md
+++ b/changelog.d/0.73.3/574.fixed.md
@@ -1,0 +1,7 @@
+- [#574](https://github.com/MakazhanAlpamys/Soup/pull/574) corrects the MCP
+  execution-tool refusal, which told operators to restart with `--allow-execute`
+  and then falsely added that execution tools "are not implemented in this
+  version" — execution shipped in v0.73.3 (#297). The refusal now names the
+  disabled tool and the flag that enables it, and the stale `build_registry`
+  docstring no longer describes `allow_execute` as reserved for future tools.
+  Closes #483.

--- a/src/soup_cli/mcp_server/registry.py
+++ b/src/soup_cli/mcp_server/registry.py
@@ -1024,8 +1024,7 @@ def _refuse_execute(name: str) -> Callable[[dict], dict]:
     def _handler(args: dict) -> dict:
         raise McpToolError(
             f"'{name}' can execute commands and is disabled; restart with "
-            "'soup mcp serve --allow-execute' to enable. Execution tools are "
-            "not implemented in this version."
+            "'soup mcp serve --allow-execute' to enable."
         )
 
     return _handler
@@ -1120,8 +1119,8 @@ def build_registry(
 
     The read-only tools are always present and executable. The mutating tools
     are always listed but refuse unless ``allow_mutating`` is set (and are
-    plan-only even then). ``allow_execute`` is retained separately for future
-    execution tools, and implies ``allow_mutating`` for the existing tools.
+    plan-only even then). ``allow_execute`` gates the execution tools
+    (``train_execute`` / ``export_execute``) and implies ``allow_mutating``.
     """
     allow_mutating = allow_mutating or allow_execute
     if allow_execute and execution is None:

--- a/tests/test_mcp_execute.py
+++ b/tests/test_mcp_execute.py
@@ -53,6 +53,21 @@ class TestMcpExecutionGates:
             )
         assert "allow-execute" in str(exc.value).lower()
 
+    def test_refusal_message_names_tool_and_flag_without_claiming_unimplemented(self):
+        # The refusal must guide the operator: name the disabled tool and the
+        # flag that enables it. It must NOT claim execution is unimplemented --
+        # execution shipped in v0.73.3 (#297), so that sentence is false and
+        # tells operators the working --allow-execute flag is a stub (#483).
+        for name in ("train_execute", "export_execute"):
+            with pytest.raises(reg.McpToolError) as exc:
+                _spec(name, allow_mutating=False, allow_execute=False).handler(
+                    {"confirmation_token": "token123"}
+                )
+            message = str(exc.value)
+            assert name in message
+            assert "allow-execute" in message.lower()
+            assert "not implemented" not in message.lower()
+
     def test_allow_execute_enables_execution(self):
         manager = ExecutionManager()
         manager.issue(kind="train", argv=["soup"], display_command="soup")

--- a/tests/test_v07128.py
+++ b/tests/test_v07128.py
@@ -527,8 +527,13 @@ class TestMutatingTools:
     def test_execute_refusal_names_flag_and_preserves_no_execution(self):
         with pytest.raises(reg.McpToolError) as exc:
             reg._refuse_execute("train_execute")({})
-        assert "allow-execute" in str(exc.value)
-        assert "not implemented" in str(exc.value)
+        message = str(exc.value)
+        # The refusal names the disabled tool and the flag that enables it ...
+        assert "train_execute" in message
+        assert "allow-execute" in message
+        # ... and must NOT claim execution is unimplemented: it shipped in
+        # v0.73.3 (#297), so that sentence was false and was removed (#483).
+        assert "not implemented" not in message
 
     def test_train_start_invalid_config_raises(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
Closes #483.

## Problem

`soup mcp serve` without `--allow-execute` refuses `train_execute` / `export_execute` with a message whose two halves contradict each other:

```
'train_execute' can execute commands and is disabled; restart with
'soup mcp serve --allow-execute' to enable. Execution tools are
not implemented in this version.
```

The first half tells the operator to restart with `--allow-execute`; the second half says it would not help. The second sentence is **false** — execution shipped in v0.73.3 (#297): `mcp_server/execution.py`, the `train_execute` / `export_execute` handlers, and the server-generated confirmation token. The string predates that release and was never updated. As written, the message actively discourages operators from using a feature that works.

## Changes

1. **`_refuse_execute`** (`registry.py`): drop the false sentence. The actionable half stays — it names the disabled tool and the `--allow-execute` flag that enables it.
2. **`build_registry` docstring** (`registry.py`): the sibling stale line described `allow_execute` as "retained separately for **future** execution tools" — same vintage, same wrong tense. Now describes it as gating the existing `train_execute` / `export_execute` tools.
3. **Behavioral test** (`test_mcp_execute.py`): calls the handler and asserts on the raised `McpToolError` — that it names the tool and `--allow-execute`, and does **not** contain "not implemented".

The test is behavioral by design, per the issue: `build_registry` always *lists* both execution tools and swaps only the handler, so a name-comparison test passes in both gate states and guards nothing (that is how the analogous #479 defect stayed invisible).

## Verification

- Test fails first for the right reason (RED), passes after the fix (GREEN).
- Confirmed **by running** — not inspection — that restoring the deleted sentence fails the test.
- `grep -rn "not implemented" src/soup_cli/mcp_server/` → no stale hits.
- `ruff check src/soup_cli/mcp_server/registry.py tests/test_mcp_execute.py` → all passed.
- Full `tests/test_mcp_execute.py` + `tests/test_issue322_mcp2_compat.py` → 48 passed.

## Acceptance criteria

- [x] No user-facing string or docstring in `mcp_server/` claims execution is unimplemented or future
- [x] A behavioural test asserts the refusal names the tool and `--allow-execute` and does not contain "not implemented"
- [x] The test fails if the sentence is restored (verified by running)
- [x] `grep -rn "not implemented" src/soup_cli/mcp_server/` returns nothing stale
