### PR TITLE
feat(peft): support Qwen4 routed expert LoRA

### DIFF
--- a/changelog.d/0.73.3/575.added.md
+++ b/changelog.d/0.73.3/575.added.md
@@ -1,0 +1,4 @@
+- [#575](https://github.com/MakazhanAlpamys/Soup/pull/575) adds opt-in PEFT
+  `target_parameters` LoRA for Qwen4-Exp routed `gate_up_proj` and `down_proj`
+  expert tensors in resident Transformers SFT and continued pretraining, with
+  validated compatibility constraints and weight-free backward/save/reload coverage.

--- a/docs/peft-and-efficiency.md
+++ b/docs/peft-and-efficiency.md
@@ -215,6 +215,32 @@ fallback because PEFT does not yet map `qwen3_5_text`. Soup targets `q_proj` and
 linear-attention layers. Explicit target lists still win unchanged. The MLX backend
 keeps its separate full-key default (`self_attn.q_proj`, `self_attn.v_proj`).
 
+Qwen4-Exp routed experts are raw 3-D parameters rather than `nn.Linear` modules, so
+`target_modules: auto` / `all-linear` deliberately does not include them. Opt into
+PEFT's parameter-targeting path for a higher-capacity resident SFT or continued-pretrain
+adapter:
+
+```yaml
+training:
+  lora:
+    r: 16
+    alpha: 32
+    dropout: 0                 # required by PEFT ParamWrapper
+    target_modules: auto       # every Qwen4-Exp linear family
+    target_parameters: auto    # routed gate_up_proj + down_proj tensors
+    rank_pattern:
+      experts.gate_up_proj: 2
+      experts.down_proj: 2
+```
+
+`target_parameters: auto` fails closed when an architecture has no registered mapping;
+an explicit list of parameter-name suffixes is also accepted. It is currently limited to
+resident text `sft` / `pretrain` on the Transformers backend and plain LoRA/rsLoRA with
+random initialization. PEFT requires zero dropout for raw parameters and warns that
+`torch.compile` may recompile or graph-break around parameter wrappers. Parameter-targeted
+MoE adapters also materialize a contribution for every expert during inference; merge the
+adapter into the base for deployment when hot-swapping is not required.
+
 See `soup_cli.utils.optimizer_zoo.SUPPORTED_OPTIMIZERS` for the complete optimizer allowlist.
 
 

--- a/src/soup_cli/config/schema.py
+++ b/src/soup_cli/config/schema.py
@@ -30,6 +30,8 @@ from soup_cli.utils.ship_verdict import (
 # v0.39.0 Part C — per-pattern LoRA rank/alpha bounds
 _MAX_LORA_RANK_PATTERN_KEYS = 256
 _MAX_LORA_RANK_PATTERN_VALUE = 1024
+_MAX_LORA_TARGET_PARAMETERS = 256
+_MAX_LORA_TARGET_PARAMETER_LEN = 512
 
 # v0.71.23 #266 — Spectrum targeted-training unfrozen-parameter caps
 _MAX_UNFROZEN_PARAMETERS = 50_000
@@ -71,6 +73,16 @@ class LoraConfig(BaseModel):
     target_modules: Union[str, List[str]] = Field(
         default="auto",
         description="Target modules for LoRA. 'auto' = let peft decide.",
+    )
+    target_parameters: Optional[Union[Literal["auto"], List[str]]] = Field(
+        default=None,
+        description=(
+            "Raw 2-D/3-D nn.Parameter tensors to adapt with PEFT LoRA. "
+            "Use 'auto' to select architecture-specific parameter targets "
+            "(currently Qwen4-Exp routed experts), a list of parameter-name "
+            "suffixes for explicit control, or omit to disable. Requires "
+            "dropout=0 and is wired for transformers SFT/pretrain."
+        ),
     )
     use_dora: bool = Field(
         default=False,
@@ -231,6 +243,67 @@ class LoraConfig(BaseModel):
                 )
             cleaned[key] = val
         return cleaned
+
+    @field_validator("target_parameters", mode="before")
+    @classmethod
+    def _validate_target_parameters(cls, value):
+        if value is None or value == "auto":
+            return value
+        if not isinstance(value, list):
+            raise ValueError("target_parameters must be 'auto', a list[str], or null")
+        if len(value) > _MAX_LORA_TARGET_PARAMETERS:
+            raise ValueError(
+                f"target_parameters caps at {_MAX_LORA_TARGET_PARAMETERS} entries, "
+                f"got {len(value)}"
+            )
+        cleaned: List[str] = []
+        seen = set()
+        for index, entry in enumerate(value):
+            if not isinstance(entry, str) or not entry.strip():
+                raise ValueError(
+                    f"target_parameters[{index}] must be a non-empty string"
+                )
+            target = entry.strip()
+            if target == "auto":
+                raise ValueError(
+                    "target_parameters: use scalar 'auto', not ['auto']"
+                )
+            if "\x00" in target:
+                raise ValueError("target_parameters entries cannot contain null bytes")
+            if len(target) > _MAX_LORA_TARGET_PARAMETER_LEN:
+                raise ValueError(
+                    "target_parameters entries cap at "
+                    f"{_MAX_LORA_TARGET_PARAMETER_LEN} characters"
+                )
+            if target not in seen:
+                cleaned.append(target)
+                seen.add(target)
+        return cleaned
+
+    @model_validator(mode="after")
+    def _validate_target_parameter_compat(self) -> "LoraConfig":
+        if not self.target_parameters:
+            return self
+        if self.dropout != 0:
+            raise ValueError(
+                "target_parameters requires lora.dropout=0 because PEFT cannot "
+                "apply dropout correctly to raw nn.Parameter tensors"
+            )
+        if self.use_dora:
+            raise ValueError(
+                "target_parameters is incompatible with use_dora=True in PEFT"
+            )
+        if self.use_vera:
+            raise ValueError(
+                "target_parameters is a LoRA-only PEFT feature and is incompatible "
+                "with use_vera=True"
+            )
+        if self.init_strategy != "random":
+            raise ValueError(
+                "target_parameters currently requires init_strategy='random'; "
+                "PiSSA, OLoRA, and LoftQ are not validated for raw 3-D parameters"
+            )
+        return self
 
     @model_validator(mode="after")
     def _validate_pattern_vera_exclusivity(self) -> "LoraConfig":
@@ -4785,6 +4858,8 @@ class SoupConfig(BaseModel):
             lora_conflicts.append("lora.use_olora")
         if lcfg.use_rslora:
             lora_conflicts.append("lora.use_rslora")
+        if lcfg.target_parameters:
+            lora_conflicts.append("lora.target_parameters")
         if tcfg.moe_lora:
             lora_conflicts.append("moe_lora")
         if tcfg.use_longlora:
@@ -4881,6 +4956,8 @@ class SoupConfig(BaseModel):
             lora_conflicts.append("lora.use_olora")
         if lcfg.use_rslora:
             lora_conflicts.append("lora.use_rslora")
+        if lcfg.target_parameters:
+            lora_conflicts.append("lora.target_parameters")
         if tcfg.moe_lora:
             lora_conflicts.append("moe_lora")
         if tcfg.use_longlora:
@@ -4969,6 +5046,8 @@ class SoupConfig(BaseModel):
             lora_conflicts.append("lora.rank_pattern")
         if lcfg.alpha_pattern is not None:
             lora_conflicts.append("lora.alpha_pattern")
+        if lcfg.target_parameters:
+            lora_conflicts.append("lora.target_parameters")
         if getattr(lcfg, "init_strategy", "random") != "random":
             lora_conflicts.append("lora.init_strategy")
         if tcfg.moe_lora:
@@ -4984,6 +5063,34 @@ class SoupConfig(BaseModel):
                 f"training.lora.r=0 means full fine-tuning (no adapter), so it "
                 f"is mutually exclusive with LoRA features: "
                 f"{', '.join(lora_conflicts)}. Set lora.r >= 1 to use them."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_lora_target_parameters_scope(self) -> "SoupConfig":
+        """#573 — raw-parameter LoRA is live in resident SFT/pretrain only."""
+        targets = self.training.lora.target_parameters
+        if not targets:
+            return self
+        if self.task not in ("sft", "pretrain"):
+            raise ValueError(
+                "training.lora.target_parameters requires task='sft' or "
+                f"task='pretrain'; got task={self.task!r}"
+            )
+        if self.backend != "transformers":
+            raise ValueError(
+                "training.lora.target_parameters requires backend='transformers'; "
+                f"got backend={self.backend!r}"
+            )
+        if self.modality != "text":
+            raise ValueError(
+                "training.lora.target_parameters requires modality='text'; "
+                f"got modality={self.modality!r}"
+            )
+        if self.training.stream_layers:
+            raise ValueError(
+                "training.lora.target_parameters is not yet supported with "
+                "training.stream_layers=true; use resident SFT/pretrain"
             )
         return self
 

--- a/src/soup_cli/trainer/pretrain.py
+++ b/src/soup_cli/trainer/pretrain.py
@@ -337,11 +337,19 @@ class PretrainTrainerWrapper:
         # of decoder layers, so it fully replaces the LoRA path below (the
         # schema cross-validator guarantees no LoRA-feature / freeze flag is
         # combined). Shared with the SFT trainer so the two cannot drift.
-        from soup_cli.utils.peft_wiring import apply_lisa_setup, resolve_lora_target_modules
+        from soup_cli.utils.peft_wiring import (
+            apply_lisa_setup,
+            build_lora_config_kwargs,
+            resolve_lora_target_modules,
+            resolve_lora_target_parameters,
+        )
 
         if not apply_lisa_setup(self.model, tcfg, console):
             # LoRA — with MoE-aware target modules if moe_lora is enabled
             target_modules = resolve_lora_target_modules(self.model, tcfg.lora.target_modules)
+            target_parameters = resolve_lora_target_parameters(
+                self.model, tcfg.lora.target_parameters
+            )
 
             if tcfg.moe_lora and is_moe:
                 moe_targets = get_moe_target_modules(self.model)
@@ -352,14 +360,12 @@ class PretrainTrainerWrapper:
                     )
 
             lora_config = LoraConfig(
-                r=tcfg.lora.r,
-                lora_alpha=tcfg.lora.alpha,
-                lora_dropout=tcfg.lora.dropout,
-                target_modules=target_modules,
-                task_type=TaskType.CAUSAL_LM,
-                bias="none",
-                use_dora=tcfg.lora.use_dora,
-                use_rslora=tcfg.lora.use_rslora,
+                **build_lora_config_kwargs(
+                    tcfg.lora,
+                    target_modules=target_modules,
+                    target_parameters=target_parameters,
+                    task_type=TaskType.CAUSAL_LM,
+                )
             )
             # v0.40.6 #67 — surgical PEFT patches.
             from soup_cli.utils.peft_wiring import (

--- a/src/soup_cli/trainer/sft.py
+++ b/src/soup_cli/trainer/sft.py
@@ -1498,10 +1498,17 @@ class SFTTrainerWrapper(StreamingSetupMixin):
             )
         else:
             # LoRA — with MoE-aware target modules if moe_lora is enabled
-            from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+            from soup_cli.utils.peft_wiring import (
+                build_lora_config_kwargs,
+                resolve_lora_target_modules,
+                resolve_lora_target_parameters,
+            )
 
             target_modules = resolve_lora_target_modules(
                 self.model, tcfg.lora.target_modules
+            )
+            target_parameters = resolve_lora_target_parameters(
+                self.model, tcfg.lora.target_parameters
             )
 
             if tcfg.moe_lora and is_moe:
@@ -1514,14 +1521,12 @@ class SFTTrainerWrapper(StreamingSetupMixin):
                     )
 
             lora_config = LoraConfig(
-                r=tcfg.lora.r,
-                lora_alpha=tcfg.lora.alpha,
-                lora_dropout=tcfg.lora.dropout,
-                target_modules=target_modules,
-                task_type=TaskType.CAUSAL_LM,
-                bias="none",
-                use_dora=tcfg.lora.use_dora,
-                use_rslora=tcfg.lora.use_rslora,
+                **build_lora_config_kwargs(
+                    tcfg.lora,
+                    target_modules=target_modules,
+                    target_parameters=target_parameters,
+                    task_type=TaskType.CAUSAL_LM,
+                )
             )
             # v0.39.0 Part D / v0.40.6 #67 — surgical PEFT patches via shared helpers.
             from soup_cli.utils.peft_wiring import (

--- a/src/soup_cli/utils/peft_wiring.py
+++ b/src/soup_cli/utils/peft_wiring.py
@@ -38,6 +38,25 @@ QWEN35_TEXT_LORA_TARGETS = (
 # tracked separately from this safe linear-module baseline.
 QWEN4_EXP_TEXT_LORA_TARGETS = "all-linear"
 
+# Qwen4-Exp's routed experts keep their projections as two raw 3-D
+# ``nn.Parameter`` tensors per decoder layer. ``all-linear`` cannot see them;
+# PEFT 0.20's ``target_parameters`` path can adapt both, with the expert axis at
+# dimension zero.
+QWEN4_EXP_TEXT_LORA_TARGET_PARAMETERS = (
+    "mlp.experts.gate_up_proj",
+    "mlp.experts.down_proj",
+)
+
+
+def _model_types(model: Any) -> set[Any]:
+    """Return outer/text model types without importing Transformers."""
+    config = getattr(model, "config", model)
+    text_config = getattr(config, "text_config", None)
+    return {
+        getattr(config, "model_type", None),
+        getattr(text_config, "model_type", None),
+    }
+
 
 def resolve_lora_target_modules(model: Any, configured: Any) -> Any:
     """Resolve ``target_modules: auto`` for models PEFT does not know yet.
@@ -51,12 +70,7 @@ def resolve_lora_target_modules(model: Any, configured: Any) -> Any:
     if configured != "auto" and configured != ["auto"]:
         return configured
 
-    config = getattr(model, "config", model)
-    text_config = getattr(config, "text_config", None)
-    model_types = {
-        getattr(config, "model_type", None),
-        getattr(text_config, "model_type", None),
-    }
+    model_types = _model_types(model)
     if model_types & {
         "qwen3_5",
         "qwen3_5_text",
@@ -67,6 +81,52 @@ def resolve_lora_target_modules(model: Any, configured: Any) -> Any:
     if "qwen4_exp_text" in model_types:
         return QWEN4_EXP_TEXT_LORA_TARGETS
     return None
+
+
+def resolve_lora_target_parameters(model: Any, configured: Any) -> Any:
+    """Resolve opt-in raw-parameter LoRA targets for supported architectures.
+
+    ``None`` and an empty list disable raw-parameter targeting. Explicit lists
+    always win unchanged. ``auto`` fails closed on unknown architectures so a
+    user cannot request expert adaptation and silently train only modules.
+    """
+    if configured is None or configured == []:
+        return configured
+    if configured != "auto":
+        return configured
+    if "qwen4_exp_text" in _model_types(model):
+        return list(QWEN4_EXP_TEXT_LORA_TARGET_PARAMETERS)
+    raise ValueError(
+        "training.lora.target_parameters='auto' has no mapping for model_type="
+        f"{sorted(str(value) for value in _model_types(model) if value is not None)!r}; "
+        "provide an explicit parameter-name list or omit target_parameters"
+    )
+
+
+def build_lora_config_kwargs(
+    lora_cfg: Any,
+    *,
+    target_modules: Any,
+    target_parameters: Any,
+    task_type: Any,
+) -> dict[str, Any]:
+    """Build the shared PEFT LoRA kwargs used by resident SFT/pretrain."""
+    kwargs = {
+        "r": lora_cfg.r,
+        "lora_alpha": lora_cfg.alpha,
+        "lora_dropout": lora_cfg.dropout,
+        "target_modules": target_modules,
+        "target_parameters": target_parameters,
+        "task_type": task_type,
+        "bias": "none",
+        "use_dora": lora_cfg.use_dora,
+        "use_rslora": lora_cfg.use_rslora,
+    }
+    if lora_cfg.rank_pattern:
+        kwargs["rank_pattern"] = dict(lora_cfg.rank_pattern)
+    if lora_cfg.alpha_pattern:
+        kwargs["alpha_pattern"] = dict(lora_cfg.alpha_pattern)
+    return kwargs
 
 
 def apply_pre_lora_patches(model: Any, base: str) -> None:

--- a/tests/test_issue573_qwen4_expert_lora.py
+++ b/tests/test_issue573_qwen4_expert_lora.py
@@ -1,0 +1,259 @@
+"""#573 — Qwen4-Exp LoRA over routed-expert raw parameters."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+
+def _soup_config(*, task="sft", backend="transformers", modality="text", lora=None):
+    from soup_cli.config.schema import SoupConfig
+
+    return SoupConfig(
+        base="Qwen/Qwen3.8-Flash-Next",
+        task=task,
+        backend=backend,
+        modality=modality,
+        data={"train": "train.jsonl"},
+        training={
+            "quantization": "none",
+            "lora": lora or {"dropout": 0, "target_parameters": "auto"},
+        },
+    )
+
+
+def test_target_parameters_schema_is_opt_in_and_normalizes_explicit_names():
+    from soup_cli.config.schema import LoraConfig
+
+    assert LoraConfig().target_parameters is None
+    config = LoraConfig(
+        dropout=0,
+        target_parameters=[
+            " mlp.experts.gate_up_proj ",
+            "mlp.experts.down_proj",
+            "mlp.experts.gate_up_proj",
+        ],
+    )
+
+    assert config.target_parameters == [
+        "mlp.experts.gate_up_proj",
+        "mlp.experts.down_proj",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("lora", "message"),
+    [
+        ({"target_parameters": "auto"}, "dropout=0"),
+        (
+            {"dropout": 0, "target_parameters": "auto", "use_dora": True},
+            "use_dora",
+        ),
+        (
+            {"dropout": 0, "target_parameters": "auto", "use_vera": True},
+            "use_vera",
+        ),
+        (
+            {
+                "dropout": 0,
+                "target_parameters": "auto",
+                "init_strategy": "pissa",
+            },
+            "init_strategy='random'",
+        ),
+        ({"dropout": 0, "target_parameters": ["auto"]}, "scalar 'auto'"),
+    ],
+)
+def test_target_parameters_rejects_unsupported_peft_combinations(lora, message):
+    with pytest.raises(ValidationError, match=message):
+        _soup_config(lora=lora)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"task": "dpo"}, "task='sft' or task='pretrain'"),
+        ({"backend": "mlx"}, "backend='transformers'"),
+        ({"modality": "vision"}, "modality='text'"),
+    ],
+)
+def test_target_parameters_is_scoped_to_resident_text_sft_and_pretrain(
+    overrides, message
+):
+    kwargs = {
+        "task": "sft",
+        "backend": "transformers",
+        "modality": "text",
+    }
+    kwargs.update(overrides)
+
+    with pytest.raises(ValidationError, match=message):
+        _soup_config(**kwargs)
+
+
+def test_qwen4_exp_auto_resolves_both_routed_expert_parameters():
+    from soup_cli.utils.peft_wiring import resolve_lora_target_parameters
+
+    outer = SimpleNamespace(
+        model_type="qwen4_exp",
+        text_config=SimpleNamespace(model_type="qwen4_exp_text"),
+    )
+
+    assert resolve_lora_target_parameters(outer, "auto") == [
+        "mlp.experts.gate_up_proj",
+        "mlp.experts.down_proj",
+    ]
+
+
+def test_target_parameters_accepts_continued_pretraining():
+    config = _soup_config(task="pretrain")
+
+    assert config.training.lora.target_parameters == "auto"
+
+
+def test_target_parameter_auto_fails_closed_for_unknown_architecture():
+    from soup_cli.utils.peft_wiring import resolve_lora_target_parameters
+
+    with pytest.raises(ValueError, match="has no mapping"):
+        resolve_lora_target_parameters(SimpleNamespace(model_type="unknown"), "auto")
+
+
+def test_shared_sft_pretrain_kwargs_forward_parameter_and_rank_targets():
+    from soup_cli.utils.peft_wiring import build_lora_config_kwargs
+
+    lora = _soup_config(
+        lora={
+            "r": 16,
+            "alpha": 32,
+            "dropout": 0,
+            "target_parameters": "auto",
+            "rank_pattern": {"experts.gate_up_proj": 2},
+            "alpha_pattern": {"experts.gate_up_proj": 4},
+        }
+    ).training.lora
+    kwargs = build_lora_config_kwargs(
+        lora,
+        target_modules="all-linear",
+        target_parameters=["mlp.experts.gate_up_proj"],
+        task_type="CAUSAL_LM",
+    )
+
+    assert kwargs["target_modules"] == "all-linear"
+    assert kwargs["target_parameters"] == ["mlp.experts.gate_up_proj"]
+    assert kwargs["rank_pattern"] == {"experts.gate_up_proj": 2}
+    assert kwargs["alpha_pattern"] == {"experts.gate_up_proj": 4}
+
+
+def _tiny_qwen4_exp_config():
+    try:
+        from transformers import Qwen4ExpConfig, Qwen4ExpTextConfig
+    except ImportError:
+        pytest.skip("installed Transformers release does not include qwen4_exp yet")
+
+    text = Qwen4ExpTextConfig(
+        vocab_size=64,
+        hidden_size=16,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        linear_conv_kernel_dim=2,
+        linear_key_head_dim=4,
+        linear_value_head_dim=4,
+        linear_num_key_heads=2,
+        linear_num_value_heads=2,
+        moe_intermediate_size=8,
+        shared_expert_intermediate_size=8,
+        num_experts_per_tok=1,
+        num_experts=2,
+        layer_types=["linear_attention", "full_attention"],
+        max_position_embeddings=64,
+        hc_count=2,
+        hc_lowrank=4,
+        ple_layer_ids=[],
+        use_cache=False,
+        indexer_n_heads=1,
+        indexer_kv_heads=1,
+        indexer_head_dim=8,
+        indexer_budget=8,
+        indexer_compress_ratio=2,
+    )
+    return Qwen4ExpConfig(text_config=text.to_dict())
+
+
+def test_qwen4_exp_expert_adapters_backward_save_and_reload(tmp_path):
+    import torch
+    from peft import LoraConfig, PeftModel, TaskType, get_peft_model
+    from peft.utils.save_and_load import get_peft_model_state_dict
+    from transformers import AutoModelForCausalLM
+
+    from soup_cli.utils.peft_wiring import (
+        build_lora_config_kwargs,
+        resolve_lora_target_modules,
+        resolve_lora_target_parameters,
+    )
+
+    config = _tiny_qwen4_exp_config()
+    torch.manual_seed(7)
+    base = AutoModelForCausalLM.from_config(config, dtype=torch.float32)
+    soup_lora = _soup_config(
+        lora={
+            "r": 2,
+            "alpha": 4,
+            "dropout": 0,
+            "target_parameters": "auto",
+            "rank_pattern": {"experts.gate_up_proj": 1},
+        }
+    ).training.lora
+    model = get_peft_model(
+        base,
+        LoraConfig(
+            **build_lora_config_kwargs(
+                soup_lora,
+                target_modules=resolve_lora_target_modules(base, "auto"),
+                target_parameters=resolve_lora_target_parameters(base, "auto"),
+                task_type=TaskType.CAUSAL_LM,
+            )
+        ),
+    )
+
+    batch = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]])
+    loss = model(input_ids=batch, labels=batch).loss
+    assert torch.isfinite(loss).item()
+    loss.backward()
+
+    expert_adapter_params = {
+        name: parameter
+        for name, parameter in model.named_parameters()
+        if parameter.requires_grad and "mlp.experts" in name
+    }
+    assert expert_adapter_params
+    assert any("base_layer.lora_A" in name for name in expert_adapter_params)
+    assert any("experts.lora_A" in name for name in expert_adapter_params)
+    assert all(parameter.grad is not None for parameter in expert_adapter_params.values())
+    assert all(
+        torch.isfinite(parameter.grad).all().item()
+        for parameter in expert_adapter_params.values()
+    )
+
+    optimizer = torch.optim.SGD(
+        [parameter for parameter in model.parameters() if parameter.requires_grad],
+        lr=0.1,
+    )
+    optimizer.step()
+    before = get_peft_model_state_dict(model)
+    model.save_pretrained(tmp_path)
+
+    torch.manual_seed(7)
+    fresh = AutoModelForCausalLM.from_config(config, dtype=torch.float32)
+    loaded = PeftModel.from_pretrained(fresh, tmp_path, is_trainable=True)
+    after = get_peft_model_state_dict(loaded)
+
+    assert loaded.peft_config["default"].target_parameters == [
+        "mlp.experts.gate_up_proj",
+        "mlp.experts.down_proj",
+    ]
+    assert before.keys() == after.keys()
+    assert all(torch.equal(before[key].cpu(), after[key].cpu()) for key in before)


### PR DESCRIPTION
## Summary

- add an opt-in, validated `training.lora.target_parameters` surface for raw 2-D/3-D PEFT LoRA parameters
- resolve Qwen4-Exp `auto` targets to `mlp.experts.gate_up_proj` and `mlp.experts.down_proj` while preserving explicit lists and failing closed on unknown architectures
- wire parameter targets and per-pattern rank/alpha overrides through resident Transformers SFT and continued pretraining
- prove finite backward gradients plus exact adapter save/reload on a tiny real Qwen4-Exp causal LM
- document PEFT ParamWrapper constraints and the deployment merge recommendation

## Compatibility policy

This is opt-in so the safe `all-linear` baseline from #572 remains unchanged. Raw-parameter LoRA requires `lora.dropout: 0`; Soup also rejects unvalidated DoRA, VeRA, non-random initialization, MLX, non-text tasks, and layer streaming instead of silently ignoring the request. Plain LoRA and rsLoRA remain supported, including `rank_pattern` / `alpha_pattern`.

## Validation

- `ruff check src/soup_cli/ scripts/ tests/`
- focused Qwen4/schema/SFT/pretrain checks: 137 passed
- full suite under Transformers 5.16.1: 18,979 passed, 82 skipped, 5 deselected; 82.81% coverage

## Dependency

Depends on #572. This PR is intentionally draft until #572 lands; its diff against `main` currently includes that prerequisite scaffold and will collapse to the routed-expert follow-up after the base merge.

Closes #573.