### PR TITLE
fix(doctor): recommend a CUDA wheel that matches the driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,8 +362,9 @@ All training tasks run on CPU for testing (quantization auto-disabled). Optional
 soup doctor    # GPU, system resources, dependencies, and version in one place
 ```
 
-- **`ImportError: DLL load failed while importing _C` (Windows)** — reinstall PyTorch for your
-  CUDA version: `pip install torch --index-url https://download.pytorch.org/whl/cu121`.
+- **`ImportError: DLL load failed while importing _C` (Windows).** PyPI's torch
+  wheel is CPU-only. Reinstall a CUDA build; `soup doctor` prints the
+  `pip install` command for the wheel your driver can run.
 - **`soup version` ≠ `pip show soup-cli`** — multiple Python installs; use a virtualenv.
 
 ## Development

--- a/changelog.d/0.73.3/612.fixed.md
+++ b/changelog.d/0.73.3/612.fixed.md
@@ -1,4 +1,6 @@
 - `soup doctor` now recommends a PyTorch CUDA wheel that matches the
   driver's `nvidia-smi` CUDA version instead of always suggesting `cu121`.
-  Unknown drivers fall back to `cu130`. Windows also notes that the PyPI
-  torch wheel is CPU-only. (#612)
+  An unreadable driver header falls back to `cu121` (conservative: a parse
+  failure is treated as an old driver, not a new one). Drivers at CUDA 11.8
+  get `cu118`. Windows also notes that the PyPI torch wheel is CPU-only.
+  (#612 by @MKnaomi2)

--- a/changelog.d/0.73.3/612.fixed.md
+++ b/changelog.d/0.73.3/612.fixed.md
@@ -1,0 +1,4 @@
+- `soup doctor` now recommends a PyTorch CUDA wheel that matches the
+  driver's `nvidia-smi` CUDA version instead of always suggesting `cu121`.
+  Unknown drivers fall back to `cu130`. Windows also notes that the PyPI
+  torch wheel is CPU-only. (#612)

--- a/src/soup_cli/commands/doctor.py
+++ b/src/soup_cli/commands/doctor.py
@@ -256,6 +256,7 @@ _TORCH_CUDA_WHEELS: tuple[tuple[int, int, str], ...] = (
     (12, 6, "cu126"),
     (12, 4, "cu124"),
     (12, 1, "cu121"),
+    (11, 8, "cu118"),
 )
 
 
@@ -270,28 +271,41 @@ def _parse_cuda_version(text: str) -> tuple[int, int] | None:
 def _torch_cuda_wheel_tag(driver: tuple[int, int] | None) -> str:
     """Pick the newest PyTorch CUDA wheel the driver can run.
 
-    Falls back to ``cu130`` (current PyTorch default CUDA build) rather than
-    the frozen ``cu121`` string from v0.40.1, which is wrong on CUDA 12.6+
-    cards — including Blackwell / RTX 50-series.
+    ``None`` (unreadable nvidia-smi header) falls back to ``cu121``, not
+    ``cu130``: a parse failure is treated as an old driver. A too-new wheel
+    is the failure mode that looks like success (pip ok, CUDA init dies).
+    A known 13.2 header still maps to ``cu132``. Drivers older than every
+    table row get ``cu118``, the oldest published tag.
     """
     if driver is None:
-        return "cu130"
+        return "cu121"
     for major, minor, tag in _TORCH_CUDA_WHEELS:
         if driver >= (major, minor):
             return tag
-    return "cu121"
+    return "cu118"
+
+
+def _nvidia_smi_executable() -> str | None:
+    """Absolute path to nvidia-smi, or None.
+
+    Bare ``nvidia-smi`` is never handed to ``subprocess`` (CWE-427):
+    Windows ``CreateProcess`` searches the current directory before PATH.
+    """
+    import shutil
+
+    return shutil.which("nvidia-smi")
 
 
 def _nvidia_smi_cuda_version() -> tuple[int, int] | None:
     """Read the driver's max CUDA version from ``nvidia-smi`` header output."""
-    import shutil
     import subprocess
 
-    if shutil.which("nvidia-smi") is None:
+    nvidia_smi = _nvidia_smi_executable()
+    if nvidia_smi is None:
         return None
     try:
         completed = subprocess.run(  # noqa: S603 — argv list, no shell
-            ["nvidia-smi"],
+            [nvidia_smi],
             capture_output=True,
             text=True,
             timeout=5,
@@ -307,14 +321,14 @@ def _detect_gpu_hw_without_torch_cuda() -> str:
     """v0.40.1 Part C / N3 — return advisory string if nvidia-smi succeeds
     but torch lacks CUDA (i.e. user installed the CPU-only wheel).
     """
-    import shutil
     import subprocess
 
-    if shutil.which("nvidia-smi") is None:
+    nvidia_smi = _nvidia_smi_executable()
+    if nvidia_smi is None:
         return ""
     try:
         completed = subprocess.run(  # noqa: S603 — argv list, no shell
-            ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
+            [nvidia_smi, "--query-gpu=name", "--format=csv,noheader"],
             capture_output=True,
             text=True,
             timeout=5,

--- a/src/soup_cli/commands/doctor.py
+++ b/src/soup_cli/commands/doctor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import platform
+import re
 import sys
 
 import typer
@@ -246,6 +247,62 @@ def _check_gpu():
         )
 
 
+# Newest-first PyTorch CUDA wheel tags. A driver that advertises CUDA N.M can
+# load any wheel whose CUDA is <= N.M (driver backward compatibility).
+_TORCH_CUDA_WHEELS: tuple[tuple[int, int, str], ...] = (
+    (13, 2, "cu132"),
+    (13, 0, "cu130"),
+    (12, 8, "cu128"),
+    (12, 6, "cu126"),
+    (12, 4, "cu124"),
+    (12, 1, "cu121"),
+)
+
+
+def _parse_cuda_version(text: str) -> tuple[int, int] | None:
+    """Extract ``(major, minor)`` from nvidia-smi ``CUDA Version: X.Y`` text."""
+    match = re.search(r"CUDA Version:\s*(\d+)\.(\d+)", text or "")
+    if match is None:
+        return None
+    return int(match.group(1)), int(match.group(2))
+
+
+def _torch_cuda_wheel_tag(driver: tuple[int, int] | None) -> str:
+    """Pick the newest PyTorch CUDA wheel the driver can run.
+
+    Falls back to ``cu130`` (current PyTorch default CUDA build) rather than
+    the frozen ``cu121`` string from v0.40.1, which is wrong on CUDA 12.6+
+    cards — including Blackwell / RTX 50-series.
+    """
+    if driver is None:
+        return "cu130"
+    for major, minor, tag in _TORCH_CUDA_WHEELS:
+        if driver >= (major, minor):
+            return tag
+    return "cu121"
+
+
+def _nvidia_smi_cuda_version() -> tuple[int, int] | None:
+    """Read the driver's max CUDA version from ``nvidia-smi`` header output."""
+    import shutil
+    import subprocess
+
+    if shutil.which("nvidia-smi") is None:
+        return None
+    try:
+        completed = subprocess.run(  # noqa: S603 — argv list, no shell
+            ["nvidia-smi"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if completed.returncode != 0:
+        return None
+    return _parse_cuda_version((completed.stdout or "") + (completed.stderr or ""))
+
+
 def _detect_gpu_hw_without_torch_cuda() -> str:
     """v0.40.1 Part C / N3 — return advisory string if nvidia-smi succeeds
     but torch lacks CUDA (i.e. user installed the CPU-only wheel).
@@ -280,10 +337,16 @@ def _detect_gpu_hw_without_torch_cuda() -> str:
         torch_version = _pkgver("torch")
     except Exception:  # noqa: BLE001
         torch_version = "?"
+    wheel = _torch_cuda_wheel_tag(_nvidia_smi_cuda_version())
+    index_url = f"https://download.pytorch.org/whl/{wheel}"
+    windows_note = ""
+    if platform.system() == "Windows":
+        windows_note = " On Windows, PyPI's torch wheel is CPU-only."
     return (
         f"GPU hardware present ({gpu_label}) but torch is the CPU build "
         f"(torch {torch_version}). To enable your GPU: "
-        f"`pip install torch --index-url https://download.pytorch.org/whl/cu121`"
+        f"`pip install torch --index-url {index_url}`"
+        f"{windows_note}"
     )
 
 

--- a/tests/test_v0401_part_c.py
+++ b/tests/test_v0401_part_c.py
@@ -151,10 +151,64 @@ def test_detect_gpu_hw_returns_advisory_when_smi_succeeds():
     with (
         patch("shutil.which", return_value="/usr/bin/nvidia-smi"),
         patch("subprocess.run", return_value=completed),
+        patch(
+            "soup_cli.commands.doctor._nvidia_smi_cuda_version",
+            return_value=None,
+        ),
     ):
         advisory = _detect_gpu_hw_without_torch_cuda()
     assert "RTX 3050" in advisory
-    assert "cu121" in advisory
+    assert "download.pytorch.org/whl/" in advisory
+    # Unknown driver → current PyTorch default CUDA build, not frozen cu121.
+    assert "cu130" in advisory
+    assert "cu121" not in advisory
+
+
+def test_detect_gpu_hw_uses_driver_cuda_wheel():
+    import subprocess
+
+    from soup_cli.commands.doctor import _detect_gpu_hw_without_torch_cuda
+
+    completed = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="NVIDIA GeForce RTX 5060 Ti\n", stderr=""
+    )
+    with (
+        patch("shutil.which", return_value="/usr/bin/nvidia-smi"),
+        patch("subprocess.run", return_value=completed),
+        patch(
+            "soup_cli.commands.doctor._nvidia_smi_cuda_version",
+            return_value=(13, 2),
+        ),
+    ):
+        advisory = _detect_gpu_hw_without_torch_cuda()
+    assert "RTX 5060 Ti" in advisory
+    assert "cu132" in advisory
+    assert "cu121" not in advisory
+
+
+def test_parse_cuda_version_from_nvidia_smi_header():
+    from soup_cli.commands.doctor import _parse_cuda_version
+
+    header = (
+        "NVIDIA-SMI 596.49                 Driver Version: 596.49"
+        "         CUDA Version: 13.2"
+    )
+    assert _parse_cuda_version(header) == (13, 2)
+    assert _parse_cuda_version("no cuda here") is None
+    assert _parse_cuda_version("") is None
+
+
+def test_torch_cuda_wheel_tag_picks_newest_supported():
+    from soup_cli.commands.doctor import _torch_cuda_wheel_tag
+
+    assert _torch_cuda_wheel_tag((13, 2)) == "cu132"
+    assert _torch_cuda_wheel_tag((13, 0)) == "cu130"
+    assert _torch_cuda_wheel_tag((12, 8)) == "cu128"
+    assert _torch_cuda_wheel_tag((12, 7)) == "cu126"
+    assert _torch_cuda_wheel_tag((12, 6)) == "cu126"
+    assert _torch_cuda_wheel_tag((12, 1)) == "cu121"
+    assert _torch_cuda_wheel_tag((11, 8)) == "cu121"
+    assert _torch_cuda_wheel_tag(None) == "cu130"
 
 
 # --- N4: dual-Python interpreter detector ---------------------------------

--- a/tests/test_v0401_part_c.py
+++ b/tests/test_v0401_part_c.py
@@ -4,6 +4,7 @@ GPU-aware model pick / lr_finder import regression.
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -159,9 +160,8 @@ def test_detect_gpu_hw_returns_advisory_when_smi_succeeds():
         advisory = _detect_gpu_hw_without_torch_cuda()
     assert "RTX 3050" in advisory
     assert "download.pytorch.org/whl/" in advisory
-    # Unknown driver → current PyTorch default CUDA build, not frozen cu121.
-    assert "cu130" in advisory
-    assert "cu121" not in advisory
+    # Unknown driver: conservative cu121 (parse failure is an old driver).
+    assert "whl/cu121" in advisory
 
 
 def test_detect_gpu_hw_uses_driver_cuda_wheel():
@@ -179,11 +179,45 @@ def test_detect_gpu_hw_uses_driver_cuda_wheel():
             "soup_cli.commands.doctor._nvidia_smi_cuda_version",
             return_value=(13, 2),
         ),
+        # Installed CUDA torch version string, as on a real GPU box.
+        # A naive `assert "cu121" not in advisory` matches this and goes
+        # red locally / green on CPU-only CI.
+        patch("importlib.metadata.version", return_value="2.5.1+cu121"),
     ):
         advisory = _detect_gpu_hw_without_torch_cuda()
     assert "RTX 5060 Ti" in advisory
-    assert "cu132" in advisory
-    assert "cu121" not in advisory
+    assert "2.5.1+cu121" in advisory
+    assert "whl/cu132" in advisory
+    assert "whl/cu121" not in advisory
+
+
+def test_nvidia_smi_invoked_by_absolute_path():
+    import subprocess
+
+    from soup_cli.commands.doctor import (
+        _detect_gpu_hw_without_torch_cuda,
+        _nvidia_smi_cuda_version,
+    )
+
+    smi = "/usr/bin/nvidia-smi"
+    failed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="")
+    with (
+        patch("shutil.which", return_value=smi),
+        patch("subprocess.run", return_value=failed) as run,
+    ):
+        _nvidia_smi_cuda_version()
+    argv = run.call_args.args[0]
+    assert argv[0] == smi
+    assert argv[0] != "nvidia-smi"
+
+    with (
+        patch("shutil.which", return_value=smi),
+        patch("subprocess.run", return_value=failed) as run,
+    ):
+        _detect_gpu_hw_without_torch_cuda()
+    argv = run.call_args.args[0]
+    assert argv[0] == smi
+    assert "--query-gpu=name" in argv
 
 
 def test_parse_cuda_version_from_nvidia_smi_header():
@@ -194,21 +228,34 @@ def test_parse_cuda_version_from_nvidia_smi_header():
         "         CUDA Version: 13.2"
     )
     assert _parse_cuda_version(header) == (13, 2)
+    assert _parse_cuda_version("CUDA Version:13.2") == (13, 2)
+    assert _parse_cuda_version("CUDA Version: 12.10") == (12, 10)
+    assert _parse_cuda_version("CUDA Version: N/A") is None
     assert _parse_cuda_version("no cuda here") is None
     assert _parse_cuda_version("") is None
 
 
 def test_torch_cuda_wheel_tag_picks_newest_supported():
-    from soup_cli.commands.doctor import _torch_cuda_wheel_tag
+    from soup_cli.commands.doctor import _TORCH_CUDA_WHEELS, _torch_cuda_wheel_tag
 
+    assert (11, 8, "cu118") in _TORCH_CUDA_WHEELS
     assert _torch_cuda_wheel_tag((13, 2)) == "cu132"
+    assert _torch_cuda_wheel_tag((13, 1)) == "cu130"
     assert _torch_cuda_wheel_tag((13, 0)) == "cu130"
     assert _torch_cuda_wheel_tag((12, 8)) == "cu128"
     assert _torch_cuda_wheel_tag((12, 7)) == "cu126"
     assert _torch_cuda_wheel_tag((12, 6)) == "cu126"
+    assert _torch_cuda_wheel_tag((12, 4)) == "cu124"
     assert _torch_cuda_wheel_tag((12, 1)) == "cu121"
-    assert _torch_cuda_wheel_tag((11, 8)) == "cu121"
-    assert _torch_cuda_wheel_tag(None) == "cu130"
+    assert _torch_cuda_wheel_tag((11, 8)) == "cu118"
+    assert _torch_cuda_wheel_tag((11, 0)) == "cu118"
+    assert _torch_cuda_wheel_tag(None) == "cu121"
+
+
+def test_readme_does_not_hardcode_a_cuda_wheel_index():
+    readme = Path(__file__).resolve().parents[1] / "README.md"
+    text = readme.read_text(encoding="utf-8")
+    assert "download.pytorch.org/whl/cu" not in text
 
 
 # --- N4: dual-Python interpreter detector ---------------------------------


### PR DESCRIPTION
soup doctor hardcoded cu121 when torch was CPU-only. That index is stale on CUDA 12.6+ cards. Parse nvidia-smi CUDA Version and pick the newest compatible PyTorch wheel. Unknown driver falls back to cu130, not cu121. Windows advisory notes that PyPI torch is CPU-only. Reproduced on RTX 5060 Ti (driver CUDA 13.2). Tests in test_v0401_part_c.py. Changelog fragment after PR number is assigned.