### PR TITLE
fix(mii): apply the model's chat template and report real finish_reason

### DIFF
--- a/changelog.d/0.73.3/607.fixed.md
+++ b/changelog.d/0.73.3/607.fixed.md
@@ -1,0 +1,3 @@
+- `soup serve --backend mii` now applies the served model's own chat template
+  (via `build_chat_prompt`) instead of a hand-rolled prompt, and reports the
+  engine's real `finish_reason` instead of always `"stop"` (#607).

--- a/src/soup_cli/commands/serve.py
+++ b/src/soup_cli/commands/serve.py
@@ -534,8 +534,25 @@ def serve(
             console.print(f"[red]Failed to create MII pipeline:[/] {exc}")
             raise typer.Exit(1) from exc
 
+        # #332's fix for the vLLM/transformers backends applies here too: a
+        # chat-tuned model needs its own template, not the generic
+        # role-prefixed fallback.
+        mii_tokenizer = _load_serve_tokenizer(
+            model_path=Path(model), base_model=None,
+            trust_remote_code=trust_remote_code,
+        )
+        if mii_tokenizer is None:
+            console.print(
+                "[yellow]Warning:[/] no tokenizer could be loaded for this "
+                "model, falling back to a generic 'User:/Assistant:' "
+                "prompt. Chat-tuned models can run on past their stop "
+                "token with this format."
+            )
+
         mii_model_name = Path(model).name
-        mii_app = build_mii_app(mii_pipeline, model_name=mii_model_name)
+        mii_app = build_mii_app(
+            mii_pipeline, model_name=mii_model_name, tokenizer=mii_tokenizer,
+        )
 
         import uvicorn
         console.print(

--- a/src/soup_cli/utils/mii.py
+++ b/src/soup_cli/utils/mii.py
@@ -91,6 +91,7 @@ def _ensure_mii_request_models():
 
 def build_mii_app(
     pipeline: Any, model_name: str, max_tokens_default: int = 512,
+    tokenizer: Any = None,
 ) -> Any:
     """Wrap a DeepSpeed-MII pipeline as a minimal OpenAI-compatible FastAPI
     app exposing ``/v1/chat/completions`` and ``/v1/models`` (#38, v0.33.0).
@@ -104,9 +105,14 @@ def build_mii_app(
             with ``.generated_text`` attributes.
         model_name: stable id surfaced in /v1/models and the response.
         max_tokens_default: default for requests that don't specify max_tokens.
+        tokenizer: the served model's own tokenizer, or None. Passed straight
+            through to ``build_chat_prompt`` (#332) so a chat-tuned model gets
+            its own template instead of the generic role-prefixed fallback.
     """
     from fastapi import FastAPI, HTTPException
     from fastapi.middleware.cors import CORSMiddleware
+
+    from soup_cli.utils.vllm import build_chat_prompt, resolve_finish_reason
 
     # Models are module-level (not closure) so FastAPI's introspection can
     # resolve forward refs.
@@ -147,16 +153,7 @@ def build_mii_app(
             raise HTTPException(
                 status_code=400, detail="max_tokens must be in [1, 16384]",
             )
-        prompt_parts = []
-        for msg in request.messages:
-            if msg.role == "system":
-                prompt_parts.append(f"System: {msg.content}")
-            elif msg.role == "user":
-                prompt_parts.append(f"User: {msg.content}")
-            elif msg.role == "assistant":
-                prompt_parts.append(f"Assistant: {msg.content}")
-        prompt_parts.append("Assistant:")
-        prompt = "\n".join(prompt_parts)
+        prompt = build_chat_prompt(request.messages, tokenizer)
 
         max_tokens = request.max_tokens or max_tokens_default
         try:
@@ -182,7 +179,7 @@ def build_mii_app(
             "choices": [{
                 "index": 0,
                 "message": {"role": "assistant", "content": text},
-                "finish_reason": "stop",
+                "finish_reason": resolve_finish_reason(first, max_tokens),
             }],
             "usage": {
                 "prompt_tokens": -1,

--- a/tests/test_part_b.py
+++ b/tests/test_part_b.py
@@ -134,6 +134,66 @@ class TestBuildMiiApp:
         })
         assert resp.status_code == 500
 
+    def test_chat_completions_applies_the_served_models_chat_template(self):
+        """A chat-tuned model must get its own template (#332), not the
+        generic 'System: .../User: .../Assistant:' prompt build_mii_app used
+        to hand-roll."""
+        pytest.importorskip("fastapi")
+        from fastapi.testclient import TestClient
+
+        from soup_cli.utils.mii import build_mii_app
+
+        captured = {}
+
+        def _pipeline(prompts, **_kwargs):
+            captured["prompt"] = prompts[0]
+            fake_response = MagicMock()
+            fake_response.generated_text = "4"
+            return [fake_response]
+
+        tokenizer = MagicMock()
+        tokenizer.chat_template = "<|template|>"
+        tokenizer.apply_chat_template.return_value = "<|from-the-model's-own-template|>"
+
+        app = build_mii_app(
+            _pipeline, model_name="test-mii-model", tokenizer=tokenizer,
+        )
+        client = TestClient(app)
+
+        resp = client.post("/v1/chat/completions", json={
+            "model": "test-mii-model",
+            "messages": [{"role": "user", "content": "2+2?"}],
+        })
+        assert resp.status_code == 200, resp.text
+        assert captured["prompt"] == "<|from-the-model's-own-template|>"
+        assert "User:" not in captured["prompt"]
+
+    def test_chat_completions_reports_length_when_engine_reports_length(self):
+        """The engine's own finish_reason must reach the client (#333),
+        not the hardcoded 'stop' build_mii_app used to always return."""
+        pytest.importorskip("fastapi")
+        from fastapi.testclient import TestClient
+
+        from soup_cli.utils.mii import build_mii_app
+
+        fake_response = MagicMock()
+        fake_response.generated_text = "truncated output"
+        fake_response.finish_reason = "length"
+
+        def _pipeline(prompts, **_kwargs):
+            return [fake_response]
+
+        app = build_mii_app(_pipeline, model_name="test-mii-model")
+        client = TestClient(app)
+
+        resp = client.post("/v1/chat/completions", json={
+            "model": "test-mii-model",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "max_tokens": 8,
+        })
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["choices"][0]["finish_reason"] == "length"
+
 
 # ---------------------------------------------------------------------------
 # #37 — auto-reexec wiring smoke (without actually exec'ing)


### PR DESCRIPTION
Fixes #606

`soup serve --backend mii`'s `/v1/chat/completions` handler hand-rolled its own
`"System: ...\nUser: ...\nAssistant:"` prompt instead of calling `build_chat_prompt`,
the single prompt builder #332 introduced so the transformers and vLLM backends
cannot drift from a chat-tuned model's own template. MII was never wired into it.
It also always reported `finish_reason: "stop"`, the same hardcoded-value bug #333
fixed for vLLM via `resolve_finish_reason`.

Both fixes mirror the vLLM backend's existing pattern exactly: `serve.py` now loads
the served model's tokenizer with the same `_load_serve_tokenizer` call `_serve_vllm`
already makes, and `build_mii_app` passes it to `build_chat_prompt` and derives
`finish_reason` with `resolve_finish_reason` instead of a literal. DeepSpeed-MII's own
`Response.finish_reason` is a `str`-backed enum with members `"stop"`/`"length"`, so it
flows straight through `resolve_finish_reason`'s trusted-value branch.

### Verification

- New regression tests in `tests/test_part_b.py::TestBuildMiiApp` fail on `main` and
  pass on this branch: one asserts the prompt sent to the pipeline comes from
  `build_chat_prompt` (not the hand-rolled string), the other asserts `finish_reason`
  reflects the engine's own reported value instead of always `"stop"`.
- Reproduced end to end in a container with a stub pipeline standing in for a real
  `deepspeed-mii` engine (GPU-only, not available here): before the fix, the prompt
  differed from `build_chat_prompt`'s output and `finish_reason` stayed `"stop"` even
  when the stub reported `"length"`; after the fix, both matched.
- `ruff check src/soup_cli/ scripts/ tests/`, all 11 tests in `test_part_b.py`, and
  the 6 MII tests in `test_multi_gpu.py` pass. I did not run the full matrix (the
  `[dev]` extra pulls in the training stack, which this change does not touch) or the
  `mlx-smoke`/`transformers-floor` jobs, which are unrelated to this file.

A changelog fragment will follow once the PR number is assigned (`changelog.d/<version>/<PR#>.fixed.md`).
