### PR TITLE
test(streaming): cover orpo and simpo with a real CUDA train() step

### DIFF
--- a/tests/test_v07204.py
+++ b/tests/test_v07204.py
@@ -388,6 +388,17 @@ def _build_streamed_wrapper(
 # ==========================================================================
 # item 1 -- schema: which tasks may stream
 # ==========================================================================
+# These two tuples are the LOCALISATION, not a convenience. #370: while
+# diagnosing #328 on the H100 box only [dpo] and [kto] failed, which read as a
+# sharp localisation to the reference forward — and was wrong. They were the
+# only two the CUDA class was parametrised over. ORPO and SimPO are genuinely
+# reference-free (v0.72.4: no `ref_model` attribute at all) and failed too.
+# So: narrowing either tuple silently narrows what the suite can localise, and
+# is a scope change that must be argued for, not an edit.
+#
+# _REFERENCE_USING is for properties that only exist when there IS a reference
+# (the disabled-adapter identity, the reference forward). Everything that
+# exercises the streamed train() step belongs to _ALL_PREFERENCE.
 _REFERENCE_USING = ("dpo", "kto")
 _ALL_PREFERENCE = ("dpo", "orpo", "simpo", "kto")
 
@@ -566,7 +577,7 @@ class TestPeakVramIsNotDoubled:
         torch.cuda.empty_cache()
         return peak, stats
 
-    @pytest.mark.parametrize("task", _REFERENCE_USING)
+    @pytest.mark.parametrize("task", _ALL_PREFERENCE)
     def test_weight_bearing_terms_are_identical_to_sft(self, tmp_path, monkeypatch, task):
         """One store, one pool. The gate measured 729.91 MB / 60.83 MB for both
         arms on a 730 MB model; here the sizes are tiny but the EQUALITY is the
@@ -590,6 +601,62 @@ class TestPeakVramIsNotDoubled:
         implicit, stats = self._peak(tmp_path / "c", monkeypatch, task)
         forced, _ = self._peak(tmp_path / "d", monkeypatch, task, second_reference=True)
         assert forced > implicit, (implicit, forced)
+
+
+@pytest.mark.skipif(not _cuda_available(), reason="the #328 meta failure is CUDA-only")
+class TestEveryPreferenceLossTakesAStreamedStep:
+    """#370 — a real ``setup()`` + ``train()`` step for ALL FOUR preference
+    losses on the device the failure actually needs.
+
+    This exists as its own slot, rather than riding on the VRAM assertions
+    above, because the property is different: those measure how much memory a
+    step costs, this asserts a step happens at all. Reverting #328's
+    ``should_enable_hf_gradient_checkpointing`` guard turns every arm here red
+    with ``RuntimeError: Tensor on device cuda:0 is not on the expected device
+    meta!`` — HF check-points the inner decoder layer on top of
+    ``StreamedDecoderLayer``'s own ``checkpoint(use_reentrant=False)``, and the
+    recompute lands after ``functional_call``'s reparametrisation has exited and
+    restored the meta placeholders.
+
+    The orpo/simpo arms are the point. #328 was reported as dpo/kto-only purely
+    because those were the only two the CUDA class was parametrised over; all
+    four fail, and ORPO/SimPO reach it with no reference model at all.
+    """
+
+    @pytest.mark.parametrize("task", _ALL_PREFERENCE)
+    def test_a_streamed_train_step_completes(self, tmp_path, monkeypatch, task):
+        """``gradient_checkpointing=True`` is load-bearing, not decoration.
+
+        It is the configuration #328 dies in: the user asks for checkpointing,
+        streaming is on, and the guard has to refuse HF's copy of it. Measured
+        on an A10G — with the guard dropped this raises for all four tasks,
+        while the same test at the config default (False) still passes, because
+        there the reverted expression returns False anyway. A default-config
+        step would look like cover and assert nothing.
+        """
+        wrapper, _, _ = _build_streamed_wrapper(
+            tmp_path, monkeypatch, task=task, gradient_checkpointing=True
+        )
+        wrapper.trainer.args.max_steps = 1
+        try:
+            wrapper.trainer.train()
+        finally:
+            wrapper._close_stream_runtime()
+
+    @pytest.mark.parametrize("task", _ALL_PREFERENCE)
+    def test_hf_checkpointing_is_off_while_streaming(self, tmp_path, monkeypatch, task):
+        """The mechanism, asserted directly so a green run above cannot be a
+        coincidence of some other layer swallowing the double-recompute."""
+        wrapper, _, _ = _build_streamed_wrapper(
+            tmp_path, monkeypatch, task=task, gradient_checkpointing=True
+        )
+        try:
+            assert wrapper.trainer.args.gradient_checkpointing is False, (
+                f"{task} let HF check-point the inner decoder layer while "
+                f"streaming — this is exactly the #328 double-recompute"
+            )
+        finally:
+            wrapper._close_stream_runtime()
 
 
 class TestBitExactVsResident:


### PR DESCRIPTION
Closes #370

Extends the CUDA preference-loss `train()` coverage to all four losses, and adds a slot that guards the #328 mechanism directly.

Verified on an **A10G** (`torch 2.13.0+cu130`, `trl 0.29.1`, `transformers 5.16.1`) — the version combination the #328 comment names.

## What changed

- `test_weight_bearing_terms_are_identical_to_sft` now runs over `_ALL_PREFERENCE` instead of `_REFERENCE_USING`, so the existing VRAM claim covers orpo and simpo too.
- New CUDA-gated `TestEveryPreferenceLossTakesAStreamedStep`, two arms per loss:
  - `test_a_streamed_train_step_completes` — a real `setup()` + `train()` step.
  - `test_hf_checkpointing_is_off_while_streaming` — asserts the mechanism directly, so a green step cannot be a coincidence of some other layer absorbing the double-recompute.
- A note on the two parametrisation tuples recording that they *are* the localisation, so narrowing either is visibly a scope change rather than an edit (acceptance criterion 3).

It is a separate class rather than more arms on `TestPeakVramIsNotDoubled` because the property differs: those measure what a step costs, this asserts a step happens at all. Hanging the #328 guard off a VRAM test means a later refactor of the memory assertions deletes the regression cover silently.

## Reverting actually turns it red (criterion 2)

Both revert forms, measured — not assumed:

| | `train_step_completes` | `hf_checkpointing_is_off` |
|---|---|---|
| fix intact | 4 passed | 4 passed |
| **(a)** drop `and not stream_layers` | **4 failed** | **4 failed** |
| **(b)** remove the kwarg entirely (pre-fix state) | **4 failed** | **4 failed** |

Both fail with the issue's exact error:

```
RuntimeError: Tensor on device cuda:0 is not on the expected device meta!
```

All four losses, not two — which is the whole point of #370.

### One thing worth flagging in the test itself

My first draft would have shipped as decorative. It called `setup()` + `train()` for orpo and simpo on CUDA, satisfied the issue's wording, passed — and passed just as happily with the guard deleted, because it used the config default `gradient_checkpointing=False`, where the reverted expression `bool(False)` returns `False` anyway.

Only running the revert exposed it. The arm now passes `gradient_checkpointing=True` — the configuration the bug actually lives in — and the docstring records the measurement so the argument does not get "simplified" away later. Criterion 2 earned its place.

## A finding beyond the issue's scope

Revert form (b) — removing the `gradient_checkpointing=` kwarg entirely, which the code comment describes as the pre-fix state — does more than re-enable checkpointing. On `trl 0.29.1`, `DPOConfig`, `KTOConfig`, `ORPOConfig` and `CPOConfig` **all default it to `True`**, against `False` on the transformers base class. Measured:

```
WITH the fix:   user asked False -> args.gradient_checkpointing = False   (dpo, orpo, simpo, kto)
FORM (b):       user asked False -> args.gradient_checkpointing = True    (dpo, orpo, simpo, kto)
```

So the guard is not only "force HF checkpointing off while streaming" — it is the only thing stopping TRL's version-dependent default from silently reversing a user's explicit `gradient_checkpointing: false` and then crashing the run. The comment's second sentence about TRL's unstable default is the load-bearing half on current TRL, not a footnote. Might be worth saying so where the guard is defined; happy to add that in this PR if you want it.

## Acceptance criteria

- [x] `orpo` and `simpo` each have a CUDA-gated test calling the real `setup()` + `train()`, not a config-parse or `_build_trainer` check
- [x] Reverting the #328 fix turns it red — verified by actually reverting, in both forms
- [x] A note that the parametrisation list is the localisation

## Checks

```
tests/test_v07204.py on A10G     78 passed  (baseline on upstream: 68)
pytest tests/ (CPU)              19193 passed, 102 skipped
ruff check src/soup_cli/ scripts/ tests/    All checks passed!
```

The 102 skips are 92 baseline + the 10 new CUDA arms skipping off-GPU.

No changelog fragment: this is test-only and not user-visible. Say the word if you would rather have one.
