### PR TITLE
test(mitigation): reconcile the reward-hack ladders and pin their thresholds (#371)

### DIFF
--- a/changelog.d/0.73.3/611.fixed.md
+++ b/changelog.d/0.73.3/611.fixed.md
@@ -1,0 +1,13 @@
+- **The reward-hack ladders' mode split is now documented, and their thresholds
+  are pinned by tests (#371 fix-path item 2, by @umran666 in #611).** The H100
+  gate record carried an open inconsistency — the beta ladder escalated on four
+  consecutive HACK votes while the rollback ladder, requiring three, never
+  fired in any arm. The code settles it: the beta ladder lives in `kl_control`
+  (no rollback rung), the rollback rung lives only in `pid_lagrangian`, and the
+  schema already rejects `reward_hack_rollback` under any other mode — so the
+  arm that fired one structurally lacks the other, and every arm with the other
+  crashed at #342 before it could run. Documented in the module docstring and
+  both run paths; comments only, no behaviour change. Tests pin the remaining
+  CPU-testable acceptance criteria: each ladder fires at its documented
+  threshold on N consecutive HACK votes with a control at N-1, and the
+  `beta == floor` degenerate case the defaults produce.

--- a/src/soup_cli/utils/reward_hack_control.py
+++ b/src/soup_cli/utils/reward_hack_control.py
@@ -9,6 +9,15 @@ only halting:
 - ``pid_lagrangian`` (Stage 2): PID-Lagrangian controller + rollback ladder.
 
 Design:
+- The two mitigation ladders live in DIFFERENT modes by design: kl_control
+  owns the bang-bang β ladder (its terminal rung is β pinned at ``beta_ceil``),
+  and the rollback-to-last-good rung exists ONLY in pid_lagrangian (the config
+  schema rejects ``reward_hack_rollback`` under any other mode). A kl_control
+  run therefore has NO rollback counter. This is the reconciliation the H100
+  gate record (``benchmarks/gate-h100-validation.md``) recorded as an open
+  inconsistency (#371) when the β ladder fired in a kl_control arm but the
+  rollback ladder "never fired in any arm": its only home was the
+  pid_lagrangian arms, which all crashed (#342) before the rung could run.
 - Pure controller pieces (``ControllerState``, ``BangBangPolicy``,
   ``PIDLagrangianPolicy``, ``combine_signals``, ``smooth_signal``, the step
   functions) are frozen dataclasses / free functions with NO torch import at
@@ -1026,7 +1035,12 @@ class _RewardHackMitigationCallback_body:  # type: ignore[misc, valid-type]  # n
     def _run_bang_bang(
         self, telemetry: dict[str, Any], signals: Mapping[str, float]
     ) -> None:
-        """kl_control: vote → bang-bang step → mutate the trainer coefficient."""
+        """kl_control: vote → bang-bang step → mutate the trainer coefficient.
+
+        No rollback rung here — by design the kl_control ladder ends with β
+        pinned at ``beta_ceil``; the rollback rung lives only in pid_lagrangian
+        (module docstring, #371).
+        """
         policy = self.bang_bang
         if policy is None:
             return
@@ -1110,7 +1124,13 @@ class _RewardHackMitigationCallback_body:  # type: ignore[misc, valid-type]  # n
         optimizer: Any,
         control: Any,
     ) -> Any:
-        """pid_lagrangian: PID β update + rollback escalation ladder."""
+        """pid_lagrangian: PID β update + rollback escalation ladder.
+
+        The ONLY mode with a rollback rung (#371). Its HACK streak counts the
+        same combined vote that drives the PID (``classify_hack_signal``'s HACK
+        band), so within this mode the β control and the ladder agree on the
+        signal and its reset rule.
+        """
         policy = self.pid
         if policy is None:
             return control

--- a/tests/test_v07126.py
+++ b/tests/test_v07126.py
@@ -2446,3 +2446,116 @@ class TestReviewFixesTdd:
                 assert not stripped.startswith(
                     ("import transformers", "from transformers")
                 ), line
+
+
+# =====================================================================
+# Part E — #371 item 2: the ladder thresholds, pinned at their documented
+# values with an N-1 control, and the beta == floor degenerate case
+# =====================================================================
+
+
+class TestLadderThresholds:
+    """N consecutive HACK votes fire each ladder at its documented threshold,
+    with a control at N-1 (#371 acceptance criteria).
+
+    The ladders live in DIFFERENT modes — the β ladder in kl_control, the
+    rollback rung in pid_lagrangian (reward_hack_control module docstring) —
+    so each is pinned here in its own mode.
+    """
+
+    def test_beta_ladder_trips_on_nth_hack_vote_with_nm1_control(self):
+        # trip_band=0.30 is exactly classify_hack_signal's HACK boundary, so a
+        # vote of 0.30 is a HACK verdict AND a trip vote — one threshold, one
+        # signal, for the verdict the rollback ladder counts in pid_lagrangian.
+        policy = _bang_policy(dwell_steps=3)
+        state, actions = _run_bang(policy, [0.3, 0.3])  # N-1 = 2: must NOT trip
+        assert not state.tripped and state.beta == pytest.approx(0.02)
+        assert all(a.reason == "hold" for a in actions)
+        assert all(a.verdict == "HACK" for a in actions)
+        state, actions = _run_bang(policy, [0.3, 0.3, 0.3])  # N = 3
+        assert state.tripped and state.beta == pytest.approx(0.02 * 1.5)
+        assert actions[0].reason == "hold" and actions[1].reason == "hold"
+        assert actions[2].reason.startswith("trip")  # fires on step N exactly
+        assert all(a.verdict == "HACK" for a in actions)
+
+    def test_rollback_ladder_fires_on_nth_hack_vote_with_nm1_control(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+
+        def _run(n_hacks):
+            # rollback_patience=3 is the documented shipped default.
+            ckpt = _FakeCkptCb(saved=[10])
+            cb = _pid_callback(
+                tmp_path,
+                _SeqBuffer([_HEALTHY] + [_HACK] * n_hacks),
+                rollback=True,
+                rollback_patience=3,
+                ckpt_cb=ckpt,
+            )
+            cb.attach(_fake_grpo_trainer(beta=0.02))
+            control = types.SimpleNamespace(should_training_stop=False)
+            fired_at = None
+            for step in range(1, 2 + n_hacks):
+                control = cb.on_step_end(
+                    None,
+                    types.SimpleNamespace(global_step=step),
+                    control,
+                    model=object(),
+                    optimizer=object(),
+                )
+                if ckpt.restore_calls and fired_at is None:
+                    fired_at = step
+            return ckpt.restore_calls, fired_at, control
+
+        calls, fired_at, control = _run(2)  # N-1 = 2: must NOT roll back
+        assert calls == [] and fired_at is None
+        assert control.should_training_stop is False
+
+        calls, fired_at, control = _run(3)  # N = 3 consecutive HACK votes
+        assert calls == [10]
+        assert fired_at == 4  # step 1 healthy, then HACK on steps 2, 3, 4
+        assert control.should_training_stop is False  # budget NOT yet spent
+
+
+class TestBetaFloorDegenerate:
+    """β == floor is the configuration the DEFAULTS produce (``grpo_beta`` ==
+    ``reward_hack_beta_floor`` == 0.02), which #371 asks a test for. The
+    ladder must run from that origin: seed to it, never cross below it, relax
+    back to EXACTLY it, and re-trip from it."""
+
+    def test_unseeded_sentinel_resolves_to_floor(self):
+        from soup_cli.utils.reward_hack_control import ControllerState, bang_bang_step
+
+        policy = _bang_policy()
+        state, action = bang_bang_step(policy, ControllerState(), vote=0.02)
+        # the 0.0 sentinel resolves to beta_floor — never emitted as β itself
+        assert action.new_beta == pytest.approx(policy.beta_floor)
+        assert state.beta == pytest.approx(policy.beta_floor)
+
+    def test_release_pressure_from_floor_never_crosses_below_floor(self):
+        policy = _bang_policy()
+        state, actions = _run_bang(policy, [0.02] * 6)  # deep in the release band
+        assert not state.tripped
+        assert state.beta == pytest.approx(policy.beta_floor)
+        assert all(a.new_beta >= policy.beta_floor for a in actions)
+
+    def test_defaults_seed_at_floor_and_the_ladder_runs_from_there(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        cb = _kl_callback(
+            tmp_path, _SeqBuffer([_HEALTHY, _HACK, _HEALTHY, _HACK, _HACK])
+        )
+        trainer = _fake_grpo_trainer(beta=0.02)  # the default coefficient
+        cb.attach(trainer)
+        betas = []
+        for step in range(1, 6):  # hold, trip, relax, re-trip, raise
+            cb.on_step_end(None, types.SimpleNamespace(global_step=step), None)
+            betas.append(trainer.beta)
+        assert betas[0] == pytest.approx(0.02)  # seeded AT the floor, hold wrote nothing
+        assert betas[1] == pytest.approx(0.04)
+        assert betas[2] == pytest.approx(0.02)  # relaxed to EXACTLY the floor
+        assert betas[3] == pytest.approx(0.04)  # re-tripped from the floor
+        assert betas[4] == pytest.approx(0.08)
+        assert all(b >= 0.02 for b in betas)  # the hard invariant: never below


### PR DESCRIPTION
**Part of #371** — fix-path item 2 (complementing @AmirF194's item-3 work in #414). Claimed in [this comment](https://github.com/MakazhanAlpamys/Soup/issues/371#issuecomment-5472636984).

## The reconciliation the gate record asks for

`benchmarks/gate-h100-validation.md` records an open inconsistency: the beta ladder escalated on four consecutive HACK votes while the rollback ladder, requiring three, *never fired in any arm*. The code settles it — **the two ladders live in different modes**:

- The beta ladder that fired is `kl_control`'s bang-bang ladder. `_run_bang_bang` has no HACK streak and no `_escalate` — its ladder ends with β pinned at `beta_ceil`.
- The rollback rung exists **only** in `pid_lagrangian` (`_run_pid`); the schema already rejects `reward_hack_rollback` under any other mode.

So the arm that fired the beta ladder structurally has no rollback counter, and every arm that *has* one (the three `pid_lagrangian` attempts) crashed at #342 before the rung could run. Not two counters over different signals — one counter absent by design. This is documented in the module docstring and both run paths, so the reconciliation lives where the code does. **Comments only; no behaviour change.**

## The remaining CPU-testable acceptance criteria

- **N consecutive HACK votes fire each ladder at its documented threshold, with a control at N-1**: `dwell_steps` for the beta ladder (fires on step N exactly, holds on N-1; a vote of exactly `0.30` is pinned as both a HACK verdict and a trip vote — one threshold, one signal), and the shipped `rollback_patience=3` default for the rollback rung (fires on the exact step the third consecutive HACK vote lands, N-1 never restores, early-stop budget not yet spent).
- **The `beta == floor` degenerate case** — the configuration the defaults produce (`grpo_beta` == `reward_hack_beta_floor` == 0.02): the unseeded sentinel resolves to the floor, sustained release pressure never crosses below it, and the full trip → relax-to-exactly-floor → re-trip cycle runs from that origin.

Item 1 (a completed `pid_lagrangian` run) needs GPU hardware and stays open.

## Test plan

- [x] `pytest tests/test_v07126.py` — 193 passed, 3 skipped (the 3 skips are the pre-existing backend-gated ones)
- [x] `pytest tests/test_issue320_lazy_callback_import.py tests/test_v07127.py` — 186 passed (adjacent modules, no regressions)
- [x] `ruff check src/soup_cli/ tests/` — clean
- All new tests are CPU-only; no torch/transformers needed at module scope
