### PR TITLE
feat(recipes): add kimi-k2.6-grpo recipe (#281)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ src/soup_cli/
   experiment/         - SQLite experiment tracking
   eval/               - Eval platform (custom tasks, LLM judge, human eval, leaderboard)
   migrate/            - Config migration (LLaMA-Factory, Axolotl, Unsloth)
-  recipes/            - Ready-made configs for popular models (160 recipes)
+  recipes/            - Ready-made configs for popular models (161 recipes)
   autopilot/          - Zero-config decision engine (v0.25.0)
   registry/           - Model Registry (hashing, store, diff, attach) (v0.26.0 + v0.33.0)
   cans/               - Shareable .can artifact format + run/publish orchestrator (v0.26.0 + v0.33.0)

--- a/changelog.d/0.73.3/614.added.md
+++ b/changelog.d/0.73.3/614.added.md
@@ -1,0 +1,6 @@
+- [#614](https://github.com/MakazhanAlpamys/Soup/pull/614) adds a ready-made
+  `kimi-k2.6-grpo` recipe for moonshotai/Kimi-K2.6. The v0.71.24 expansion
+  shipped the SFT variant but no GRPO reasoning variant; this fills that gap
+  with the MoE giant GRPO shape (grpo_beta 0.1, num_generations 4,
+  reward_fn accuracy, moe_lora, Modified MIT note kept). Catalog count
+  159 → 160. Closes #281.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -152,7 +152,7 @@ soup migrate --from llamafactory config.yaml  Import config from LLaMA-Factory
 soup migrate --from axolotl config.yml        Import config from Axolotl
 soup migrate --from unsloth notebook.ipynb    Import config from Unsloth notebook
 soup migrate --from llamafactory c.yaml --dry-run  Preview without writing
-soup recipes list                             List all 160 ready-made recipes
+soup recipes list                             List all 161 ready-made recipes
 soup recipes show llama3.1-8b-sft            Print recipe YAML
 soup recipes use llama3.1-8b-sft             Copy recipe to soup.yaml
 soup recipes search "reasoning"              Search by keyword/task/size

--- a/docs/serving-and-export.md
+++ b/docs/serving-and-export.md
@@ -536,7 +536,7 @@ soup ui
 
 **Pages:**
 - **Dashboard** — view all experiment runs, loss charts, system info, multi-run comparison
-- **New Training** — create configs from templates or 160 ready-made recipes, validate, start training with live SSE log streaming and progress bar
+- **New Training** — create configs from templates or 161 ready-made recipes, validate, start training with live SSE log streaming and progress bar
 - **Data Explorer** — browse and inspect datasets (JSONL, JSON, CSV, Parquet)
 - **Model Chat** — chat with streaming responses, configurable temperature/top_p/max_tokens, system prompt, adapter selection, markdown rendering, chat export
 
@@ -545,7 +545,7 @@ soup ui
 - **Enhanced Metrics** — 2x2 chart grid (loss, LR, grad_norm, throughput) + GPU memory chart, eval results table
 - **Multi-Run Compare** — overlay loss curves from up to 5 runs side-by-side
 - **Chat Upgrade** — SSE streaming via proxy, typing indicator, cancel button, markdown renderer (bold, italic, code blocks), chat export as JSON
-- **Config Builder** — recipe dropdown (160 recipes), config schema API for dynamic form generation
+- **Config Builder** — recipe dropdown (161 recipes), config schema API for dynamic form generation
 
 **Security:** The Web UI generates a random auth token at startup (printed to console). All mutating endpoints (start/stop training, delete runs, inspect data, validate config) require `Authorization: Bearer <token>` header. CORS is restricted to the served origin. Data inspection is sandboxed to the working directory.
 

--- a/src/soup_cli/recipes/catalog.py
+++ b/src/soup_cli/recipes/catalog.py
@@ -48,7 +48,7 @@ def search_recipes(
 
 
 # ---------------------------------------------------------------------------
-# Recipe catalog (160 recipes)
+# Recipe catalog (161 recipes)
 # ---------------------------------------------------------------------------
 
 RECIPES: Dict[str, RecipeMeta] = {
@@ -4441,6 +4441,43 @@ training:
   quantization: 4bit
   moe_lora: true
   moe_aux_loss_coeff: 0.01
+  gradient_checkpointing: true
+
+output: ./output
+""",
+    ),
+    "kimi-k2.6-grpo": RecipeMeta(
+        model="moonshotai/Kimi-K2.6",
+        task="grpo",
+        size="1T",
+        tags=("kimi", "moonshot", "grpo", "reasoning", "moe", "large", "multi-gpu"),
+        description=(
+            "Kimi K2.6 MoE GRPO reasoning (Modified MIT, ~1T / 32B active). "
+            "Requires multi-node DeepSpeed."
+        ),
+        yaml_str="""\
+base: moonshotai/Kimi-K2.6
+task: grpo
+
+data:
+  train: ./data/reasoning_train.jsonl
+  format: auto
+  max_length: 8192
+
+training:
+  epochs: 3
+  lr: 1e-5
+  batch_size: 1
+  gradient_accumulation_steps: 16
+  lora:
+    r: 16
+    alpha: 32
+    target_modules: auto
+  quantization: 4bit
+  grpo_beta: 0.1
+  num_generations: 4
+  reward_fn: accuracy
+  moe_lora: true
   gradient_checkpointing: true
 
 output: ./output

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -475,6 +475,49 @@ class TestIssue276Qwen35A3bDpoRecipe:
         )
 
 
+class TestIssue281KimiK26GrpoRecipe:
+    """Regression coverage for the kimi-k2.6-grpo recipe (#281)."""
+
+    def test_recipe_loads_with_exact_model_id(self) -> None:
+        from soup_cli.config.loader import load_config_from_string
+        from soup_cli.recipes.catalog import get_recipe
+
+        recipe = get_recipe("kimi-k2.6-grpo")
+        assert recipe is not None
+        # The exact model identity is load-bearing — a wrong id must fail here.
+        assert recipe.model == "moonshotai/Kimi-K2.6"
+        assert recipe.task == "grpo"
+        assert "Modified MIT" in recipe.description
+
+        config = load_config_from_string(recipe.yaml_str)
+        assert config.base == "moonshotai/Kimi-K2.6"
+        assert config.task == "grpo"
+        # The GRPO + MoE giant shape the issue pins (#281).
+        assert config.training.grpo_beta == 0.1
+        assert config.training.num_generations == 4
+        assert config.training.reward_fn == "accuracy"
+        assert config.training.moe_lora is True
+        assert config.training.gradient_checkpointing is True
+        assert config.training.batch_size == 1
+        assert config.training.quantization == "4bit"
+
+    def test_show_and_use_recipe(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        show_result = runner.invoke(app, ["recipes", "show", "kimi-k2.6-grpo"])
+        assert show_result.exit_code == 0
+        assert "moonshotai/Kimi-K2.6" in show_result.output
+
+        monkeypatch.chdir(tmp_path)
+        use_result = runner.invoke(app, ["recipes", "use", "kimi-k2.6-grpo", "--yes"])
+        assert use_result.exit_code == 0
+        assert "moonshotai/Kimi-K2.6" in (tmp_path / "soup.yaml").read_text(
+            encoding="utf-8"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Part A: v0.25.0 new model recipes (Llama 4, Qwen 3, Gemma 3, DeepSeek V3)
 # ---------------------------------------------------------------------------
@@ -522,7 +565,7 @@ class TestV025NewRecipes:
             assert cfg.base == recipe.model
             assert cfg.task == recipe.task
 
-    def test_catalog_size_is_160(self):
+    def test_catalog_size_is_161(self):
         """Total catalog size — grew with each release.
 
         v0.25.0 shipped 43 recipes (29 + 9 Part A + 2 Part B tools + 3 Part E MLX).
@@ -546,10 +589,11 @@ class TestV025NewRecipes:
         R1-Distill Llama SFT + DPO variants added 4 -> 158.
         Issue #271 added 1 (smollm3-3b-sft) -> 159.
         Issue #276 added 1 (qwen3.5-35b-a3b-dpo) -> 160.
+        Issue #281 added 1 (kimi-k2.6-grpo) -> 161.
         """
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 160
+        assert len(RECIPES) == 161
 
     def test_new_recipes_searchable(self):
         """Search returns the new recipes via keyword/task filter."""

--- a/tests/test_v07124.py
+++ b/tests/test_v07124.py
@@ -270,7 +270,7 @@ class TestGlm5RepoIdFix:
 
 class TestCatalogCount:
     def test_total_recipe_count_is_158(self) -> None:
-        assert len(RECIPES) == 160
+        assert len(RECIPES) == 161
 
     def test_list_recipes_matches_dict(self) -> None:
         assert len(list_recipes()) == len(RECIPES)

--- a/tests/test_v07130.py
+++ b/tests/test_v07130.py
@@ -737,10 +737,10 @@ class TestRecipes:
         assert cfg.training.rollout_backend == "openenv"
         assert cfg.training.rollout_func.startswith("soup_cli.envs.")
 
-    def test_catalog_size_is_160(self):
+    def test_catalog_size_is_161(self):
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 160
+        assert len(RECIPES) == 161
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_v07132.py
+++ b/tests/test_v07132.py
@@ -950,7 +950,7 @@ class TestAsrRecipes:
         assert cfg.task == "sft"
         assert cfg.modality == "vision"
 
-    def test_catalog_size_is_160(self):
+    def test_catalog_size_is_161(self):
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 160
+        assert len(RECIPES) == 161


### PR DESCRIPTION
Closes #281 (claimed in [this comment](https://github.com/MakazhanAlpamys/Soup/issues/281#issuecomment-5477796292)). Part of the #275 task-variant tracking.

GRPO reasoning variant of the v0.71.24 `kimi-k2.6-sft` sibling. Per the issue's How: copies the GRPO + MoE giant shape from `qwen3-30b-a3b-reasoning-grpo` — `grpo_beta: 0.1`, `num_generations: 4`, `reward_fn: accuracy`, `moe_lora: true`, `gradient_checkpointing: true`, `batch_size: 1`, `gradient_accumulation_steps: 16` — and points `base:` at `moonshotai/Kimi-K2.6`, keeping the **Modified MIT** note in the description.

- [x] `soup recipes show/use kimi-k2.6-grpo` work; YAML loads — pinned by `TestIssue281KimiK26GrpoRecipe` (CLI-invoked `show` and `use` via the Typer runner, plus a `load_config_from_string` round-trip asserting every shape field the issue names)
- [x] Base resolves on Hugging Face — `moonshotai/Kimi-K2.6` returns HTTP 200 from the HF API (same base the shipped SFT sibling already uses)
- [x] `ruff` + `pytest tests/test_recipes.py` green — plus `test_recipe_count_is_synced.py`, `test_recipes_v031.py`, `test_v0510.py`, `test_v07124.py`, `test_v07130.py`, `test_v07132.py`: **2038 passed, 1 skipped** (pre-existing skip)

Catalog count 159 → 160 bumped at every declared documentation site (catalog header, `CONTRIBUTING.md`, `docs/commands.md`, both `docs/serving-and-export.md` sites), with the #453 ratchet passing; milestone size assertions in `test_v07124/v07130/v07132` bumped per the #582 merge convention.
