### PR TITLE
fix(sglang): use shared chat-template prompt + real finish_reason (#360)

### DIFF
--- a/changelog.d/0.73.3/581.fixed.md
+++ b/changelog.d/0.73.3/581.fixed.md
@@ -1,0 +1,10 @@
+- [#581](https://github.com/MakazhanAlpamys/Soup/pull/581) ports two v0.73.0
+  vLLM serve fixes to the SGLang backend, which had the identical pair standing.
+  The prompt now applies the model's own chat template via the shared
+  `build_chat_prompt` (with the legacy `User:`/`Assistant:` fallback for
+  template-less models) instead of a hand-rolled third copy, so the model no
+  longer sees a format it was never trained on. And `finish_reason` reports
+  `"length"` when a response hits `max_tokens` (on both the sync and streaming
+  paths) instead of a hardcoded `"stop"`, so a client doing continue-on-length
+  can tell a truncated answer from a completed one. Live verification against a
+  real SGLang runtime on Linux remains an open follow-up on #360.

--- a/changelog.d/0.73.3/581.fixed.md
+++ b/changelog.d/0.73.3/581.fixed.md
@@ -6,5 +6,9 @@
   longer sees a format it was never trained on. And `finish_reason` reports
   `"length"` when a response hits `max_tokens` (on both the sync and streaming
   paths) instead of a hardcoded `"stop"`, so a client doing continue-on-length
-  can tell a truncated answer from a completed one. Live verification against a
-  real SGLang runtime on Linux remains an open follow-up on #360.
+  can tell a truncated answer from a completed one. The tokenizer load in
+  `soup serve --backend sglang` now uses the same `trust_remote_code` setting
+  the SGLang runtime itself uses, so a custom-code model no longer falls back
+  to the legacy prompt in silence, and the three-branch operator warning vLLM
+  prints about the chat template is now printed here too. Live verification
+  against a real SGLang runtime on Linux remains an open follow-up on #360.

--- a/docs/serving-and-export.md
+++ b/docs/serving-and-export.md
@@ -302,6 +302,13 @@ soup serve --model ./output --backend sglang
 soup serve --model ./output --backend sglang --tensor-parallel 2
 ```
 
+Like the transformers and vLLM backends, the SGLang backend applies the
+**model's own chat template** via the same shared prompt builder (falling back
+to a generic `User:` / `Assistant:` prompt for template-less models), and
+`finish_reason` reports `"length"` when a response hits `max_tokens` and
+`"stop"` otherwise — so a client doing continue-on-length can tell a truncated
+answer from a completed one (#360).
+
 ### Speculative Decoding
 
 Use a smaller draft model to speed up generation. **Measure before you trust it** — see

--- a/src/soup_cli/commands/serve.py
+++ b/src/soup_cli/commands/serve.py
@@ -1279,8 +1279,35 @@ def _serve_sglang(
     console.print("[bold green]SGLang runtime ready![/]")
 
     # Load the tokenizer whose chat template the shared prompt builder applies
-    # (#360). None degrades to the legacy role-prefixed prompt, same as vLLM.
-    tokenizer = _load_serve_tokenizer(model_path, base_model)
+    # (#360). trust_remote_code matches what create_sglang_runtime already used
+    # to load this very model a few lines above, and what the panel printed
+    # here promises. Loading it with the default False instead meant a
+    # custom-code model failed to load a tokenizer, tokenizer became None, and
+    # the fix silently degraded to the legacy prompt -- for exactly the models
+    # whose chat template matters most.
+    tokenizer = _load_serve_tokenizer(
+        model_path=model_path,
+        base_model=base_model,
+        trust_remote_code=True,
+    )
+
+    # A failure here is announced, never silent -- the same three-branch
+    # contract vLLM has at _serve_vllm. Falling back to the legacy
+    # role-prefixed prompt is what made Llama-3.1-8B loop, and on SGLang that
+    # fallback used to happen with nothing printed at all.
+    if tokenizer is None:
+        console.print(
+            "[yellow]Warning:[/] no tokenizer could be loaded for this model — "
+            "falling back to a generic 'User:/Assistant:' prompt. Chat-tuned "
+            "models can run on past their stop token with this format."
+        )
+    elif not getattr(tokenizer, "chat_template", None):
+        console.print(
+            "[yellow]Warning:[/] this model ships no chat template — using the "
+            "generic 'User:/Assistant:' prompt format."
+        )
+    else:
+        console.print("[green]Chat template:[/] applying the model's own template.")
 
     app = create_sglang_app(
         runtime=runtime,

--- a/src/soup_cli/commands/serve.py
+++ b/src/soup_cli/commands/serve.py
@@ -1278,11 +1278,16 @@ def _serve_sglang(
     )
     console.print("[bold green]SGLang runtime ready![/]")
 
+    # Load the tokenizer whose chat template the shared prompt builder applies
+    # (#360). None degrades to the legacy role-prefixed prompt, same as vLLM.
+    tokenizer = _load_serve_tokenizer(model_path, base_model)
+
     app = create_sglang_app(
         runtime=runtime,
         runtime_model_name=runtime_model_name,
         model_name=str(model_path.name),
         max_tokens_default=max_tokens_default,
+        tokenizer=tokenizer,
     )
 
     return app

--- a/src/soup_cli/utils/sglang.py
+++ b/src/soup_cli/utils/sglang.py
@@ -4,6 +4,12 @@ import json
 import logging
 from typing import Any, Optional
 
+# The OpenAI finish_reason vocabulary Soup emits, imported rather than
+# redefined: a second copy of this set is exactly the kind of duplicated source
+# of truth that #372, #392 and #424 were each caused by. utils.vllm is
+# torch-free at import time, so this does not weigh down CLI startup.
+from soup_cli.utils.vllm import _FINISH_REASONS
+
 logger = logging.getLogger(__name__)
 
 
@@ -37,10 +43,6 @@ def decode_sglang_response(response: Any) -> dict:
     raise ValueError(
         f"SGLang returned an unsupported response type {type(response).__name__}"
     )
-
-
-# OpenAI's finish_reason vocabulary Soup emits (mirrors vllm._FINISH_REASONS).
-_FINISH_REASONS = frozenset({"stop", "length"})
 
 
 def resolve_sglang_finish_reason(meta_info: Any, max_tokens: Optional[int]) -> str:

--- a/src/soup_cli/utils/sglang.py
+++ b/src/soup_cli/utils/sglang.py
@@ -39,6 +39,39 @@ def decode_sglang_response(response: Any) -> dict:
     )
 
 
+# OpenAI's finish_reason vocabulary Soup emits (mirrors vllm._FINISH_REASONS).
+_FINISH_REASONS = frozenset({"stop", "length"})
+
+
+def resolve_sglang_finish_reason(meta_info: Any, max_tokens: Optional[int]) -> str:
+    """Map SGLang ``meta_info`` to an OpenAI ``finish_reason`` (#360).
+
+    Mirrors ``vllm.resolve_finish_reason``: trust the engine's own
+    ``finish_reason`` when it maps to one Soup emits, otherwise derive it from
+    the token count — a generation that spent the whole budget was truncated,
+    not naturally stopped. The pre-fix code hardcoded ``"stop"``, so a client
+    doing continue-on-length silently stopped early.
+
+    SGLang reports ``finish_reason`` as ``{"type": "stop"|"length"|"abort"}`` in
+    recent versions and as a bare string in older ones — both are accepted so a
+    dict-only read cannot silently break a previously-working sglang.
+    """
+    info = meta_info if isinstance(meta_info, dict) else {}
+    reported = info.get("finish_reason")
+    if isinstance(reported, dict):
+        reported = reported.get("type")
+    if isinstance(reported, str) and reported in _FINISH_REASONS:
+        return reported
+    completion_tokens = info.get("completion_tokens")
+    try:
+        produced = int(completion_tokens) if completion_tokens is not None else 0
+    except (TypeError, ValueError):
+        produced = 0
+    if max_tokens and produced >= int(max_tokens):
+        return "length"
+    return "stop"
+
+
 def check_sglang_available() -> bool:
     """Check if SGLang is installed."""
     try:
@@ -121,6 +154,7 @@ def create_sglang_app(
     runtime_model_name: str,
     model_name: str,
     max_tokens_default: int = 512,
+    tokenizer=None,
 ):
     """Create a FastAPI app using SGLang runtime for inference.
 
@@ -129,6 +163,9 @@ def create_sglang_app(
         runtime_model_name: Model name used by SGLang.
         model_name: Display model name for API responses.
         max_tokens_default: Default max tokens for generation.
+        tokenizer: HF tokenizer for the served model — its chat template is
+            applied by the shared ``build_chat_prompt`` (#360). None degrades to
+            the legacy role-prefixed format, same as the vLLM backend.
 
     Returns:
         FastAPI application.
@@ -142,6 +179,10 @@ def create_sglang_app(
     from fastapi.responses import StreamingResponse
     from pydantic import BaseModel as PydanticBaseModel
     from pydantic import Field
+
+    # THE single prompt builder shared with the transformers and vLLM backends
+    # (#332), so the three cannot drift again. Was a hand-rolled third copy.
+    from soup_cli.utils.vllm import build_chat_prompt
 
     app = FastAPI(title="Soup Inference Server (SGLang)", version="1.0.0")
 
@@ -189,8 +230,9 @@ def create_sglang_app(
         max_tokens = request.max_tokens or max_tokens_default
         request_id = f"chatcmpl-{uuid.uuid4().hex[:8]}"
 
-        # Build prompt from messages
-        prompt = _build_prompt(request.messages)
+        # Apply the model's own chat template (legacy fallback when there is no
+        # tokenizer / template), shared with the transformers + vLLM backends.
+        prompt = build_chat_prompt(request.messages, tokenizer)
 
         sampling_params = {
             "temperature": request.temperature,
@@ -233,7 +275,9 @@ def create_sglang_app(
                             "role": "assistant",
                             "content": response_text,
                         },
-                        "finish_reason": "stop",
+                        "finish_reason": resolve_sglang_finish_reason(
+                            response.get("meta_info"), max_tokens
+                        ),
                     }
                 ],
                 "usage": {
@@ -246,21 +290,6 @@ def create_sglang_app(
         except Exception:
             logger.exception("SGLang generation error")
             raise HTTPException(status_code=500, detail="Internal server error")
-
-    def _build_prompt(messages: list[ChatMessage]) -> str:
-        """Build a simple prompt from chat messages."""
-        parts = []
-        for msg in messages:
-            role = msg.role
-            content = msg.content
-            if role == "system":
-                parts.append(f"System: {content}")
-            elif role == "user":
-                parts.append(f"User: {content}")
-            elif role == "assistant":
-                parts.append(f"Assistant: {content}")
-        parts.append("Assistant:")
-        return "\n".join(parts)
 
     async def _stream_sglang_response(
         runtime,
@@ -277,6 +306,7 @@ def create_sglang_app(
                 runtime.generate(prompt, sampling_params=sampling_params)
             )
             response_text = response["text"]
+            meta_info = response.get("meta_info")
         except Exception:
             logger.exception("SGLang stream error")
             yield 'data: {"error": "Internal server error"}\n\n'
@@ -311,7 +341,9 @@ def create_sglang_app(
                 {
                     "index": 0,
                     "delta": {},
-                    "finish_reason": "stop",
+                    "finish_reason": resolve_sglang_finish_reason(
+                        meta_info, sampling_params.get("max_new_tokens")
+                    ),
                 }
             ],
         }

--- a/tests/test_issue332_vllm_prompt.py
+++ b/tests/test_issue332_vllm_prompt.py
@@ -175,9 +175,26 @@ class TestBothBackendsShareOneBuilder:
         place — inside the shared fallback."""
         serve_src = Path("src/soup_cli/commands/serve.py").read_text(encoding="utf-8")
         vllm_src = Path("src/soup_cli/utils/vllm.py").read_text(encoding="utf-8")
+        # #360: sglang.py is the file that carried the third hand-rolled copy,
+        # so it is the file most likely to grow one again. Guarding vllm.py and
+        # serve.py while leaving it unscanned protected everything except the
+        # place the defect actually was.
+        sglang_src = Path("src/soup_cli/utils/sglang.py").read_text(encoding="utf-8")
 
         assert 'f"User: {content}"' not in serve_src
+        assert 'f"User: {content}"' not in sglang_src
         assert vllm_src.count('f"User: {content}"') == 1
+
+    def test_sglang_does_not_redefine_the_finish_reason_vocabulary(self):
+        """#360 item 4: one source of truth for the finish_reason set.
+
+        A second ``_FINISH_REASONS = frozenset(...)`` in sglang.py is the same
+        duplicated-constant shape that #372, #392 and #424 were caused by.
+        """
+        sglang_src = Path("src/soup_cli/utils/sglang.py").read_text(encoding="utf-8")
+
+        assert "_FINISH_REASONS = frozenset" not in sglang_src
+        assert "from soup_cli.utils.vllm import _FINISH_REASONS" in sglang_src
 
 
 # ============================================================

--- a/tests/test_issue360_sglang_prompt_finish_reason.py
+++ b/tests/test_issue360_sglang_prompt_finish_reason.py
@@ -1,0 +1,179 @@
+"""#360 — port the two vLLM prompt/finish_reason fixes to the SGLang backend.
+
+v0.73.0 fixed two defects in the vLLM serve backend and left the identical pair
+standing in ``utils/sglang.py``:
+
+1. The prompt was hand-rolled as ``"User: …\nAssistant:"`` instead of applying
+   the model's own chat template — the model saw a format it was never trained
+   on. The shared ``build_chat_prompt`` (used by the transformers and vLLM
+   backends) applies the template with a warned legacy fallback for
+   template-less models; SGLang should use it, not a third copy.
+2. ``finish_reason`` was hardcoded ``"stop"``, so a client doing
+   continue-on-length could not tell a completed answer from one truncated at
+   ``max_tokens``.
+
+These are CPU-verifiable (prompt string + finish_reason mapping); a live SGLang
+runtime on Linux is a separate follow-up per the issue.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _has_fastapi() -> bool:
+    try:
+        import fastapi  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# resolve_sglang_finish_reason — the mapping, mirrors vLLM's resolve_finish_reason
+# ---------------------------------------------------------------------------
+class TestResolveSglangFinishReason:
+    def _fn(self):
+        from soup_cli.utils.sglang import resolve_sglang_finish_reason
+
+        return resolve_sglang_finish_reason
+
+    def test_reported_dict_type_length(self):
+        # SGLang's modern shape: meta_info["finish_reason"] == {"type": "length"}.
+        assert self._fn()({"finish_reason": {"type": "length"}}, 128) == "length"
+
+    def test_reported_dict_type_stop(self):
+        assert self._fn()({"finish_reason": {"type": "stop"}}, 128) == "stop"
+
+    def test_reported_bare_string_older_shape(self):
+        # Older SGLang reported a bare string — accept it too (a control, so a
+        # dict-only fix cannot silently break previously-working versions).
+        assert self._fn()({"finish_reason": "length"}, 128) == "length"
+
+    def test_derives_length_from_token_budget(self):
+        # No reported reason: a generation that spent the whole budget was
+        # truncated, not naturally stopped.
+        assert self._fn()({"completion_tokens": 128}, 128) == "length"
+
+    def test_derives_stop_when_under_budget(self):
+        assert self._fn()({"completion_tokens": 4}, 128) == "stop"
+
+    def test_unmapped_reason_falls_through_to_token_count(self):
+        # "abort" is not an OpenAI finish_reason — do not leak it; derive.
+        meta = {"finish_reason": {"type": "abort"}, "completion_tokens": 4}
+        assert self._fn()(meta, 128) == "stop"
+
+    def test_missing_meta_info_is_stop(self):
+        assert self._fn()(None, 128) == "stop"
+        assert self._fn()({}, None) == "stop"
+
+
+# ---------------------------------------------------------------------------
+# The app uses the shared build_chat_prompt (not the hand-rolled "User:/Assistant:")
+# ---------------------------------------------------------------------------
+class _FakeTokenizer:
+    chat_template = "A-REAL-TEMPLATE"
+
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True):
+        rendered = " ".join(f"{m['role']}={m['content']}" for m in messages)
+        return f"<TPL>{rendered}<GEN>"
+
+
+def _mock_runtime(text="hi there", meta_info=None):
+    runtime = MagicMock()
+    payload = {"text": text}
+    payload["meta_info"] = meta_info if meta_info is not None else {}
+    runtime.generate = MagicMock(return_value=payload)
+    return runtime
+
+
+@pytest.mark.skipif(not _has_fastapi(), reason="fastapi not installed")
+class TestSglangUsesSharedPromptBuilder:
+    def _post(self, app, body):
+        from fastapi.testclient import TestClient
+
+        return TestClient(app).post("/v1/chat/completions", json=body)
+
+    def test_prompt_uses_chat_template_when_tokenizer_has_one(self):
+        from soup_cli.utils.sglang import create_sglang_app
+
+        runtime = _mock_runtime()
+        app = create_sglang_app(
+            runtime=runtime,
+            runtime_model_name="m",
+            model_name="m",
+            tokenizer=_FakeTokenizer(),
+        )
+        self._post(app, {"messages": [{"role": "user", "content": "hello"}]})
+        sent_prompt = runtime.generate.call_args.args[0]
+        assert sent_prompt.startswith("<TPL>")
+        assert "user=hello" in sent_prompt
+        # The hand-rolled format must be gone.
+        assert "User: hello" not in sent_prompt
+
+    def test_prompt_matches_shared_builder_legacy_fallback_without_tokenizer(self):
+        from soup_cli.utils.sglang import create_sglang_app
+        from soup_cli.utils.vllm import build_chat_prompt
+
+        runtime = _mock_runtime()
+        app = create_sglang_app(
+            runtime=runtime, runtime_model_name="m", model_name="m", tokenizer=None
+        )
+        messages = [{"role": "user", "content": "hello"}]
+        self._post(app, {"messages": messages})
+        sent_prompt = runtime.generate.call_args.args[0]
+        # SGLang now delegates to the shared builder — identical output.
+        assert sent_prompt == build_chat_prompt(messages, None)
+
+
+# ---------------------------------------------------------------------------
+# finish_reason is reported truthfully on both the sync and streaming paths
+# ---------------------------------------------------------------------------
+@pytest.mark.skipif(not _has_fastapi(), reason="fastapi not installed")
+class TestSglangReportsFinishReason:
+    def _post(self, app, body):
+        from fastapi.testclient import TestClient
+
+        return TestClient(app).post("/v1/chat/completions", json=body)
+
+    def test_sync_reports_length_when_budget_hit(self):
+        from soup_cli.utils.sglang import create_sglang_app
+
+        runtime = _mock_runtime(
+            text="a b c", meta_info={"prompt_tokens": 3, "completion_tokens": 8}
+        )
+        app = create_sglang_app(runtime=runtime, runtime_model_name="m", model_name="m")
+        resp = self._post(app, {"messages": [{"role": "user", "content": "hi"}], "max_tokens": 8})
+        assert resp.json()["choices"][0]["finish_reason"] == "length"
+
+    def test_sync_reports_stop_when_under_budget(self):
+        from soup_cli.utils.sglang import create_sglang_app
+
+        runtime = _mock_runtime(
+            text="a b c", meta_info={"prompt_tokens": 3, "completion_tokens": 3}
+        )
+        app = create_sglang_app(runtime=runtime, runtime_model_name="m", model_name="m")
+        resp = self._post(app, {"messages": [{"role": "user", "content": "hi"}], "max_tokens": 128})
+        assert resp.json()["choices"][0]["finish_reason"] == "stop"
+
+    def test_stream_final_chunk_reports_length(self):
+        import json
+
+        from soup_cli.utils.sglang import create_sglang_app
+
+        runtime = _mock_runtime(
+            text="a b c", meta_info={"prompt_tokens": 3, "completion_tokens": 8}
+        )
+        app = create_sglang_app(runtime=runtime, runtime_model_name="m", model_name="m")
+        resp = self._post(
+            app,
+            {"messages": [{"role": "user", "content": "hi"}], "max_tokens": 8, "stream": True},
+        )
+        reasons = []
+        for line in resp.text.splitlines():
+            if line.startswith("data: ") and line != "data: [DONE]":
+                payload = json.loads(line[len("data: ") :])
+                if "choices" in payload:
+                    reasons.append(payload["choices"][0].get("finish_reason"))
+        assert reasons[-1] == "length"

--- a/tests/test_issue360_sglang_prompt_finish_reason.py
+++ b/tests/test_issue360_sglang_prompt_finish_reason.py
@@ -177,3 +177,166 @@ class TestSglangReportsFinishReason:
                 if "choices" in payload:
                     reasons.append(payload["choices"][0].get("finish_reason"))
         assert reasons[-1] == "length"
+
+    def test_control_stream_final_chunk_still_reports_stop(self):
+        """Control for the length case above (#360 review item 3).
+
+        Without this, hardcoding the streaming final chunk to ``"length"`` --
+        the exact mirror image of the bug being fixed, and one that makes a
+        continue-on-length client loop forever -- passes the whole suite.
+        Ported from ``test_issue332_vllm_prompt.py``, where vLLM already has it.
+        """
+        import json
+
+        from soup_cli.utils.sglang import create_sglang_app
+
+        runtime = _mock_runtime(
+            text="a b c", meta_info={"prompt_tokens": 3, "completion_tokens": 3}
+        )
+        app = create_sglang_app(runtime=runtime, runtime_model_name="m", model_name="m")
+        resp = self._post(
+            app,
+            {"messages": [{"role": "user", "content": "hi"}], "max_tokens": 128, "stream": True},
+        )
+        reasons = []
+        for line in resp.text.splitlines():
+            if line.startswith("data: ") and line != "data: [DONE]":
+                payload = json.loads(line[len("data: ") :])
+                if "choices" in payload:
+                    reasons.append(payload["choices"][0].get("finish_reason"))
+        assert reasons[-1] == "stop"
+
+
+class _TemplatelessTokenizer:
+    """A tokenizer that loads fine but ships no chat template.
+
+    Distinct from ``tokenizer=None``: the object exists, so any code that
+    branches on truthiness of the tokenizer rather than of its template takes
+    the wrong path. #360 asks for the legacy fallback to be pinned for
+    template-less models, which is this case, not the missing-tokenizer one.
+    """
+
+    chat_template = None
+
+    def apply_chat_template(self, *args, **kwargs):  # pragma: no cover — must not be called
+        raise AssertionError(
+            "apply_chat_template must not be called on a template-less tokenizer"
+        )
+
+
+@pytest.mark.skipif(not _has_fastapi(), reason="fastapi not installed")
+class TestSglangTemplatelessTokenizer:
+    """#360 review item 3: pin the fallback for a tokenizer with no template."""
+
+    def _post(self, app, body):
+        from fastapi.testclient import TestClient
+
+        return TestClient(app).post("/v1/chat/completions", json=body)
+
+    def test_templateless_tokenizer_uses_the_shared_legacy_fallback(self):
+        from soup_cli.utils.sglang import create_sglang_app
+        from soup_cli.utils.vllm import build_chat_prompt
+
+        runtime = _mock_runtime()
+        app = create_sglang_app(
+            runtime=runtime,
+            runtime_model_name="m",
+            model_name="m",
+            tokenizer=_TemplatelessTokenizer(),
+        )
+        messages = [{"role": "user", "content": "hello"}]
+        self._post(app, {"messages": messages})
+        sent_prompt = runtime.generate.call_args.args[0]
+
+        # Identical to what the shared builder produces with no tokenizer at
+        # all -- the fallback is the shared one, not a third code path.
+        assert sent_prompt == build_chat_prompt(messages, None)
+        assert not sent_prompt.startswith("<TPL>")
+
+
+# ---------------------------------------------------------------------------
+# Production wiring: what `soup serve --backend sglang` actually executes
+# ---------------------------------------------------------------------------
+class TestServeSglangWiring:
+    """#360 review items 1 and 2.
+
+    Every prompt test above constructs ``create_sglang_app`` directly with a
+    hand-supplied tokenizer, so deleting the tokenizer load in ``_serve_sglang``
+    -- the one line every real ``soup serve --backend sglang`` runs, and the
+    line that makes the whole fix reach users -- passed 112 tests.
+    """
+
+    def _serve(self, monkeypatch, tokenizer, capture):
+        from pathlib import Path
+
+        import soup_cli.commands.serve as serve_mod
+        import soup_cli.utils.sglang as sglang_mod
+
+        monkeypatch.setattr(
+            sglang_mod,
+            "create_sglang_runtime",
+            lambda **kwargs: (MagicMock(), "runtime-model"),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            sglang_mod, "create_sglang_app", lambda **kwargs: kwargs, raising=False
+        )
+
+        def _fake_loader(**kwargs):
+            capture["kwargs"] = kwargs
+            return tokenizer
+
+        monkeypatch.setattr(serve_mod, "_load_serve_tokenizer", _fake_loader)
+
+        printed = []
+        monkeypatch.setattr(
+            serve_mod.console, "print", lambda *args, **kwargs: printed.append(str(args[0]))
+        )
+        capture["printed"] = printed
+
+        return serve_mod._serve_sglang(
+            model_path=Path("/models/custom-code-model"),
+            base_model=None,
+            is_adapter=False,
+            max_tokens_default=256,
+            tensor_parallel=1,
+            gpu_memory_utilization=0.9,
+        )
+
+    def test_tokenizer_load_uses_the_trust_setting_the_runtime_uses(self, monkeypatch):
+        """The runtime loads this model with trust_remote_code=True and the
+        panel says so. Loading the tokenizer with the default False meant a
+        custom-code model produced tokenizer=None and the fix silently did
+        nothing -- for exactly the models whose chat template matters most."""
+        capture = {}
+        self._serve(monkeypatch, _FakeTokenizer(), capture)
+
+        assert capture["kwargs"]["trust_remote_code"] is True
+
+    def test_the_loaded_tokenizer_is_passed_into_the_app(self, monkeypatch):
+        """Kills the mutation that deletes the wiring outright."""
+        capture = {}
+        tokenizer = _FakeTokenizer()
+        app_kwargs = self._serve(monkeypatch, tokenizer, capture)
+
+        assert app_kwargs["tokenizer"] is tokenizer
+
+    def test_missing_tokenizer_is_announced(self, monkeypatch):
+        """#360 item 2: on vLLM the operator is told; on SGLang the silent
+        fallback was invisible."""
+        capture = {}
+        self._serve(monkeypatch, None, capture)
+
+        assert any("no tokenizer could be loaded" in line for line in capture["printed"])
+
+    def test_templateless_model_is_announced(self, monkeypatch):
+        capture = {}
+        self._serve(monkeypatch, _TemplatelessTokenizer(), capture)
+
+        assert any("ships no chat template" in line for line in capture["printed"])
+
+    def test_applying_the_models_template_is_announced(self, monkeypatch):
+        capture = {}
+        self._serve(monkeypatch, _FakeTokenizer(), capture)
+
+        assert any("applying the model's own template" in line for line in capture["printed"])


### PR DESCRIPTION
Refs #360 — **does not close it**: the code + CPU coverage are here, but the issue's acceptance requires verification against a real SGLang runtime on Linux, which I can't run. Details below.

## Problem

v0.73.0 fixed two defects in the vLLM backend (#332/#333) and left the identical pair standing in `utils/sglang.py`:

1. **Hand-rolled prompt.** `_build_prompt` built its own `"User: …\nAssistant:"` string instead of applying the model's chat template, so the model saw a format it was never trained on. `build_chat_prompt` already exists and is shared by the transformers and vLLM backends.
2. **Hardcoded `finish_reason`.** Returned `"stop"` unconditionally, including when the response hit `max_tokens` — clients can't tell a completed answer from a truncated one.

## Changes

- **Prompt:** SGLang now calls the shared `build_chat_prompt(messages, tokenizer)` (deleted the third hand-rolled copy). `create_sglang_app` takes a `tokenizer`, and `_serve_sglang` loads it via the existing `_load_serve_tokenizer` — mirroring the vLLM caller. `tokenizer=None` degrades to the legacy role-prefixed prompt, same as vLLM.
- **`finish_reason`:** new `resolve_sglang_finish_reason(meta_info, max_tokens)`, mirroring vLLM's `resolve_finish_reason`. Reports `"length"` when the budget was spent, on both the **sync** and **streaming final-chunk** paths. It trusts SGLang's own `finish_reason` when it maps to an OpenAI value — accepting both the modern `{"type": …}` dict and the older bare string, so a dict-only read can't silently break a previously-working sglang (the #76 control pattern) — otherwise derives from the token count.
- **Docs:** `docs/serving-and-export.md` SGLang section now states the chat-template + `finish_reason` behavior.

## Tests (`tests/test_issue360_sglang_prompt_finish_reason.py`, CPU-only)

- `resolve_sglang_finish_reason`: dict `type`, older bare-string (control), token-count derivation both ways, unmapped `"abort"` falls through, missing meta_info.
- Prompt: with a chat-template tokenizer the prompt is the templated output (not `User:`); with `tokenizer=None` it equals `build_chat_prompt(messages, None)` (legacy-fallback control).
- `finish_reason` end-to-end via `TestClient`: `"length"` when the budget is hit, `"stop"` under it, on the sync path and the streaming final chunk.

12 new tests pass; existing sglang + vLLM + #76 suites stay green (100 passed locally); `ruff` clean.

## What still needs hardware

Per the issue: *"Anything here needs verification on a Linux box with a real SGLang runtime, not just unit tests"* — SGLang isn't importable in the test env and has had platform-specific behavior (#76 was Linux-only). I can't run that, so I've scoped this PR to the code + CPU-verifiable coverage and left the live check as the open acceptance item. Happy to adjust if you'd rather the live run land first, or if a maintainer can run it.
