### PR TITLE
fix(security): reject abbreviated/decimal/hex/octal IPv4 in SSRF guards

### DIFF
--- a/changelog.d/0.73.3/604.security.md
+++ b/changelog.d/0.73.3/604.security.md
@@ -1,0 +1,10 @@
+- **Telemetry and webhook SSRF guards now reject abbreviated, decimal, hex,
+  and octal IPv4 forms (#600 by @here-2007 in #604).** `_is_private_or_link_local()`
+  in `utils/hubs.py`, `utils/hf.py`, and `utils/webhooks.py` previously delegated
+  exclusively to `ipaddress.ip_address()`, which raises `ValueError` on non-canonical
+  IPv4 representations like `127.1`, `2130706433`, `0x7f000001`, and `0177.0.0.1`.
+  On Linux (glibc), the OS resolver (`getaddrinfo`/`inet_aton`) parses these forms,
+  allowing crafted `--slack-url https://2852039166/` webhooks or telemetry overrides
+  to reach internal network addresses and cloud metadata (`169.254.169.254`). All three
+  guards now normalise non-standard IPv4 literals via in-process `socket.inet_aton()`
+  and strip trailing FQDN dots before verifying against `ipaddress.ip_address()`.

--- a/src/soup_cli/utils/hf.py
+++ b/src/soup_cli/utils/hf.py
@@ -104,7 +104,8 @@ def resolve_endpoint() -> str:
         raise ValueError(
             "HF_ENDPOINT 0.0.0.0 is ambiguous; use 127.0.0.1 or localhost"
         )
-    if parsed.scheme == "http" and host not in _LOOPBACK_HOSTS:
+    host_clean = host.lower().rstrip(".")
+    if parsed.scheme == "http" and host_clean not in _LOOPBACK_HOSTS:
         # Reject plain HTTP for RFC1918 / link-local / cloud metadata too —
         # HF_ENDPOINT=http://169.254.169.254 or http://192.168.1.1 would
         # otherwise route SDK traffic to internal targets.
@@ -121,15 +122,33 @@ def resolve_endpoint() -> str:
 
 
 def _is_private_or_link_local(host: str) -> bool:
-    """Whether ``host`` resolves to a private / link-local / loopback IP."""
+    """Whether ``host`` resolves to a private / link-local / loopback IP.
+
+    Handles canonical IPv4/IPv6 via :func:`ipaddress.ip_address` **and**
+    abbreviated / decimal / hex / octal IPv4 forms (e.g. ``127.1``,
+    ``2130706433``, ``0x7f000001``, ``0177.0.0.1``) via the platform C
+    library :func:`socket.inet_aton`.  The latter is a pure in-process
+    string parser — no DNS lookup is performed.
+    """
+    import socket  # noqa: PLC0415 — lazy import (stdlib, negligible cost)
+
+    clean_host = host.rstrip(".")
     try:
-        addr = ipaddress.ip_address(host)
+        addr = ipaddress.ip_address(clean_host)
+        return addr.is_private or addr.is_link_local or addr.is_loopback
     except ValueError:
-        # Hostname — we don't resolve DNS here (the SDK does), so fall back
-        # to "treat as public". A malicious DNS record pointing to a private
-        # IP is out of scope for this local-tool threat model.
+        pass
+    # Fallback: C-level inet_aton accepts abbreviated/integer/hex/octal
+    # IPv4 representations that Python's ipaddress module rejects.
+    try:
+        canonical = socket.inet_ntoa(socket.inet_aton(clean_host))
+        addr = ipaddress.ip_address(canonical)
+        return addr.is_private or addr.is_link_local or addr.is_loopback
+    except (OSError, ValueError):
+        # Hostname — we don't resolve DNS here (the SDK does), so fall
+        # back to "treat as public". A malicious DNS record pointing to
+        # a private IP is out of scope for this local-tool threat model.
         return False
-    return addr.is_private or addr.is_link_local or addr.is_loopback
 
 
 def validate_repo_id(repo_id: str) -> None:

--- a/src/soup_cli/utils/hubs.py
+++ b/src/soup_cli/utils/hubs.py
@@ -113,13 +113,28 @@ def endpoint_env_var(hub: str) -> str:
 def _is_private_or_link_local(host: str) -> bool:
     """Whether ``host`` is a private / link-local / loopback IP.
 
-    DNS resolution intentionally not performed (matches v0.29.0 hf.py policy).
+    Handles canonical IPv4/IPv6 via :func:`ipaddress.ip_address` **and**
+    abbreviated / decimal / hex / octal IPv4 forms (e.g. ``127.1``,
+    ``2130706433``, ``0x7f000001``, ``0177.0.0.1``) via the platform C
+    library :func:`socket.inet_aton`.  The latter is a pure in-process
+    string parser — no DNS lookup is performed.
     """
+    import socket  # noqa: PLC0415 — lazy import (stdlib, negligible cost)
+
+    clean_host = host.rstrip(".")
     try:
-        addr = ipaddress.ip_address(host)
+        addr = ipaddress.ip_address(clean_host)
+        return addr.is_private or addr.is_link_local or addr.is_loopback
     except ValueError:
+        pass
+    # Fallback: C-level inet_aton accepts abbreviated/integer/hex/octal
+    # IPv4 representations that Python's ipaddress module rejects.
+    try:
+        canonical = socket.inet_ntoa(socket.inet_aton(clean_host))
+        addr = ipaddress.ip_address(canonical)
+        return addr.is_private or addr.is_link_local or addr.is_loopback
+    except (OSError, ValueError):
         return False
-    return addr.is_private or addr.is_link_local or addr.is_loopback
 
 
 def validate_hub_endpoint(endpoint: str, *, hub: str | None = None) -> str:
@@ -164,7 +179,8 @@ def validate_hub_endpoint(endpoint: str, *, hub: str | None = None) -> str:
         raise ValueError(
             f"{label} 0.0.0.0 is ambiguous; use 127.0.0.1 or localhost"
         )
-    if parsed.scheme == "http" and host not in _LOOPBACK_HOSTS:
+    host_clean = host.lower().rstrip(".")
+    if parsed.scheme == "http" and host_clean not in _LOOPBACK_HOSTS:
         if _is_private_or_link_local(host):
             raise ValueError(
                 f"{label} plain HTTP is only allowed for loopback "

--- a/src/soup_cli/utils/webhooks.py
+++ b/src/soup_cli/utils/webhooks.py
@@ -31,20 +31,39 @@ _LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 def _is_private_or_link_local(host: str) -> bool:
     """Return True iff ``host`` resolves to a non-loopback private/reserved IP.
 
+    Handles canonical IPv4/IPv6 via :func:`ipaddress.ip_address` **and**
+    abbreviated / decimal / hex / octal IPv4 forms (e.g. ``127.1``,
+    ``2130706433``, ``0x7f000001``, ``0177.0.0.1``) via the platform C
+    library :func:`socket.inet_aton`.  The latter is a pure in-process
+    string parser — no DNS lookup is performed.
+
     Explicit parentheses on the final clause (mirrors v0.63.0 drift-alarm
     code-review MEDIUM fix): Python binds ``and`` tighter than ``or``, but
     the SSRF gate is safety-critical and a future edit should not need to
     re-derive the precedence rules to verify the logic.
     """
+    import socket  # noqa: PLC0415 — lazy import (stdlib, negligible cost)
+
+    clean_host = host.rstrip(".")
+
+    def _check(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+        return (
+            ip.is_private
+            or ip.is_link_local
+            or (ip.is_loopback is False and (ip.is_reserved or ip.is_multicast))
+        )
+
     try:
-        ip = ipaddress.ip_address(host)
+        return _check(ipaddress.ip_address(clean_host))
     except ValueError:
+        pass
+    # Fallback: C-level inet_aton accepts abbreviated/integer/hex/octal
+    # IPv4 representations that Python's ipaddress module rejects.
+    try:
+        canonical = socket.inet_ntoa(socket.inet_aton(clean_host))
+        return _check(ipaddress.ip_address(canonical))
+    except (OSError, ValueError):
         return False
-    return (
-        ip.is_private
-        or ip.is_link_local
-        or (ip.is_loopback is False and (ip.is_reserved or ip.is_multicast))
-    )
 
 
 def validate_webhook_url(url: object, *, allow_private_hosts: bool = False) -> str:
@@ -89,7 +108,8 @@ def validate_webhook_url(url: object, *, allow_private_hosts: bool = False) -> s
     # any ``https://10.x`` / ``192.168.x`` sail straight through to the return.
     # Loopback hosts stay allowed (they are handled by the ``_LOOPBACK_HOSTS``
     # guard below), so an explicit ``http://localhost`` webhook still works.
-    if host not in _LOOPBACK_HOSTS:
+    host_clean = host.lower().rstrip(".")
+    if host_clean not in _LOOPBACK_HOSTS:
         if _is_private_or_link_local(host) and not allow_private_hosts:
             raise ValueError(
                 "webhook URL private/link-local/reserved hosts are not "

--- a/tests/test_issue600_abbreviated_ipv4_ssrf.py
+++ b/tests/test_issue600_abbreviated_ipv4_ssrf.py
@@ -1,0 +1,288 @@
+"""#600 — abbreviated/decimal/hex/octal IPv4 forms bypass SSRF guards.
+
+Verifies that:
+1. All three copies of ``_is_private_or_link_local`` (hubs.py, hf.py, webhooks.py)
+   reject non-canonical IPv4 forms and trailing-dot FQDN variants.
+2. High-level callers (trackers._telemetry_endpoint_is_safe,
+   trackers._resolve_posthog_target, webhooks.validate_webhook_url) reject
+   non-canonical IPv4 endpoint overrides end-to-end.
+"""
+from __future__ import annotations
+
+import pytest
+
+# =====================================================================
+# Unit: hubs.py — _is_private_or_link_local
+# =====================================================================
+
+
+class TestHubsPrivateOrLinkLocalAbbreviated:
+    """socket.inet_aton fallback in hubs._is_private_or_link_local."""
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            # Canonical forms:
+            "127.0.0.1",
+            "10.0.0.1",
+            "192.168.1.1",
+            "172.16.0.1",
+            "169.254.169.254",
+            "::1",
+            "fe80::1",
+            "::ffff:10.0.0.1",
+            # Abbreviated / non-canonical forms (#600 bypass vectors):
+            "127.1",           # abbreviated loopback
+            "127.0.1",         # abbreviated loopback (3-octet)
+            "2130706433",      # decimal 127.0.0.1
+            "0x7f000001",      # hex 127.0.0.1
+            "0177.0.0.1",      # octal 127.0.0.1
+            "10.1",            # abbreviated 10.0.0.1
+            "167772161",       # decimal 10.0.0.1
+            "2852039166",      # decimal 169.254.169.254 (cloud metadata)
+            # Trailing-dot forms:
+            "127.0.0.1.",
+            "169.254.169.254.",
+            "127.1.",
+            "2852039166.",
+        ],
+    )
+    def test_rejects_private_ip(self, host: str) -> None:
+        from soup_cli.utils.hubs import _is_private_or_link_local
+
+        assert _is_private_or_link_local(host) is True, (
+            f"_is_private_or_link_local({host!r}) must return True"
+        )
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "8.8.8.8",
+            "1.1.1.1",
+            "us.i.posthog.com",
+            "eu.i.posthog.com",
+            "example.com",
+            "8.8.8.8.",
+        ],
+    )
+    def test_allows_public_host(self, host: str) -> None:
+        from soup_cli.utils.hubs import _is_private_or_link_local
+
+        assert _is_private_or_link_local(host) is False, (
+            f"_is_private_or_link_local({host!r}) must return False"
+        )
+
+
+# =====================================================================
+# Unit: hf.py — _is_private_or_link_local
+# =====================================================================
+
+
+class TestHfPrivateOrLinkLocalAbbreviated:
+    """socket.inet_aton fallback in hf._is_private_or_link_local."""
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "127.0.0.1",
+            "127.1",
+            "2130706433",
+            "0x7f000001",
+            "0177.0.0.1",
+            "10.1",
+            "167772161",
+            "2852039166",
+            "169.254.169.254.",
+        ],
+    )
+    def test_rejects_private_ip(self, host: str) -> None:
+        from soup_cli.utils.hf import _is_private_or_link_local
+
+        assert _is_private_or_link_local(host) is True, (
+            f"hf._is_private_or_link_local({host!r}) must return True"
+        )
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "8.8.8.8",
+            "us.i.posthog.com",
+            "example.com",
+        ],
+    )
+    def test_allows_public_host(self, host: str) -> None:
+        from soup_cli.utils.hf import _is_private_or_link_local
+
+        assert _is_private_or_link_local(host) is False, (
+            f"hf._is_private_or_link_local({host!r}) must return False"
+        )
+
+
+# =====================================================================
+# Unit: webhooks.py — _is_private_or_link_local
+# =====================================================================
+
+
+class TestWebhooksPrivateOrLinkLocalAbbreviated:
+    """socket.inet_aton fallback in webhooks._is_private_or_link_local."""
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "10.0.0.1",
+            "192.168.1.1",
+            "169.254.169.254",
+            "127.1",
+            "2130706433",
+            "0x7f000001",
+            "10.1",
+            "167772161",
+            "2852039166",
+            "169.254.169.254.",
+            "2852039166.",
+        ],
+    )
+    def test_rejects_private_ip(self, host: str) -> None:
+        from soup_cli.utils.webhooks import _is_private_or_link_local
+
+        assert _is_private_or_link_local(host) is True, (
+            f"webhooks._is_private_or_link_local({host!r}) must return True"
+        )
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "8.8.8.8",
+            "1.1.1.1",
+            "us.i.posthog.com",
+            "example.com",
+        ],
+    )
+    def test_allows_public_host(self, host: str) -> None:
+        from soup_cli.utils.webhooks import _is_private_or_link_local
+
+        assert _is_private_or_link_local(host) is False, (
+            f"webhooks._is_private_or_link_local({host!r}) must return False"
+        )
+
+
+# =====================================================================
+# End-to-End: Telemetry SSRF Guard Pinning (#600)
+# =====================================================================
+
+
+class TestTelemetrySSRFEndToEndPinning:
+    """Pins #600 at the telemetry caller layer (trackers.py)."""
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "https://127.1/",
+            "https://127.0.1/capture/",
+            "https://2130706433/",
+            "https://0x7f000001/",
+            "https://0177.0.0.1/",
+            "https://10.1/",
+            "https://167772161/",
+            "https://2852039166/capture/",
+            "https://169.254.169.254./capture/",
+            "https://127.1./",
+        ],
+    )
+    def test_telemetry_endpoint_is_safe_rejects_abbreviated_forms(
+        self, endpoint: str
+    ) -> None:
+        from soup_cli.utils.trackers import _telemetry_endpoint_is_safe
+
+        assert _telemetry_endpoint_is_safe(endpoint) is False
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "https://us.i.posthog.com/",
+            "https://eu.i.posthog.com/i/v0/e/",
+            "https://telemetry.example.com/capture",
+        ],
+    )
+    def test_telemetry_endpoint_is_safe_allows_public(
+        self, endpoint: str
+    ) -> None:
+        from soup_cli.utils.trackers import _telemetry_endpoint_is_safe
+
+        assert _telemetry_endpoint_is_safe(endpoint) is True
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "https://127.1/",
+            "https://2130706433/",
+            "https://2852039166/",
+            "https://10.1/",
+        ],
+    )
+    def test_resolve_posthog_target_rejects_abbreviated_arg(
+        self, endpoint: str
+    ) -> None:
+        from soup_cli.utils.trackers import _resolve_posthog_target
+
+        assert _resolve_posthog_target("phc_key", endpoint=endpoint) is None
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "https://127.1/",
+            "https://2130706433/",
+            "https://2852039166/",
+            "https://167772161/",
+        ],
+    )
+    def test_resolve_posthog_target_rejects_abbreviated_env(
+        self, endpoint: str
+    ) -> None:
+        from soup_cli.utils.trackers import _resolve_posthog_target
+
+        env = {"SOUP_POSTHOG_ENDPOINT": endpoint}
+        assert _resolve_posthog_target(None, env=env) is None
+
+
+# =====================================================================
+# End-to-End: Webhooks SSRF Guard Pinning (#600)
+# =====================================================================
+
+
+class TestWebhookSSRFEndToEndPinning:
+    """Pins #600 at the webhook caller layer (webhooks.py)."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://2852039166/hook",
+            "https://10.1/hook",
+            "https://167772161/hook",
+            "https://169.254.169.254./hook",
+            "https://2852039166./hook",
+            "http://10.1/hook",
+        ],
+    )
+    def test_validate_webhook_url_rejects_abbreviated_private_ips(
+        self, url: str
+    ) -> None:
+        from soup_cli.utils.webhooks import validate_webhook_url
+
+        with pytest.raises(ValueError):
+            validate_webhook_url(url)
+
+    def test_validate_webhook_url_permits_explicit_allow_private(self) -> None:
+        from soup_cli.utils.webhooks import validate_webhook_url
+
+        url = "https://10.1/hook"
+        assert (
+            validate_webhook_url(url, allow_private_hosts=True)
+            == "https://10.1/hook"
+        )
+
+    def test_validate_webhook_url_allows_public(self) -> None:
+        from soup_cli.utils.webhooks import validate_webhook_url
+
+        url = "https://hooks.slack.com/services/T/B/x"
+        assert validate_webhook_url(url) == url


### PR DESCRIPTION
## Summary

Closes #600.

`_is_private_or_link_local()` in `hubs.py`, `hf.py`, and `webhooks.py` delegated exclusively to `ipaddress.ip_address()`, which raises `ValueError` on non-canonical IPv4 forms (`127.1`, `2130706433`, `0x7f000001`, `0177.0.0.1`) and trailing-dot FQDN variants (`169.254.169.254.`).

On Linux (measured on Ubuntu, glibc 2.39), `getaddrinfo` and `inet_aton` resolve these forms to their canonical private/loopback IPs, allowing:
1. Overridden telemetry endpoints (`SOUP_POSTHOG_ENDPOINT="https://2852039166/"`) to bypass `_telemetry_endpoint_is_safe`.
2. Webhook URLs (`--slack-url https://2852039166/` or `--slack-url https://169.254.169.254./`) to reach cloud metadata (`169.254.169.254`) and internal LAN addresses.

*(On Windows, `WSAStringToAddress` / `getaddrinfo` returns `gaierror` for abbreviated forms, making this a live vector specifically in Linux container/server training environments).*

---

### Key Bypass Vectors (All Verified & Blocked)

| Form | Canonical IP | Category | Linux glibc Resolver | Windows Resolver |
|---|---|---|---|---|
| `127.1` | `127.0.0.1` | Abbreviated loopback | `127.0.0.1` | `gaierror` |
| `127.0.1` | `127.0.0.1` | Abbreviated loopback (3-octet) | `127.0.0.1` | `gaierror` |
| `2130706433` | `127.0.0.1` | 32-bit decimal | `127.0.0.1` | `gaierror` |
| `0x7f000001` | `127.0.0.1` | 32-bit hexadecimal | `127.0.0.1` | `gaierror` |
| `0177.0.0.1` | `127.0.0.1` | Octal dotted | `127.0.0.1` | `gaierror` |
| `10.1` | `10.0.0.1` | Abbreviated RFC1918 | `10.0.0.1` | `gaierror` |
| `167772161` | `10.0.0.1` | 32-bit decimal | `10.0.0.1` | `gaierror` |
| `2852039166` | `169.254.169.254` | Cloud metadata (decimal) | `169.254.169.254` | `gaierror` |
| `169.254.169.254.` | `169.254.169.254` | Trailing-dot FQDN | `169.254.169.254` | `169.254.169.254` |

---

### Fix Details

1. **`socket.inet_aton` Fallback:** When `ipaddress.ip_address()` raises `ValueError`, fall back to `socket.inet_aton(clean_host)`. Because `inet_aton` uses the platform C parser, it mirrors the exact resolver semantics in-process with **zero DNS lookups, zero network calls, and zero latency overhead**.
2. **Trailing-Dot Normalisation:** `clean_host = host.rstrip(".")` ensures trailing-dot FQDN variants (e.g. `169.254.169.254.`) are stripped before parsing.
3. **Scope & Posture:**
   - `src/soup_cli/utils/webhooks.py`: Active security protection against SSRF reaching internal hosts / metadata on both HTTP and HTTPS.
   - `src/soup_cli/utils/trackers.py`: Re-evaluates via `_telemetry_endpoint_is_safe` using `_is_private_or_link_local`.
   - `src/soup_cli/utils/hubs.py` & `src/soup_cli/utils/hf.py`: Error message parity in plain-HTTP rejection selection.

---

### Testing & Verification

- **82 parametrised tests** in `tests/test_issue600_abbreviated_ipv4_ssrf.py`:
  - Unit tests for all three `_is_private_or_link_local` implementations.
  - End-to-end pinning at the caller level for `trackers._telemetry_endpoint_is_safe`, `trackers._resolve_posthog_target` (args & env vars), and `webhooks.validate_webhook_url`.
- Full SSRF / telemetry test sweep: **528 passed** (`-k "ssrf or telemetry or hub or tracker or posthog or webhook"`).
- Rebased cleanly onto `upstream/main` (`2ee8e13`).
- Zero direct `CHANGELOG.md` edits; fragment placed at `changelog.d/0.73.3/604.security.md` (validated with `test_issue487_changelog_fragments.py`).
- `ruff check` clean.