### PR TITLE
fix(train): raise accelerate floor to keep FSDP+PEFT checkpoints adapter-only

### DIFF
--- a/changelog.d/0.73.3/591.fixed.md
+++ b/changelog.d/0.73.3/591.fixed.md
@@ -1,0 +1,4 @@
+- A LoRA/PEFT run under FSDP no longer writes a full consolidated copy of the
+  frozen base model into every checkpoint. Raised the `accelerate` floor to
+  0.27.0, the first release whose FSDP checkpoint save/load path can be
+  restricted to the trainable adapter (#352, #591).

--- a/changelog.d/0.73.3/591.fixed.md
+++ b/changelog.d/0.73.3/591.fixed.md
@@ -1,4 +1,5 @@
-- A LoRA/PEFT run under FSDP no longer writes a full consolidated copy of the
-  frozen base model into every checkpoint. Raised the `accelerate` floor to
-  0.27.0, the first release whose FSDP checkpoint save/load path can be
-  restricted to the trainable adapter (#352, #591).
+- Raised the `accelerate` floor to 0.27.0, the first release whose FSDP
+  checkpoint save/load path can be restricted to the trainable adapter. This
+  closes a remaining way a LoRA/PEFT run under FSDP could regress back to
+  writing the full frozen base model into every checkpoint on an unpinned
+  `accelerate` install (#352, #591).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,10 @@ train = [
     "trl>=0.29.0,<1.0.0",
     "datasets>=2.14.0",
     "bitsandbytes>=0.41.0",
-    "accelerate>=0.25.0",
+    # #352: 0.27.0 added `adapter_only` to `save_fsdp_model`/`load_fsdp_model`, which
+    # transformers 5.16.1 feature-detects to keep a PEFT run's FSDP resume checkpoint
+    # to the adapter instead of the full frozen base.
+    "accelerate>=0.27.0",
 ]
 # v0.71.0 — convenience meta-extra pulling the main optional stacks.
 all = ["soup-cli[train,serve,ui,data,mcp]"]

--- a/src/soup_cli/commands/doctor.py
+++ b/src/soup_cli/commands/doctor.py
@@ -22,7 +22,7 @@ DEPS = [
     ("trl", "trl", "0.29.0", True),
     ("datasets", "datasets", "2.14.0", True),
     ("bitsandbytes", "bitsandbytes", "0.41.0", True),
-    ("accelerate", "accelerate", "0.25.0", True),
+    ("accelerate", "accelerate", "0.27.0", True),
     ("pydantic", "pydantic", "2.0.0", True),
     ("typer", "typer", "0.9.0", True),
     ("rich", "rich", "13.0.0", True),

--- a/tests/test_issue352_fsdp_peft_checkpoint.py
+++ b/tests/test_issue352_fsdp_peft_checkpoint.py
@@ -1,0 +1,72 @@
+"""#352: a LoRA run under FSDP must not write the frozen base into checkpoints.
+
+`Trainer._save_optimizer_and_scheduler` writes a separate FSDP resume checkpoint
+(`pytorch_model_fsdp.bin`) via `accelerate.utils.save_fsdp_model`, independently of the
+adapter-only save `Trainer.save_model` already produces. Accelerate 0.25.0/0.26.0 has no
+`adapter_only` parameter on that function, so the resume checkpoint always gathers the
+full (frozen base + adapter) state dict regardless of the model being a `PeftModel`.
+0.27.0 added `adapter_only`, and `transformers.trainer.get_fsdp_ckpt_kwargs()`
+feature-detects it and threads it through on both save and load. This pins the accelerate
+floor bump in `pyproject.toml` to the real state-dict-size mechanism the issue reports,
+rather than to the dependency string alone.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from pathlib import Path
+
+
+def test_pyproject_accelerate_floor_supports_adapter_only_fsdp_checkpoints():
+    pyproject = Path(__file__).parent.parent / "pyproject.toml"
+    match = re.search(r'"accelerate>=([0-9.]+)"', pyproject.read_text(encoding="utf-8"))
+    assert match, "accelerate floor pin not found in pyproject.toml"
+    floor = tuple(int(part) for part in match.group(1).split("."))
+    assert floor >= (0, 27, 0), (
+        f"accelerate>={match.group(1)} predates save_fsdp_model's adapter_only "
+        "parameter (added in 0.27.0) and will regress #352"
+    )
+
+
+def test_installed_accelerate_save_fsdp_model_supports_adapter_only():
+    from accelerate.utils import save_fsdp_model
+
+    assert "adapter_only" in inspect.signature(save_fsdp_model).parameters
+
+
+def test_installed_accelerate_load_fsdp_model_supports_adapter_only():
+    from accelerate.utils import load_fsdp_model
+
+    assert "adapter_only" in inspect.signature(load_fsdp_model).parameters
+
+
+def test_fsdp_resume_checkpoint_state_dict_is_adapter_only_for_peft_model():
+    """Acceptance criterion from #352: checkpoint size is O(adapter), not O(base)."""
+    import torch.nn as nn
+    from accelerate.utils.fsdp_utils import _get_model_state_dict
+    from peft import LoraConfig, get_peft_model
+
+    class TinyBase(nn.Module):
+        def __init__(self):
+            super().__init__()
+            # A lopsided frozen-base-vs-adapter ratio, mirroring the issue's own
+            # measurement (37 GB frozen base next to a 131 MB adapter).
+            self.big = nn.Linear(2048, 2048, bias=False)
+
+        def forward(self, x):
+            return self.big(x)
+
+    model = get_peft_model(TinyBase(), LoraConfig(target_modules=["big"], r=4, lora_alpha=8))
+
+    full_numel = sum(v.numel() for v in _get_model_state_dict(model, adapter_only=False).values())
+    resume_sd = _get_model_state_dict(model, adapter_only=True)
+    resume_numel = sum(v.numel() for v in resume_sd.values())
+
+    assert all("lora_" in key for key in resume_sd), (
+        f"expected only adapter keys in the FSDP resume checkpoint, got {list(resume_sd)}"
+    )
+    # The frozen base (2048*2048 = 4_194_304 params) must not appear at all; only the
+    # rank-4 LoRA A/B matrices (2 * 4 * 2048 = 16_384 params) should.
+    assert resume_numel == 16_384
+    assert resume_numel < full_numel / 100


### PR DESCRIPTION
## Root cause

`Trainer._save_checkpoint` writes two independent things under FSDP: `save_model()` (adapter-only for a `PeftModel`, correctly) and, unless `save_only_model=True`, `_save_optimizer_and_scheduler()`, which calls `accelerate.utils.save_fsdp_model()` to write a separate resume checkpoint (`pytorch_model_fsdp.bin`).

accelerate 0.25.0/0.26.0's `save_fsdp_model`/`load_fsdp_model` have no `adapter_only` parameter, so that resume checkpoint always gathers `model.state_dict()` in full, frozen base included, regardless of the model being a `PeftModel`. accelerate 0.27.0 added `adapter_only`, and `transformers.trainer.get_fsdp_ckpt_kwargs()` (present in the 5.16.1 floor this project already pins) feature-detects the parameter and threads it through on both save and load. `pyproject.toml`'s own `accelerate>=0.25.0` floor is loose enough to resolve a version that predates the fix.

## Fix

Raise the `accelerate` floor to `>=0.27.0` in `pyproject.toml`. No `soup_cli` source code changes: the adapter-only behavior is entirely inside `transformers`/`accelerate`, gated purely on the installed `accelerate` version.

## Verification

- Read `transformers==5.16.1`'s `Trainer._save_checkpoint`/`_save_optimizer_and_scheduler`/`get_fsdp_ckpt_kwargs` and `accelerate`'s `save_fsdp_model`/`load_fsdp_model`/`_get_model_state_dict` source to trace the exact write path for `pytorch_model_fsdp.bin`, and bisected accelerate releases in Docker: `save_fsdp_model` gained `adapter_only` between 0.26.0 (absent) and 0.27.0 (present).
- Added `tests/test_issue352_fsdp_peft_checkpoint.py`, run in Docker against this project's own `.github/constraints/transformers-floor.txt` pins (torch 2.5.1, transformers 5.16.1, trl 0.29.0, peft 0.20.0): a tiny `PeftModel` (2048x2048 frozen base, rank-4 LoRA adapter) shows the FSDP resume state dict is adapter-only (16,384 params) versus the full state dict (4,210,688 params). The `pyproject.toml`-floor assertion fails on unmodified `main` and passes on this branch; the library-behavior assertions exercise the real installed `accelerate`/`peft`, not mocked.
- Ran the full `pytest -o addopts= --no-cov -q` suite under the floor constraints plus every FSDP/PEFT/accelerate-adjacent test file (1008 passed, 26 pre-existing failures reproduced identically on unmodified `main`, unrelated to this change, 19 skipped), and `ruff check src/soup_cli/ scripts/ tests/` clean.
- Not run: an actual multi-GPU FSDP training job. The fix is a dependency-floor bump with no `soup_cli` runtime code path of its own, so I verified the exact library functions that decide what gets written rather than an end-to-end 8-GPU checkpoint.

Fixes #352
