### PR TITLE
docs(sglang): record that the trust_remote_code gate now covers the backend (#360)

### DIFF
--- a/docs/performance-and-quantization.md
+++ b/docs/performance-and-quantization.md
@@ -612,6 +612,13 @@ soup infer --model my-org/custom-arch-model --input prompts.jsonl --trust-remote
 soup export --model ./adapter --format gguf --trust-remote-code
 ```
 
+`soup serve` resolves this gate **once** and hands the result to whichever backend
+runs. That was true of the transformers and vLLM backends from the start, and is
+true of the SGLang backend as of #619 — before that its runtime and tokenizer
+loaded with `trust_remote_code` hardcoded on, so the sentence above did not hold
+for `--backend sglang`. A custom-code model on that backend now fails to load
+without the flag where it previously loaded and ran silently.
+
 ### Chat-template hardening
 
 Tokenizers without a chat template now raise a `ValueError` with a fix suggestion instead of silently building garbage `f"{role}: {content}"` strings.

--- a/docs/serving-and-export.md
+++ b/docs/serving-and-export.md
@@ -309,6 +309,16 @@ to a generic `User:` / `Assistant:` prompt for template-less models), and
 `"stop"` otherwise — so a client doing continue-on-length can tell a truncated
 answer from a completed one (#360).
 
+It also honours `--trust-remote-code` like every other backend. **This changed:**
+the SGLang runtime and its tokenizer previously loaded with `trust_remote_code`
+hardcoded on, so a model's custom repo code executed whether or not you opted in
+— the pre-flight panel announced it but offered no way to decline. A model that
+needs custom code now **fails to load** on this backend unless you pass the flag:
+
+```bash
+soup serve --model ./output --backend sglang --trust-remote-code
+```
+
 ### Speculative Decoding
 
 Use a smaller draft model to speed up generation. **Measure before you trust it** — see


### PR DESCRIPTION
Follow-up you asked for when merging #619, as a separate PR.

## What was wrong

`docs/performance-and-quantization.md:600` states:

> Every command that loads a model now requires `--trust-remote-code` to execute custom Python from a model repo

and lists `soup serve` in its coverage. **That sentence was false for `--backend sglang`** until #619 merged: the runtime and the tokenizer both loaded with `trust_remote_code` hardcoded on, so a model's custom repo code executed whether or not the user opted in. The docs promised a gate the backend did not apply — which is arguably worse than the hole itself, since a reader had no reason to check.

`docs/serving-and-export.md`'s SGLang section documented the #360 chat-template fix and said nothing about trust at all.

## What this changes

Both pages now cover it, and both name the **behaviour change** rather than only the new state — per your note that this is breaking:

- `serving-and-export.md` — added to the SGLang backend section, mirroring the shape already used for the #360 `finish_reason` paragraph, with the `--trust-remote-code` invocation spelled out.
- `performance-and-quantization.md" — a paragraph after the examples saying the gate is resolved once and handed to whichever backend runs; true for transformers and vLLM from the start, true for SGLang as of #619, and explicitly not true before it.

The wording is deliberately "fails to load ... where it previously loaded and ran silently", so someone hitting the new failure finds the reason rather than filing it as a regression.

## Verification

```
pytest tests/ -k "docs or doc_"   -> 32 passed, 19522 deselected
```

Docs only — no code, no changelog fragment (#619 already carries the `.security.md` entry describing the behaviour change).

`Refs #360`.