### PR TITLE
fix(train): make FSDP QLoRA dtype-compatible

### DIFF
--- a/changelog.d/0.73.3/588.fixed.md
+++ b/changelog.d/0.73.3/588.fixed.md
@@ -1,0 +1,5 @@
+- [#588](https://github.com/MakazhanAlpamys/Soup/pull/588) makes FSDP + BNB
+  4-bit training resolve quantized storage and trainable adapter
+  parameters to the same floating compute dtype, preventing the integer-storage
+  and mixed-dtype flattening failures that made the `llama3-70b-fsdp2` recipe
+  unrunnable. The recipe now pins bf16 storage for its A100/H100 target hardware.

--- a/docs/performance-and-quantization.md
+++ b/docs/performance-and-quantization.md
@@ -172,7 +172,8 @@ base: TheBloke/Llama-2-7B-Chat-GPTQ
 training:
   quantization: gptq        # or: awq, hqq:4bit, aqlm, eetq, mxfp4, fp8
 
-# FSDP + QLoRA — set quant_storage:
+# FSDP + QLoRA — Soup resolves this to the compute dtype automatically;
+# pin it explicitly when the recipe targets known bf16 hardware:
 training:
   quantization: 4bit
   bnb_4bit_quant_storage: bfloat16
@@ -193,8 +194,11 @@ training:
 
 **Compatibility matrix.** `soup train` runs `check_quant_distributed_compat()` at
 startup. HQQ / EETQ / AQLM hard-fail with FSDP and ZeRO-3 (sourced from
-LlamaFactory's matrix at `quantization.py:199/211`); BNB 4-bit + FSDP without
-`bnb_4bit_quant_storage` emits a yellow warning.
+LlamaFactory's matrix at `quantization.py:199/211`). BNB 4-bit + FSDP resolves
+`bnb_4bit_quant_storage` to the effective floating compute dtype before model
+load, then aligns trainable adapter parameters to that dtype before FSDP wraps
+the model. This avoids both FSDP failure modes: integer storage and mixed
+adapter/storage dtypes.
 
 **Pre-quantized + QAT.** `gptq` / `awq` / `hqq:*` / `aqlm` / `eetq` / `mxfp4` /
 `fp8` all carry their own scale; combining with `quantization_aware` (int8 QAT or

--- a/src/soup_cli/commands/train.py
+++ b/src/soup_cli/commands/train.py
@@ -836,6 +836,25 @@ def train(
         fsdp_kwargs = get_fsdp_training_args(fsdp)
         console.print(f"[green]FSDP2 enabled:[/] {fsdp}")
 
+    # #350 — BNB's default uint8 quant storage is not merely slow under FSDP:
+    # FSDP cannot flatten it. Resolve storage to the exact BNB compute dtype
+    # before any trainer builds its BitsAndBytesConfig. This updates the
+    # effective config shared by every wrapper and the reproducibility receipt.
+    from soup_cli.utils.quant_menu import resolve_fsdp_qlora_quant_storage
+
+    original_quant_storage = cfg.training.bnb_4bit_quant_storage
+    resolved_training = resolve_fsdp_qlora_quant_storage(
+        cfg.training,
+        fsdp=bool(fsdp),
+    )
+    if resolved_training is not cfg.training:
+        cfg = cfg.model_copy(update={"training": resolved_training})
+        action = "selected" if original_quant_storage is None else "overrode"
+        console.print(
+            f"[green]FSDP QLoRA:[/] {action} bnb_4bit_quant_storage="
+            f"{resolved_training.bnb_4bit_quant_storage} to match compute dtype"
+        )
+
     # --- v0.38.0 Quant Menu × multi-GPU compatibility check ---
     from soup_cli.utils.quant_menu import check_quant_distributed_compat
 
@@ -1434,6 +1453,26 @@ def train(
 
         trainer_wrapper = SFTTrainerWrapper(cfg, **trainer_kwargs)
     trainer_wrapper.setup(dataset)
+
+    # #350 — PEFT promotes newly-created adapters to fp32. FSDP cannot flatten
+    # those beside bf16/float16 BNB storage, so align every trainable floating
+    # tensor after setup creates PEFT modules and before train() wraps the model.
+    aligned_fsdp_params = 0
+    if fsdp and cfg.training.quantization == "4bit":
+        from soup_cli.utils.gpu import get_compute_dtype
+        from soup_cli.utils.mixed_precision import align_trainable_dtype_for_fsdp_qlora
+
+        aligned_fsdp_params = align_trainable_dtype_for_fsdp_qlora(
+            getattr(trainer_wrapper, "model", None),
+            fsdp=True,
+            quantization=cfg.training.quantization,
+            compute_dtype=get_compute_dtype(),
+        )
+    if aligned_fsdp_params:
+        console.print(
+            f"[green]FSDP QLoRA:[/] aligned {aligned_fsdp_params} trainable "
+            "parameter tensor(s) to the compute dtype"
+        )
 
     # --- HF auto-push callback (Part B of v0.29.0) ---
     if push_as:

--- a/src/soup_cli/config/schema.py
+++ b/src/soup_cli/config/schema.py
@@ -1141,9 +1141,9 @@ class TrainingConfig(BaseModel):
     ] = Field(
         default=None,
         description=(
-            "v0.38.0 Part G — BNB 4-bit storage dtype. Required for FSDP+QLoRA "
-            "(set to 'bfloat16' or 'float16' to match compute dtype). "
-            "When None, BNB picks 'uint8' (legacy default)."
+            "v0.38.0 Part G — BNB 4-bit storage dtype. FSDP+QLoRA resolves "
+            "this automatically to the effective floating compute dtype; "
+            "outside FSDP, None keeps BNB's legacy uint8 default."
         ),
     )
     quantization_aware: Union[bool, Literal["fp8"]] = Field(

--- a/src/soup_cli/recipes/catalog.py
+++ b/src/soup_cli/recipes/catalog.py
@@ -1414,6 +1414,7 @@ training:
     alpha: 32
     target_modules: auto
   quantization: 4bit
+  bnb_4bit_quant_storage: bfloat16
   use_fsdp2_compile: true
   gradient_checkpointing: true
 

--- a/src/soup_cli/utils/mixed_precision.py
+++ b/src/soup_cli/utils/mixed_precision.py
@@ -110,3 +110,37 @@ def align_trainable_dtype_for_fp16(model, *, fp16: bool, bf16: bool) -> int:
             param.data = param.data.to(torch.float32)
             casted += 1
     return casted
+
+
+def align_trainable_dtype_for_fsdp_qlora(
+    model,
+    *,
+    fsdp: bool,
+    quantization: str,
+    compute_dtype,
+) -> int:
+    """Cast every trainable floating QLoRA parameter to FSDP's storage dtype.
+
+    ``get_peft_model`` normally promotes LoRA weights to fp32. Under FSDP +
+    BNB 4-bit, the frozen quantized parameters use a floating ``quant_storage``
+    matching BNB's compute dtype, and FSDP requires every floating parameter in
+    a flat unit to share that dtype. Cast only the trainable floating set: the
+    packed 4-bit base stays untouched, as do frozen non-quantized parameters.
+
+    The command calls this after every wrapper's ``setup()`` (and therefore
+    after PEFT creates adapters) but before ``train()`` lets HF wrap the model.
+    Returns the number of parameter tensors cast.
+    """
+    if model is None or not fsdp or quantization != "4bit":
+        return 0
+
+    casted = 0
+    for _name, param in model.named_parameters():
+        if (
+            param.requires_grad
+            and param.is_floating_point()
+            and param.dtype != compute_dtype
+        ):
+            param.data = param.data.to(compute_dtype)
+            casted += 1
+    return casted

--- a/src/soup_cli/utils/quant_menu.py
+++ b/src/soup_cli/utils/quant_menu.py
@@ -324,6 +324,51 @@ def _distributed_strategy(deepspeed: object, fsdp: bool) -> str:
     return "ddp"
 
 
+def _floating_dtype_name(dtype: object) -> str:
+    """Return a schema-compatible name for a floating compute dtype.
+
+    Accepting the string form keeps the policy unit-testable without importing
+    torch. Runtime callers pass a real ``torch.dtype`` from
+    :func:`soup_cli.utils.gpu.get_compute_dtype`.
+    """
+    name = str(dtype).removeprefix("torch.")
+    if name not in {"float16", "bfloat16", "float32"}:
+        raise ValueError(
+            "FSDP + BNB 4-bit requires a floating compute dtype for "
+            f"quant storage; got {name!r}"
+        )
+    return name
+
+
+def resolve_fsdp_qlora_quant_storage(
+    tcfg: TrainingConfig,
+    *,
+    fsdp: bool,
+    compute_dtype: object | None = None,
+) -> TrainingConfig:
+    """Resolve FSDP QLoRA storage to the effective BNB compute dtype.
+
+    BNB's legacy uint8 storage cannot be flattened by FSDP. A floating storage
+    dtype gets past that boundary, but it must also match the trainable adapter
+    dtype or FSDP fails one step later on a mixed-dtype flat-parameter unit.
+    Resolve both sides from the same compute dtype rather than leaving users to
+    coordinate two independent settings (#350).
+
+    A copy is returned only for the exact FSDP + BNB-4bit combination. This
+    leaves ordinary QLoRA and non-BNB quantization byte-for-byte unchanged.
+    """
+    if not fsdp or tcfg.quantization != "4bit":
+        return tcfg
+    if compute_dtype is None:
+        from soup_cli.utils.gpu import get_compute_dtype
+
+        compute_dtype = get_compute_dtype()
+    storage = _floating_dtype_name(compute_dtype)
+    if tcfg.bnb_4bit_quant_storage == storage:
+        return tcfg
+    return tcfg.model_copy(update={"bnb_4bit_quant_storage": storage})
+
+
 def build_quantization_config_for_loader(
     *,
     tcfg: TrainingConfig,
@@ -477,12 +522,7 @@ def check_quant_distributed_compat(
     msg = _INCOMPATIBLE.get((family, strategy))
     if msg:
         problems.append(msg)
-    # BNB 4-bit + FSDP without quant_storage = silent perf foot-gun.
-    if family == "bnb4" and strategy == "fsdp" and not bnb_4bit_quant_storage:
-        problems.append(
-            "warning: BNB 4-bit + FSDP without bnb_4bit_quant_storage causes "
-            "all-gather to upcast to fp32. Set bnb_4bit_quant_storage to your "
-            "compute dtype (bfloat16 or float16) for a 2-3x speed-up. "
-            "(LlamaFactory quantization.py:178 'crucial for fsdp+qlora')"
-        )
+    # #350 resolves BNB 4-bit storage to the compute dtype before this check.
+    # Missing storage is therefore no longer a user warning: the shipped uint8
+    # default is a hard FSDP stop, so execution fixes it rather than advising.
     return problems

--- a/tests/test_issue350_fsdp_qlora.py
+++ b/tests/test_issue350_fsdp_qlora.py
@@ -1,0 +1,273 @@
+"""#350 — make FSDP + BNB 4-bit a runnable configuration.
+
+The shipped 70B recipe reached FSDP with uint8 quantized storage and fp32 LoRA
+parameters. FSDP cannot flatten either the integer storage or the mixed
+bf16/fp32 unit, so both decisions are tested here without requiring eight GPUs.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+
+class _FakeData:
+    def __init__(self, dtype: object) -> None:
+        self.dtype = dtype
+        self.casts: list[object] = []
+
+    def to(self, dtype: object) -> "_FakeData":
+        self.dtype = dtype
+        self.casts.append(dtype)
+        return self
+
+
+class _FakeParam:
+    def __init__(
+        self,
+        dtype: object,
+        *,
+        requires_grad: bool,
+        floating: bool = True,
+    ) -> None:
+        self.requires_grad = requires_grad
+        self._floating = floating
+        self.data = _FakeData(dtype)
+
+    @property
+    def dtype(self) -> object:
+        return self.data.dtype
+
+    def is_floating_point(self) -> bool:
+        return self._floating
+
+
+class _FakeModel:
+    def __init__(self, **params: _FakeParam) -> None:
+        self._params = params
+
+    def named_parameters(self):
+        return self._params.items()
+
+
+def test_fsdp_4bit_resolves_storage_to_compute_dtype() -> None:
+    from soup_cli.config.schema import TrainingConfig
+    from soup_cli.utils.quant_menu import resolve_fsdp_qlora_quant_storage
+
+    original = TrainingConfig(quantization="4bit")
+    resolved = resolve_fsdp_qlora_quant_storage(
+        original,
+        fsdp=True,
+        compute_dtype="bfloat16",
+    )
+
+    assert original.bnb_4bit_quant_storage is None
+    assert resolved.bnb_4bit_quant_storage == "bfloat16"
+
+
+def test_runtime_resolution_asks_the_shared_compute_dtype_probe(monkeypatch) -> None:
+    from soup_cli.config.schema import TrainingConfig
+    from soup_cli.utils import gpu
+    from soup_cli.utils.quant_menu import resolve_fsdp_qlora_quant_storage
+
+    monkeypatch.setattr(gpu, "get_compute_dtype", lambda: "bfloat16")
+    resolved = resolve_fsdp_qlora_quant_storage(
+        TrainingConfig(quantization="4bit"),
+        fsdp=True,
+    )
+
+    assert resolved.bnb_4bit_quant_storage == "bfloat16"
+    assert resolve_fsdp_qlora_quant_storage(
+        resolved,
+        fsdp=True,
+        compute_dtype="bfloat16",
+    ) is resolved
+
+
+def test_resolved_storage_reaches_bitsandbytes_config(monkeypatch) -> None:
+    from soup_cli.config.schema import TrainingConfig
+    from soup_cli.utils import gpu
+    from soup_cli.utils.quant_menu import (
+        build_quantization_config_for_loader,
+        resolve_fsdp_qlora_quant_storage,
+    )
+
+    bf16 = object()
+    fake_torch = ModuleType("torch")
+    fake_torch.uint8 = object()  # type: ignore[attr-defined]
+    fake_torch.float16 = object()  # type: ignore[attr-defined]
+    fake_torch.bfloat16 = bf16  # type: ignore[attr-defined]
+    fake_torch.float32 = object()  # type: ignore[attr-defined]
+
+    class FakeBitsAndBytesConfig:
+        def __init__(self, **kwargs) -> None:
+            self.__dict__.update(kwargs)
+
+    fake_transformers = ModuleType("transformers")
+    fake_transformers.BitsAndBytesConfig = FakeBitsAndBytesConfig  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+    monkeypatch.setattr(gpu, "get_compute_dtype", lambda: bf16)
+
+    resolved = resolve_fsdp_qlora_quant_storage(
+        TrainingConfig(quantization="4bit"),
+        fsdp=True,
+        compute_dtype="bfloat16",
+    )
+    quant_config = build_quantization_config_for_loader(tcfg=resolved, base="m")
+
+    assert quant_config.bnb_4bit_quant_storage is bf16
+
+
+def test_fsdp_4bit_overrides_integer_storage() -> None:
+    from soup_cli.config.schema import TrainingConfig
+    from soup_cli.utils.quant_menu import resolve_fsdp_qlora_quant_storage
+
+    original = TrainingConfig(
+        quantization="4bit",
+        bnb_4bit_quant_storage="uint8",
+    )
+    resolved = resolve_fsdp_qlora_quant_storage(
+        original,
+        fsdp=True,
+        compute_dtype="float16",
+    )
+
+    assert resolved.bnb_4bit_quant_storage == "float16"
+
+
+def test_storage_resolution_is_independent_of_fsdp_compile() -> None:
+    from soup_cli.config.schema import TrainingConfig
+    from soup_cli.utils.quant_menu import resolve_fsdp_qlora_quant_storage
+
+    for compile_enabled in (False, True):
+        original = TrainingConfig(
+            quantization="4bit",
+            use_fsdp2_compile=compile_enabled,
+        )
+        resolved = resolve_fsdp_qlora_quant_storage(
+            original,
+            fsdp=True,
+            compute_dtype="bfloat16",
+        )
+        assert resolved.use_fsdp2_compile is compile_enabled
+        assert resolved.bnb_4bit_quant_storage == "bfloat16"
+
+
+def test_non_fsdp_or_non_4bit_config_is_unchanged() -> None:
+    from soup_cli.config.schema import TrainingConfig
+    from soup_cli.utils.quant_menu import resolve_fsdp_qlora_quant_storage
+
+    four_bit = TrainingConfig(quantization="4bit")
+    eight_bit = TrainingConfig(quantization="8bit")
+
+    assert resolve_fsdp_qlora_quant_storage(
+        four_bit,
+        fsdp=False,
+        compute_dtype="bfloat16",
+    ) is four_bit
+    assert resolve_fsdp_qlora_quant_storage(
+        eight_bit,
+        fsdp=True,
+        compute_dtype="bfloat16",
+    ) is eight_bit
+
+
+def test_fsdp_4bit_rejects_non_floating_compute_storage() -> None:
+    from soup_cli.config.schema import TrainingConfig
+    from soup_cli.utils.quant_menu import resolve_fsdp_qlora_quant_storage
+
+    tcfg = TrainingConfig(quantization="4bit")
+
+    try:
+        resolve_fsdp_qlora_quant_storage(tcfg, fsdp=True, compute_dtype="uint8")
+    except ValueError as exc:
+        assert "floating compute dtype" in str(exc)
+    else:  # pragma: no cover - the assertion above is the intended path
+        raise AssertionError("integer FSDP quant storage was accepted")
+
+
+def test_fsdp_qlora_casts_every_trainable_float_to_compute_dtype() -> None:
+    from soup_cli.utils.mixed_precision import align_trainable_dtype_for_fsdp_qlora
+
+    model = _FakeModel(
+        lora_A=_FakeParam("float32", requires_grad=True),
+        lora_B=_FakeParam("float32", requires_grad=True),
+        modules_to_save_head=_FakeParam("float16", requires_grad=True),
+        frozen_base=_FakeParam("float32", requires_grad=False),
+        packed_4bit=_FakeParam("uint8", requires_grad=False, floating=False),
+    )
+
+    casted = align_trainable_dtype_for_fsdp_qlora(
+        model,
+        fsdp=True,
+        quantization="4bit",
+        compute_dtype="bfloat16",
+    )
+
+    assert casted == 3
+    assert all(
+        param.dtype == "bfloat16"
+        for param in model._params.values()
+        if param.requires_grad and param.is_floating_point()
+    )
+    assert model._params["frozen_base"].dtype == "float32"
+    assert model._params["packed_4bit"].dtype == "uint8"
+
+
+def test_fsdp_qlora_alignment_is_gated_to_the_exact_combination() -> None:
+    from soup_cli.utils.mixed_precision import align_trainable_dtype_for_fsdp_qlora
+
+    for fsdp, quantization in ((False, "4bit"), (True, "8bit"), (False, "8bit")):
+        param = _FakeParam("float32", requires_grad=True)
+        model = _FakeModel(lora_A=param)
+        assert align_trainable_dtype_for_fsdp_qlora(
+            model,
+            fsdp=fsdp,
+            quantization=quantization,
+            compute_dtype="bfloat16",
+        ) == 0
+        assert param.dtype == "float32"
+
+
+def test_train_command_wires_both_fsdp_qlora_guards() -> None:
+    """A tested helper that the command never calls would leave #350 live."""
+    import inspect
+
+    from soup_cli.commands import train
+
+    source = inspect.getsource(train.train)
+    assert "resolve_fsdp_qlora_quant_storage" in source
+    assert "align_trainable_dtype_for_fsdp_qlora" in source
+    assert source.index("resolve_fsdp_qlora_quant_storage") < source.index(
+        "trainer_wrapper.setup(dataset)"
+    )
+    assert source.index("trainer_wrapper.setup(dataset)") < source.index(
+        "align_trainable_dtype_for_fsdp_qlora"
+    )
+
+
+def test_llama3_70b_fsdp2_recipe_pins_bf16_storage() -> None:
+    import yaml
+
+    from soup_cli.recipes.catalog import RECIPES
+
+    recipe = yaml.safe_load(RECIPES["llama3-70b-fsdp2"].yaml_str)
+    assert recipe["training"]["quantization"] == "4bit"
+    assert recipe["training"]["bnb_4bit_quant_storage"] == "bfloat16"
+    assert recipe["training"]["use_fsdp2_compile"] is True
+
+
+def test_alignment_accepts_wrapper_model_shape() -> None:
+    """Document the exact command-boundary object shape used after setup()."""
+    from soup_cli.utils.mixed_precision import align_trainable_dtype_for_fsdp_qlora
+
+    wrapper = SimpleNamespace(
+        model=_FakeModel(lora_A=_FakeParam("float32", requires_grad=True))
+    )
+    assert align_trainable_dtype_for_fsdp_qlora(
+        wrapper.model,
+        fsdp=True,
+        quantization="4bit",
+        compute_dtype="bfloat16",
+    ) == 1

--- a/tests/test_quant_menu.py
+++ b/tests/test_quant_menu.py
@@ -426,7 +426,7 @@ class TestCompatMatrix:
         )
         assert problems == []
 
-    def test_compat_check_4bit_fsdp_warns_without_quant_storage(self):
+    def test_compat_check_4bit_fsdp_without_storage_is_auto_resolved(self):
         from soup_cli.utils.quant_menu import check_quant_distributed_compat
 
         problems = check_quant_distributed_compat(
@@ -435,9 +435,9 @@ class TestCompatMatrix:
             fsdp=True,
             bnb_4bit_quant_storage=None,
         )
-        # Returned as a 'warning' tag, not a hard error.
-        warnings = [p for p in problems if "warning" in p.lower()]
-        assert any("quant_storage" in w.lower() for w in warnings)
+        # #350 resolves this to the compute dtype before model loading, so the
+        # old advisory (which understated a hard stop as a speed warning) is gone.
+        assert problems == []
 
     def test_compat_check_gptq_ddp_clean(self):
         from soup_cli.utils.quant_menu import check_quant_distributed_compat


### PR DESCRIPTION
Closes #350

## What

- resolve BNB 4-bit quant storage to the effective floating compute dtype whenever `--fsdp` is active
- align every trainable floating PEFT parameter to that dtype after trainer setup and before FSDP wrapping
- pin bf16 storage in the 70B FSDP2 recipe and document the automatic behavior
- replace the old speed-warning behavior, which understated a hard runtime failure

## Verification

- `ruff check src/soup_cli/ scripts/ tests/`
- 131 focused tests passed, 1 platform-dependent test skipped
- new dependency-light regression coverage verifies storage resolution, the emitted BitsAndBytesConfig, adapter/module-to-save casting, non-FSDP controls, compile on/off, central command wiring, and the recipe

## Hardware limitation

I do not have an 8×H100 environment. The CPU-testable policy and wiring are covered here, but the acceptance run `soup train --config <llama3-70b-fsdp2> --gpus 8 --fsdp full_shard` still needs maintainer hardware validation through step 1.