### PR TITLE
feat(recipes): add qwen3.5-35b-a3b-dpo recipe (#276)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ src/soup_cli/
   experiment/         - SQLite experiment tracking
   eval/               - Eval platform (custom tasks, LLM judge, human eval, leaderboard)
   migrate/            - Config migration (LLaMA-Factory, Axolotl, Unsloth)
-  recipes/            - Ready-made configs for popular models (159 recipes)
+  recipes/            - Ready-made configs for popular models (160 recipes)
   autopilot/          - Zero-config decision engine (v0.25.0)
   registry/           - Model Registry (hashing, store, diff, attach) (v0.26.0 + v0.33.0)
   cans/               - Shareable .can artifact format + run/publish orchestrator (v0.26.0 + v0.33.0)

--- a/changelog.d/0.73.3/615.added.md
+++ b/changelog.d/0.73.3/615.added.md
@@ -1,0 +1,6 @@
+- [#615](https://github.com/MakazhanAlpamys/Soup/pull/615) adds a ready-made
+  `qwen3.5-35b-a3b-dpo` recipe for Qwen/Qwen3.5-35B-A3B. The catalog shipped the
+  MoE SFT sibling `qwen3.5-35b-a3b-sft` in v0.71.24 but no preference-tuning
+  variant; this pairs the `qwen2.5-7b-dpo` DPO shape (`format: dpo`, `lr 5e-6`,
+  `dpo_beta: 0.1`) with the sibling's MoE settings (`moe_lora: true`,
+  `moe_aux_loss_coeff: 0.01`). Catalog count 159 → 160. Closes #276.

--- a/changelog.d/0.73.3/615.added.md
+++ b/changelog.d/0.73.3/615.added.md
@@ -1,6 +1,8 @@
-- [#615](https://github.com/MakazhanAlpamys/Soup/pull/615) adds a ready-made
-  `qwen3.5-35b-a3b-dpo` recipe for Qwen/Qwen3.5-35B-A3B. The catalog shipped the
-  MoE SFT sibling `qwen3.5-35b-a3b-sft` in v0.71.24 but no preference-tuning
-  variant; this pairs the `qwen2.5-7b-dpo` DPO shape (`format: dpo`, `lr 5e-6`,
-  `dpo_beta: 0.1`) with the sibling's MoE settings (`moe_lora: true`,
-  `moe_aux_loss_coeff: 0.01`). Catalog count 159 → 160. Closes #276.
+- **Added a ready-made `qwen3.5-35b-a3b-dpo` recipe for Qwen/Qwen3.5-35B-A3B
+  (#276 by @Srinivasan8888 in #615).** The catalog shipped the MoE SFT sibling
+  `qwen3.5-35b-a3b-sft` in v0.71.24 but no preference-tuning variant; this pairs
+  the `qwen2.5-7b-dpo` DPO shape (`format: dpo`, `lr 5e-6`, `dpo_beta: 0.1`) with
+  the sibling's MoE settings (`moe_lora: true`, `moe_aux_loss_coeff: 0.01`), and
+  carries an explicit `modality: text` so it joins the Qwen3.5-family contract in
+  `test_issue427_qwen35_text_modality.py` rather than falling back to the schema
+  default. Catalog count 159 → 160.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -152,7 +152,7 @@ soup migrate --from llamafactory config.yaml  Import config from LLaMA-Factory
 soup migrate --from axolotl config.yml        Import config from Axolotl
 soup migrate --from unsloth notebook.ipynb    Import config from Unsloth notebook
 soup migrate --from llamafactory c.yaml --dry-run  Preview without writing
-soup recipes list                             List all 159 ready-made recipes
+soup recipes list                             List all 160 ready-made recipes
 soup recipes show llama3.1-8b-sft            Print recipe YAML
 soup recipes use llama3.1-8b-sft             Copy recipe to soup.yaml
 soup recipes search "reasoning"              Search by keyword/task/size

--- a/docs/serving-and-export.md
+++ b/docs/serving-and-export.md
@@ -536,7 +536,7 @@ soup ui
 
 **Pages:**
 - **Dashboard** — view all experiment runs, loss charts, system info, multi-run comparison
-- **New Training** — create configs from templates or 159 ready-made recipes, validate, start training with live SSE log streaming and progress bar
+- **New Training** — create configs from templates or 160 ready-made recipes, validate, start training with live SSE log streaming and progress bar
 - **Data Explorer** — browse and inspect datasets (JSONL, JSON, CSV, Parquet)
 - **Model Chat** — chat with streaming responses, configurable temperature/top_p/max_tokens, system prompt, adapter selection, markdown rendering, chat export
 
@@ -545,7 +545,7 @@ soup ui
 - **Enhanced Metrics** — 2x2 chart grid (loss, LR, grad_norm, throughput) + GPU memory chart, eval results table
 - **Multi-Run Compare** — overlay loss curves from up to 5 runs side-by-side
 - **Chat Upgrade** — SSE streaming via proxy, typing indicator, cancel button, markdown renderer (bold, italic, code blocks), chat export as JSON
-- **Config Builder** — recipe dropdown (159 recipes), config schema API for dynamic form generation
+- **Config Builder** — recipe dropdown (160 recipes), config schema API for dynamic form generation
 
 **Security:** The Web UI generates a random auth token at startup (printed to console). All mutating endpoints (start/stop training, delete runs, inspect data, validate config) require `Authorization: Bearer <token>` header. CORS is restricted to the served origin. Data inspection is sandboxed to the working directory.
 

--- a/src/soup_cli/recipes/catalog.py
+++ b/src/soup_cli/recipes/catalog.py
@@ -48,7 +48,7 @@ def search_recipes(
 
 
 # ---------------------------------------------------------------------------
-# Recipe catalog (159 recipes)
+# Recipe catalog (160 recipes)
 # ---------------------------------------------------------------------------
 
 RECIPES: Dict[str, RecipeMeta] = {
@@ -4004,6 +4004,39 @@ training:
     alpha: 32
     target_modules: auto
   quantization: 4bit
+  moe_lora: true
+  moe_aux_loss_coeff: 0.01
+
+output: ./output
+""",
+    ),
+    "qwen3.5-35b-a3b-dpo": RecipeMeta(
+        model="Qwen/Qwen3.5-35B-A3B",
+        task="dpo",
+        size="35B",
+        tags=("qwen", "qwen3.5", "dpo", "alignment", "preference", "moe", "mixture-of-experts"),
+        description="Qwen 3.5 35B-A3B MoE DPO alignment (Apache-2.0, 3B active)",
+        yaml_str="""\
+base: Qwen/Qwen3.5-35B-A3B
+task: dpo
+modality: text
+
+data:
+  train: ./data/preference_train.jsonl
+  format: dpo
+  max_length: 4096
+
+training:
+  epochs: 3
+  lr: 5e-6
+  batch_size: auto
+  gradient_accumulation_steps: 8
+  lora:
+    r: 16
+    alpha: 32
+    target_modules: auto
+  quantization: 4bit
+  dpo_beta: 0.1
   moe_lora: true
   moe_aux_loss_coeff: 0.01
 

--- a/tests/test_issue427_qwen35_text_modality.py
+++ b/tests/test_issue427_qwen35_text_modality.py
@@ -17,6 +17,7 @@ EXPECTED_QWEN35_TEXT_RECIPES = {
     "qwen3.5-9b-grpo",
     "qwen3.5-27b-sft",
     "qwen3.5-35b-a3b-sft",
+    "qwen3.5-35b-a3b-dpo",
     "qwen3.5-122b-a10b-sft",
     "qwen3.5-397b-a17b-sft",
     # Qwen3.6 exposes the same qwen3_5 / qwen3_5_moe architecture on the Hub.

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -416,6 +416,65 @@ class TestIssue271SmolLM3Recipe:
         )
 
 
+class TestIssue276Qwen35A3bDpoRecipe:
+    """Regression coverage for the qwen3.5-35b-a3b-dpo recipe (#276)."""
+
+    def test_recipe_loads_with_expected_dpo_moe_shape(self) -> None:
+        from soup_cli.config.loader import load_config_from_string
+        from soup_cli.recipes.catalog import get_recipe
+
+        recipe = get_recipe("qwen3.5-35b-a3b-dpo")
+        assert recipe is not None
+        # The exact model identity is load-bearing - a wrong id must fail here.
+        assert recipe.model == "Qwen/Qwen3.5-35B-A3B"
+        assert recipe.task == "dpo"
+
+        config = load_config_from_string(recipe.yaml_str)
+        assert config.base == "Qwen/Qwen3.5-35B-A3B"
+        assert config.task == "dpo"
+        # The DPO half, taken from the qwen2.5-7b-dpo shape.
+        assert config.data.format == "dpo"
+        assert config.training.dpo_beta == 0.1
+        assert config.training.lr == 5e-6
+        # The MoE half, taken from the qwen3.5-35b-a3b-sft sibling.
+        assert config.training.moe_lora is True
+        assert config.training.moe_aux_loss_coeff == 0.01
+        assert config.training.lora.r == 16
+        assert config.training.lora.alpha == 32
+        assert config.training.quantization == "4bit"
+        assert config.training.gradient_accumulation_steps == 8
+
+    def test_shares_the_base_model_with_its_sft_sibling(self) -> None:
+        """#276 is the DPO variant of an existing recipe, not a new model."""
+        from soup_cli.recipes.catalog import get_recipe
+
+        dpo = get_recipe("qwen3.5-35b-a3b-dpo")
+        sft = get_recipe("qwen3.5-35b-a3b-sft")
+        assert dpo is not None and sft is not None
+        assert dpo.model == sft.model
+        assert dpo.size == sft.size
+        assert dpo.task != sft.task
+
+    def test_show_and_use_recipe(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        show_result = runner.invoke(app, ["recipes", "show", "qwen3.5-35b-a3b-dpo"])
+        assert show_result.exit_code == 0
+        assert "Qwen/Qwen3.5-35B-A3B" in show_result.output
+
+        monkeypatch.chdir(tmp_path)
+        use_result = runner.invoke(
+            app,
+            ["recipes", "use", "qwen3.5-35b-a3b-dpo", "--yes"],
+        )
+        assert use_result.exit_code == 0
+        assert "Qwen/Qwen3.5-35B-A3B" in (tmp_path / "soup.yaml").read_text(
+            encoding="utf-8"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Part A: v0.25.0 new model recipes (Llama 4, Qwen 3, Gemma 3, DeepSeek V3)
 # ---------------------------------------------------------------------------
@@ -463,7 +522,7 @@ class TestV025NewRecipes:
             assert cfg.base == recipe.model
             assert cfg.task == recipe.task
 
-    def test_catalog_size_is_159(self):
+    def test_catalog_size_is_160(self):
         """Total catalog size — grew with each release.
 
         v0.25.0 shipped 43 recipes (29 + 9 Part A + 2 Part B tools + 3 Part E MLX).
@@ -486,10 +545,11 @@ class TestV025NewRecipes:
         Catalog expansion added 7 SFT recipes (Qwen2.5-Coder/Math, R1-Distill-Qwen) -> 154.
         R1-Distill Llama SFT + DPO variants added 4 -> 158.
         Issue #271 added 1 (smollm3-3b-sft) -> 159.
+        Issue #276 added 1 (qwen3.5-35b-a3b-dpo) -> 160.
         """
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 159
+        assert len(RECIPES) == 160
 
     def test_new_recipes_searchable(self):
         """Search returns the new recipes via keyword/task filter."""

--- a/tests/test_v07124.py
+++ b/tests/test_v07124.py
@@ -270,7 +270,7 @@ class TestGlm5RepoIdFix:
 
 class TestCatalogCount:
     def test_total_recipe_count_is_158(self) -> None:
-        assert len(RECIPES) == 159
+        assert len(RECIPES) == 160
 
     def test_list_recipes_matches_dict(self) -> None:
         assert len(list_recipes()) == len(RECIPES)

--- a/tests/test_v07130.py
+++ b/tests/test_v07130.py
@@ -740,7 +740,7 @@ class TestRecipes:
     def test_catalog_size_is_159(self):
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 159
+        assert len(RECIPES) == 160
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_v07130.py
+++ b/tests/test_v07130.py
@@ -737,7 +737,7 @@ class TestRecipes:
         assert cfg.training.rollout_backend == "openenv"
         assert cfg.training.rollout_func.startswith("soup_cli.envs.")
 
-    def test_catalog_size_is_159(self):
+    def test_catalog_size_is_160(self):
         from soup_cli.recipes.catalog import RECIPES
 
         assert len(RECIPES) == 160

--- a/tests/test_v07132.py
+++ b/tests/test_v07132.py
@@ -953,4 +953,4 @@ class TestAsrRecipes:
     def test_catalog_size_is_159(self):
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 159
+        assert len(RECIPES) == 160

--- a/tests/test_v07132.py
+++ b/tests/test_v07132.py
@@ -950,7 +950,7 @@ class TestAsrRecipes:
         assert cfg.task == "sft"
         assert cfg.modality == "vision"
 
-    def test_catalog_size_is_159(self):
+    def test_catalog_size_is_160(self):
         from soup_cli.recipes.catalog import RECIPES
 
         assert len(RECIPES) == 160


### PR DESCRIPTION
Adds the ready-made `qwen3.5-35b-a3b-dpo` recipe. The catalog shipped the MoE SFT
sibling `qwen3.5-35b-a3b-sft` in v0.71.24 but no preference-tuning variant for the
same base.

`Closes #276.`

## Overlap with #512 — read this first

**#512 by @kok-o covers this issue and has done since 2026-08-23, eight days ahead
of me.** I did not see it before claiming: #276 carried no claim comment and #512's
overlap is visible only in its title. @MakazhanAlpamys has since asked @kok-o to
release #276 and told me to open this anyway, with @kok-o keeping the right to
reclaim it today. If they take it back, close this — they filed first and that
counts.

**One correction to my own claim comment.** I described the `modality: text`
contract as something I found. I found it independently, as a red test rather than
by reading — but it is not novel: **#512 registered the same entry in
`tests/test_issue427_qwen35_text_modality.py` eight days before I started.**
@kok-o hit that contract first. I would rather say so here than have a reviewer
find it by diffing the two branches.

## The one substantive difference between the two implementations

Every DPO recipe in the catalog uses the same learning rate. Measured, not assumed:

```
$ python - <<'PY'
from soup_cli.recipes.catalog import RECIPES
from soup_cli.config.loader import load_config_from_string
for n, r in RECIPES.items():
    if r.task == "dpo":
        print(load_config_from_string(r.yaml_str).training.lr, n)
PY

5e-06   deepseek-r1-distill-llama-8b-dpo     5e-06   llama3.1-8b-dpo
5e-06   deepseek-r1-distill-qwen-1.5b-dpo    5e-06   llama4-scout-17b-dpo
5e-06   deepseek-r1-distill-qwen-7b-dpo      5e-06   mistral-7b-dpo
5e-06   gemma3-27b-dpo                       5e-06   pixtral-dpo
5e-06   glm-5.1-dpo                          5e-06   qwen2.5-7b-dpo
```

Unanimous, 10 of 10. This PR uses `5e-6`, matching that and the issue's explicit
instruction to copy the `qwen2.5-7b-dpo` shape. #512 uses `1e-5`, which would be
the only DPO recipe in the catalog off the family value. Stating it as a fact for
whoever reviews; it is not an argument about who should land.

## Shape

The `qwen2.5-7b-dpo` DPO half — `format: dpo`, `lr: 5e-6`, `dpo_beta: 0.1`,
`preference_train.jsonl` — with the MoE settings from the `qwen3.5-35b-a3b-sft`
sibling: `moe_lora: true`, `moe_aux_loss_coeff: 0.01`, LoRA r16/a32, 4-bit,
grad-accum 8, `max_length: 4096`.

`modality: text` is taken from the SFT sibling rather than from the
`qwen2.5-7b-dpo` template, which has no modality line.
`test_issue427_qwen35_text_modality.py` holds every Qwen3.5/3.6/3.8 recipe to the
measured decoder-only decision instead of letting it fall back to the schema
default, and its family audit fails on any unregistered new sibling. A literal copy
of the template would have shipped a recipe escaping that contract.

Catalog count 159 → 160 across the three doc-count sites and the four catalog-size
checkpoints the sync guard enforces.

## Mutations — five killed, one equivalent

| Mutation | Result |
|---|---|
| typo in the model id (`Qwen3.5-35B-A3B` → `Qwen3.5-35B-A3`) | 2 fail |
| recipe entry deleted entirely | 5 fail |
| MoE settings dropped (plain dense DPO) | 1 fails |
| `modality: text` removed (falls back to schema default) | family audit fails |
| `format: dpo` → `format: auto` | 1 fails |
| **`dpo_beta: 0.1` dropped** | **survives — equivalent** |

The survivor is not a coverage gap and I am deliberately not killing it. `dpo_beta`
defaults to `0.1` at `src/soup_cli/config/schema.py:1237`:

```python
dpo_beta: float = Field(default=0.1, gt=0, description="DPO beta — KL penalty coefficient")
```

so removing the line produces a byte-identical `SoupConfig` — there is no behaviour
left to detect. Killing it would require asserting on the YAML source text rather
than on the loaded config, and a test that pins source strings instead of behaviour
is a shape this project has removed from its own suite before.

`glm-5.1-dpo` has the identical property. That makes it a repo-wide question about
whether explicitly-declared recipe values should be pinned against drift in schema
defaults — not something to answer asymmetrically inside this PR. Per
@MakazhanAlpamys on #276, it stays unaddressed here; happy to open it as its own
issue if it is wanted.

## Verification

```
pytest tests/test_recipes.py tests/test_recipes_v031.py \
       tests/test_issue427_qwen35_text_modality.py tests/test_v07124.py \
       tests/test_v07130.py tests/test_v07132.py tests/test_config.py \
       tests/test_cli_startup_is_light.py      -> 1792 passed, 1 skipped
pytest tests/ -k "recipe"                      -> 1993 passed, 17466 deselected
ruff check src/soup_cli/ scripts/ tests/       -> All checks passed
git diff -- tests/ | grep -c "^-[^-]"          -> 5
```

All five removed test lines are the `159 → 160` count-bump sites themselves
(`assert len(RECIPES) == 159` ×4 and the `test_catalog_size_is_159` rename). No
test deleted, skipped or weakened.

`Qwen/Qwen3.5-35B-A3B` resolves on the Hub (`/api/models/...` → 200); it is also
the id the SFT sibling already ships. `soup recipes show` and `soup recipes use`
were both run live, not only asserted on.

The full default suite with the `--cov-fail-under=77` gate is still running locally
at the time of opening; I will report the result in a comment rather than leave the
claim implied. Everything above is from runs that completed.
