### PR TITLE
fix(tests): set chat_template in the SFT smoke fixture

### DIFF
--- a/tests/test_smoke_train.py
+++ b/tests/test_smoke_train.py
@@ -69,7 +69,13 @@ def tiny_dpo_data(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def sft_config_yaml(tmp_path: Path, tiny_train_data: Path) -> Path:
-    """Create a minimal SFT config for smoke testing with tiny-gpt2."""
+    """Create a minimal SFT config for smoke testing with tiny-gpt2.
+
+    ``chat_template`` is set even though ``format`` already says chatml: the
+    two are separate fields, and tiny-gpt2 ships no template of its own. Since
+    v0.36.0 the missing-template case is a hard error rather than the silent
+    ``f"{role}: {content}"`` fallback that produced wrong loss labels.
+    """
     config_path = tmp_path / "soup.yaml"
     output_dir = tmp_path / "output"
     config_path.write_text(
@@ -79,6 +85,7 @@ task: sft
 data:
   train: {tiny_train_data}
   format: chatml
+  chat_template: chatml
   val_split: 0.0
   max_length: 128
 


### PR DESCRIPTION
## What does this PR do?

Fixes `tests/test_smoke_train.py::test_sft_smoke`, which has been failing since
v0.36.0. The fixture sets `data.format: chatml` but not `data.chat_template`, and
`sshleifer/tiny-gpt2` carries no chat template of its own, so `sft_format.py:183`
raises:

```
ValueError: Tokenizer has no chat_template. Pass data.chat_template: chatml
(or llama3/qwen2.5/mistral/gemma3/phi4/deepseek-r1) in soup.yaml, or supply a raw
Jinja string. The previous silent f-string fallback produced wrong loss labels and
was removed in v0.36.0.
```

The fix is the one line the error message asks for. The trainer is fine — the run
gets through model load and LoRA attach (`64 trainable / 102,778 total`) and dies
at data formatting.

### Why it went unnoticed

Nothing runs this test. The default `addopts` exclude `-m smoke`, and the only
smoke job in CI is `mlx-smoke`, which selects `-k mlx_sft_smoke` on an install
that asserts the PyTorch stack is *absent* (`ci.yml:62-68`). So `test_sft_smoke`
and `test_dpo_smoke` run in neither the default suite nor CI, which is how a
fixture could drift out of sync with a hard error added in v0.36.0.

I have not touched that, since making CI run the PyTorch smoke tests means model
downloads and runner minutes — your call, not something to fold into this PR.

### Scope

Only `sft_config_yaml` is changed. `mlx_sft_config_yaml` has the same
`format: chatml` line, but it goes through the MLX backend rather than
`sft_format.py`, and it is the one smoke test CI does run and pass, so I left it
alone rather than change a green path I cannot execute (MLX is Apple-Silicon
only; I am on an Intel Mac).

The DPO fixture is unaffected — it uses `format: dpo` and passed throughout.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Tests

## Verification

Run on `linux/amd64`, Python 3.12, torch 2.13.0, transformers 5.16.1, via
`pip install ".[train]"`:

```
before:  1 failed, 1 passed, 1 skipped     (test_sft_smoke failed)
after:   2 passed, 1 skipped               (test_mlx_sft_smoke skips, no MLX)
ruff check tests/test_smoke_train.py  ->  All checks passed!
```

## Checklist

- [x] `ruff check src/soup_cli/ scripts/ tests/` passes
- [ ] `pytest tests/ -v` passes — **not verified on a supported platform.** My
  local machine is an Intel Mac, where `[train]` cannot resolve: torch ships no
  macOS x86_64 wheel past 2.2.2, but `transformers>=5.16.1` needs torch >= 2.5,
  so transformers disables its torch backend and `peft` fails to import. The full
  suite there is 18552 passed / 402 failed, all from that. I verified the changed
  file in a Linux container instead, as above. Happy to run the full suite there
  too if useful.
- [x] Updated relevant docs — n/a, test-only
- [x] New tests added for new functionality — n/a; this restores an existing test
- [x] No breaking changes
- [x] Changelog fragment — n/a, no user-visible impact

## One question

The run also prints:

```
train_on_responses_only requested but tokenizer has no chat_template —
falling back to text path. Pass data.chat_template explicitly to enable masking.
```

So that path degrades gracefully on a missing template while `sft_format.py` hard
-errors on it. I assume that is deliberate given the wrong-loss-labels history,
but flagging in case the asymmetry is not intended.
