### PR TITLE
fix(trainer/grpo): prevent silent fallback on GRPO objective variants (#584)

### DIFF
--- a/changelog.d/0.73.3/585.fixed.md
+++ b/changelog.d/0.73.3/585.fixed.md
@@ -1,0 +1,8 @@
+- **GRPO objective variants now execute without silently falling back to stock
+  TRL loss (#584 by @here-2007 in #585).** `_GRPOTrainerVariant.compute_loss()`
+  previously checked `inputs` for `per_token_logps`, which is never
+  pre-populated by TRL's rollout dataloader. The trainer now obtains
+  per-token log probabilities in a single forward pass via
+  `_get_per_token_logps_and_entropies` without duplicating forward computation
+  or increasing peak VRAM, ensuring `gspo`, `dapo`, `dr_grpo`, `bnpo`,
+  `two_sided`, and `rft` objectives train their intended loss formulations.

--- a/src/soup_cli/trainer/grpo.py
+++ b/src/soup_cli/trainer/grpo.py
@@ -76,34 +76,64 @@ def _make_grpo_trainer_variant_cached(base_cls: type, variant: str) -> type:
                 reason,
             )
 
-        def compute_loss(self, model, inputs, return_outputs=False, **kwargs):
-            # v0.53.11 review fix (code-review HIGH) — read kernel inputs
-            # FIRST and only call super() as a fallback. The previous
-            # ordering ran an extra forward pass on every step that was
-            # discarded when the kernel produced a loss, doubling VRAM
-            # peak. The TRL trainer stores per-batch tensors on ``inputs``
-            # by the time compute_loss is called, so we can probe them
-            # without burning a forward pass.
-            #
-            # Probe TRL ≥0.9 attribute name ``per_token_logps`` — drop the
-            # earlier ``logits_to_keep`` probe (code-review HIGH fix:
-            # ``logits_to_keep`` is a position mask, not log-probs).
+        def _compute_variant_loss(self, model, inputs):
+            """Evaluate the requested GRPO variant loss on the batch.
+
+            Reuses TRL's ``_get_per_token_logps_and_entropies`` to obtain
+            per-token log probabilities in a single forward pass without
+            duplicating forward computation or allocating extra VRAM.
+            """
             logp_new = _read_attr(inputs, "per_token_logps")
-            logp_old = _read_attr(inputs, "old_per_token_logps")
-            if logp_old is None:
-                logp_old = _read_attr(inputs, "ref_per_token_logps")
-            advantages = _read_attr(inputs, "advantages")
+            prompt_ids = _read_attr(inputs, "prompt_ids")
+            completion_ids = _read_attr(inputs, "completion_ids")
+            prompt_mask = _read_attr(inputs, "prompt_mask")
             completion_mask = _read_attr(inputs, "completion_mask")
+            advantages = _read_attr(inputs, "advantages")
+
+            if logp_new is None and prompt_ids is not None and completion_ids is not None:
+                import torch
+
+                if prompt_mask is None:
+                    prompt_mask = torch.ones_like(prompt_ids)
+                if completion_mask is None:
+                    completion_mask = torch.ones_like(completion_ids)
+                input_ids = torch.cat([prompt_ids, completion_ids], dim=1)
+                attention_mask = torch.cat([prompt_mask, completion_mask], dim=1)
+                logits_to_keep = completion_ids.size(1)
+
+                if hasattr(self, "_get_per_token_logps_and_entropies"):
+                    logp_new, _ = self._get_per_token_logps_and_entropies(
+                        model,
+                        input_ids,
+                        attention_mask,
+                        logits_to_keep,
+                        compute_entropy=False,
+                        pixel_values=_read_attr(inputs, "pixel_values"),
+                        image_grid_thw=_read_attr(inputs, "image_grid_thw"),
+                        num_images=_read_attr(inputs, "num_images"),
+                        pixel_attention_mask=_read_attr(inputs, "pixel_attention_mask"),
+                        image_sizes=_read_attr(inputs, "image_sizes"),
+                        token_type_ids=_read_attr(inputs, "token_type_ids"),
+                        mm_token_type_ids=_read_attr(inputs, "mm_token_type_ids"),
+                    )
+
+            logp_old = _read_attr(inputs, "old_per_token_logps")
+            if logp_old is None and logp_new is not None:
+                logp_old = logp_new.detach()
 
             if logp_new is None or logp_old is None or advantages is None:
-                # Fall back to the original loss — defence-in-depth so a
-                # TRL internal rename does not crash the training loop.
                 self._warn_fallback("missing per-token log-prob inputs")
-                return super().compute_loss(model, inputs, return_outputs=return_outputs, **kwargs)
+                return None
 
-            beta_attr = getattr(self.args, "beta", None)
+            beta_attr = getattr(getattr(self, "args", None), "beta", None)
             beta = float(beta_attr) if beta_attr is not None else 0.0
             delta = getattr(self, "_soup_grpo_delta", None)
+            ref_logp = _read_attr(inputs, "ref_per_token_logps")
+            mask = completion_mask
+            tool_mask = _read_attr(inputs, "tool_mask")
+            if mask is not None and tool_mask is not None:
+                mask = mask * tool_mask
+
             try:
                 variant_loss = apply_variant_loss(
                     self._soup_grpo_variant,
@@ -112,17 +142,41 @@ def _make_grpo_trainer_variant_cached(base_cls: type, variant: str) -> type:
                     advantages=advantages,
                     beta=beta,
                     delta=delta,
-                    completion_mask=completion_mask,
+                    completion_mask=mask,
+                    reference_logp=ref_logp,
                 )
             except (TypeError, ValueError) as exc:
                 self._warn_fallback(f"kernel error: {exc}")
-                return super().compute_loss(model, inputs, return_outputs=return_outputs, **kwargs)
+                return None
+
             if variant_loss is None:
-                self._warn_fallback("kernel returned None")
+                return None
+
+            mode = "train" if getattr(getattr(self, "model", model), "training", True) else "eval"
+            normalizer = (
+                getattr(self, "current_gradient_accumulation_steps", 1.0)
+                if mode == "train"
+                else 1.0
+            )
+            return variant_loss / normalizer
+
+        def _compute_loss(self, model, inputs):
+            loss = self._compute_variant_loss(model, inputs)
+            if loss is not None:
+                return loss
+            if hasattr(super(), "_compute_loss"):
+                return super()._compute_loss(model, inputs)
+            return super().compute_loss(model, inputs)
+
+        def compute_loss(self, model, inputs, return_outputs=False, **kwargs):
+            if hasattr(super(), "_compute_loss"):
                 return super().compute_loss(model, inputs, return_outputs=return_outputs, **kwargs)
-            if return_outputs:
-                return variant_loss, None
-            return variant_loss
+            loss = self._compute_variant_loss(model, inputs)
+            if loss is not None:
+                if return_outputs:
+                    return loss, None
+                return loss
+            return super().compute_loss(model, inputs, return_outputs=return_outputs, **kwargs)
 
     _GRPOTrainerVariant.__name__ = f"_GRPOTrainerVariant_{variant}"
     return _GRPOTrainerVariant

--- a/tests/test_v05311.py
+++ b/tests/test_v05311.py
@@ -563,6 +563,176 @@ class TestGRPOTrainerVariantFactory:
         assert float(result) == 42.0
 
 
+class TestGRPOVariantRuntimeContract:
+    """Regression tests for GRPO variant execution on realistic TRL runtime contracts.
+
+    Tests that variants do NOT require per_token_logps to be pre-injected in inputs,
+    and instead resolve logps in a single forward pass via _get_per_token_logps_and_entropies
+    without triggering fallback to stock TRL loss.
+    """
+
+    class _MockTRLTrainer:
+        def __init__(self, beta=0.0):
+            self.args = type("Args", (), {"beta": beta})()
+            self.model = type("Model", (), {"training": True})()
+            self.current_gradient_accumulation_steps = 1
+            self._get_logps_called = 0
+
+        def _get_per_token_logps_and_entropies(
+            self, model, input_ids, attention_mask, logits_to_keep, **kwargs
+        ):
+            self._get_logps_called += 1
+            b = input_ids.size(0)
+            t = logits_to_keep
+            # Distinct logps to test math
+            logps = torch.tensor(
+                [[-0.1, -0.2, -0.3], [-0.4, -0.5, -0.6]], requires_grad=True
+            )
+            return logps, torch.zeros(b, t)
+
+        def _compute_loss(self, model, inputs):
+            return torch.tensor(777.0)
+
+        def compute_loss(self, model, inputs, return_outputs=False, **kwargs):
+            return self._compute_loss(model, inputs)
+
+    @pytest.fixture
+    def realistic_batch(self):
+        return {
+            "prompt_ids": torch.tensor([[1, 2], [3, 4]]),
+            "prompt_mask": torch.tensor([[1, 1], [1, 1]]),
+            "completion_ids": torch.tensor([[5, 6, 7], [8, 9, 10]]),
+            "completion_mask": torch.tensor([[1, 1, 1], [1, 1, 1]]),
+            "advantages": torch.tensor([1.2, -0.8]),
+            "num_items_in_batch": 2,
+        }
+
+    def test_realistic_batch_without_precomputed_logps_computes_variant_loss(
+        self, realistic_batch
+    ):
+        """Realistic batch (no per_token_logps in inputs) must execute variant without fallback."""
+        from soup_cli.trainer.grpo import make_grpo_trainer_variant
+
+        variant_cls = make_grpo_trainer_variant(self._MockTRLTrainer, "gspo")
+        trainer = variant_cls()
+        loss = trainer.compute_loss(model=None, inputs=realistic_batch)
+
+        assert not trainer._soup_fallback_warned
+        assert float(loss.detach()) != 777.0
+        assert trainer._get_logps_called == 1
+
+    @pytest.mark.parametrize("variant", ["gspo", "dapo", "dr_grpo", "bnpo", "rft"])
+    def test_all_variants_execute_without_fallback_on_realistic_batch(
+        self, realistic_batch, variant
+    ):
+        """Every supported variant must execute cleanly without fallback."""
+        from soup_cli.trainer.grpo import make_grpo_trainer_variant
+
+        variant_cls = make_grpo_trainer_variant(self._MockTRLTrainer, variant)
+        trainer = variant_cls()
+        loss = trainer.compute_loss(model=None, inputs=realistic_batch)
+
+        assert not trainer._soup_fallback_warned
+        assert float(loss.detach()) != 777.0
+
+    def test_two_sided_variant_with_delta_executes(self, realistic_batch):
+        """two_sided variant with delta executes cleanly without fallback."""
+        from soup_cli.trainer.grpo import make_grpo_trainer_variant
+
+        variant_cls = make_grpo_trainer_variant(self._MockTRLTrainer, "two_sided")
+        trainer = variant_cls()
+        trainer._soup_grpo_delta = 0.2
+        loss = trainer.compute_loss(model=None, inputs=realistic_batch)
+
+        assert not trainer._soup_fallback_warned
+        assert float(loss.detach()) != 777.0
+
+    def test_standard_variant_delegates_to_stock_loss_without_warning(
+        self, realistic_batch
+    ):
+        """'standard' variant delegates directly to stock _compute_loss."""
+        from soup_cli.trainer.grpo import make_grpo_trainer_variant
+
+        variant_cls = make_grpo_trainer_variant(self._MockTRLTrainer, "standard")
+        trainer = variant_cls()
+        loss = trainer.compute_loss(model=None, inputs=realistic_batch)
+
+        assert not trainer._soup_fallback_warned
+        assert float(loss) == 777.0
+
+    def test_fallback_warns_once_on_corrupted_inputs(self):
+        """Corrupted inputs missing prompt_ids and logps must trigger fallback with warning."""
+        from soup_cli.trainer.grpo import make_grpo_trainer_variant
+
+        variant_cls = make_grpo_trainer_variant(self._MockTRLTrainer, "gspo")
+        trainer = variant_cls()
+        loss = trainer.compute_loss(model=None, inputs={"corrupted": True})
+
+        assert trainer._soup_fallback_warned
+        assert float(loss) == 777.0
+
+    def test_variant_loss_differs_from_stock_and_between_objectives(
+        self, realistic_batch
+    ):
+        """Different objectives produce mathematically distinct losses on identical data."""
+        from soup_cli.trainer.grpo import make_grpo_trainer_variant
+
+        losses = {}
+        for var in ["gspo", "dapo", "dr_grpo", "bnpo", "rft"]:
+            cls_ = make_grpo_trainer_variant(self._MockTRLTrainer, var)
+            tr = cls_()
+            losses[var] = float(tr.compute_loss(model=None, inputs=realistic_batch).detach())
+
+        # rft computes NLL on positive advantages whereas gspo uses centered ratio
+        assert losses["rft"] != losses["gspo"]
+
+    def test_real_trl_grpotrainer_end_to_end_step(self, tmp_path):
+        """End-to-end single step with real trl.GRPOTrainer and tiny model."""
+        from datasets import Dataset
+        from transformers import AutoTokenizer, GPT2Config, GPT2LMHeadModel
+        from trl import GRPOConfig, GRPOTrainer
+
+        from soup_cli.trainer.grpo import make_grpo_trainer_variant
+
+        config = GPT2Config(
+            n_layer=1,
+            n_head=1,
+            n_embd=32,
+            vocab_size=50257,
+            attn_pdrop=0.0,
+            resid_pdrop=0.0,
+            embd_pdrop=0.0,
+        )
+        model = GPT2LMHeadModel(config)
+        tokenizer = AutoTokenizer.from_pretrained("gpt2")
+        tokenizer.pad_token = tokenizer.eos_token
+        dataset = Dataset.from_dict({"prompt": ["Hello", "World"]})
+
+        training_args = GRPOConfig(
+            output_dir=str(tmp_path / "grpo_out"),
+            per_device_train_batch_size=2,
+            num_generations=2,
+            max_completion_length=4,
+            report_to="none",
+            learning_rate=1e-4,
+            max_steps=1,
+            use_cpu=True,
+        )
+
+        variant_cls = make_grpo_trainer_variant(GRPOTrainer, "gspo")
+        trainer = variant_cls(
+            model=model,
+            reward_funcs=lambda prompts, completions, **k: [1.0] * len(completions),
+            args=training_args,
+            train_dataset=dataset,
+            processing_class=tokenizer,
+        )
+
+        assert not trainer._soup_fallback_warned
+        trainer.train()
+        assert not trainer._soup_fallback_warned
+
+
 # ---------------------------------------------------------------------------
 # v0.53.11 #126 — PRM Trainer subclass factory + dataset prep
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes #584 — `_GRPOTrainerVariant.compute_loss()` in `src/soup_cli/trainer/grpo.py` checked `inputs` for `per_token_logps` before computing loss. Because `per_token_logps` represents the trainable policy log-probabilities requiring active gradients, it is never pre-populated in `inputs` by TRL's `_generate_and_score_completions()`. This caused `logp_new` to always be `None`, tripping the fallback condition on every training step and silently running the standard stock TRL GRPO loss instead of the user's requested objective (`gspo`, `dapo`, `dr_grpo`, `bnpo`, `two_sided`, `rft`).

**Fix:**
- In `_compute_variant_loss`, when `per_token_logps` is not pre-populated in `inputs`, reconstruct `input_ids` and `attention_mask` and compute `per_token_logps` in a single forward pass via `self._get_per_token_logps_and_entropies(model, ...)`.
- Fall back to `per_token_logps.detach()` for `old_per_token_logps` when missing (matching TRL's single-iteration behavior).
- Route loss computation through `_compute_loss` and `compute_loss` with gradient accumulation scaling (`current_gradient_accumulation_steps`).
- Preserves single-forward-pass efficiency and peak VRAM without redundant forward passes.
- `grpo_variant: standard` delegates directly to stock TRL loss without warning.
- Add `TestGRPOVariantRuntimeContract` with 7 regression tests in `tests/test_v05311.py`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Tests

## Checklist

- [x] `ruff check src/soup_cli/ scripts/ tests/` passes
- [x] `pytest tests/ -v` passes
- [x] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed
- [x] Added a changelog fragment, or this change has no user-visible impact