### PR TITLE
fix(telemetry): tiered SSRF guard with primary allowlist, internal TLDs, and DNS defence in depth

### DIFF
--- a/changelog.d/0.73.3/624.security.md
+++ b/changelog.d/0.73.3/624.security.md
@@ -1,0 +1,10 @@
+- **Telemetry SSRF guard now applies a tiered architecture with primary allowlist,
+  internal TLD rejection, and DNS defence in depth (#599 by @here-2007 in #624).**
+  `_telemetry_endpoint_is_safe()` previously only checked literal IP formats, allowing
+  hostnames resolving to private addresses (`10.0.0.1.nip.io`, `localtest.me`) or internal
+  TLDs (`metadata.internal`) to bypass validation. The guard now validates via three tiers:
+  (1) a primary allowlist for canonical PostHog domains (`*.posthog.com`) with zero DNS
+  lookups, (2) static string rejection of internal TLD suffixes (`.local`, `.internal`,
+  `.lan`, `.home`, `.corp`, `.intranet`) and literal private IPs, and (3) defence-in-depth
+  DNS resolution for custom non-default FQDNs that fails closed on resolver errors/timeouts
+  and rejects private or loopback target IPs.

--- a/src/soup_cli/utils/trackers.py
+++ b/src/soup_cli/utils/trackers.py
@@ -227,24 +227,86 @@ def _resolve_posthog_target(
     return key, resolved_endpoint
 
 
+# Internal / non-routable TLD suffixes rejected without DNS resolution (#599).
+_INTERNAL_TLD_SUFFIXES: tuple[str, ...] = (
+    ".local",
+    ".internal",
+    ".localhost",
+    ".lan",
+    ".home",
+    ".corp",
+    ".intranet",
+)
+
+_INTERNAL_TLD_EXACT: frozenset[str] = frozenset({
+    "local",
+    "internal",
+    "localhost",
+    "lan",
+    "home",
+    "corp",
+    "intranet",
+})
+
+
+def _is_trusted_posthog_domain(host: str) -> bool:
+    """Return True if ``host`` belongs to the trusted PostHog domain hierarchy."""
+    return host == "posthog.com" or host.endswith(".posthog.com")
+
+
+def _resolve_host_ips(host: str, *, timeout: float = 1.0) -> list[str] | None:
+    """Resolve ``host`` to IP addresses within ``timeout`` seconds.
+
+    Returns a list of IP strings, or ``None`` on resolution failure,
+    resolver error, or timeout (fail-closed).
+    """
+    import socket  # noqa: PLC0415
+    import threading  # noqa: PLC0415
+
+    result: list[str] = []
+    error: list[Exception] = []
+
+    def _worker() -> None:
+        try:
+            info = socket.getaddrinfo(host, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+            for item in info:
+                sockaddr = item[4]
+                ip = sockaddr[0]
+                if ip:
+                    result.append(ip)
+        except Exception as exc:
+            error.append(exc)
+
+    thread = threading.Thread(target=_worker, daemon=True)
+    thread.start()
+    thread.join(timeout=timeout)
+    if thread.is_alive() or error or not result:
+        return None
+    return result
+
+
 def _telemetry_endpoint_is_safe(endpoint: str) -> bool:
-    """Layered SSRF guard for telemetry endpoints (#593).
+    """Tiered endpoint guard for telemetry destinations (#593, #599).
 
-    Two-layer validation:
+    Three-tier validation architecture:
 
-    1. :func:`~soup_cli.utils.hubs.validate_hub_endpoint` — baseline
-       sanitization (CRLF rejection, null-byte rejection, type guards,
-       ``0.0.0.0`` handling, scheme allowlist).  This layer is shared
-       with model-hub endpoints and intentionally permits private HTTPS
-       hosts for self-hosted hubs.
-    2. **Telemetry-strict rejection** — rejects loopback hosts
-       (``localhost``, ``127.0.0.1``, ``::1``), private IPs (RFC 1918),
-       and link-local addresses (``169.254.x.x``) on *any* scheme.
-       Telemetry has no legitimate self-hosted-private-endpoint case,
-       so this layer is stricter than hub validation.
+    1. **Primary Control (Trusted Allowlist):** Canonical PostHog domains
+       (``us.i.posthog.com``, ``eu.i.posthog.com``, ``*.posthog.com``) are
+       accepted immediately. This guarantees sub-millisecond validation with
+       zero network requests and zero risk of resolver timeout on default paths.
+    2. **Static Syntactic & Suffix Guards:** For custom endpoint URLs, reject
+       loopback names (``localhost``), literal private/link-local/loopback IPs
+       (including abbreviated/hex/octal IPv4 forms), and internal TLD suffixes
+       (``.local``, ``.internal``, ``.lan``, ``.home``, ``.corp``, etc.) without
+       performing network lookups.
+    3. **Defence-in-Depth DNS Resolution:** For custom non-default FQDNs, resolve
+       the host to IP addresses with a bounded timeout and fail closed. Rejects if
+       any resolved address is a loopback, private, or link-local IP. This raises
+       the bar against hostname indirection (e.g. ``10.0.0.1.nip.io``,
+       ``localtest.me``). Note: this does not prevent DNS rebinding across separate
+       lookups, but provides defence in depth for custom endpoint configurations.
 
-    The HTTPS-only requirement (``startswith("https://")``) is applied
-    first and is independent of both layers.
+    The HTTPS-only requirement (``startswith("https://")``) is applied first.
     """
     if not isinstance(endpoint, str) or not endpoint.startswith("https://"):
         return False
@@ -257,8 +319,6 @@ def _telemetry_endpoint_is_safe(endpoint: str) -> bool:
     except (TypeError, ValueError):
         return False
 
-    # Layer 2: telemetry-strict private/loopback/link-local rejection.
-    # Imports are lazy per AGENTS.md convention (heavy deps inside fns).
     from urllib.parse import urlparse  # noqa: PLC0415
 
     from soup_cli.utils.hubs import (  # noqa: PLC0415
@@ -266,18 +326,34 @@ def _telemetry_endpoint_is_safe(endpoint: str) -> bool:
         _is_private_or_link_local,
     )
 
-    # Normalise: lowercase + strip FQDN trailing dot so "LOCALHOST."
-    # matches the _LOOPBACK_HOSTS frozenset entry "localhost".
     host = (urlparse(endpoint).hostname or "").lower().rstrip(".")
     if not host:
         return False
-    # _is_private_or_link_local uses ipaddress.ip_address which raises
-    # ValueError on domain strings ("localhost"), so it returns False.
-    # The explicit _LOOPBACK_HOSTS check covers named loopbacks.
+
+    # Tier 1: Primary Control — Trusted PostHog domain allowlist.
+    # Eliminates DNS lookups for default configurations (99%+ of runs).
+    if _is_trusted_posthog_domain(host):
+        return True
+
+    # Tier 2: Static rejection (literal IPs, loopback hosts, internal TLDs).
     if host in _LOOPBACK_HOSTS:
         return False
     if _is_private_or_link_local(host):
         return False
+    if host in _INTERNAL_TLD_EXACT or host.endswith(_INTERNAL_TLD_SUFFIXES):
+        return False
+
+    # Tier 3: Defence-in-depth DNS resolution for custom non-default FQDNs.
+    # Raises the bar against hostname indirection; fails closed on error/timeout.
+    resolved_ips = _resolve_host_ips(host)
+    if not resolved_ips:
+        return False
+
+    for ip in resolved_ips:
+        clean_ip = ip.rstrip(".")
+        if clean_ip in _LOOPBACK_HOSTS or _is_private_or_link_local(clean_ip):
+            return False
+
     return True
 
 

--- a/tests/test_issue599_telemetry_dns_ssrf.py
+++ b/tests/test_issue599_telemetry_dns_ssrf.py
@@ -1,0 +1,254 @@
+"""#599 — Telemetry SSRF: Hostname DNS resolution & tiered validation.
+
+Verifies:
+1. Tier 1 (Primary Control): Trusted PostHog domain allowlist (*.posthog.com)
+   accepts immediately with zero DNS lookups.
+2. Tier 2 (Static Guards): Rejects loopback names, literal private IPs, and
+   internal TLD suffixes (.local, .internal, .lan, .corp, etc.) without DNS.
+3. Tier 3 (Defence in Depth): Resolves custom non-default FQDNs with bounded
+   timeout, rejecting if any resolved IP is private/loopback/link-local, and
+   failing closed on resolver errors/timeouts.
+"""
+from __future__ import annotations
+
+import socket
+from unittest.mock import patch
+
+import pytest
+
+from soup_cli.utils.trackers import (
+    _INTERNAL_TLD_SUFFIXES,
+    _is_trusted_posthog_domain,
+    _resolve_host_ips,
+    _resolve_posthog_target,
+    _telemetry_endpoint_is_safe,
+)
+
+# =====================================================================
+# Tier 1: Primary Control (Trusted Domain Allowlist)
+# =====================================================================
+
+
+class TestTier1TrustedAllowlist:
+    """Primary control: trusted PostHog domains accept with zero DNS queries."""
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "posthog.com",
+            "us.i.posthog.com",
+            "eu.i.posthog.com",
+            "app.posthog.com",
+            "custom.subdomain.posthog.com",
+        ],
+    )
+    def test_is_trusted_posthog_domain_helper(self, host: str) -> None:
+        assert _is_trusted_posthog_domain(host) is True
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "notposthog.com",
+            "fake-posthog.com",
+            "posthog.com.attacker.com",
+            "example.com",
+            "10.0.0.1.nip.io",
+        ],
+    )
+    def test_untrusted_domains_rejected_by_tier1(self, host: str) -> None:
+        assert _is_trusted_posthog_domain(host) is False
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "https://us.i.posthog.com/",
+            "https://eu.i.posthog.com/i/v0/e/",
+            "https://app.posthog.com/capture/",
+            "https://custom.sub.posthog.com/capture",
+        ],
+    )
+    def test_tier1_allows_trusted_posthog_endpoints(self, endpoint: str) -> None:
+        assert _telemetry_endpoint_is_safe(endpoint) is True
+
+    def test_tier1_never_performs_dns_resolution(self) -> None:
+        """Default/trusted endpoints must execute in sub-ms with 0 network calls."""
+        with patch("socket.getaddrinfo") as mock_gai:
+            mock_gai.side_effect = AssertionError("DNS resolution must not be called for Tier 1")
+            assert _telemetry_endpoint_is_safe("https://us.i.posthog.com/") is True
+            assert _telemetry_endpoint_is_safe("https://eu.i.posthog.com/i/v0/e/") is True
+            assert mock_gai.call_count == 0
+
+
+# =====================================================================
+# Tier 2: Static Syntactic & Internal TLD Rejection
+# =====================================================================
+
+
+class TestTier2StaticRejection:
+    """Static guards: reject literal private IPs and internal TLDs without DNS."""
+
+    @pytest.mark.parametrize(
+        "suffix",
+        [
+            ".local",
+            ".internal",
+            ".localhost",
+            ".lan",
+            ".home",
+            ".corp",
+            ".intranet",
+        ],
+    )
+    def test_all_expected_internal_tlds_covered(self, suffix: str) -> None:
+        assert suffix in _INTERNAL_TLD_SUFFIXES
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "https://metadata.internal/capture/",
+            "https://service.local/capture/",
+            "https://myhost.lan/capture/",
+            "https://gateway.home/capture/",
+            "https://portal.corp/capture/",
+            "https://secure.intranet/capture/",
+            "https://test.localhost/capture/",
+        ],
+    )
+    def test_tier2_rejects_internal_tld_endpoints(self, endpoint: str) -> None:
+        assert _telemetry_endpoint_is_safe(endpoint) is False
+
+    def test_tier2_internal_tld_never_performs_dns(self) -> None:
+        """Internal TLDs must be rejected as a pure string decision without DNS."""
+        with patch("socket.getaddrinfo") as mock_gai:
+            mock_gai.side_effect = AssertionError("DNS resolution must not be called for Tier 2")
+            assert _telemetry_endpoint_is_safe("https://metadata.internal/capture/") is False
+            assert _telemetry_endpoint_is_safe("https://router.local/capture/") is False
+            assert mock_gai.call_count == 0
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "https://10.0.0.1/capture/",
+            "https://127.0.0.1/capture/",
+            "https://169.254.169.254/capture/",
+            "https://192.168.1.1/capture/",
+            "https://127.1/capture/",
+            "https://2130706433/capture/",
+            "https://[::1]/capture/",
+            "https://[fe80::1]/capture/",
+            "https://localhost/capture/",
+        ],
+    )
+    def test_tier2_rejects_literal_private_and_loopback_ips(self, endpoint: str) -> None:
+        assert _telemetry_endpoint_is_safe(endpoint) is False
+
+
+# =====================================================================
+# Tier 3: Defence-in-Depth DNS Resolution for Custom FQDNs
+# =====================================================================
+
+
+class TestTier3DNSDefenceInDepth:
+    """DNS resolution checks custom hostnames to raise the bar against indirection."""
+
+    def test_tier3_rejects_hostname_resolving_to_private_rfc1918(self) -> None:
+        """10.0.0.1.nip.io or custom domain pointing to private IP is rejected."""
+        fake_addrinfo = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.1", 443))
+        ]
+        with patch("socket.getaddrinfo", return_value=fake_addrinfo):
+            assert (
+                _telemetry_endpoint_is_safe("https://custom-analytics.example.com/capture")
+                is False
+            )
+
+    def test_tier3_rejects_hostname_resolving_to_loopback(self) -> None:
+        """localtest.me or domain pointing to 127.0.0.1 is rejected."""
+        fake_addrinfo = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 443))
+        ]
+        with patch("socket.getaddrinfo", return_value=fake_addrinfo):
+            assert _telemetry_endpoint_is_safe("https://localtest.me/capture/") is False
+
+    def test_tier3_rejects_hostname_resolving_to_cloud_metadata(self) -> None:
+        fake_addrinfo = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 443))
+        ]
+        with patch("socket.getaddrinfo", return_value=fake_addrinfo):
+            assert _telemetry_endpoint_is_safe("https://cloud-meta.custom.org/capture") is False
+
+    def test_tier3_rejects_dual_stack_multi_ip_when_any_ip_is_private(self) -> None:
+        """Dual-stack (public IPv4 + loopback IPv6) must reject."""
+        fake_addrinfo = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443)),
+            (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", 443, 0, 0)),
+        ]
+        with patch("socket.getaddrinfo", return_value=fake_addrinfo):
+            assert _telemetry_endpoint_is_safe("https://dual-stack.example.com/capture") is False
+
+    def test_tier3_allows_custom_self_hosted_domain_resolving_to_public_ip(self) -> None:
+        """Custom self-hosted PostHog on a legitimate public IP is permitted."""
+        fake_addrinfo = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))
+        ]
+        with patch("socket.getaddrinfo", return_value=fake_addrinfo):
+            assert _telemetry_endpoint_is_safe("https://telemetry.mycorp.org/capture/") is True
+
+    def test_tier3_fails_closed_on_resolution_error(self) -> None:
+        gai_err = socket.gaierror(-2, "Name or service not known")
+        with patch("socket.getaddrinfo", side_effect=gai_err):
+            assert _telemetry_endpoint_is_safe("https://unresolvable.invalid/capture") is False
+
+    def test_tier3_fails_closed_on_resolution_timeout(self) -> None:
+        with patch("soup_cli.utils.trackers._resolve_host_ips", return_value=None):
+            assert _telemetry_endpoint_is_safe("https://hanging-dns.example.com/capture") is False
+
+    def test_resolve_host_ips_helper_timeout_handling(self) -> None:
+        """_resolve_host_ips returns None when resolution exceeds timeout deadline."""
+        def slow_getaddrinfo(*args: object, **kwargs: object) -> list[object]:
+            import time
+            time.sleep(0.5)
+            return []
+
+        with patch("socket.getaddrinfo", side_effect=slow_getaddrinfo):
+            # 0.05s timeout should trigger timeout return None
+            assert _resolve_host_ips("example.com", timeout=0.05) is None
+
+
+# =====================================================================
+# End-to-End: _resolve_posthog_target Integration
+# =====================================================================
+
+
+class TestResolvePosthogTargetTieredIntegration:
+    """Integration tests for target resolution with environment variables."""
+
+    def test_resolve_default_posthog_target_succeeds(self) -> None:
+        resolved = _resolve_posthog_target(None, env={})
+        assert resolved is not None
+        key, endpoint = resolved
+        assert "posthog.com" in endpoint
+
+    def test_resolve_rejects_hostname_ssrf_via_env(self) -> None:
+        fake_addrinfo = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.1", 443))
+        ]
+        with patch("socket.getaddrinfo", return_value=fake_addrinfo):
+            env = {"SOUP_POSTHOG_ENDPOINT": "https://10.0.0.1.nip.io/capture/"}
+            assert _resolve_posthog_target(None, env=env) is None
+
+    def test_resolve_rejects_internal_tld_via_env(self) -> None:
+        env = {"SOUP_POSTHOG_ENDPOINT": "https://metadata.internal/capture/"}
+        assert _resolve_posthog_target(None, env=env) is None
+
+    def test_resolve_accepts_valid_custom_endpoint_via_env(self) -> None:
+        fake_addrinfo = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))
+        ]
+        with patch("socket.getaddrinfo", return_value=fake_addrinfo):
+            env = {"SOUP_POSTHOG_ENDPOINT": "https://telemetry.selfhosted.io/capture/"}
+            resolved = _resolve_posthog_target("phc_custom", env=env)
+            assert resolved is not None
+            key, endpoint = resolved
+            assert key == "phc_custom"
+            assert endpoint == "https://telemetry.selfhosted.io/capture/"

--- a/tests/test_issue600_abbreviated_ipv4_ssrf.py
+++ b/tests/test_issue600_abbreviated_ipv4_ssrf.py
@@ -201,7 +201,7 @@ class TestTelemetrySSRFEndToEndPinning:
         [
             "https://us.i.posthog.com/",
             "https://eu.i.posthog.com/i/v0/e/",
-            "https://telemetry.example.com/capture",
+            "https://app.posthog.com/capture/",
         ],
     )
     def test_telemetry_endpoint_is_safe_allows_public(

--- a/tests/test_telemetry_ssrf.py
+++ b/tests/test_telemetry_ssrf.py
@@ -144,13 +144,20 @@ class TestTelemetrySSRFAcceptance:
         )
 
     def test_accepts_custom_posthog_host(self) -> None:
-        """A company's self-hosted public PostHog must pass."""
-        assert (
-            _telemetry_endpoint_is_safe(
-                "https://posthog.mycompany.com/capture/"
+        """A company's self-hosted public PostHog must pass when resolving to public IP."""
+        import socket
+        from unittest.mock import patch
+
+        fake_addrinfo = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))
+        ]
+        with patch("socket.getaddrinfo", return_value=fake_addrinfo):
+            assert (
+                _telemetry_endpoint_is_safe(
+                    "https://posthog.mycompany.com/capture/"
+                )
+                is True
             )
-            is True
-        )
 
     def test_accepts_default_posthog_endpoint(self) -> None:
         """The hardcoded default must always be accepted."""


### PR DESCRIPTION
## Summary

Closes #599.

Follow-up to #593 and #598. Closes the hostname indirection bypass in `_telemetry_endpoint_is_safe()` where domain names resolving to private/loopback addresses (e.g. `10.0.0.1.nip.io`, `localtest.me`) or internal TLDs (`metadata.internal`) bypassed literal IP checks.

---

### Architecture: Tiered Endpoint Validation

```
[Candidate Telemetry Endpoint]
              │
              ├─► Tier 1: Primary Control (Trusted Allowlist)
              │      └─► Canonical PostHog domains (*.posthog.com, us/eu.i.posthog.com)
              │          Accepted immediately (0ms, zero DNS queries, 100% offline-friendly for 99%+ runs).
              │
              ├─► Tier 2: Static Syntactic & Suffix Guards
              │      ├─► Scheme == "https"
              │      ├─► Host in _LOOPBACK_HOSTS (localhost, ::1, 127.0.0.1)
              │      ├─► Literal private/link-local IP check via _is_private_or_link_local()
              │      └─► Internal TLD suffix rejection (.local, .internal, .lan, .home, .corp, .intranet)
              │          Rejected immediately as pure string decisions with zero network lookups.
              │
              └─► Tier 3: Defence-in-Depth DNS Resolution (Custom Non-Default FQDNs)
                     ├─► Resolves custom hostnames via socket.getaddrinfo() with a bounded timeout.
                     ├─► Rejects if ANY resolved address is private, loopback, or link-local.
                     └─► Fails closed on resolution errors or timeouts.
```

---

### Key Security & Operational Principles

1. **Primary Control (Tier 1):** The trusted PostHog domain allowlist is the primary defense line. Default configurations never perform DNS queries or block in air-gapped environments.
2. **Honest Security Posture:** The Tier 3 DNS check raises the bar against hostname indirection for custom endpoint configurations; it is documented as defence-in-depth rather than preventing DNS rebinding.
3. **No Unbounded Latency & No Permissive Caching:** Unchecked `lru_cache` is omitted to avoid permanently trusting rebound IPs. Custom FQDN DNS checks run with a bounded join deadline.
4. **No Code Duplication:** Utilizes `_LOOPBACK_HOSTS` and `_is_private_or_link_local` from `hubs.py` without introducing redundant predicate copies.

---

### Tests

- **51 new tests** in `tests/test_issue599_telemetry_dns_ssrf.py` testing each tier independently:
  - `TestTier1TrustedAllowlist`: Verifies trusted allowlist and asserts DNS is never called.
  - `TestTier2StaticRejection`: Verifies internal TLDs and asserts DNS is never called.
  - `TestTier3DNSDefenceInDepth`: Verifies rejection of `10.0.0.1.nip.io`, `localtest.me`, cloud metadata, dual-stack mixed IPs, and timeout/error fail-closed handling.
  - `TestResolvePosthogTargetTieredIntegration`: End-to-end integration via `_resolve_posthog_target`.
- **Full sweep passed:** 161 tests across `test_issue599_telemetry_dns_ssrf.py`, `test_issue600_abbreviated_ipv4_ssrf.py`, and `test_telemetry_ssrf.py`.
- **Linter:** `ruff check` clean.