### PR TITLE
fix(trackers): close telemetry SSRF guard bypass on HTTPS private IPs (#593)

### DIFF
--- a/changelog.d/0.73.3/598.fixed.md
+++ b/changelog.d/0.73.3/598.fixed.md
@@ -1,0 +1,7 @@
+- [#598](https://github.com/MakazhanAlpamys/Soup/pull/598) fixes the
+  telemetry endpoint SSRF guard (_telemetry_endpoint_is_safe) which could
+  not reject private/loopback HTTPS endpoints because the upstream HTTPS
+  requirement bypassed the scheme-conditional private-IP check in
+  alidate_hub_endpoint. The fix layers a telemetry-strict
+  private/loopback/link-local rejection on top of the existing hub
+  sanitization without modifying hubs.py.

--- a/changelog.d/0.73.3/598.fixed.md
+++ b/changelog.d/0.73.3/598.fixed.md
@@ -1,7 +1,6 @@
-- [#598](https://github.com/MakazhanAlpamys/Soup/pull/598) fixes the
-  telemetry endpoint SSRF guard (_telemetry_endpoint_is_safe) which could
-  not reject private/loopback HTTPS endpoints because the upstream HTTPS
-  requirement bypassed the scheme-conditional private-IP check in
-  alidate_hub_endpoint. The fix layers a telemetry-strict
-  private/loopback/link-local rejection on top of the existing hub
-  sanitization without modifying hubs.py.
+- `_telemetry_endpoint_is_safe` could not reject private/loopback HTTPS
+  endpoints because the upstream HTTPS requirement bypassed the
+  scheme-conditional private-IP check in `validate_hub_endpoint`. The fix
+  layers a telemetry-strict private, loopback, and link-local rejection
+  on top of the existing hub sanitisation without modifying `hubs.py`
+  (#593, #598).

--- a/docs/backends-and-ops.md
+++ b/docs/backends-and-ops.md
@@ -789,7 +789,7 @@ pip install soup-cli[trackers]   # mlflow + swanlab + trackio
 
 ## Telemetry (not yet wired)
 
-Soup contains opt-in, hardware-info-only telemetry primitives in `utils/trackers.py` (`build_telemetry_payload` / `send_telemetry_payload`), but they are **not wired to any command** — no data is ever sent, and no environment variable enables sending today. When wired, the payload will carry only `soup_version` / `command` / `python` major.minor / `os` / `arch` / optional `duration_seconds` — never dataset paths, model names, or config contents — behind a 1-second hard timeout and the same HTTPS-only, private-IP-rejecting SSRF policy as hub endpoints, swallowing every exception so telemetry can never crash training. Wiring is deferred until a public privacy policy is published.
+Soup contains opt-in, hardware-info-only telemetry primitives in `utils/trackers.py` (`build_telemetry_payload` / `send_telemetry_payload`), but they are **not wired to any command** — no data is ever sent, and no environment variable enables sending today. When wired, the payload will carry only `soup_version` / `command` / `python` major.minor / `os` / `arch` / optional `duration_seconds` — never dataset paths, model names, or config contents — behind a 1-second hard timeout and the hub endpoint sanitisation plus a telemetry-strict private, loopback and link-local rejection on every scheme, swallowing every exception so telemetry can never crash training. Wiring is deferred until a public privacy policy is published.
 
 
 ## Plugin System

--- a/src/soup_cli/utils/trackers.py
+++ b/src/soup_cli/utils/trackers.py
@@ -228,21 +228,55 @@ def _resolve_posthog_target(
 
 
 def _telemetry_endpoint_is_safe(endpoint: str) -> bool:
-    """Re-validate the telemetry endpoint via the v0.51.0 SSRF policy.
+    """Layered SSRF guard for telemetry endpoints (#593).
 
-    Even though :func:`send_telemetry_payload` only POSTs to a static
-    PostHog URL by default, callers can override ``endpoint``. Re-run the
-    same private-IP / link-local rejection used for hub endpoints so a
-    crafted ``endpoint='https://10.0.0.1/'`` cannot reach an internal
-    network from a misconfigured caller.
+    Two-layer validation:
+
+    1. :func:`~soup_cli.utils.hubs.validate_hub_endpoint` — baseline
+       sanitization (CRLF rejection, null-byte rejection, type guards,
+       ``0.0.0.0`` handling, scheme allowlist).  This layer is shared
+       with model-hub endpoints and intentionally permits private HTTPS
+       hosts for self-hosted hubs.
+    2. **Telemetry-strict rejection** — rejects loopback hosts
+       (``localhost``, ``127.0.0.1``, ``::1``), private IPs (RFC 1918),
+       and link-local addresses (``169.254.x.x``) on *any* scheme.
+       Telemetry has no legitimate self-hosted-private-endpoint case,
+       so this layer is stricter than hub validation.
+
+    The HTTPS-only requirement (``startswith("https://")``) is applied
+    first and is independent of both layers.
     """
     if not isinstance(endpoint, str) or not endpoint.startswith("https://"):
         return False
+
+    # Layer 1: baseline sanitization (CRLF, null bytes, types, 0.0.0.0).
     try:
         from soup_cli.utils.hubs import validate_hub_endpoint
 
         validate_hub_endpoint(endpoint, hub="telemetry")
     except (TypeError, ValueError):
+        return False
+
+    # Layer 2: telemetry-strict private/loopback/link-local rejection.
+    # Imports are lazy per AGENTS.md convention (heavy deps inside fns).
+    from urllib.parse import urlparse  # noqa: PLC0415
+
+    from soup_cli.utils.hubs import (  # noqa: PLC0415
+        _LOOPBACK_HOSTS,
+        _is_private_or_link_local,
+    )
+
+    # Normalise: lowercase + strip FQDN trailing dot so "LOCALHOST."
+    # matches the _LOOPBACK_HOSTS frozenset entry "localhost".
+    host = (urlparse(endpoint).hostname or "").lower().rstrip(".")
+    if not host:
+        return False
+    # _is_private_or_link_local uses ipaddress.ip_address which raises
+    # ValueError on domain strings ("localhost"), so it returns False.
+    # The explicit _LOOPBACK_HOSTS check covers named loopbacks.
+    if host in _LOOPBACK_HOSTS:
+        return False
+    if _is_private_or_link_local(host):
         return False
     return True
 

--- a/tests/test_telemetry_ssrf.py
+++ b/tests/test_telemetry_ssrf.py
@@ -1,0 +1,288 @@
+"""Tests for #593 - telemetry endpoint SSRF guard bypass.
+
+`_telemetry_endpoint_is_safe` must reject private/loopback/link-local
+hosts on HTTPS (not just HTTP), while still accepting legitimate public
+PostHog endpoints. The guard uses a two-layer design:
+
+1. `validate_hub_endpoint` for baseline sanitization (CRLF, null, types).
+2. Telemetry-strict private/loopback/link-local rejection on any scheme.
+
+Every test class here is structured so that **deleting** or **neutering**
+the Layer 2 guard deterministically fails at least one named test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from soup_cli.utils.trackers import (
+    _resolve_posthog_target,
+    _telemetry_endpoint_is_safe,
+)
+
+# --- Rejection: private / loopback / link-local must be refused ----------
+
+
+class TestTelemetrySSRFRejection:
+    """Every private/loopback/link-local HTTPS endpoint must be refused."""
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "https://10.0.0.1/",
+            "https://10.255.255.255/capture/",
+        ],
+        ids=["rfc1918-10-simple", "rfc1918-10-upper"],
+    )
+    def test_rejects_private_ipv4_class_a(self, endpoint: str) -> None:
+        assert _telemetry_endpoint_is_safe(endpoint) is False
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "https://172.16.0.1/",
+            "https://172.31.255.255/",
+        ],
+        ids=["rfc1918-172-lower", "rfc1918-172-upper"],
+    )
+    def test_rejects_private_ipv4_class_b(self, endpoint: str) -> None:
+        assert _telemetry_endpoint_is_safe(endpoint) is False
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "https://192.168.0.1/",
+            "https://192.168.1.1/capture/",
+        ],
+        ids=["rfc1918-192-simple", "rfc1918-192-subnet"],
+    )
+    def test_rejects_private_ipv4_class_c(self, endpoint: str) -> None:
+        assert _telemetry_endpoint_is_safe(endpoint) is False
+
+    def test_rejects_loopback_ipv4(self) -> None:
+        assert _telemetry_endpoint_is_safe("https://127.0.0.1/") is False
+
+    def test_rejects_cloud_metadata(self) -> None:
+        """169.254.169.254 is the cloud metadata service endpoint."""
+        assert (
+            _telemetry_endpoint_is_safe("https://169.254.169.254/")
+            is False
+        )
+
+    def test_rejects_ipv6_loopback_bracketed(self) -> None:
+        """urlparse('https://[::1]/').hostname strips brackets."""
+        assert (
+            _telemetry_endpoint_is_safe("https://[::1]/") is False
+        )
+
+    def test_rejects_ipv4_mapped_ipv6(self) -> None:
+        """IPv4-mapped IPv6 (::ffff:10.0.0.1) must not bypass the guard."""
+        assert (
+            _telemetry_endpoint_is_safe(
+                "https://[::ffff:10.0.0.1]/"
+            )
+            is False
+        )
+
+    def test_rejects_localhost(self) -> None:
+        assert (
+            _telemetry_endpoint_is_safe("https://localhost/") is False
+        )
+
+    def test_rejects_localhost_uppercase(self) -> None:
+        """Hostname normalisation must be case-insensitive."""
+        assert (
+            _telemetry_endpoint_is_safe("https://LOCALHOST/") is False
+        )
+
+    def test_rejects_localhost_trailing_dot(self) -> None:
+        """FQDN trailing dot: 'LOCALHOST.' -> 'localhost' after strip."""
+        assert (
+            _telemetry_endpoint_is_safe("https://LOCALHOST./") is False
+        )
+
+    def test_rejects_http_any(self) -> None:
+        """HTTP is rejected before either layer runs."""
+        assert (
+            _telemetry_endpoint_is_safe(
+                "http://us.i.posthog.com/capture/"
+            )
+            is False
+        )
+
+    def test_rejects_non_string(self) -> None:
+        assert _telemetry_endpoint_is_safe(42) is False  # type: ignore[arg-type]
+        assert _telemetry_endpoint_is_safe(None) is False  # type: ignore[arg-type]
+
+    def test_rejects_empty_string(self) -> None:
+        assert _telemetry_endpoint_is_safe("") is False
+
+
+# --- Acceptance: legitimate public endpoints must pass -------------------
+
+
+class TestTelemetrySSRFAcceptance:
+    """Valid public PostHog endpoints must be accepted.
+
+    A validator that rejects everything is worse than the bug it fixes.
+    """
+
+    def test_accepts_public_posthog(self) -> None:
+        assert (
+            _telemetry_endpoint_is_safe(
+                "https://us.i.posthog.com/capture/"
+            )
+            is True
+        )
+
+    def test_accepts_eu_posthog(self) -> None:
+        assert (
+            _telemetry_endpoint_is_safe(
+                "https://eu.i.posthog.com/capture/"
+            )
+            is True
+        )
+
+    def test_accepts_custom_posthog_host(self) -> None:
+        """A company's self-hosted public PostHog must pass."""
+        assert (
+            _telemetry_endpoint_is_safe(
+                "https://posthog.mycompany.com/capture/"
+            )
+            is True
+        )
+
+    def test_accepts_default_posthog_endpoint(self) -> None:
+        """The hardcoded default must always be accepted."""
+        from soup_cli.utils.trackers import _POSTHOG_ENDPOINT
+
+        assert _telemetry_endpoint_is_safe(_POSTHOG_ENDPOINT) is True
+
+
+# --- Mutation controls: guard deletion must fail a named test ------------
+
+
+class TestTelemetrySSRFMutationControl:
+    """Negative controls proving the guard is load-bearing.
+
+    Each test patches away a specific part of the Layer 2 guard and
+    verifies that a private endpoint would then be accepted -- proving
+    the guard's presence is what causes rejection, not some other
+    mechanism.
+    """
+
+    def test_private_ip_guard_has_teeth(self) -> None:
+        """Removing _is_private_or_link_local check would accept 10.0.0.1.
+
+        This proves the guard is not dead code. If you delete the
+        `_is_private_or_link_local(host)` branch from
+        `_telemetry_endpoint_is_safe`, this test fails.
+        """
+        import soup_cli.utils.trackers as trackers_mod
+
+        original_fn = trackers_mod._telemetry_endpoint_is_safe
+
+        def _neutered_safe(endpoint: str) -> bool:
+            """Bypass: skip the _is_private_or_link_local check."""
+            if not isinstance(endpoint, str):
+                return False
+            if not endpoint.startswith("https://"):
+                return False
+            try:
+                from soup_cli.utils.hubs import validate_hub_endpoint
+
+                validate_hub_endpoint(endpoint, hub="telemetry")
+            except (TypeError, ValueError):
+                return False
+            # Layer 2 deliberately omitted -- this is the mutation.
+            return True
+
+        # With the guard neutered, a private IP passes through.
+        assert _neutered_safe("https://10.0.0.1/") is True
+        # But the real implementation rejects it.
+        assert original_fn("https://10.0.0.1/") is False
+
+    def test_loopback_guard_has_teeth(self) -> None:
+        """Removing _LOOPBACK_HOSTS check would accept localhost.
+
+        `_is_private_or_link_local('localhost')` returns False because
+        `ipaddress.ip_address('localhost')` raises ValueError. Without
+        the explicit `_LOOPBACK_HOSTS` check, `https://localhost/`
+        would slip through.
+        """
+        import ipaddress
+
+        # Prove the gap: ipaddress cannot parse "localhost".
+        with pytest.raises(ValueError):
+            ipaddress.ip_address("localhost")
+
+        from soup_cli.utils.hubs import _is_private_or_link_local
+
+        # Prove _is_private_or_link_local does NOT catch localhost.
+        assert _is_private_or_link_local("localhost") is False
+
+        # But the real guard catches it via _LOOPBACK_HOSTS.
+        assert (
+            _telemetry_endpoint_is_safe("https://localhost/") is False
+        )
+
+
+# --- Integration: _resolve_posthog_target respects the guard -------------
+
+
+class TestResolvePosthogTargetSSRF:
+    """End-to-end: endpoint overrides go through the SSRF guard."""
+
+    def test_env_override_private_ip_blocked(self) -> None:
+        """SOUP_POSTHOG_ENDPOINT pointing to a private IP -> None."""
+        result = _resolve_posthog_target(
+            "phc_test",
+            endpoint="https://10.0.0.1/capture/",
+        )
+        assert result is None
+
+    def test_env_override_cloud_metadata_blocked(self) -> None:
+        result = _resolve_posthog_target(
+            "phc_test",
+            endpoint="https://169.254.169.254/capture/",
+        )
+        assert result is None
+
+    def test_env_override_localhost_blocked(self) -> None:
+        result = _resolve_posthog_target(
+            "phc_test",
+            endpoint="https://localhost/capture/",
+        )
+        assert result is None
+
+    def test_env_override_valid_accepted(self) -> None:
+        """A valid custom PostHog host must resolve."""
+        result = _resolve_posthog_target(
+            "phc_test",
+            endpoint="https://custom.posthog.com/capture/",
+        )
+        assert result is not None
+        key, ep = result
+        assert key == "phc_test"
+        assert ep == "https://custom.posthog.com/capture/"
+
+    def test_env_var_override_private_ip_blocked(self) -> None:
+        """SOUP_POSTHOG_ENDPOINT env var with private IP -> None."""
+        result = _resolve_posthog_target(
+            None,
+            env={"SOUP_POSTHOG_ENDPOINT": "https://10.0.0.1/capture/"},
+        )
+        assert result is None
+
+    def test_env_var_override_valid_accepted(self) -> None:
+        """SOUP_POSTHOG_ENDPOINT env var with public host -> tuple."""
+        result = _resolve_posthog_target(
+            None,
+            env={
+                "SOUP_POSTHOG_ENDPOINT":
+                    "https://eu.i.posthog.com/capture/",
+            },
+        )
+        assert result is not None
+        _, ep = result
+        assert ep == "https://eu.i.posthog.com/capture/"


### PR DESCRIPTION
Closes #593

## What does this PR do?

Closes the SSRF guard bypass in `_telemetry_endpoint_is_safe` where private, loopback, and link-local addresses were accepted when supplied over HTTPS.

The previous implementation delegated to `validate_hub_endpoint(endpoint, hub="telemetry")`. Because `validate_hub_endpoint` only executes its private-IP rejection branch when `scheme == "http"`, and `_telemetry_endpoint_is_safe` enforces `https://` upstream, the private-IP check was structurally unreachable. Consequently, `https://10.0.0.1/`, `https://169.254.169.254/` (cloud metadata), and `https://[::1]/` were accepted.

### Solution: Layered SSRF Guard

Per discussion on #593, this PR implements the layered design:

1. **Layer 1 (Baseline Sanitization):** Calls `validate_hub_endpoint(endpoint, hub="telemetry")` for CRLF / header injection rejection, null-byte rejection, type validation, `0.0.0.0` ambiguity handling, and scheme allowlisting.
2. **Layer 2 (Telemetry-Strict Rejection):**
   - Normalizes the parsed hostname with `(urlparse(endpoint).hostname or "").lower().rstrip(".")`.
   - Rejects loopback hosts via `_LOOPBACK_HOSTS` (`localhost`, `127.0.0.1`, `::1`), covering domain strings that `ipaddress.ip_address` cannot parse.
   - Rejects private, link-local, and reserved IPs via `_is_private_or_link_local(host)`.
   - **`hubs.py` is intentionally untouched.** The scheme-conditional check in `hubs.py` is preserved for its own callers (self-hosted model hubs).

### Behavioral Verification

```
refused   https://10.0.0.1/capture/           (was ACCEPTED)
refused   https://127.0.0.1/capture/          (was ACCEPTED)
refused   https://169.254.169.254/capture/    (was ACCEPTED)
refused   https://[::1]/capture/              (was ACCEPTED)
refused   https://localhost/capture/           (was ACCEPTED)
refused   https://LOCALHOST./capture/          (trailing-dot bypass)
refused   https://[::ffff:10.0.0.1]/          (IPv4-mapped IPv6)
refused   http://us.i.posthog.com/capture/    (unchanged)
ACCEPTED  https://us.i.posthog.com/capture/   (unchanged)
```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Tests

## Test Matrix (28 tests in `tests/test_telemetry_ssrf.py`)

- **`TestTelemetrySSRFRejection` (16 tests):** RFC 1918 Class A/B/C (`10.x`, `172.16-31.x`, `192.168.x`), loopbacks (`127.0.0.1`), cloud metadata (`169.254.169.254`), bracketed IPv6 loopbacks (`[::1]`), IPv4-mapped IPv6 (`[::ffff:10.0.0.1]`), `localhost`, uppercase `LOCALHOST`, FQDN trailing-dot `LOCALHOST.`, non-HTTPS schemes, non-string, and empty string.
- **`TestTelemetrySSRFAcceptance` (4 positive controls):** `https://us.i.posthog.com/capture/`, `https://eu.i.posthog.com/capture/`, custom public PostHog hosts, and default PostHog endpoint.
- **`TestTelemetrySSRFMutationControl` (2 negative controls):** 
  - `test_private_ip_guard_has_teeth`: Proves removing the Layer 2 `_is_private_or_link_local` check accepts `https://10.0.0.1/`.
  - `test_loopback_guard_has_teeth`: Proves `_is_private_or_link_local("localhost")` returns `False` (due to `ValueError` in `ipaddress.ip_address`), and that the explicit `_LOOPBACK_HOSTS` membership check is the load-bearing gate that catches named loopbacks.
- **`TestResolvePosthogTargetSSRF` (6 integration tests):** End-to-end resolution via `_resolve_posthog_target` across explicit parameters and `SOUP_POSTHOG_ENDPOINT` env var overrides.

## Checklist

- [x] `ruff check src/soup_cli/ scripts/ tests/` passes (0 errors, 0 warnings)
- [x] `pytest tests/test_telemetry_ssrf.py tests/test_tracker.py tests/test_v05310.py` passes (53 passed)
- [x] Updated relevant docstrings (`_telemetry_endpoint_is_safe` updated to reflect the two-layer policy)
- [x] Added changelog fragment in `changelog.d/0.73.3/598.fixed.md`
- [x] No breaking changes (all 10 existing `TestPostHogEnvOverride` tests pass unmodified)
