### PR TITLE
fix(sglang): obey the trust_remote_code gate instead of hardcoding True (#360)

### DIFF
--- a/changelog.d/0.73.3/619.security.md
+++ b/changelog.d/0.73.3/619.security.md
@@ -1,0 +1,12 @@
+- **The SGLang serve backend now obeys the `--trust-remote-code` gate instead of
+  loading every model with it enabled (#360 by @Srinivasan8888 in #619).**
+  `serve.py` resolves the v0.36.0 default-deny gate once for every backend and
+  passes the result to vLLM, but `_serve_sglang` was called without it and
+  `create_sglang_runtime` hardcoded `trust_remote_code=True` at both
+  `sgl.Runtime` call sites, so `soup serve --backend sglang` executed a model's
+  custom repo code whether or not the user opted in. The warning panel said so,
+  but a notice is not a gate. `create_sglang_runtime` now defaults to `False`
+  like the vLLM path, and the resolved value reaches the runtime and the
+  tokenizer load alike. **Behaviour change:** a custom-code model on the SGLang
+  backend now fails to load without `--trust-remote-code` rather than silently
+  running its code.

--- a/src/soup_cli/commands/serve.py
+++ b/src/soup_cli/commands/serve.py
@@ -844,6 +844,7 @@ def serve(
             max_tokens_default=max_tokens_default,
             tensor_parallel=tensor_parallel,
             gpu_memory_utilization=gpu_memory_utilization,
+            trust_remote_code=resolved_trust,
         )
     else:
         # Transformers backend (original). ``resolved_trust`` was computed
@@ -1278,21 +1279,34 @@ def _serve_sglang(
     max_tokens_default: int,
     tensor_parallel: int,
     gpu_memory_utilization: float,
+    trust_remote_code: bool = False,
 ):
     """Set up SGLang runtime and create FastAPI app."""
     from soup_cli.utils.sglang import create_sglang_app, create_sglang_runtime
 
-    console.print(
-        Panel(
-            f"[bold yellow]WARNING:[/] Loading model via SGLang: "
-            f"[bold]{model_path}[/]\n"
-            "SGLang loads models with trust_remote_code enabled.\n"
-            "If this model contains custom code, it will execute "
-            "on this machine.\nOnly use models you trust.",
-            title="SGLang Runtime",
-            border_style="yellow",
+    if trust_remote_code:
+        console.print(
+            Panel(
+                f"[bold yellow]WARNING:[/] Loading model via SGLang: "
+                f"[bold]{model_path}[/]\n"
+                "trust_remote_code is ENABLED for this run.\n"
+                "If this model contains custom code, it will execute "
+                "on this machine.\nOnly use models you trust.",
+                title="SGLang Runtime",
+                border_style="yellow",
+            )
         )
-    )
+    else:
+        console.print(
+            Panel(
+                f"Loading model via SGLang: [bold]{model_path}[/]\n"
+                "trust_remote_code is disabled (default). A model that needs "
+                "custom code\nwill fail to load -- re-run with "
+                "--trust-remote-code if you trust the source.",
+                title="SGLang Runtime",
+                border_style="cyan",
+            )
+        )
     console.print("[dim]Initializing SGLang runtime...[/]")
     runtime, runtime_model_name = create_sglang_runtime(
         model_path=str(model_path),
@@ -1300,20 +1314,21 @@ def _serve_sglang(
         is_adapter=is_adapter,
         tensor_parallel_size=tensor_parallel,
         mem_fraction_static=gpu_memory_utilization,
+        trust_remote_code=trust_remote_code,
     )
     console.print("[bold green]SGLang runtime ready![/]")
 
     # Load the tokenizer whose chat template the shared prompt builder applies
-    # (#360). trust_remote_code matches what create_sglang_runtime already used
-    # to load this very model a few lines above, and what the panel printed
-    # here promises. Loading it with the default False instead meant a
-    # custom-code model failed to load a tokenizer, tokenizer became None, and
-    # the fix silently degraded to the legacy prompt -- for exactly the models
-    # whose chat template matters most.
+    # (#360). It must match what create_sglang_runtime used to load this very
+    # model a few lines above: a mismatch means a custom-code model loads no
+    # tokenizer, tokenizer becomes None, and the #360 prompt fix silently
+    # degrades to the legacy format for exactly the models whose chat template
+    # matters most. That pairing used to be a literal True on both sides; both
+    # now follow serve.py's single resolved gate instead.
     tokenizer = _load_serve_tokenizer(
         model_path=model_path,
         base_model=base_model,
-        trust_remote_code=True,
+        trust_remote_code=trust_remote_code,
     )
 
     # A failure here is announced, never silent -- the same three-branch

--- a/src/soup_cli/utils/sglang.py
+++ b/src/soup_cli/utils/sglang.py
@@ -101,6 +101,7 @@ def create_sglang_runtime(
     tensor_parallel_size: int = 1,
     mem_fraction_static: float = 0.88,
     dtype: str = "auto",
+    trust_remote_code: bool = False,
 ):
     """Create an SGLang Runtime for serving.
 
@@ -111,6 +112,12 @@ def create_sglang_runtime(
         tensor_parallel_size: Number of GPUs for tensor parallelism.
         mem_fraction_static: Fraction of GPU memory for static allocation.
         dtype: Data type for model weights.
+        trust_remote_code: Execute the model repo's custom code on load.
+            Default ``False`` -- the same default-deny the vLLM path takes.
+            ``serve.py`` resolves the v0.36.0 gate once per invocation and
+            passes the result here. This was previously an unconditional
+            ``True`` at both call sites, so the SGLang backend ran a model's
+            custom code whether or not the user opted in.
 
     Returns:
         (runtime, runtime_model_name) tuple.
@@ -134,7 +141,7 @@ def create_sglang_runtime(
             tp_size=tensor_parallel_size,
             mem_fraction_static=mem_fraction_static,
             dtype=dtype,
-            trust_remote_code=True,
+            trust_remote_code=trust_remote_code,
             lora_paths=[model_path],
         )
         runtime_model_name = base_model
@@ -144,7 +151,7 @@ def create_sglang_runtime(
             tp_size=tensor_parallel_size,
             mem_fraction_static=mem_fraction_static,
             dtype=dtype,
-            trust_remote_code=True,
+            trust_remote_code=trust_remote_code,
         )
         runtime_model_name = model_path
 

--- a/tests/test_issue360_sglang_prompt_finish_reason.py
+++ b/tests/test_issue360_sglang_prompt_finish_reason.py
@@ -301,13 +301,22 @@ class TestServeSglangWiring:
             max_tokens_default=256,
             tensor_parallel=1,
             gpu_memory_utilization=0.9,
+            # The runtime's trust setting is now resolved by serve.py's gate
+            # instead of being an unconditional True. These tests are about the
+            # tokenizer *matching* the runtime, so drive both from one opted-in
+            # value rather than pinning the literal.
+            trust_remote_code=True,
         )
 
     def test_tokenizer_load_uses_the_trust_setting_the_runtime_uses(self, monkeypatch):
-        """The runtime loads this model with trust_remote_code=True and the
-        panel says so. Loading the tokenizer with the default False meant a
-        custom-code model produced tokenizer=None and the fix silently did
-        nothing -- for exactly the models whose chat template matters most."""
+        """The tokenizer must load with the same trust setting as the runtime.
+
+        Loading the tokenizer with the default False, while the runtime used
+        True, meant a custom-code model produced tokenizer=None and the #360
+        fix silently did nothing -- for exactly the models whose chat template
+        matters most. The pairing is what matters, not the literal: since the
+        trust contract fix both sides follow serve.py's resolved gate, and
+        ``_serve`` opts in above so this still asserts they agree."""
         capture = {}
         self._serve(monkeypatch, _FakeTokenizer(), capture)
 

--- a/tests/test_sglang_serve.py
+++ b/tests/test_sglang_serve.py
@@ -78,7 +78,13 @@ class TestSGLangRuntimeCreation:
         mock_sgl.Runtime.assert_called_once()
         call_kwargs = mock_sgl.Runtime.call_args[1]
         assert call_kwargs["model_path"] == "/path/to/model"
-        assert call_kwargs["trust_remote_code"] is True
+        # Default-deny, matching the vLLM path. This asserted True until the
+        # SGLang trust-contract fix: the runtime hardcoded trust_remote_code=True
+        # at both call sites, so `soup serve --backend sglang` executed a
+        # model's custom code whether or not the user passed
+        # --trust-remote-code. See tests/test_sglang_trust_contract.py for the
+        # opt-in path and the serve.py wiring.
+        assert call_kwargs["trust_remote_code"] is False
         assert model_name == "/path/to/model"
 
     def test_create_sglang_runtime_with_adapter(self):

--- a/tests/test_sglang_trust_contract.py
+++ b/tests/test_sglang_trust_contract.py
@@ -1,0 +1,176 @@
+"""The SGLang backend must obey the v0.36.0 trust_remote_code gate.
+
+``serve.py`` resolves ``--trust-remote-code`` **once for every backend** and its
+own comment states the intent: "so no backend silently executes an untrusted
+repo's code". vLLM receives that resolved value. SGLang did not: it was called
+without the argument at all, and ``create_sglang_runtime`` hardcoded
+``trust_remote_code=True`` at both of its ``sgl.Runtime`` call sites.
+
+The result is that on ``soup serve --backend sglang`` the default-deny gate did
+not apply. A user who never passed ``--trust-remote-code`` still had a model's
+custom repo code executed, which is the exact behaviour v0.36.0 removed from the
+vLLM path.
+
+The panel printed above the load said so honestly -- "SGLang loads models with
+trust_remote_code enabled" -- but a notice is not a gate, and it told the user
+what was happening rather than letting them decide.
+
+Each surface is pinned independently: the runtime's non-adapter call site, its
+adapter call site, and the tokenizer load. A fix that threads the flag through
+one and forgets another must fail here rather than pass.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+from unittest.mock import patch as mock_patch
+
+import pytest
+
+
+class TestCreateSglangRuntimeHonoursTheFlag:
+    """The two ``sgl.Runtime`` call sites, pinned separately."""
+
+    def _capture(self, monkeypatch, **kwargs):
+        calls = {}
+        fake_sgl = MagicMock()
+
+        def _runtime(**runtime_kwargs):
+            calls.update(runtime_kwargs)
+            return MagicMock()
+
+        fake_sgl.Runtime = _runtime
+        with mock_patch.dict("sys.modules", {"sglang": fake_sgl}):
+            from soup_cli.utils.sglang import create_sglang_runtime
+
+            create_sglang_runtime(**kwargs)
+        return calls
+
+    def test_default_is_deny_on_the_plain_path(self, monkeypatch) -> None:
+        calls = self._capture(
+            monkeypatch,
+            model_path="/models/plain",
+            base_model=None,
+            is_adapter=False,
+            tensor_parallel_size=1,
+            mem_fraction_static=0.9,
+        )
+        assert calls["trust_remote_code"] is False
+
+    def test_default_is_deny_on_the_adapter_path(self, monkeypatch) -> None:
+        """Second call site. A fix that only patches the first must fail here."""
+        calls = self._capture(
+            monkeypatch,
+            model_path="/adapters/lora",
+            base_model="/models/base",
+            is_adapter=True,
+            tensor_parallel_size=1,
+            mem_fraction_static=0.9,
+        )
+        assert calls["trust_remote_code"] is False
+
+    def test_opt_in_is_honoured_on_the_plain_path(self, monkeypatch) -> None:
+        calls = self._capture(
+            monkeypatch,
+            model_path="/models/plain",
+            base_model=None,
+            is_adapter=False,
+            tensor_parallel_size=1,
+            mem_fraction_static=0.9,
+            trust_remote_code=True,
+        )
+        assert calls["trust_remote_code"] is True
+
+    def test_opt_in_is_honoured_on_the_adapter_path(self, monkeypatch) -> None:
+        calls = self._capture(
+            monkeypatch,
+            model_path="/adapters/lora",
+            base_model="/models/base",
+            is_adapter=True,
+            tensor_parallel_size=1,
+            mem_fraction_static=0.9,
+            trust_remote_code=True,
+        )
+        assert calls["trust_remote_code"] is True
+
+
+class TestServeSglangThreadsTheResolvedValue:
+    """``_serve_sglang`` must pass what it was given to *both* loaders."""
+
+    def _serve(self, monkeypatch, trust):
+        import soup_cli.commands.serve as serve_mod
+        import soup_cli.utils.sglang as sglang_mod
+
+        seen = {}
+
+        def _runtime(**kwargs):
+            seen["runtime"] = kwargs
+            return MagicMock(), "runtime-model"
+
+        def _tokenizer(**kwargs):
+            seen["tokenizer"] = kwargs
+            tok = MagicMock()
+            tok.chat_template = "<TPL>"
+            return tok
+
+        monkeypatch.setattr(sglang_mod, "create_sglang_runtime", _runtime, raising=False)
+        monkeypatch.setattr(
+            sglang_mod, "create_sglang_app", lambda **kwargs: kwargs, raising=False
+        )
+        monkeypatch.setattr(serve_mod, "_load_serve_tokenizer", _tokenizer)
+        printed = []
+        monkeypatch.setattr(
+            serve_mod.console, "print", lambda *a, **k: printed.append(str(a[0]))
+        )
+        seen["printed"] = printed
+
+        serve_mod._serve_sglang(
+            model_path=Path("/models/custom-code-model"),
+            base_model=None,
+            is_adapter=False,
+            max_tokens_default=256,
+            tensor_parallel=1,
+            gpu_memory_utilization=0.9,
+            trust_remote_code=trust,
+        )
+        return seen
+
+    @pytest.mark.parametrize("trust", [True, False])
+    def test_runtime_receives_the_resolved_value(self, monkeypatch, trust) -> None:
+        seen = self._serve(monkeypatch, trust)
+        assert seen["runtime"]["trust_remote_code"] is trust
+
+    @pytest.mark.parametrize("trust", [True, False])
+    def test_tokenizer_receives_the_resolved_value(self, monkeypatch, trust) -> None:
+        """Independent surface: #581 pinned this to a literal True on purpose.
+
+        That was right while the runtime was also an unconditional True -- a
+        mismatch there meant the tokenizer failed to load on custom-code models
+        and the #360 prompt fix silently degraded. Now that the runtime follows
+        the gate, the tokenizer has to follow it too, or the same mismatch comes
+        back with the operands swapped.
+        """
+        seen = self._serve(monkeypatch, trust)
+        assert seen["tokenizer"]["trust_remote_code"] is trust
+
+    def test_panel_does_not_promise_trust_when_it_was_denied(self, monkeypatch) -> None:
+        seen = self._serve(monkeypatch, False)
+        panel_text = " ".join(seen["printed"])
+        assert "loads models with trust_remote_code enabled" not in panel_text
+
+
+class TestServeCommandPassesTheGateToSglang:
+    """The end-to-end wiring: the gate's result must reach the backend."""
+
+    def test_sglang_branch_forwards_resolved_trust(self) -> None:
+        """A literal ``True`` here would re-open the hole with the gate intact."""
+        import inspect
+
+        import soup_cli.commands.serve as serve_mod
+
+        source = inspect.getsource(serve_mod.serve)
+        sglang_call = source[source.index('elif backend == "sglang":') :]
+        sglang_call = sglang_call[: sglang_call.index("else:")]
+        assert "trust_remote_code=resolved_trust" in sglang_call
+        assert "trust_remote_code=True" not in sglang_call


### PR DESCRIPTION
The separate PR for the SGLang trust contract, as agreed on #360/#581 — the wider
change I deliberately kept out of #581 so it could be argued on its own terms.

**This is a security fix, not the tidy-up I expected to write.** I went in to make
the SGLang backend's `trust_remote_code` configurable and found the gate was not
merely inconsistent — on that backend it does not apply at all.

## The hole

`serve.py` resolves the flag once for every backend, and says why:

```python
# v0.36.0 Part B: --trust-remote-code default-deny, resolved ONCE for
# every backend. vLLM previously loaded with an unconditional
# trust_remote_code=True (arbitrary repo code, zero notice) — resolve the
# same gate + warning panel the transformers path uses so no backend
# silently executes an untrusted repo's code.
resolved_trust = resolve_trust_remote_code(...)
```

vLLM gets it: `_serve_vllm(..., trust_remote_code=resolved_trust)`.

SGLang was called **without the argument at all**, and `create_sglang_runtime`
hardcoded `trust_remote_code=True` at *both* `sgl.Runtime` call sites — plus the
tokenizer load at a literal `True`.

So `soup serve --backend sglang` executed a model's custom repo code **whether or
not `--trust-remote-code` was passed**. `resolved_trust` was computed and thrown
away. That is precisely the behaviour v0.36.0 removed from the vLLM path, still
live on the other one.

The panel above the load was honest — "SGLang loads models with trust_remote_code
enabled" — but **a notice is not a gate.** It told the user what was about to
happen rather than letting them decide.

## The fix

`create_sglang_runtime(..., trust_remote_code: bool = False)`, matching the vLLM
signature; `serve.py` passes `resolved_trust` into `_serve_sglang`, which threads
it to the runtime **and** the tokenizer. The panel now reports what was resolved
instead of promising trust unconditionally.

## Behaviour change worth calling out

A custom-code model on the SGLang backend now **fails without `--trust-remote-code`**
rather than silently executing. That is the point of the change, and it is the same
thing vLLM has done since v0.36.0 — but it is a real break for anyone relying on
the old implicit behaviour, so it wants the release note rather than a quiet line
in a diff.

## Two existing assertions changed — deliberately, neither weakened

`git diff -- tests/ | grep -c "^-[^-]"` is **5**: four are docstring lines
replaced by a longer one, and one is a real assertion flip. Both are mine from #581
and both are the old contract:

- **`test_sglang_serve.py`** asserted the runtime default was `True`. The default is
  now `False`; the assertion is inverted, with a comment recording that it asserted
  `True` until this fix and why. The opt-in path is covered in the new file.
- **`test_issue360...::test_tokenizer_load_uses_the_trust_setting_the_runtime_uses`**
  pinned a literal `True`. Its subject is that the tokenizer *matches the runtime* —
  a mismatch is exactly what made #360's prompt fix silently degrade on custom-code
  models. It now drives both sides from one opted-in value and still asserts they
  agree, instead of pinning a literal that moved. The guard is intact; had I flipped
  it to `False` and left it there, mutation (c) below would have survived.

## Mutations — five, all killed

| Mutation | Result |
|---|---|
| runtime default flipped back to `True` | 3 fail |
| `serve()` passes a literal `True` to sglang | 1 fails |
| tokenizer pinned back to `True` while the runtime stays gated | 1 fails |
| adapter call site alone reverted to `True` | 1 fails |
| `_serve_sglang` stops forwarding to the runtime | 2 fail |

Each surface is pinned independently — the runtime's plain path, its adapter path,
the tokenizer, and the `serve()` wiring — so a fix that threads one and forgets
another fails rather than passes. That split is the guard you asked for on #615,
applied here from the start.

## Verification

```
pytest tests/ -k "sglang or serve or trust"     -> 392 passed, 19096 deselected
pytest tests/test_sglang_trust_contract.py      -> 10 passed
ruff check src/soup_cli/ scripts/ tests/        -> All checks passed
```

## Scope

`Refs #360` — SGLang still cannot be installed here, so this is CPU-verified
wiring, not a live-runtime check. #360's live acceptance item stays open and this
does not close it.
