### PR TITLE
fix(train): warn on unwired convergence detection (#583)

### DIFF
--- a/changelog.d/0.73.3/583.fixed.md
+++ b/changelog.d/0.73.3/583.fixed.md
@@ -1,0 +1,3 @@
+`soup train` now warns when `training.convergence_detection` is enabled but not
+yet wired into the live training loop, matching the existing honesty guard for
+other advisory training-intelligence flags.

--- a/changelog.d/0.73.3/583.fixed.md
+++ b/changelog.d/0.73.3/583.fixed.md
@@ -1,3 +1,3 @@
-`soup train` now warns when `training.convergence_detection` is enabled but not
+- `soup train` now warns when `training.convergence_detection` is enabled but not
 yet wired into the live training loop, matching the existing honesty guard for
-other advisory training-intelligence flags.
+other advisory training-intelligence flags (#583).

--- a/docs/peft-and-efficiency.md
+++ b/docs/peft-and-efficiency.md
@@ -578,7 +578,9 @@ training:
   convergence_rel_tol: 0.005  # Relative range below this == plateau
 ```
 
-Surfaces `continue` / `early_stop` / `lower_lr` advice based on the loss curve.
+Computes `continue` / `early_stop` / `lower_lr` advice from the loss curve for
+callers that invoke the detector. `soup train` currently reports this option as
+not enforced; a live training callback remains a follow-up.
 
 ### VRAM Pressure Advisory
 

--- a/src/soup_cli/commands/train.py
+++ b/src/soup_cli/commands/train.py
@@ -724,6 +724,7 @@ def train(
             ("forgetting_detection", cfg.training.forgetting_detection),
             ("checkpoint_intelligence", cfg.training.checkpoint_intelligence),
             ("early_stop_on_regression", cfg.training.early_stop_on_regression),
+            ("convergence_detection", cfg.training.convergence_detection),
         )
         if on
     ]

--- a/tests/test_code_review_critical.py
+++ b/tests/test_code_review_critical.py
@@ -178,6 +178,43 @@ def test_eval_benchmark_rejects_trust_remote_code_injection(tmp_path, monkeypatc
     assert "trust_remote_code" in result.output or "delimiters" in result.output
 
 
+def test_train_warns_for_unwired_convergence_detection(tmp_path, monkeypatch):
+    """The accepted convergence flag must be covered by the honesty guard."""
+    from typer.testing import CliRunner
+
+    import soup_cli.commands.train as train_mod
+    from soup_cli.cli import app
+
+    data_path = tmp_path / "train.jsonl"
+    data_path.write_text('{"text": "hello"}\n', encoding="utf-8")
+    config_path = tmp_path / "soup.yaml"
+    config_path.write_text(
+        "base: sshleifer/tiny-gpt2\n"
+        "task: sft\n"
+        f"output: {tmp_path / 'out'}\n"
+        "data:\n"
+        f"  train: {data_path}\n"
+        "training:\n"
+        "  convergence_detection: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(train_mod, "detect_device", lambda backend=None: ("cpu", "CPU"))
+    monkeypatch.setattr(
+        train_mod, "get_gpu_info", lambda backend=None: {"memory_total": "N/A"}
+    )
+    monkeypatch.setattr(
+        train_mod,
+        "load_dataset",
+        lambda *args, **kwargs: {"train": [{"text": "hello"}]},
+    )
+
+    result = CliRunner().invoke(
+        app, ["train", "--config", str(config_path), "--dry-run", "--yes"]
+    )
+    assert result.exit_code == 0, (result.output, repr(result.exception))
+    assert "convergence_detection are set but not enforced" in result.output
+
+
 # ─────────────────────────── CRITICAL 4: webhook SSRF ──────────────────────────
 
 


### PR DESCRIPTION
## Summary

- Include training.convergence_detection in the existing train-command honesty guard.
- Add an end-to-end dry-run regression test for the user-visible warning.
- Document that the detector remains advisory until a live callback wires it in, and add a changelog fragment.

Fixes #583.

## Validation

- PYTHONPATH=src pytest tests/test_code_review_critical.py tests/test_training_intelligence.py --no-cov -q — 58 passed
- uff check src/soup_cli/ tests/ — passed
- git diff --check — passed
- Mutation: removing convergence_detection from the guard made the new regression test fail.