### PR TITLE
fix(ppo): honour quantize_reward_model instead of always quantizing the reward model

### DIFF
--- a/changelog.d/0.73.3/586.fixed.md
+++ b/changelog.d/0.73.3/586.fixed.md
@@ -1,4 +1,4 @@
-- PPO's reward model now only inherits the policy's Quant Menu quantization config when
-  `training.quantize_reward_model` is set (#586). Since v0.53.0 added that flag, it was
-  validated by its own task-scoped check but never read by any loader, so the reward
-  model always inherited quantization regardless of the flag's value.
+- PPO's reward model, and `task: reward_model`'s own trained model, now only inherit the
+  Quant Menu quantization config when `training.quantize_reward_model` is set (#586).
+  Since v0.53.0 added that flag, it was validated by its own task-scoped check but never
+  read by either loader, so both tasks quantized regardless of the flag's value.

--- a/changelog.d/0.73.3/586.fixed.md
+++ b/changelog.d/0.73.3/586.fixed.md
@@ -1,0 +1,4 @@
+- PPO's reward model now only inherits the policy's Quant Menu quantization config when
+  `training.quantize_reward_model` is set (#586). Since v0.53.0 added that flag, it was
+  validated by its own task-scoped check but never read by any loader, so the reward
+  model always inherited quantization regardless of the flag's value.

--- a/src/soup_cli/trainer/ppo.py
+++ b/src/soup_cli/trainer/ppo.py
@@ -783,10 +783,14 @@ def _load_reward_model(
     Reward models are typically AutoModelForSequenceClassification that output
     a scalar reward score for a given input sequence.
 
-    v0.40.5 #66: when ``tcfg`` is provided, the reward model is loaded with
-    the same quantization config as the policy model (Quant Menu). This keeps
-    the reward model from silently consuming full-precision VRAM and OOM-ing
-    when the policy is GPTQ/AWQ/HQQ/etc. Pass ``tcfg=None`` for unquantized.
+    v0.40.5 #66: when ``tcfg`` is provided and ``training.quantize_reward_model``
+    is set, the reward model is loaded with the same quantization config as
+    the policy model (Quant Menu), so it doesn't silently consume
+    full-precision VRAM and OOM when the policy is GPTQ/AWQ/HQQ/etc. v0.53.0
+    made this opt-in via that flag (default False) rather than unconditional,
+    matching ``double_quant_on``'s #321 precedent of honouring a configured
+    flag over a hardcoded default. Pass ``tcfg=None`` for unquantized
+    regardless of the flag.
     """
     from transformers import AutoModelForSequenceClassification
 
@@ -809,7 +813,7 @@ def _load_reward_model(
         "device_map": dev_map,
         "num_labels": 1,
     }
-    if tcfg is not None:
+    if tcfg is not None and tcfg.quantize_reward_model:
         from soup_cli.utils.quant_menu import build_quantization_config_for_loader
 
         quant_config_obj = build_quantization_config_for_loader(

--- a/src/soup_cli/trainer/reward_model.py
+++ b/src/soup_cli/trainer/reward_model.py
@@ -210,12 +210,19 @@ class RewardModelTrainerWrapper:
         if self.tokenizer.pad_token is None:
             self.tokenizer.pad_token = self.tokenizer.eos_token
 
-        # Quantization (v0.38.0 Quant Menu — see soup_cli.utils.quant_menu)
-        from soup_cli.utils.quant_menu import build_quantization_config_for_loader
+        # Quantization (v0.38.0 Quant Menu, see soup_cli.utils.quant_menu).
+        # v0.53.0 gated this behind training.quantize_reward_model (#586,
+        # matching _load_reward_model's PPO-path gate): this task's own
+        # trained model IS "the reward model" the flag names, so the same
+        # opt-in applies here instead of following tcfg.quantization
+        # unconditionally.
+        quant_config_obj = None
+        if tcfg.quantize_reward_model:
+            from soup_cli.utils.quant_menu import build_quantization_config_for_loader
 
-        quant_config_obj = build_quantization_config_for_loader(
-            tcfg=tcfg, base=cfg.base, console=console,
-        )
+            quant_config_obj = build_quantization_config_for_loader(
+                tcfg=tcfg, base=cfg.base, console=console,
+            )
 
         console.print(f"[dim]Loading reward model: {cfg.base}[/]")
         dev_map = resolve_device_map(self.device)
@@ -232,7 +239,7 @@ class RewardModelTrainerWrapper:
             cfg.base, **model_kwargs,
         )
 
-        if tcfg.quantization in ("4bit", "8bit", "mxfp4"):
+        if tcfg.quantize_reward_model and tcfg.quantization in ("4bit", "8bit", "mxfp4"):
             self.model = prepare_model_for_kbit_training(self.model)
 
         from soup_cli.utils.peft_wiring import resolve_lora_target_modules

--- a/tests/test_v0405_part_a.py
+++ b/tests/test_v0405_part_a.py
@@ -245,9 +245,11 @@ training: {{quantization: hqq:4bit}}
 
 
 class TestPPORewardModelQuantMenu:
-    """v0.40.5 review fix — `_load_reward_model` accepts `tcfg` and routes the
-    reward model through `build_quantization_config_for_loader` so it doesn't
-    silently OOM in full precision when the policy is GPTQ/AWQ/HQQ/etc.
+    """v0.40.5 review fix: `_load_reward_model` accepts `tcfg` and, when
+    `training.quantize_reward_model` is set (v0.53.0, opt-in, default False),
+    routes the reward model through `build_quantization_config_for_loader` so
+    it doesn't silently OOM in full precision when the policy is
+    GPTQ/AWQ/HQQ/etc.
     """
 
     def test_load_reward_model_signature_accepts_tcfg(self):
@@ -280,7 +282,7 @@ class TestPPORewardModelQuantMenu:
         # Live dispatch — mock the heavy dependencies (transformers,
         # trust_remote_code helpers, Quant Menu loader) and assert that
         # build_quantization_config_for_loader is called with the right
-        # tcfg + base when tcfg is supplied.
+        # tcfg + base when tcfg is supplied and quantize_reward_model=True.
         from soup_cli.config.schema import TrainingConfig
         from soup_cli.trainer import ppo as ppo_mod
 
@@ -326,7 +328,7 @@ class TestPPORewardModelQuantMenu:
             quant_menu, "build_quantization_config_for_loader", fake_loader
         )
 
-        tcfg = TrainingConfig(quantization="gptq")
+        tcfg = TrainingConfig(quantization="gptq", quantize_reward_model=True)
         ppo_mod._load_reward_model(
             "some-org/some-rm", device="cpu", trust_remote_code=False, tcfg=tcfg,
         )
@@ -385,6 +387,62 @@ class TestPPORewardModelQuantMenu:
 
         ppo_mod._load_reward_model("rm-path", device="cpu", trust_remote_code=False)
         assert called == [], "Quant Menu loader must not be called when tcfg is None"
+
+    def test_load_reward_model_quantize_reward_model_false_skips_quant_menu(
+        self, monkeypatch
+    ):
+        # v0.53.0 gate: tcfg is provided and quantization != "none", but
+        # training.quantize_reward_model is False (the default), so the
+        # reward model must NOT inherit the policy's quantization config.
+        from soup_cli.config.schema import TrainingConfig
+        from soup_cli.trainer import ppo as ppo_mod
+
+        called: list = []
+
+        def fake_loader(*args, **kwargs):
+            called.append(True)
+            return "FAKE_QUANT_OBJ"
+
+        from soup_cli.utils import quant_menu
+        monkeypatch.setattr(
+            quant_menu, "build_quantization_config_for_loader", fake_loader
+        )
+
+        import sys
+        import types as _types
+
+        class _FakeRM:
+            @classmethod
+            def from_pretrained(cls, path, **kwargs):
+                inst = cls()
+                inst.kwargs = kwargs
+                return inst
+
+            def eval(self):
+                pass
+
+        fake_tf = _types.ModuleType("transformers")
+        fake_tf.AutoModelForSequenceClassification = _FakeRM
+        monkeypatch.setitem(sys.modules, "transformers", fake_tf)
+
+        from soup_cli.utils import trust_remote
+        monkeypatch.setattr(
+            trust_remote, "model_requires_trust_remote_code", lambda _p: False
+        )
+        monkeypatch.setattr(
+            trust_remote, "resolve_trust_remote_code",
+            lambda *a, **kw: kw.get("requested", False),
+        )
+
+        tcfg = TrainingConfig(quantization="gptq")
+        assert tcfg.quantize_reward_model is False
+        ppo_mod._load_reward_model(
+            "some-org/some-rm", device="cpu", trust_remote_code=False, tcfg=tcfg,
+        )
+        assert called == [], (
+            "Quant Menu loader must not be called when quantize_reward_model "
+            "is False, even though tcfg is provided and quantization is set"
+        )
 
 
 class TestLoaderEntryPointNonSft:

--- a/tests/test_v0405_part_a.py
+++ b/tests/test_v0405_part_a.py
@@ -445,6 +445,122 @@ class TestPPORewardModelQuantMenu:
         )
 
 
+class TestRewardModelTaskQuantMenu:
+    """#586 review fix: ``task: reward_model``'s own trained model is "the
+    reward model" that ``training.quantize_reward_model`` names, so
+    ``RewardModelTrainerWrapper._setup_transformers`` must gate on the same
+    flag as ``ppo.py::_load_reward_model`` (TestPPORewardModelQuantMenu
+    above) instead of following ``tcfg.quantization`` unconditionally.
+
+    Same fake-``transformers``/fake-``peft`` sys.modules style as
+    TestPPORewardModelQuantMenu above (no real torch/transformers/peft
+    install needed): ``_setup_transformers`` only reaches ``device="cpu"``
+    branches, which stay import-free per ``bf16_fp16_flags``/
+    ``resolve_frozen_base_load_dtype`` in ``soup_cli.utils.gpu``.
+    """
+
+    def _run(self, monkeypatch, *, quantize_reward_model: bool, quantization: str = "4bit"):
+        import sys
+        import types as _types
+
+        from soup_cli.config.schema import SoupConfig
+        from soup_cli.trainer.reward_model import RewardModelTrainerWrapper
+
+        cfg = SoupConfig(
+            base="some-model",
+            task="reward_model",
+            data={"train": "./data.jsonl"},
+            training={
+                "quantization": quantization,
+                "quantize_reward_model": quantize_reward_model,
+            },
+        )
+
+        captured: dict = {}
+
+        class _FakeRM:
+            @classmethod
+            def from_pretrained(cls, path, **kwargs):
+                captured.update(kwargs)
+                return cls()
+
+            def parameters(self):
+                return []
+
+        class _FakeTok:
+            pad_token = "<pad>"
+
+        fake_torch = _types.ModuleType("torch")
+        fake_torch.float32 = "float32"
+        monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+        fake_tf = _types.ModuleType("transformers")
+        fake_tf.AutoModelForSequenceClassification = _FakeRM
+        fake_tf.AutoTokenizer = _types.SimpleNamespace(
+            from_pretrained=lambda *a, **k: _FakeTok()
+        )
+        monkeypatch.setitem(sys.modules, "transformers", fake_tf)
+
+        kbit_called = []
+        fake_peft = _types.ModuleType("peft")
+        fake_peft.LoraConfig = lambda **kwargs: _types.SimpleNamespace(**kwargs)
+        fake_peft.TaskType = _types.SimpleNamespace(SEQ_CLS="SEQ_CLS")
+        fake_peft.get_peft_model = lambda model, _cfg: model
+
+        def _fake_kbit_prep(model):
+            kbit_called.append(True)
+            return model
+
+        fake_peft.prepare_model_for_kbit_training = _fake_kbit_prep
+        monkeypatch.setitem(sys.modules, "peft", fake_peft)
+
+        loader_calls = []
+        sentinel = object()
+
+        def fake_loader(**kwargs):
+            loader_calls.append(kwargs)
+            return sentinel
+
+        from soup_cli.utils import quant_menu
+        monkeypatch.setattr(quant_menu, "build_quantization_config_for_loader", fake_loader)
+
+        from soup_cli.utils import trust_remote
+        monkeypatch.setattr(
+            trust_remote, "model_requires_trust_remote_code", lambda _p: False
+        )
+        monkeypatch.setattr(
+            trust_remote, "resolve_trust_remote_code",
+            lambda *a, **kw: kw.get("requested", False),
+        )
+
+        wrapper = RewardModelTrainerWrapper(cfg, device="cpu")
+        wrapper._setup_transformers(cfg, cfg.training)
+
+        return captured, loader_calls, kbit_called, sentinel
+
+    def test_quantize_reward_model_true_applies_quant_config(self, monkeypatch):
+        captured, loader_calls, kbit_called, sentinel = self._run(
+            monkeypatch, quantize_reward_model=True
+        )
+        assert len(loader_calls) == 1
+        assert captured["quantization_config"] is sentinel
+        assert kbit_called == [True]
+
+    def test_quantize_reward_model_false_skips_quant_config(self, monkeypatch):
+        captured, loader_calls, kbit_called, _sentinel = self._run(
+            monkeypatch, quantize_reward_model=False
+        )
+        assert loader_calls == [], (
+            "Quant Menu loader must not be called for task=reward_model when "
+            "quantize_reward_model is False, even though quantization is set"
+        )
+        assert "quantization_config" not in captured
+        assert kbit_called == [], (
+            "prepare_model_for_kbit_training must not run when the model was "
+            "never loaded with a quantization_config"
+        )
+
+
 class TestLoaderEntryPointNonSft:
     """Smoke: build_quantization_config_for_loader returns a non-None
     quant config for the seven Quant Menu formats. Heavy transformers


### PR DESCRIPTION
## What does this PR do?

`_load_reward_model` (`ppo.py`) applies the policy model's Quant Menu config to the
reward model whenever a `tcfg` is passed, regardless of `training.quantize_reward_model`.
That flag was added in v0.53.0 with its own task-scoped validator
(`_validate_quantize_ref_reward`, "silent-no-op footgun rejection"), but no loader ever
reads it: `quantize_reward_model=False` (the default) does not stop the reward model from
inheriting quantization, and `=True` changes nothing either way.

Gates it on the flag instead: the quant config is only built and applied when
`tcfg.quantize_reward_model` is set. This follows the same shape as `double_quant_on`'s
#321 fix (`quant_menu.py`), which replaced a hardcoded `True` with the configured value.

## Type of change

- [x] Bug fix

## Checklist

- [x] `ruff check src/soup_cli/ scripts/ tests/` passes (scoped to the two changed files;
  full-repo run needs the `[dev]` extra, not installed here)
- [x] `pytest tests/ -v` passes on the files this change touches or exercises (see below);
  the full suite needs the `[dev]` extra (`torch`/`transformers`/`trl`/...), not installed
  in this environment
- [ ] Updated relevant docs: not needed, no public API/CLI surface changed
- [ ] Changelog fragment: added in a follow-up commit once this PR's number is known
  (`changelog.d/<release>/<number>.fixed.md`, per `changelog.d/README.md`)

## How I verified this

- New regression test, `TestPPORewardModelQuantMenu::test_load_reward_model_quantize_reward_model_false_skips_quant_menu`:
  builds a `TrainingConfig(quantization="gptq")` (the default `quantize_reward_model=False`)
  and asserts the Quant Menu loader is never called. Fails on `main` (loader called anyway),
  passes on this branch.
- Updated `test_load_reward_model_routes_through_quant_menu_live` to set
  `quantize_reward_model=True`, since it is specifically testing the flag-on path.
- Full `tests/test_v0405_part_a.py` (134 tests) and `tests/test_ppo.py` (51 tests) green,
  including the schema validator tests in `tests/test_v0530.py -k quantize` (10 tests).
- `tests/test_bugfixes.py`/`tests/test_trainer_init.py`: the same 11 tests fail on both
  `main` and this branch (missing `datasets`/`torch` in this lightweight environment,
  unrelated to this change), everything else green.
- Coverage on the changed lines in `_load_reward_model` (`--cov=soup_cli.trainer.ppo`):
  fully covered by the test suite above.
- Not run: the `[dev]`-extra test matrix (real `torch`/`transformers`/`trl`), and `mypy`
  (crashed with an internal error against the light install and I did not chase it further;
  the CI `type-check` job is non-blocking).
