### PR TITLE
bench: publish bitsandbytes reproduction harness

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -34,9 +34,10 @@ on trust. It starts small on purpose — most of this session's ~20 harnesses li
 only in a scratchpad on a machine that is gone, which is
 [#379](https://github.com/MakazhanAlpamys/Soup/issues/379).
 
-| Script | Question it answers | Cost |
-|---|---|---|
-| [`issue331_qlora_scope.py`](harness/issue331_qlora_scope.py) | Does the #331 wrong-gradient defect reach **ordinary QLoRA**? Three arms in one process, with the positive control that makes an exact result mean something. Answer: no — 0.0 against a control that diverges by 3.77e-01 | ~15 s, 4 GB card, no downloads |
+| Script | STEP / record | Question or claim | Cost / requirements |
+|---|---|---|---|
+| [`issue331_qlora_scope.py`](harness/issue331_qlora_scope.py) | #331 | Does the wrong-gradient defect reach **ordinary QLoRA**? Three arms in one process, with a positive control. Answer: no — 0.0 against a control that diverges by 3.77e-01 | ~15 s, 4 GB card, no downloads |
+| [`bnb_repro.py`](harness/bnb_repro.py) | Upstream bitsandbytes #2034 / NF4 defect | Minimal standalone reproducer for the NF4 stale-gradient mechanism: recycled buffers expose `MatMul4Bit`'s `ctx` lifetime issue; private buffers are the reference and bf16 is the control | CUDA GPU required; no downloads; historical environment: torch 2.13.0+cu130, bitsandbytes 0.50.0; ~1 min |
 
 ## Hardware
 

--- a/benchmarks/harness/bnb_repro.py
+++ b/benchmarks/harness/bnb_repro.py
@@ -1,0 +1,174 @@
+"""Standalone reproducer for bitsandbytes issue #2034.
+
+This is the upstream minimal reproducer used to demonstrate that
+``MatMul4Bit`` keeps the packed weight and quantization state on the
+autograd context as ordinary attributes instead of saved tensors.
+
+Requirements
+------------
+- CUDA GPU required.
+- No model download is required.
+- Historical environment: torch 2.13.0+cu130, bitsandbytes 0.50.0.
+- The original reproducer uses one CUDA device and takes about one minute.
+
+Protocol
+--------
+Compare three arms using gradient checkpointing:
+
+- NF4 with recycled buffers: expected to reproduce the defect.
+- NF4 with private buffers: reference.
+- bf16 with recycled buffers: control.
+
+The trainable parameter is upstream of the 4-bit matmul so its gradient
+depends on the value consumed by ``MatMul4Bit.backward``.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import bitsandbytes as bnb
+import torch
+import torch.nn.functional as functional
+from bitsandbytes.functional import quantize_4bit
+from torch.utils.checkpoint import checkpoint
+
+DEV = "cuda"
+DTYPE = torch.bfloat16
+N_LAYERS = 8
+DIM = 4096
+TOKENS = 256
+POOL_SLOTS = 2
+
+
+class SlotPool:
+    """Round-robin device buffers used by the recycled-buffer arm."""
+
+    def __init__(self, n_slots, like):
+        self.slots = [torch.empty_like(like) for _ in range(n_slots)]
+        self.cursor = 0
+
+    def acquire(self, src):
+        slot = self.slots[self.cursor % len(self.slots)]
+        self.cursor += 1
+        slot.copy_(src)
+        return slot
+
+
+def run(quant, recycle, params_init):
+    torch.manual_seed(0)
+    weights = [
+        torch.randn(DIM, DIM, device=DEV, dtype=DTYPE) / 32
+        for _ in range(N_LAYERS)
+    ]
+
+    if quant == "nf4":
+        sources, states = [], []
+        for weight in weights:
+            packed, state = quantize_4bit(
+                weight,
+                blocksize=64,
+                quant_type="nf4",
+                compress_statistics=True,
+            )
+            sources.append(packed)
+            states.append(state)
+    else:
+        sources, states = weights, [None] * N_LAYERS
+
+    pool = SlotPool(POOL_SLOTS, sources[0]) if recycle else None
+    params = [param.clone().requires_grad_(True) for param in params_init]
+
+    def body(idx):
+        def fn(x, scale):
+            hidden = x * scale
+
+            # The buffer refill occurs inside the checkpointed region.
+            weight = pool.acquire(sources[idx]) if recycle else sources[idx]
+
+            if quant == "nf4":
+                return bnb.matmul_4bit(
+                    hidden,
+                    weight.t(),
+                    quant_state=states[idx],
+                )
+
+            return functional.linear(hidden, weight)
+
+        return fn
+
+    x = torch.randn(
+        TOKENS,
+        DIM,
+        device=DEV,
+        dtype=DTYPE,
+        requires_grad=True,
+    )
+
+    for index in range(N_LAYERS):
+        x = checkpoint(
+            body(index),
+            x,
+            params[index],
+            use_reentrant=False,
+        )
+
+    x.float().pow(2).mean().backward()
+
+    return [param.grad.detach().float().clone() for param in params]
+
+
+def main() -> int:
+    if not torch.cuda.is_available():
+        print("SKIP: CUDA is required for bnb_repro.py")
+        return 0
+
+    print(f"torch         {torch.__version__}")
+    print(f"bitsandbytes  {bnb.__version__}")
+    print(f"gpu           {torch.cuda.get_device_name(0)}")
+    print(
+        f"shape         {N_LAYERS} layers x {DIM} x {DIM}, "
+        f"M={TOKENS}, dtype={DTYPE}"
+    )
+
+    torch.manual_seed(1234)
+    init = [
+        torch.ones(DIM, device=DEV, dtype=DTYPE)
+        + 0.01 * torch.randn(DIM, device=DEV, dtype=DTYPE)
+        for _ in range(N_LAYERS)
+    ]
+
+    reference = run("nf4", recycle=False, params_init=init)
+    recycled = run("nf4", recycle=True, params_init=init)
+    bf16_recycled = run("bf16", recycle=True, params_init=init)
+    bf16_reference = run("bf16", recycle=False, params_init=init)
+
+    print()
+    print(
+        f"{'layer':>5}  "
+        f"{'nf4 recycled vs private':>24}  "
+        f"{'bf16 recycled vs private':>25}"
+    )
+
+    for index in range(N_LAYERS):
+        nf4_diff = (
+            recycled[index] - reference[index]
+        ).abs().max().item()
+        bf16_diff = (
+            bf16_recycled[index] - bf16_reference[index]
+        ).abs().max().item()
+
+        nf4_status = "MISMATCH" if nf4_diff else "ok"
+        bf16_status = "MISMATCH" if bf16_diff else "ok"
+
+        print(
+            f"{index:>5}  "
+            f"{nf4_diff:>16.6e} {nf4_status:>9}  "
+            f"{bf16_diff:>16.6e} {bf16_status:>9}"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/harness/bnb_repro.py
+++ b/benchmarks/harness/bnb_repro.py
@@ -21,10 +21,23 @@ Compare three arms using gradient checkpointing:
 
 The trainable parameter is upstream of the 4-bit matmul so its gradient
 depends on the value consumed by ``MatMul4Bit.backward``.
+
+Negative control
+---------------
+``--bypass-pool`` deliberately disables the recycled-buffer allocation
+for the NF4 candidate arm. The NF4 mismatch must then disappear. The
+harness treats that as a detected mutation and exits non-zero, proving
+that the reproduction depends on the recycled-buffer path.
+
+The normal invocation also requires the NF4 recycled/private comparison
+to mismatch. If ``pool.acquire()`` is bypassed or removed by a mutation,
+that comparison becomes equal and the harness fails instead of silently
+returning success.
 """
 
 from __future__ import annotations
 
+import argparse
 import sys
 
 import bitsandbytes as bnb
@@ -55,7 +68,8 @@ class SlotPool:
         return slot
 
 
-def run(quant, recycle, params_init):
+def run(quant, recycle, params_init, bypass_pool=False):
+    """Run one arm and return gradients for the trainable scale parameters."""
     torch.manual_seed(0)
     weights = [
         torch.randn(DIM, DIM, device=DEV, dtype=DTYPE) / 32
@@ -73,8 +87,10 @@ def run(quant, recycle, params_init):
             )
             sources.append(packed)
             states.append(state)
-    else:
+    elif quant == "bf16":
         sources, states = weights, [None] * N_LAYERS
+    else:
+        raise ValueError(f"unsupported quantisation: {quant!r}")
 
     pool = SlotPool(POOL_SLOTS, sources[0]) if recycle else None
     params = [param.clone().requires_grad_(True) for param in params_init]
@@ -83,8 +99,12 @@ def run(quant, recycle, params_init):
         def fn(x, scale):
             hidden = x * scale
 
-            # The buffer refill occurs inside the checkpointed region.
-            weight = pool.acquire(sources[idx]) if recycle else sources[idx]
+            if recycle and not bypass_pool:
+                # The buffer refill occurs inside the checkpointed region.
+                weight = pool.acquire(sources[idx])
+            else:
+                # Negative control: deliberately bypass recycled buffers.
+                weight = sources[idx]
 
             if quant == "nf4":
                 return bnb.matmul_4bit(
@@ -118,7 +138,59 @@ def run(quant, recycle, params_init):
     return [param.grad.detach().float().clone() for param in params]
 
 
+def max_gradient_diff(left, right):
+    """Return the largest absolute gradient difference between two arms."""
+    return max(
+        (candidate - reference).abs().max().item()
+        for candidate, reference in zip(left, right)
+    )
+
+
+def print_comparison(reference, candidate, label):
+    """Print per-layer differences and return the number of mismatches."""
+    print()
+    print(f"{'layer':>5}  {label:>24}")
+
+    mismatches = 0
+
+    for index in range(N_LAYERS):
+        diff = (
+            candidate[index] - reference[index]
+        ).abs().max().item()
+
+        status = "MISMATCH" if diff else "ok"
+
+        if diff:
+            mismatches += 1
+
+        print(
+            f"{index:>5}  "
+            f"{diff:>16.6e} {status:>9}"
+        )
+
+    return mismatches
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Reproduce bitsandbytes issue #2034."
+    )
+    parser.add_argument(
+        "--bypass-pool",
+        action="store_true",
+        help=(
+            "negative control: bypass recycled-buffer allocation for the "
+            "NF4 candidate arm. The expected NF4 mismatch must disappear; "
+            "the harness then exits non-zero because the mutation was "
+            "detected."
+        ),
+    )
+    return parser.parse_args()
+
+
 def main() -> int:
+    args = parse_args()
+
     if not torch.cuda.is_available():
         print("SKIP: CUDA is required for bnb_repro.py")
         return 0
@@ -131,6 +203,9 @@ def main() -> int:
         f"M={TOKENS}, dtype={DTYPE}"
     )
 
+    if args.bypass_pool:
+        print("mode          NEGATIVE CONTROL: pool reuse bypassed")
+
     torch.manual_seed(1234)
     init = [
         torch.ones(DIM, device=DEV, dtype=DTYPE)
@@ -138,34 +213,94 @@ def main() -> int:
         for _ in range(N_LAYERS)
     ]
 
-    reference = run("nf4", recycle=False, params_init=init)
-    recycled = run("nf4", recycle=True, params_init=init)
-    bf16_recycled = run("bf16", recycle=True, params_init=init)
-    bf16_reference = run("bf16", recycle=False, params_init=init)
-
-    print()
-    print(
-        f"{'layer':>5}  "
-        f"{'nf4 recycled vs private':>24}  "
-        f"{'bf16 recycled vs private':>25}"
+    reference = run(
+        "nf4",
+        recycle=False,
+        params_init=init,
     )
 
-    for index in range(N_LAYERS):
-        nf4_diff = (
-            recycled[index] - reference[index]
-        ).abs().max().item()
-        bf16_diff = (
-            bf16_recycled[index] - bf16_reference[index]
-        ).abs().max().item()
+    recycled = run(
+        "nf4",
+        recycle=True,
+        params_init=init,
+        bypass_pool=args.bypass_pool,
+    )
 
-        nf4_status = "MISMATCH" if nf4_diff else "ok"
-        bf16_status = "MISMATCH" if bf16_diff else "ok"
+    bf16_recycled = run(
+        "bf16",
+        recycle=True,
+        params_init=init,
+    )
+
+    bf16_reference = run(
+        "bf16",
+        recycle=False,
+        params_init=init,
+    )
+
+    nf4_mismatches = print_comparison(
+        reference,
+        recycled,
+        "nf4 recycled vs private",
+    )
+
+    bf16_mismatches = print_comparison(
+        bf16_reference,
+        bf16_recycled,
+        "bf16 recycled vs private",
+    )
+
+    nf4_diff = max_gradient_diff(recycled, reference)
+    bf16_diff = max_gradient_diff(
+        bf16_recycled,
+        bf16_reference,
+    )
+
+    print()
+
+    if args.bypass_pool:
+        # The mutation deliberately removes the recycled-buffer mechanism.
+        # A successful reproduction here would mean the harness is not
+        # sensitive to the mechanism it claims to test.
+        if nf4_diff != 0:
+            print(
+                "ERROR: bypassing pool reuse still produced an NF4 mismatch."
+            )
+            print(
+                "RESULT: negative control was NOT caught."
+            )
+            return 2
 
         print(
-            f"{index:>5}  "
-            f"{nf4_diff:>16.6e} {nf4_status:>9}  "
-            f"{bf16_diff:>16.6e} {bf16_status:>9}"
+            "NEGATIVE CONTROL: bypassing pool reuse removed the NF4 mismatch."
         )
+        print("RESULT: mutation detected; exiting non-zero.")
+        return 1
+
+    # Normal reproduction: the recycled NF4 arm must differ from the
+    # private-buffer reference. This is the mutation guard: if pool.acquire()
+    # is removed or bypassed, the comparison becomes equal and the harness
+    # fails rather than silently returning success.
+    if nf4_diff == 0:
+        print(
+            "ERROR: expected NF4 recycled/private mismatch was not reproduced."
+        )
+        return 1
+
+    # The bf16 arm is the control: recycling should not introduce the
+    # corresponding NF4 stale-gradient mismatch.
+    if bf16_diff != 0:
+        print(
+            "ERROR: bf16 recycled/private control unexpectedly mismatched."
+        )
+        return 1
+
+    print(
+        f"RESULT: NF4 mismatch detected across "
+        f"{nf4_mismatches}/{N_LAYERS} layers; "
+        f"bf16 control matched across "
+        f"{N_LAYERS - bf16_mismatches}/{N_LAYERS} layers."
+    )
 
     return 0
 


### PR DESCRIPTION
## Summary

First reproducibility-only slice for #379.

This publishes the standalone bitsandbytes #2034 NF4 reproduction harness under `benchmarks/harness/` and indexes it in `benchmarks/README.md`.

The harness preserves the experiment with NF4 recycled buffers, NF4 private buffers as the reference, and bf16 recycled buffers as the control, using gradient checkpointing and no model downloads.

No benchmark methodology or underlying Soup implementation was changed.

## Validation

- `python -m ruff check benchmarks/harness/bnb_repro.py` — passed
- `python -m pytest -q` — 18,901 passed, 283 skipped, 5 deselected
- `git diff --check` — passed

The harness was not executed end-to-end locally because the development machine has no CUDA GPU; it exits cleanly with:

`SKIP: CUDA is required for bnb_repro.py`