### PR TITLE
fix(eval-gate): use active rubric scale for judge score normalization (#577)

### DIFF
--- a/changelog.d/0.73.3/578.fixed.md
+++ b/changelog.d/0.73.3/578.fixed.md
@@ -1,0 +1,11 @@
+- **Eval-gate LLM judge normalization uses the active rubric scale instead of
+  hardcoded `/ 10.0` (#577 by @here-2007 in #578).** `_run_judge_task` in
+  `eval/gate.py` divided the aggregate judge score by `10.0`, assuming a 1–10
+  scale, while `DEFAULT_RUBRIC` in `eval/judge.py` uses 1–5. A perfect judge
+  score of 5.0 normalized to 0.50 instead of 1.00, making typical gate
+  thresholds (0.70, 0.80) impossible to satisfy and triggering false-positive
+  training stops under `on_regression: stop`. Normalization now dynamically
+  derives `scale_min` and `scale_max` from `evaluator.rubric["scale"]` via
+  min-max scaling to `[0.0, 1.0]`, clamps out-of-bounds values, handles
+  degenerate scales (`min == max`), and aligns with the existing dynamic
+  normalization in `commands/ship.py`.

--- a/src/soup_cli/eval/gate.py
+++ b/src/soup_cli/eval/gate.py
@@ -425,8 +425,8 @@ def _run_judge_task(
     task: GateTask, generate_fn: Callable[[str], str],
 ) -> float:
     """Run a type=judge task. Generates a completion per prompt, then asks
-    the judge model to score the (prompt, response) pair on a 1-10 scale.
-    Aggregate score is normalised to [0, 1] (mean / 10).
+    the judge model to score the (prompt, response) pair according to the
+    evaluator's rubric. Aggregate score is normalised to [0, 1] via min-max.
     """
     if not task.prompts:
         raise ValueError(f"task '{task.name}' is type=judge but 'prompts' is missing")
@@ -470,9 +470,27 @@ def _run_judge_task(
         return 0.0
 
     results = evaluator.evaluate_batch(items)
-    # results.overall_score is on a 1-10 scale; normalise to [0, 1].
-    overall = float(getattr(results, "overall_score", 0.0))
-    return max(0.0, min(1.0, overall / 10.0))
+    # Normalise to [0, 1] using the judge's ACTUAL rubric scale (DEFAULT_RUBRIC
+    # is 1-5, not 1-10), via min-max so the rubric floor maps to 0.0.
+    scale = evaluator.rubric.get("scale", {}) if isinstance(evaluator.rubric, dict) else {}
+    if not isinstance(scale, dict):
+        scale = {}
+
+    def _num(value: object, default: float) -> float:
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+        return default
+
+    scale_min = _num(scale.get("min", 1), 1.0)
+    scale_max = _num(scale.get("max", 5), 5.0)
+    span = scale_max - scale_min
+
+    overall = float(getattr(results, "overall_score", scale_min))
+    if span > 0:
+        normalized = (overall - scale_min) / span
+    else:
+        normalized = overall
+    return max(0.0, min(1.0, normalized))
 
 
 def _run_benchmark_task(

--- a/tests/test_eval_gate.py
+++ b/tests/test_eval_gate.py
@@ -510,3 +510,136 @@ class TestJudgeModelValidation:
                 prompts="prompts.jsonl",
                 judge_model="http://localhost.attacker.com/model",
             )
+
+
+# ---------------------------------------------------------------------------
+# Judge task score normalization
+# ---------------------------------------------------------------------------
+
+
+class TestJudgeTaskNormalization:
+    """Regression tests for judge score normalization against active rubric scale."""
+
+    @pytest.fixture
+    def prompts_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        prompts = tmp_path / "prompts.jsonl"
+        prompts.write_text('{"prompt": "test prompt"}\n', encoding="utf-8")
+        return prompts
+
+    def _run_with_mock_judge(self, prompts_file, overall_score, rubric=None):
+        from soup_cli.eval.gate import GateTask, _run_judge_task
+        from soup_cli.eval.judge import DEFAULT_RUBRIC, JudgeResults
+
+        task = GateTask(
+            type="judge",
+            name="quality",
+            threshold=0.7,
+            prompts=str(prompts_file.name),
+            judge_model="ollama://llama3",
+        )
+
+        mock_evaluator = MagicMock()
+        mock_evaluator.rubric = rubric if rubric is not None else DEFAULT_RUBRIC
+        mock_evaluator.evaluate_batch.return_value = JudgeResults(
+            scores=[], overall_score=overall_score,
+        )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("soup_cli.eval.judge.JudgeEvaluator", lambda **kw: mock_evaluator)
+            return _run_judge_task(task, generate_fn=lambda p: "test response")
+
+    def test_perfect_score_default_rubric_normalizes_to_one(self, prompts_file):
+        """A 5.0 score on the default 1-5 rubric must normalize to 1.0, not 0.50."""
+        score = self._run_with_mock_judge(prompts_file, overall_score=5.0)
+        assert score == pytest.approx(1.0)
+
+    def test_midpoint_score_default_rubric(self, prompts_file):
+        """A 3.0 score on the default 1-5 rubric must normalize to 0.50, not 0.30."""
+        score = self._run_with_mock_judge(prompts_file, overall_score=3.0)
+        assert score == pytest.approx(0.50)
+
+    def test_minimum_score_default_rubric(self, prompts_file):
+        """A 1.0 score on the default 1-5 rubric must normalize to 0.0, not 0.10."""
+        score = self._run_with_mock_judge(prompts_file, overall_score=1.0)
+        assert score == pytest.approx(0.0)
+
+    def test_intermediate_score_default_rubric(self, prompts_file):
+        """A 4.0 score on the default 1-5 rubric must normalize to 0.75, not 0.40."""
+        score = self._run_with_mock_judge(prompts_file, overall_score=4.0)
+        assert score == pytest.approx(0.75)
+
+    def test_custom_rubric_scale_dynamic_normalization(self, prompts_file):
+        """A 1-10 custom rubric must normalize dynamically: (8-1)/9 = 7/9."""
+        custom_rubric = {"scale": {"min": 1, "max": 10}}
+        score = self._run_with_mock_judge(
+            prompts_file, overall_score=8.0, rubric=custom_rubric,
+        )
+        assert score == pytest.approx(7.0 / 9.0)
+
+        score_max = self._run_with_mock_judge(
+            prompts_file, overall_score=10.0, rubric=custom_rubric,
+        )
+        assert score_max == pytest.approx(1.0)
+
+        score_min = self._run_with_mock_judge(
+            prompts_file, overall_score=1.0, rubric=custom_rubric,
+        )
+        assert score_min == pytest.approx(0.0)
+
+    def test_clamping_out_of_bounds_scores(self, prompts_file):
+        """Pathological scores outside [min, max] must clamp strictly to [0.0, 1.0]."""
+        # Score above max
+        score_high = self._run_with_mock_judge(prompts_file, overall_score=7.0)
+        assert score_high == pytest.approx(1.0)
+
+        # Score below min
+        score_low = self._run_with_mock_judge(prompts_file, overall_score=0.0)
+        assert score_low == pytest.approx(0.0)
+
+    def test_degenerate_scale_handled_safely(self, prompts_file):
+        """If min == max, division by zero is avoided and score is safely clamped."""
+        degenerate_rubric = {"scale": {"min": 5, "max": 5}}
+        score = self._run_with_mock_judge(
+            prompts_file, overall_score=5.0, rubric=degenerate_rubric,
+        )
+        assert 0.0 <= score <= 1.0
+
+    def test_end_to_end_gate_passes_for_perfect_judge_score(self, tmp_path, monkeypatch):
+        """End-to-end: a perfect 5/5 score must pass a threshold of 0.70."""
+        monkeypatch.chdir(tmp_path)
+        from soup_cli.eval.gate import EvalSuite, GateTask, run_gate
+        from soup_cli.eval.judge import DEFAULT_RUBRIC, JudgeResults
+
+        prompts = tmp_path / "eval_prompts.jsonl"
+        prompts.write_text('{"prompt": "Summarize this article"}\n', encoding="utf-8")
+
+        suite = EvalSuite(
+            suite="judge_quality_suite",
+            tasks=[
+                GateTask(
+                    type="judge",
+                    name="quality_check",
+                    threshold=0.70,
+                    prompts=str(prompts.name),
+                    judge_model="ollama://llama3.1",
+                ),
+            ],
+        )
+
+        mock_evaluator = MagicMock()
+        mock_evaluator.rubric = DEFAULT_RUBRIC
+        # Perfect 5/5 score from judge
+        mock_evaluator.evaluate_batch.return_value = JudgeResults(
+            scores=[], overall_score=5.0,
+        )
+
+        monkeypatch.setattr("soup_cli.eval.judge.JudgeEvaluator", lambda **kw: mock_evaluator)
+
+        result = run_gate(suite, generate_fn=lambda prompt: "Summary output")
+        assert len(result.task_results) == 1
+        task_res = result.task_results[0]
+        # Under the old buggy implementation, score was 0.50 and failed threshold 0.70!
+        assert task_res.score == pytest.approx(1.0)
+        assert task_res.passed is True
+        assert result.passed is True


### PR DESCRIPTION
## What does this PR do?

Fixes #577 — `_run_judge_task` in `src/soup_cli/eval/gate.py` hardcoded `/ 10.0` normalization, assuming a 1–10 judge scale, while `DEFAULT_RUBRIC` in `src/soup_cli/eval/judge.py` uses a 1–5 scale. This caused a perfect judge score of `5.0` to normalize to `0.50` instead of `1.00`, making typical gate thresholds (`0.70`, `0.80`) impossible to satisfy and triggering false-positive training stops under `on_regression: stop`.

**Fix:** Replace hardcoded `/ 10.0` with dynamic min-max normalization derived from `evaluator.rubric["scale"]`, aligning `eval/gate.py` with the existing dynamic normalization in `commands/ship.py`. The fix safely handles degenerate scales (`min == max`), rejects non-numeric/bool rubric values, and clamps output to `[0.0, 1.0]`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Tests

## Checklist

- [x] `ruff check src/soup_cli/ scripts/ tests/` passes
- [x] `pytest tests/ -v` passes
- [x] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed
- [x] Added a changelog fragment, or this change has no user-visible impact