### PR TITLE
feat(autodistill): add same-tokenizer teacher-only capture

### DIFF
--- a/changelog.d/0.73.3/629.added.md
+++ b/changelog.d/0.73.3/629.added.md
@@ -1,0 +1,4 @@
+- Added the internal AutoDistill Milestone B1 same-tokenizer, teacher-only MLX capture and
+  transactional shard publication boundary, with immutable input fingerprints, explicit
+  corruption/resume checks, and proof that no student model is loaded during capture
+  (#580 by @Amix29 in #629).

--- a/docs/autodistill.md
+++ b/docs/autodistill.md
@@ -243,17 +243,22 @@ root. The controller writes its final receipt only after that child has exited s
 the exact `available` manifest has been reopened. The plan still contains the immutable student
 fingerprint as future-consumer metadata; it is never resolved or loaded during capture.
 
-For this boundary, MLX-LM loads both model and tokenizer from the same local checkpoint root.
-`capture.backend_version` is the exact installed `mlx-lm` distribution version and the tokenizer
-renderer is `mlx-lm@<version>`. Both must match the plan before publication. MLX/MLX-LM remain
-lazy imports inside the worker.
+For this boundary, MLX-LM loads the teacher model from its immutable local checkpoint root and
+loads the canonical shared tokenizer separately from a tokenizer-only root. That tokenizer root
+may be derived from the student's tokenizer bytes, but it contains no student weights and the
+worker never resolves a student model. `capture.backend_version` is the exact installed `mlx-lm`
+distribution version and the tokenizer renderer is `mlx-lm@<version>`. Both must match the plan
+before publication. MLX/MLX-LM remain lazy imports inside the worker.
 
-The worker also verifies the loaded floating-parameter dtype against `capture.dtype`. An
-unquantized checkpoint uses the literal quantization identity `none`. If `config.json` contains
+The worker also verifies the loaded floating-parameter dtypes against `capture.dtype`. An
+unquantized checkpoint must expose exactly that dtype and uses the literal quantization identity
+`none`. A quantized checkpoint must expose the declared base dtype; float32 auxiliary parameters
+are allowed, while any other undeclared floating dtype fails closed. If `config.json` contains
 `quantization` or `quantization_config`, its identity is
 `config-sha256:<sha256(canonical JSON of those active fields)>`. This binds the plan to the exact
 quantization recipe without pretending that names such as `4-bit` uniquely identify a runtime.
-The observed dtype and quantization identity are repeated in the child receipt.
+The declared inference dtype, all observed floating-parameter dtypes, and the quantization
+identity are repeated in the child receipt.
 
 The bound dataset is canonical JSONL with versioned, already-tokenized rows:
 

--- a/docs/autodistill.md
+++ b/docs/autodistill.md
@@ -234,6 +234,37 @@ available -> reserved -> committed
   `replay_of` equals the prior committed event hash. The source artifact stays immutable.
 - Replay policy is explicit in every plan; it is not inferred from a filename or task.
 
+### 7.4 Milestone B1 MLX teacher boundary
+
+The first Apple Silicon capture worker is an internal, opt-in implementation surface; it
+does not add a task, CLI command, or `SoupConfig` field. The controller starts a fresh Python
+process whose request accepts teacher, tokenizer, dataset, and publication roots but no student
+root. The controller writes its final receipt only after that child has exited successfully and
+the exact `available` manifest has been reopened. The plan still contains the immutable student
+fingerprint as future-consumer metadata; it is never resolved or loaded during capture.
+
+For this boundary, MLX-LM loads both model and tokenizer from the same local checkpoint root.
+`capture.backend_version` is the exact installed `mlx-lm` distribution version and the tokenizer
+renderer is `mlx-lm@<version>`. Both must match the plan before publication. MLX/MLX-LM remain
+lazy imports inside the worker.
+
+The bound dataset is canonical JSONL with versioned, already-tokenized rows:
+
+```json
+{"schema":"soup.autodistill.tokenized-teacher-example.v1","example_id":"ex-1","prompt_token_ids":[1,2],"target_token_ids":[3,4]}
+```
+
+Prompt IDs are non-empty because a causal next-token distribution needs a preceding position.
+Every source byte, normalized row, tokenizer file, teacher config, and listed teacher weight is
+verified before model load. A worker request selects a half-open example range, but the complete
+dataset fingerprint and total planned target-token count are verified before that shard subset is
+accepted. Ranges never split one example trajectory.
+
+Without truncation, one causal forward captures all target positions in an example. Once the
+declared sequence limit requires truncation, the worker evaluates the exact recorded context for
+each position. Only the final vocabulary row is converted to float32 host values; selected IDs are
+not renormalized. Process exit, rather than cache reclamation alone, is the memory-isolation gate.
+
 ## 8. Transactional publication, resume, and corruption
 
 The capture writer follows a write-last manifest protocol on one filesystem:

--- a/docs/autodistill.md
+++ b/docs/autodistill.md
@@ -248,6 +248,13 @@ For this boundary, MLX-LM loads both model and tokenizer from the same local che
 renderer is `mlx-lm@<version>`. Both must match the plan before publication. MLX/MLX-LM remain
 lazy imports inside the worker.
 
+The worker also verifies the loaded floating-parameter dtype against `capture.dtype`. An
+unquantized checkpoint uses the literal quantization identity `none`. If `config.json` contains
+`quantization` or `quantization_config`, its identity is
+`config-sha256:<sha256(canonical JSON of those active fields)>`. This binds the plan to the exact
+quantization recipe without pretending that names such as `4-bit` uniquely identify a runtime.
+The observed dtype and quantization identity are repeated in the child receipt.
+
 The bound dataset is canonical JSONL with versioned, already-tokenized rows:
 
 ```json

--- a/scripts/autodistill_b1_hardware_smoke.py
+++ b/scripts/autodistill_b1_hardware_smoke.py
@@ -1,0 +1,228 @@
+"""Run a tiny, reproducible B1 teacher-capture smoke on a local MLX checkpoint."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import time
+from importlib.metadata import version
+from pathlib import Path
+
+from rich.console import Console
+
+from soup_cli.autodistill.contract import (
+    AutoDistillPlan,
+    FileDigest,
+    build_plan_estimate,
+    canonical_json_bytes,
+    canonicalize_jsonl_bytes,
+)
+from soup_cli.autodistill.mlx_worker import run_mlx_teacher_capture_process
+
+console = Console()
+
+
+def _digest(path: Path, root: Path) -> FileDigest:
+    payload = path.read_bytes()
+    return FileDigest(
+        path=path.relative_to(root).as_posix(),
+        bytes=len(payload),
+        sha256=hashlib.sha256(payload).hexdigest(),
+    )
+
+
+def _quantization(config: dict[str, object]) -> str:
+    active = {
+        key: config[key]
+        for key in ("quantization", "quantization_config")
+        if config.get(key) is not None
+    }
+    if not active:
+        return "none"
+    digest = hashlib.sha256(canonical_json_bytes(active)).hexdigest()
+    return f"config-sha256:{digest}"
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-root", required=True)
+    parser.add_argument("--output-root", required=True)
+    parser.add_argument("--revision", required=True)
+    parser.add_argument("--model-id", default="HuggingFaceTB/SmolLM2-135M-Instruct")
+    parser.add_argument("--prompt", default="The capital of France is")
+    parser.add_argument("--target", default=" Paris.")
+    parser.add_argument("--top-k", type=int, default=8)
+    return parser.parse_args()
+
+
+def main() -> int:
+    arguments = _arguments()
+    model_root = Path(os.path.realpath(arguments.model_root))
+    output_root = Path(os.path.realpath(arguments.output_root))
+    if output_root.exists():
+        raise FileExistsError("output root must not already exist")
+    output_root.mkdir(parents=True)
+    dataset_root = output_root / "dataset"
+    publication_root = output_root / "publication"
+    dataset_root.mkdir()
+
+    config_path = model_root / "config.json"
+    config_bytes = config_path.read_bytes()
+    config = json.loads(config_bytes)
+    if not isinstance(config, dict):
+        raise ValueError("config.json must contain an object")
+    dtype = str(config.get("torch_dtype", "")).removeprefix("torch.")
+    if dtype not in {"float16", "bfloat16", "float32"}:
+        raise ValueError("checkpoint torch_dtype is not supported by the B1 plan")
+
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(model_root, local_files_only=True)
+    prompt_ids = tuple(tokenizer.encode(arguments.prompt, add_special_tokens=False))
+    full_ids = tuple(
+        tokenizer.encode(arguments.prompt + arguments.target, add_special_tokens=False)
+    )
+    if not prompt_ids or full_ids[: len(prompt_ids)] != prompt_ids:
+        raise ValueError("prompt tokenization is not a prefix of prompt plus target")
+    target_ids = full_ids[len(prompt_ids) :]
+    if not target_ids:
+        raise ValueError("target must produce at least one token")
+    row = {
+        "schema": "soup.autodistill.tokenized-teacher-example.v1",
+        "example_id": "hardware-smoke-1",
+        "prompt_token_ids": list(prompt_ids),
+        "target_token_ids": list(target_ids),
+    }
+    dataset_bytes = canonical_json_bytes(row) + b"\n"
+    dataset_path = dataset_root / "prompts.jsonl"
+    dataset_path.write_bytes(dataset_bytes)
+
+    weight_paths = sorted(model_root.glob("*.safetensors"))
+    if not weight_paths:
+        raise ValueError("checkpoint has no root-level safetensors weights")
+    tokenizer_names = (
+        "merges.txt",
+        "special_tokens_map.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "vocab.json",
+    )
+    tokenizer_paths = [
+        model_root / name for name in tokenizer_names if (model_root / name).is_file()
+    ]
+    if not tokenizer_paths:
+        raise ValueError("checkpoint has no recognized tokenizer files")
+    teacher = {
+        "model_id": arguments.model_id,
+        "revision": arguments.revision,
+        "config_sha256": hashlib.sha256(config_bytes).hexdigest(),
+        "weights": [
+            item.model_dump(mode="json")
+            for item in (_digest(path, model_root) for path in weight_paths)
+        ],
+    }
+    tokenizer_fingerprint = {
+        "tokenizer_id": arguments.model_id,
+        "revision": arguments.revision,
+        "vocab_size": int(config["vocab_size"]),
+        "files": [
+            item.model_dump(mode="json")
+            for item in (_digest(path, model_root) for path in tokenizer_paths)
+        ],
+        "chat_template_sha256": hashlib.sha256(
+            (tokenizer.chat_template or "").encode("utf-8")
+        ).hexdigest(),
+        "renderer": f"mlx-lm@{version('mlx-lm')}",
+    }
+    estimate = build_plan_estimate(
+        token_count=len(target_ids),
+        vocab_size=int(config["vocab_size"]),
+        top_k=arguments.top_k,
+        max_forced_tokens_per_position=2,
+        token_id_bytes=4,
+        log_probability_bytes=4,
+        tail_mass_bytes=8,
+        entropy_bytes=8,
+    )
+    plan = AutoDistillPlan.model_validate(
+        {
+            "schema": "soup.autodistill.plan.v1",
+            "run_id": "mlx-hardware-smoke-1",
+            "capture_boundary": "same_tokenizer",
+            "teacher": teacher,
+            "student": teacher,
+            "tokenizer": tokenizer_fingerprint,
+            "dataset": {
+                "normalization": "soup-jsonl-c14n-v1",
+                "normalized_sha256": hashlib.sha256(
+                    canonicalize_jsonl_bytes(dataset_bytes)
+                ).hexdigest(),
+                "rows": 1,
+                "source_files": [_digest(dataset_path, dataset_root).model_dump(mode="json")],
+            },
+            "capture": {
+                "planned_token_count": len(target_ids),
+                "vocab_size": int(config["vocab_size"]),
+                "max_forced_tokens_per_position": 2,
+                "backend": "mlx",
+                "backend_version": version("mlx-lm"),
+                "dtype": dtype,
+                "quantization": _quantization(config),
+                "max_sequence_length": int(config.get("max_position_embeddings", 2048)),
+                "truncation": "none",
+            },
+            "probability_policy": {
+                "name": "topk_union_forced_tail.v1",
+                "top_k": arguments.top_k,
+                "forced_token_sources": ["target", "student_sample"],
+                "token_id_bytes": 4,
+                "log_probability_bytes": 4,
+                "tail_mass_bytes": 8,
+                "entropy_bytes": 8,
+                "temperature": 1.0,
+                "renormalize_selected": False,
+            },
+            "consumption_policy": {
+                "teacher_expert_replay": "explicit",
+                "student_rollout_replay": "forbidden",
+                "reservation_recovery": "release_if_checkpoint_absent",
+                "commit_requires_checkpoint_sha256": True,
+            },
+            "throughput_profile": None,
+            "estimate": estimate.model_dump(mode="json"),
+        }
+    )
+    plan_path = output_root / "plan.json"
+    plan_path.write_bytes(canonical_json_bytes(plan) + b"\n")
+
+    started = time.monotonic()
+    result = run_mlx_teacher_capture_process(
+        plan=plan,
+        teacher_root=model_root,
+        tokenizer_root=model_root,
+        dataset_root=dataset_root,
+        publication_root=publication_root,
+        shard_id="shard-0001",
+        transaction_id="transaction-0001",
+        python_executable=os.fspath(Path(os.sys.executable)),
+        timeout_seconds=300,
+    )
+    elapsed = time.monotonic() - started
+    console.print(
+        {
+            "status": "PASS",
+            "elapsed_seconds": round(elapsed, 3),
+            "prompt_token_ids": prompt_ids,
+            "target_token_ids": target_ids,
+            "plan": os.fspath(plan_path),
+            "publication": os.fspath(publication_root),
+            "result": result.model_dump(mode="json", by_alias=True),
+        }
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/autodistill_b1_hardware_smoke.py
+++ b/scripts/autodistill_b1_hardware_smoke.py
@@ -51,6 +51,12 @@ def _arguments() -> argparse.Namespace:
     parser.add_argument("--output-root", required=True)
     parser.add_argument("--revision", required=True)
     parser.add_argument("--model-id", default="HuggingFaceTB/SmolLM2-135M-Instruct")
+    parser.add_argument("--student-root")
+    parser.add_argument("--student-id")
+    parser.add_argument("--student-revision")
+    parser.add_argument("--tokenizer-root")
+    parser.add_argument("--tokenizer-id")
+    parser.add_argument("--tokenizer-revision")
     parser.add_argument("--prompt", default="The capital of France is")
     parser.add_argument("--target", default=" Paris.")
     parser.add_argument("--top-k", type=int, default=8)
@@ -60,6 +66,12 @@ def _arguments() -> argparse.Namespace:
 def main() -> int:
     arguments = _arguments()
     model_root = Path(os.path.realpath(arguments.model_root))
+    student_root = Path(os.path.realpath(arguments.student_root or model_root))
+    tokenizer_root = Path(os.path.realpath(arguments.tokenizer_root or student_root))
+    student_id = arguments.student_id or arguments.model_id
+    student_revision = arguments.student_revision or arguments.revision
+    tokenizer_id = arguments.tokenizer_id or student_id
+    tokenizer_revision = arguments.tokenizer_revision or student_revision
     output_root = Path(os.path.realpath(arguments.output_root))
     if output_root.exists():
         raise FileExistsError("output root must not already exist")
@@ -73,13 +85,15 @@ def main() -> int:
     config = json.loads(config_bytes)
     if not isinstance(config, dict):
         raise ValueError("config.json must contain an object")
-    dtype = str(config.get("torch_dtype", "")).removeprefix("torch.")
+    dtype = str(config.get("dtype") or config.get("torch_dtype") or "").removeprefix(
+        "torch."
+    )
     if dtype not in {"float16", "bfloat16", "float32"}:
         raise ValueError("checkpoint torch_dtype is not supported by the B1 plan")
 
     from transformers import AutoTokenizer
 
-    tokenizer = AutoTokenizer.from_pretrained(model_root, local_files_only=True)
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_root, local_files_only=True)
     prompt_ids = tuple(tokenizer.encode(arguments.prompt, add_special_tokens=False))
     full_ids = tuple(
         tokenizer.encode(arguments.prompt + arguments.target, add_special_tokens=False)
@@ -99,37 +113,48 @@ def main() -> int:
     dataset_path = dataset_root / "prompts.jsonl"
     dataset_path.write_bytes(dataset_bytes)
 
-    weight_paths = sorted(model_root.glob("*.safetensors"))
-    if not weight_paths:
-        raise ValueError("checkpoint has no root-level safetensors weights")
     tokenizer_names = (
+        "added_tokens.json",
+        "chat_template.jinja",
+        "config.json",
         "merges.txt",
         "special_tokens_map.json",
+        "tokenizer.model",
         "tokenizer.json",
         "tokenizer_config.json",
         "vocab.json",
     )
     tokenizer_paths = [
-        model_root / name for name in tokenizer_names if (model_root / name).is_file()
+        tokenizer_root / name
+        for name in tokenizer_names
+        if (tokenizer_root / name).is_file()
     ]
     if not tokenizer_paths:
         raise ValueError("checkpoint has no recognized tokenizer files")
-    teacher = {
-        "model_id": arguments.model_id,
-        "revision": arguments.revision,
-        "config_sha256": hashlib.sha256(config_bytes).hexdigest(),
-        "weights": [
-            item.model_dump(mode="json")
-            for item in (_digest(path, model_root) for path in weight_paths)
-        ],
-    }
+    def model_fingerprint(root: Path, model_id: str, revision: str) -> dict[str, object]:
+        root_config = (root / "config.json").read_bytes()
+        root_weights = sorted(root.glob("*.safetensors"))
+        if not root_weights:
+            raise ValueError(f"checkpoint {model_id!r} has no root-level safetensors weights")
+        return {
+            "model_id": model_id,
+            "revision": revision,
+            "config_sha256": hashlib.sha256(root_config).hexdigest(),
+            "weights": [
+                item.model_dump(mode="json")
+                for item in (_digest(path, root) for path in root_weights)
+            ],
+        }
+
+    teacher = model_fingerprint(model_root, arguments.model_id, arguments.revision)
+    student = model_fingerprint(student_root, student_id, student_revision)
     tokenizer_fingerprint = {
-        "tokenizer_id": arguments.model_id,
-        "revision": arguments.revision,
-        "vocab_size": int(config["vocab_size"]),
+        "tokenizer_id": tokenizer_id,
+        "revision": tokenizer_revision,
+        "vocab_size": len(tokenizer.get_vocab()),
         "files": [
             item.model_dump(mode="json")
-            for item in (_digest(path, model_root) for path in tokenizer_paths)
+            for item in (_digest(path, tokenizer_root) for path in tokenizer_paths)
         ],
         "chat_template_sha256": hashlib.sha256(
             (tokenizer.chat_template or "").encode("utf-8")
@@ -138,7 +163,7 @@ def main() -> int:
     }
     estimate = build_plan_estimate(
         token_count=len(target_ids),
-        vocab_size=int(config["vocab_size"]),
+        vocab_size=len(tokenizer.get_vocab()),
         top_k=arguments.top_k,
         max_forced_tokens_per_position=2,
         token_id_bytes=4,
@@ -152,7 +177,7 @@ def main() -> int:
             "run_id": "mlx-hardware-smoke-1",
             "capture_boundary": "same_tokenizer",
             "teacher": teacher,
-            "student": teacher,
+            "student": student,
             "tokenizer": tokenizer_fingerprint,
             "dataset": {
                 "normalization": "soup-jsonl-c14n-v1",
@@ -164,7 +189,7 @@ def main() -> int:
             },
             "capture": {
                 "planned_token_count": len(target_ids),
-                "vocab_size": int(config["vocab_size"]),
+                "vocab_size": len(tokenizer.get_vocab()),
                 "max_forced_tokens_per_position": 2,
                 "backend": "mlx",
                 "backend_version": version("mlx-lm"),
@@ -201,7 +226,7 @@ def main() -> int:
     result = run_mlx_teacher_capture_process(
         plan=plan,
         teacher_root=model_root,
-        tokenizer_root=model_root,
+        tokenizer_root=tokenizer_root,
         dataset_root=dataset_root,
         publication_root=publication_root,
         shard_id="shard-0001",

--- a/src/soup_cli/autodistill/__init__.py
+++ b/src/soup_cli/autodistill/__init__.py
@@ -16,6 +16,7 @@ from soup_cli.autodistill.contract import (
     build_plan_estimate,
 )
 from soup_cli.autodistill.fingerprints import (
+    verified_dataset_bytes,
     verify_dataset_fingerprint,
     verify_teacher_fingerprint,
     verify_tokenizer_fingerprint,
@@ -38,4 +39,5 @@ __all__ = [
     "verify_dataset_fingerprint",
     "verify_teacher_fingerprint",
     "verify_tokenizer_fingerprint",
+    "verified_dataset_bytes",
 ]

--- a/src/soup_cli/autodistill/__init__.py
+++ b/src/soup_cli/autodistill/__init__.py
@@ -19,6 +19,7 @@ from soup_cli.autodistill.fingerprints import (
     verified_dataset_bytes,
     verify_dataset_fingerprint,
     verify_teacher_fingerprint,
+    verify_tokenizer_file_fingerprint,
     verify_tokenizer_fingerprint,
 )
 from soup_cli.autodistill.publisher import CaptureShardPublisher
@@ -38,6 +39,7 @@ __all__ = [
     "capture_teacher_expert_trajectory",
     "verify_dataset_fingerprint",
     "verify_teacher_fingerprint",
+    "verify_tokenizer_file_fingerprint",
     "verify_tokenizer_fingerprint",
     "verified_dataset_bytes",
 ]

--- a/src/soup_cli/autodistill/__init__.py
+++ b/src/soup_cli/autodistill/__init__.py
@@ -1,5 +1,10 @@
-"""Model-free contracts for Soup's future offline AutoDistill pipeline."""
+"""Model-free foundations for Soup's future offline AutoDistill pipeline."""
 
+from soup_cli.autodistill.capture import (
+    TeacherExpertExample,
+    build_teacher_expert_capture_token,
+    capture_teacher_expert_trajectory,
+)
 from soup_cli.autodistill.contract import (
     AUTODISTILL_PLAN_SCHEMA,
     CAPTURE_TOKEN_SCHEMA,
@@ -10,6 +15,12 @@ from soup_cli.autodistill.contract import (
     ShardManifest,
     build_plan_estimate,
 )
+from soup_cli.autodistill.fingerprints import (
+    verify_dataset_fingerprint,
+    verify_teacher_fingerprint,
+    verify_tokenizer_fingerprint,
+)
+from soup_cli.autodistill.publisher import CaptureShardPublisher
 
 __all__ = [
     "AUTODISTILL_PLAN_SCHEMA",
@@ -18,6 +29,13 @@ __all__ = [
     "SHARD_MANIFEST_SCHEMA",
     "AutoDistillPlan",
     "CaptureToken",
+    "CaptureShardPublisher",
     "ShardManifest",
+    "TeacherExpertExample",
     "build_plan_estimate",
+    "build_teacher_expert_capture_token",
+    "capture_teacher_expert_trajectory",
+    "verify_dataset_fingerprint",
+    "verify_teacher_fingerprint",
+    "verify_tokenizer_fingerprint",
 ]

--- a/src/soup_cli/autodistill/capture.py
+++ b/src/soup_cli/autodistill/capture.py
@@ -1,0 +1,186 @@
+"""Deterministic, model-free construction of AutoDistill capture rows.
+
+This module turns already-computed teacher logits into the versioned Milestone A
+artifact.  It deliberately does not import or load an ML runtime; backend workers
+remain responsible for producing one logit vector per target position.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+from soup_cli.autodistill.contract import CaptureToken, ProbabilityPolicy
+
+
+def _validate_token_ids(
+    token_ids: Sequence[int],
+    *,
+    field: str,
+    vocab_size: int,
+    allow_empty: bool,
+) -> tuple[int, ...]:
+    result = tuple(token_ids)
+    if not allow_empty and not result:
+        raise ValueError(f"{field} must not be empty")
+    if any(isinstance(token_id, bool) or not isinstance(token_id, int) for token_id in result):
+        raise TypeError(f"{field} must contain integer token ids")
+    if any(token_id < 0 or token_id >= vocab_size for token_id in result):
+        raise ValueError(f"{field} contains an id outside the vocabulary")
+    return result
+
+
+@dataclass(frozen=True)
+class TeacherExpertExample:
+    """One tokenized supervised example presented to a teacher backend."""
+
+    example_id: str
+    prompt_token_ids: tuple[int, ...]
+    target_token_ids: tuple[int, ...]
+
+
+def _teacher_log_probabilities(
+    logits: Sequence[float],
+    *,
+    vocab_size: int,
+    temperature: float,
+) -> tuple[float, ...]:
+    if len(logits) != vocab_size:
+        raise ValueError("teacher logits length must equal vocab_size")
+    if any(isinstance(value, bool) or not isinstance(value, (int, float)) for value in logits):
+        raise TypeError("teacher logits must contain finite numbers")
+    scaled = tuple(float(value) / temperature for value in logits)
+    if any(not math.isfinite(value) for value in scaled):
+        raise ValueError("teacher logits must contain finite numbers")
+
+    maximum = max(scaled)
+    log_normalizer = maximum + math.log(math.fsum(math.exp(value - maximum) for value in scaled))
+    return tuple(value - log_normalizer for value in scaled)
+
+
+def build_teacher_expert_capture_token(
+    *,
+    example_id: str,
+    position: int,
+    context_token_ids: Sequence[int],
+    target_token_id: int,
+    teacher_logits: Sequence[float],
+    vocab_size: int,
+    probability_policy: ProbabilityPolicy,
+) -> CaptureToken:
+    """Build one sparse teacher-expert row without losing selected probabilities."""
+
+    if isinstance(vocab_size, bool) or not isinstance(vocab_size, int):
+        raise TypeError("vocab_size must be an integer")
+    if vocab_size <= 0:
+        raise ValueError("vocab_size must be positive")
+    if probability_policy.top_k > vocab_size:
+        raise ValueError("top_k must not exceed vocab_size")
+    context = _validate_token_ids(
+        context_token_ids,
+        field="context_token_ids",
+        vocab_size=vocab_size,
+        allow_empty=True,
+    )
+    target = _validate_token_ids(
+        (target_token_id,),
+        field="target_token_id",
+        vocab_size=vocab_size,
+        allow_empty=False,
+    )[0]
+
+    log_probabilities = _teacher_log_probabilities(
+        teacher_logits,
+        vocab_size=vocab_size,
+        temperature=probability_policy.temperature,
+    )
+    ranked_ids = sorted(
+        range(vocab_size),
+        key=lambda token_id: (-log_probabilities[token_id], token_id),
+    )
+    top_k_ids = tuple(sorted(ranked_ids[: probability_policy.top_k]))
+    forced_ids = (target,)
+    selected_ids = tuple(sorted(set(top_k_ids) | set(forced_ids)))
+    selected_log_probabilities = tuple(log_probabilities[token_id] for token_id in selected_ids)
+    omitted_ids = set(range(vocab_size)) - set(selected_ids)
+    tail_mass = math.fsum(math.exp(log_probabilities[token_id]) for token_id in omitted_ids)
+    entropy = math.fsum(
+        -math.exp(log_probability) * log_probability
+        for log_probability in log_probabilities
+    )
+
+    return CaptureToken(
+        schema="soup.autodistill.capture-token.v1",
+        example_id=example_id,
+        trajectory_kind="teacher_expert",
+        position=position,
+        vocab_size=vocab_size,
+        context_token_ids=context,
+        target_token_id=target,
+        student_sampled_token_id=None,
+        top_k_token_ids=top_k_ids,
+        forced_token_ids=forced_ids,
+        selected_token_ids=selected_ids,
+        teacher_log_probabilities=selected_log_probabilities,
+        tail_mass=tail_mass,
+        teacher_entropy=entropy,
+        temperature=probability_policy.temperature,
+    )
+
+
+def capture_teacher_expert_trajectory(
+    *,
+    example: TeacherExpertExample,
+    teacher_logits_by_position: Sequence[Sequence[float]],
+    vocab_size: int,
+    probability_policy: ProbabilityPolicy,
+    max_sequence_length: int,
+    truncation: Literal["left", "right", "none"],
+) -> tuple[CaptureToken, ...]:
+    """Capture every supervised target position with its exact inference context."""
+
+    if isinstance(max_sequence_length, bool) or not isinstance(max_sequence_length, int):
+        raise TypeError("max_sequence_length must be an integer")
+    if max_sequence_length <= 0:
+        raise ValueError("max_sequence_length must be positive")
+    if truncation not in {"left", "right", "none"}:
+        raise ValueError("truncation must be left, right, or none")
+    prompt = _validate_token_ids(
+        example.prompt_token_ids,
+        field="prompt_token_ids",
+        vocab_size=vocab_size,
+        allow_empty=True,
+    )
+    targets = _validate_token_ids(
+        example.target_token_ids,
+        field="target_token_ids",
+        vocab_size=vocab_size,
+        allow_empty=False,
+    )
+    if len(teacher_logits_by_position) != len(targets):
+        raise ValueError("one teacher logit vector is required per target position")
+
+    captures: list[CaptureToken] = []
+    for position, (target, logits) in enumerate(zip(targets, teacher_logits_by_position)):
+        context = prompt + targets[:position]
+        if len(context) > max_sequence_length:
+            if truncation == "none":
+                raise ValueError("teacher context exceeds max_sequence_length")
+            if truncation == "left":
+                context = context[-max_sequence_length:]
+            else:
+                context = context[:max_sequence_length]
+        captures.append(
+            build_teacher_expert_capture_token(
+                example_id=example.example_id,
+                position=position,
+                context_token_ids=context,
+                target_token_id=target,
+                teacher_logits=logits,
+                vocab_size=vocab_size,
+                probability_policy=probability_policy,
+            )
+        )
+    return tuple(captures)

--- a/src/soup_cli/autodistill/fingerprints.py
+++ b/src/soup_cli/autodistill/fingerprints.py
@@ -13,6 +13,21 @@ from soup_cli.autodistill.contract import (
     canonicalize_jsonl_bytes,
 )
 
+_HASH_CHUNK_BYTES = 8 * 1024 * 1024
+
+
+def _stream_file(path: Path, *, retain_bytes: bool) -> tuple[int, str, bytes]:
+    digest = hashlib.sha256()
+    size = 0
+    retained: list[bytes] = []
+    with path.open("rb") as handle:
+        while chunk := handle.read(_HASH_CHUNK_BYTES):
+            size += len(chunk)
+            digest.update(chunk)
+            if retain_bytes:
+                retained.append(chunk)
+    return size, digest.hexdigest(), b"".join(retained)
+
 
 def _safe_file(root: Path, relative_path: str) -> Path:
     root_absolute = os.path.abspath(root)
@@ -37,11 +52,19 @@ def _safe_file(root: Path, relative_path: str) -> Path:
     return path
 
 
-def _verify_file(root: Path, expected: FileDigest) -> bytes:
-    data = _safe_file(root, expected.path).read_bytes()
-    if len(data) != expected.bytes:
+def _verify_file(
+    root: Path,
+    expected: FileDigest,
+    *,
+    retain_bytes: bool = True,
+) -> bytes:
+    size, digest, data = _stream_file(
+        _safe_file(root, expected.path),
+        retain_bytes=retain_bytes,
+    )
+    if size != expected.bytes:
         raise ArtifactCorruptionError(f"fingerprinted file {expected.path!r} byte count mismatch")
-    if hashlib.sha256(data).hexdigest() != expected.sha256:
+    if digest != expected.sha256:
         raise ArtifactCorruptionError(f"fingerprinted file {expected.path!r} sha256 mismatch")
     return data
 
@@ -54,11 +77,14 @@ def verify_teacher_fingerprint(
     """Verify only the teacher files needed by capture; no student path is accepted."""
 
     root = Path(teacher_root)
-    config = _safe_file(root, "config.json").read_bytes()
-    if hashlib.sha256(config).hexdigest() != plan.teacher.config_sha256:
+    _, config_digest, _ = _stream_file(
+        _safe_file(root, "config.json"),
+        retain_bytes=False,
+    )
+    if config_digest != plan.teacher.config_sha256:
         raise ArtifactCorruptionError("teacher config.json sha256 mismatch")
     for expected in plan.teacher.weights:
-        _verify_file(root, expected)
+        _verify_file(root, expected, retain_bytes=False)
 
 
 def verify_tokenizer_fingerprint(
@@ -87,7 +113,7 @@ def verify_tokenizer_file_fingerprint(
 
     root = Path(tokenizer_root)
     for expected in plan.tokenizer.files:
-        _verify_file(root, expected)
+        _verify_file(root, expected, retain_bytes=False)
 
 
 def verify_dataset_fingerprint(

--- a/src/soup_cli/autodistill/fingerprints.py
+++ b/src/soup_cli/autodistill/fingerprints.py
@@ -1,0 +1,107 @@
+"""Local byte verification for inputs bound by an AutoDistill plan."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+from soup_cli.autodistill.contract import (
+    ArtifactCorruptionError,
+    AutoDistillPlan,
+    FileDigest,
+    canonicalize_jsonl_bytes,
+)
+
+
+def _safe_file(root: Path, relative_path: str) -> Path:
+    root_absolute = os.path.abspath(root)
+    root_real = os.path.realpath(root_absolute)
+    candidate = os.path.abspath(os.path.join(root_absolute, relative_path))
+    candidate_real = os.path.realpath(candidate)
+    try:
+        contained = os.path.commonpath((root_real, candidate_real)) == root_real
+    except ValueError as exc:
+        raise ArtifactCorruptionError("fingerprinted file escapes its root") from exc
+    if not contained:
+        raise ArtifactCorruptionError("fingerprinted file escapes its root")
+    path = Path(candidate)
+    relative_parts = Path(relative_path.replace("\\", "/")).parts
+    lexical = Path(root_absolute)
+    has_symlink = lexical.is_symlink()
+    for part in relative_parts:
+        lexical /= part
+        has_symlink = has_symlink or lexical.is_symlink()
+    if has_symlink or not path.is_file():
+        raise ArtifactCorruptionError(f"fingerprinted file {relative_path!r} is missing")
+    return path
+
+
+def _verify_file(root: Path, expected: FileDigest) -> bytes:
+    data = _safe_file(root, expected.path).read_bytes()
+    if len(data) != expected.bytes:
+        raise ArtifactCorruptionError(f"fingerprinted file {expected.path!r} byte count mismatch")
+    if hashlib.sha256(data).hexdigest() != expected.sha256:
+        raise ArtifactCorruptionError(f"fingerprinted file {expected.path!r} sha256 mismatch")
+    return data
+
+
+def verify_teacher_fingerprint(
+    plan: AutoDistillPlan,
+    *,
+    teacher_root: str | os.PathLike[str],
+) -> None:
+    """Verify only the teacher files needed by capture; no student path is accepted."""
+
+    root = Path(teacher_root)
+    config = _safe_file(root, "config.json").read_bytes()
+    if hashlib.sha256(config).hexdigest() != plan.teacher.config_sha256:
+        raise ArtifactCorruptionError("teacher config.json sha256 mismatch")
+    for expected in plan.teacher.weights:
+        _verify_file(root, expected)
+
+
+def verify_tokenizer_fingerprint(
+    plan: AutoDistillPlan,
+    *,
+    tokenizer_root: str | os.PathLike[str],
+    chat_template: str,
+    renderer: str,
+) -> None:
+    """Verify shared tokenizer bytes and the exact runtime rendering identity."""
+
+    if renderer != plan.tokenizer.renderer:
+        raise ArtifactCorruptionError("tokenizer renderer does not match plan")
+    template_digest = hashlib.sha256(chat_template.encode("utf-8")).hexdigest()
+    if template_digest != plan.tokenizer.chat_template_sha256:
+        raise ArtifactCorruptionError("tokenizer chat template sha256 mismatch")
+    root = Path(tokenizer_root)
+    for expected in plan.tokenizer.files:
+        _verify_file(root, expected)
+
+
+def verify_dataset_fingerprint(
+    plan: AutoDistillPlan,
+    *,
+    dataset_root: str | os.PathLike[str],
+) -> None:
+    """Verify ordered source bytes and their combined canonical JSONL identity."""
+
+    root = Path(dataset_root)
+    normalized_parts: list[bytes] = []
+    row_count = 0
+    for expected in plan.dataset.source_files:
+        source = _verify_file(root, expected)
+        try:
+            normalized = canonicalize_jsonl_bytes(source)
+        except ValueError as exc:
+            raise ArtifactCorruptionError(
+                f"dataset file {expected.path!r} is not valid canonicalizable JSONL"
+            ) from exc
+        normalized_parts.append(normalized)
+        row_count += len(normalized.splitlines())
+    normalized_bytes = b"".join(normalized_parts)
+    if hashlib.sha256(normalized_bytes).hexdigest() != plan.dataset.normalized_sha256:
+        raise ArtifactCorruptionError("dataset normalized sha256 mismatch")
+    if row_count != plan.dataset.rows:
+        raise ArtifactCorruptionError("dataset normalized row count mismatch")

--- a/src/soup_cli/autodistill/fingerprints.py
+++ b/src/soup_cli/autodistill/fingerprints.py
@@ -75,6 +75,16 @@ def verify_tokenizer_fingerprint(
     template_digest = hashlib.sha256(chat_template.encode("utf-8")).hexdigest()
     if template_digest != plan.tokenizer.chat_template_sha256:
         raise ArtifactCorruptionError("tokenizer chat template sha256 mismatch")
+    verify_tokenizer_file_fingerprint(plan, tokenizer_root=tokenizer_root)
+
+
+def verify_tokenizer_file_fingerprint(
+    plan: AutoDistillPlan,
+    *,
+    tokenizer_root: str | os.PathLike[str],
+) -> None:
+    """Verify bound tokenizer bytes before a backend instantiates the tokenizer."""
+
     root = Path(tokenizer_root)
     for expected in plan.tokenizer.files:
         _verify_file(root, expected)

--- a/src/soup_cli/autodistill/fingerprints.py
+++ b/src/soup_cli/autodistill/fingerprints.py
@@ -87,6 +87,16 @@ def verify_dataset_fingerprint(
 ) -> None:
     """Verify ordered source bytes and their combined canonical JSONL identity."""
 
+    verified_dataset_bytes(plan, dataset_root=dataset_root)
+
+
+def verified_dataset_bytes(
+    plan: AutoDistillPlan,
+    *,
+    dataset_root: str | os.PathLike[str],
+) -> bytes:
+    """Return bound canonical JSONL bytes after all source and logical checks pass."""
+
     root = Path(dataset_root)
     normalized_parts: list[bytes] = []
     row_count = 0
@@ -105,3 +115,4 @@ def verify_dataset_fingerprint(
         raise ArtifactCorruptionError("dataset normalized sha256 mismatch")
     if row_count != plan.dataset.rows:
         raise ArtifactCorruptionError("dataset normalized row count mismatch")
+    return normalized_bytes

--- a/src/soup_cli/autodistill/mlx_worker.py
+++ b/src/soup_cli/autodistill/mlx_worker.py
@@ -123,6 +123,8 @@ class MlxTeacherWorkerReceipt(_FrozenModel):
     token_count: int = Field(gt=0)
     mlx_version: str = Field(min_length=1, max_length=128)
     mlx_lm_version: str = Field(min_length=1, max_length=128)
+    inference_dtype: Literal["float16", "bfloat16", "float32"]
+    quantization: str = Field(min_length=1, max_length=128)
 
 
 class MlxTeacherCaptureResult(_FrozenModel):
@@ -244,10 +246,66 @@ def _logit_row(output: object, *, context_length: int, row_index: int, vocab_siz
     return logits[0, row_index, :]
 
 
+def _quantization_descriptor(teacher_root: str) -> str:
+    config_path = Path(teacher_root) / "config.json"
+    config = json.loads(config_path.read_bytes())
+    if not isinstance(config, dict):
+        raise ValueError("teacher config.json must contain a JSON object")
+    active = {
+        key: config[key]
+        for key in ("quantization", "quantization_config")
+        if config.get(key) is not None
+    }
+    if not active:
+        return "none"
+    return f"config-sha256:{hashlib.sha256(canonical_json_bytes(active)).hexdigest()}"
+
+
+def _parameter_dtype(value: object) -> str | None:
+    dtype = getattr(value, "dtype", None)
+    if dtype is None:
+        return None
+    name = str(dtype).removeprefix("mlx.core.")
+    if name in {"float16", "bfloat16", "float32"}:
+        return name
+    return None
+
+
+def _floating_parameter_dtypes(parameters: object) -> set[str]:
+    if isinstance(parameters, dict):
+        values = parameters.values()
+    elif isinstance(parameters, (list, tuple)):
+        values = parameters
+    else:
+        dtype = _parameter_dtype(parameters)
+        return {dtype} if dtype is not None else set()
+    observed: set[str] = set()
+    for value in values:
+        observed.update(_floating_parameter_dtypes(value))
+    return observed
+
+
+def _verify_capture_runtime(request: MlxTeacherCaptureRequest, model: object) -> tuple[str, str]:
+    quantization = _quantization_descriptor(request.teacher_root)
+    if quantization != request.plan.capture.quantization:
+        raise ValueError("loaded teacher quantization does not match capture.quantization")
+    parameters_method = getattr(model, "parameters", None)
+    if not callable(parameters_method):
+        raise ValueError("MLX teacher does not expose parameters for dtype verification")
+    dtypes = _floating_parameter_dtypes(parameters_method())
+    expected = request.plan.capture.dtype
+    if dtypes != {expected}:
+        rendered = ", ".join(sorted(dtypes)) or "none"
+        raise ValueError(
+            f"loaded teacher floating parameter dtypes ({rendered}) do not match {expected}"
+        )
+    return expected, quantization
+
+
 def _capture_examples_with_mlx(
     request: MlxTeacherCaptureRequest,
     examples: tuple[TokenizedTeacherExample, ...],
-) -> tuple[tuple[CaptureToken, ...], str, str]:
+) -> tuple[tuple[CaptureToken, ...], str, str, str, str]:
     import mlx
     import mlx.core as mx
     import mlx_lm
@@ -258,6 +316,7 @@ def _capture_examples_with_mlx(
     if mlx_lm_version != request.plan.capture.backend_version:
         raise ValueError("installed MLX-LM version does not match capture.backend_version")
     model, tokenizer = load(request.teacher_root)
+    inference_dtype, quantization = _verify_capture_runtime(request, model)
     verify_tokenizer_fingerprint(
         request.plan,
         tokenizer_root=request.tokenizer_root,
@@ -321,17 +380,17 @@ def _capture_examples_with_mlx(
         del model
         del tokenizer
         mx.clear_cache()
-    return tuple(captures), mlx_version, mlx_lm_version
+    return tuple(captures), mlx_version, mlx_lm_version, inference_dtype, quantization
 
 
 def _package_version(distribution: str, module: object) -> str:
+    module_version = getattr(module, "__version__", None)
+    if isinstance(module_version, str) and module_version:
+        return module_version
     try:
         return version(distribution)
     except PackageNotFoundError:
-        value = getattr(module, "__version__", None)
-        if not isinstance(value, str) or not value:
-            raise ValueError(f"cannot determine {distribution} version") from None
-        return value
+        raise ValueError(f"cannot determine {distribution} version") from None
 
 
 def _run_worker(request_path: Path) -> None:
@@ -341,10 +400,13 @@ def _run_worker(request_path: Path) -> None:
     try:
         verify_teacher_fingerprint(request.plan, teacher_root=request.teacher_root)
         examples = _load_bound_examples(request)
-        captures, mlx_version, mlx_lm_version = _capture_examples_with_mlx(
-            request,
-            examples,
-        )
+        (
+            captures,
+            mlx_version,
+            mlx_lm_version,
+            inference_dtype,
+            quantization,
+        ) = _capture_examples_with_mlx(request, examples)
         manifest = CaptureShardPublisher(
             root=request.publication_root,
             plan=request.plan,
@@ -364,6 +426,8 @@ def _run_worker(request_path: Path) -> None:
             token_count=manifest.token_count,
             mlx_version=mlx_version,
             mlx_lm_version=mlx_lm_version,
+            inference_dtype=inference_dtype,
+            quantization=quantization,
         )
         _atomic_write(
             _contained_path(worker_root, _WORKER_RECEIPT_NAME),

--- a/src/soup_cli/autodistill/mlx_worker.py
+++ b/src/soup_cli/autodistill/mlx_worker.py
@@ -31,6 +31,7 @@ from soup_cli.autodistill.contract import (
 from soup_cli.autodistill.fingerprints import (
     verified_dataset_bytes,
     verify_teacher_fingerprint,
+    verify_tokenizer_file_fingerprint,
     verify_tokenizer_fingerprint,
 )
 from soup_cli.autodistill.publisher import CaptureShardPublisher
@@ -101,8 +102,6 @@ class MlxTeacherCaptureRequest(_FrozenModel):
     def _mlx_only(self) -> MlxTeacherCaptureRequest:
         if self.plan.capture.backend != "mlx":
             raise ValueError("MLX teacher worker requires capture.backend=mlx")
-        if os.path.realpath(self.teacher_root) != os.path.realpath(self.tokenizer_root):
-            raise ValueError("MLX B1 requires tokenizer_root to equal teacher_root")
         if self.example_end is not None and self.example_end <= self.example_start:
             raise ValueError("example_end must be greater than example_start")
         return self
@@ -124,6 +123,9 @@ class MlxTeacherWorkerReceipt(_FrozenModel):
     mlx_version: str = Field(min_length=1, max_length=128)
     mlx_lm_version: str = Field(min_length=1, max_length=128)
     inference_dtype: Literal["float16", "bfloat16", "float32"]
+    floating_parameter_dtypes: tuple[
+        Literal["float16", "bfloat16", "float32"], ...
+    ] = Field(min_length=1)
     quantization: str = Field(min_length=1, max_length=128)
 
 
@@ -285,38 +287,55 @@ def _floating_parameter_dtypes(parameters: object) -> set[str]:
     return observed
 
 
-def _verify_capture_runtime(request: MlxTeacherCaptureRequest, model: object) -> tuple[str, str]:
+def _verify_declared_quantization(request: MlxTeacherCaptureRequest) -> str:
     quantization = _quantization_descriptor(request.teacher_root)
     if quantization != request.plan.capture.quantization:
-        raise ValueError("loaded teacher quantization does not match capture.quantization")
+        raise ValueError("teacher config quantization does not match capture.quantization")
+    return quantization
+
+
+def _verify_capture_runtime_dtype(
+    request: MlxTeacherCaptureRequest,
+    model: object,
+    *,
+    quantization: str,
+) -> tuple[str, tuple[str, ...]]:
     parameters_method = getattr(model, "parameters", None)
     if not callable(parameters_method):
         raise ValueError("MLX teacher does not expose parameters for dtype verification")
     dtypes = _floating_parameter_dtypes(parameters_method())
     expected = request.plan.capture.dtype
-    if dtypes != {expected}:
+    allowed = {expected} if quantization == "none" else {expected, "float32"}
+    if expected not in dtypes or not dtypes <= allowed:
         rendered = ", ".join(sorted(dtypes)) or "none"
         raise ValueError(
             f"loaded teacher floating parameter dtypes ({rendered}) do not match {expected}"
         )
-    return expected, quantization
+    return expected, tuple(sorted(dtypes))
 
 
 def _capture_examples_with_mlx(
     request: MlxTeacherCaptureRequest,
     examples: tuple[TokenizedTeacherExample, ...],
-) -> tuple[tuple[CaptureToken, ...], str, str, str, str]:
+) -> tuple[tuple[CaptureToken, ...], str, str, str, tuple[str, ...], str]:
     import mlx
     import mlx.core as mx
     import mlx_lm
     from mlx_lm import load
+    from mlx_lm.utils import load_tokenizer
 
     mlx_version = _package_version("mlx", mlx)
     mlx_lm_version = _package_version("mlx-lm", mlx_lm)
     if mlx_lm_version != request.plan.capture.backend_version:
         raise ValueError("installed MLX-LM version does not match capture.backend_version")
-    model, tokenizer = load(request.teacher_root)
-    inference_dtype, quantization = _verify_capture_runtime(request, model)
+    quantization = _verify_declared_quantization(request)
+    model, teacher_tokenizer = load(request.teacher_root)
+    inference_dtype, floating_parameter_dtypes = _verify_capture_runtime_dtype(
+        request,
+        model,
+        quantization=quantization,
+    )
+    tokenizer = load_tokenizer(request.tokenizer_root)
     verify_tokenizer_fingerprint(
         request.plan,
         tokenizer_root=request.tokenizer_root,
@@ -379,8 +398,16 @@ def _capture_examples_with_mlx(
     finally:
         del model
         del tokenizer
+        del teacher_tokenizer
         mx.clear_cache()
-    return tuple(captures), mlx_version, mlx_lm_version, inference_dtype, quantization
+    return (
+        tuple(captures),
+        mlx_version,
+        mlx_lm_version,
+        inference_dtype,
+        floating_parameter_dtypes,
+        quantization,
+    )
 
 
 def _package_version(distribution: str, module: object) -> str:
@@ -399,12 +426,17 @@ def _run_worker(request_path: Path) -> None:
     worker_root = request_path.parent
     try:
         verify_teacher_fingerprint(request.plan, teacher_root=request.teacher_root)
+        verify_tokenizer_file_fingerprint(
+            request.plan,
+            tokenizer_root=request.tokenizer_root,
+        )
         examples = _load_bound_examples(request)
         (
             captures,
             mlx_version,
             mlx_lm_version,
             inference_dtype,
+            floating_parameter_dtypes,
             quantization,
         ) = _capture_examples_with_mlx(request, examples)
         manifest = CaptureShardPublisher(
@@ -427,6 +459,7 @@ def _run_worker(request_path: Path) -> None:
             mlx_version=mlx_version,
             mlx_lm_version=mlx_lm_version,
             inference_dtype=inference_dtype,
+            floating_parameter_dtypes=floating_parameter_dtypes,
             quantization=quantization,
         )
         _atomic_write(

--- a/src/soup_cli/autodistill/mlx_worker.py
+++ b/src/soup_cli/autodistill/mlx_worker.py
@@ -1,0 +1,490 @@
+"""Spawn-isolated MLX teacher capture for AutoDistill Milestone B1.
+
+The controller and its request/receipt schemas are import-light.  MLX and
+MLX-LM are imported only inside the child worker after immutable local inputs
+have been verified.  The request intentionally has no student model field.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from soup_cli.autodistill.capture import build_teacher_expert_capture_token
+from soup_cli.autodistill.contract import (
+    AutoDistillPlan,
+    CaptureToken,
+    ShardManifest,
+    canonical_json_bytes,
+    canonical_sha256,
+)
+from soup_cli.autodistill.fingerprints import (
+    verified_dataset_bytes,
+    verify_teacher_fingerprint,
+    verify_tokenizer_fingerprint,
+)
+from soup_cli.autodistill.publisher import CaptureShardPublisher
+
+MLX_TEACHER_REQUEST_SCHEMA = "soup.autodistill.mlx-teacher-request.v1"
+MLX_TEACHER_WORKER_RECEIPT_SCHEMA = "soup.autodistill.mlx-teacher-worker-receipt.v1"
+MLX_TEACHER_RESULT_SCHEMA = "soup.autodistill.mlx-teacher-result.v1"
+TOKENIZED_TEACHER_EXAMPLE_SCHEMA = "soup.autodistill.tokenized-teacher-example.v1"
+_REQUEST_NAME = "request.json"
+_WORKER_RECEIPT_NAME = "worker-receipt.json"
+_RESULT_NAME = "result.json"
+_ERROR_NAME = "error.json"
+_MAX_CONTROL_BYTES = 8 * 1024 * 1024
+_MAX_CAPTURE_ROWS = 1_000_000
+_ARTIFACT_ID_PATTERN = r"^[A-Za-z0-9][-A-Za-z0-9_.:]{0,127}$"
+_SHA256_PATTERN = r"^[0-9a-f]{64}$"
+
+
+class _FrozenModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, populate_by_name=True)
+
+
+class TokenizedTeacherExample(_FrozenModel):
+    """Bound JSONL row interpreted by the B1 MLX capture worker."""
+
+    schema_id: Literal["soup.autodistill.tokenized-teacher-example.v1"] = Field(
+        alias="schema"
+    )
+    example_id: str = Field(min_length=1, max_length=128, pattern=r"^[A-Za-z0-9_.:-]+$")
+    prompt_token_ids: tuple[int, ...] = Field(min_length=1)
+    target_token_ids: tuple[int, ...] = Field(min_length=1)
+
+    @field_validator("prompt_token_ids", "target_token_ids", mode="before")
+    @classmethod
+    def _token_ids_are_integers(cls, value: object, info) -> object:
+        if isinstance(value, (str, bytes)) or not isinstance(value, (list, tuple)):
+            raise TypeError(f"{info.field_name} must be a token-id sequence")
+        if any(
+            isinstance(token_id, bool)
+            or not isinstance(token_id, int)
+            or token_id < 0
+            for token_id in value
+        ):
+            raise ValueError(f"{info.field_name} must contain non-negative integers")
+        return value
+
+
+class MlxTeacherCaptureRequest(_FrozenModel):
+    schema_id: Literal["soup.autodistill.mlx-teacher-request.v1"] = Field(alias="schema")
+    plan: AutoDistillPlan
+    teacher_root: str = Field(min_length=1)
+    tokenizer_root: str = Field(min_length=1)
+    dataset_root: str = Field(min_length=1)
+    publication_root: str = Field(min_length=1)
+    shard_id: str = Field(pattern=_ARTIFACT_ID_PATTERN)
+    transaction_id: str = Field(pattern=_ARTIFACT_ID_PATTERN)
+    example_start: int = Field(ge=0)
+    example_end: int | None = Field(default=None, gt=0)
+
+    @field_validator("example_start", "example_end", mode="before")
+    @classmethod
+    def _example_bounds_not_bool(cls, value: object, info) -> object:
+        if isinstance(value, bool):
+            raise TypeError(f"{info.field_name} must be an integer, not bool")
+        return value
+
+    @model_validator(mode="after")
+    def _mlx_only(self) -> MlxTeacherCaptureRequest:
+        if self.plan.capture.backend != "mlx":
+            raise ValueError("MLX teacher worker requires capture.backend=mlx")
+        if os.path.realpath(self.teacher_root) != os.path.realpath(self.tokenizer_root):
+            raise ValueError("MLX B1 requires tokenizer_root to equal teacher_root")
+        if self.example_end is not None and self.example_end <= self.example_start:
+            raise ValueError("example_end must be greater than example_start")
+        return self
+
+
+class MlxTeacherWorkerReceipt(_FrozenModel):
+    schema_id: Literal["soup.autodistill.mlx-teacher-worker-receipt.v1"] = Field(
+        alias="schema"
+    )
+    worker_pid: int = Field(gt=0)
+    student_loaded: Literal[False]
+    plan_sha256: str = Field(pattern=_SHA256_PATTERN)
+    teacher_fingerprint_sha256: str = Field(pattern=_SHA256_PATTERN)
+    tokenizer_fingerprint_sha256: str = Field(pattern=_SHA256_PATTERN)
+    dataset_fingerprint_sha256: str = Field(pattern=_SHA256_PATTERN)
+    available_manifest_sha256: str = Field(pattern=_SHA256_PATTERN)
+    row_count: int = Field(gt=0)
+    token_count: int = Field(gt=0)
+    mlx_version: str = Field(min_length=1, max_length=128)
+    mlx_lm_version: str = Field(min_length=1, max_length=128)
+
+
+class MlxTeacherCaptureResult(_FrozenModel):
+    schema_id: Literal["soup.autodistill.mlx-teacher-result.v1"] = Field(alias="schema")
+    worker_pid: int = Field(gt=0)
+    worker_exit_code: Literal[0]
+    worker_exit_confirmed: Literal[True]
+    student_loaded: Literal[False]
+    worker_receipt_sha256: str = Field(pattern=_SHA256_PATTERN)
+    available_manifest_sha256: str = Field(pattern=_SHA256_PATTERN)
+    row_count: int = Field(gt=0)
+    token_count: int = Field(gt=0)
+
+
+def _contained_path(root: Path, name: str) -> Path:
+    if not name or name != os.path.basename(name) or "\x00" in name:
+        raise ValueError("worker artifact name must be a portable basename")
+    root_real = os.path.realpath(root)
+    candidate = os.path.abspath(os.path.join(root_real, name))
+    candidate_real = os.path.realpath(candidate)
+    try:
+        contained = os.path.commonpath((root_real, candidate_real)) == root_real
+    except ValueError as exc:
+        raise ValueError("worker artifact escapes its root") from exc
+    if not contained:
+        raise ValueError("worker artifact escapes its root")
+    path = Path(candidate)
+    if path.is_symlink():
+        raise ValueError("worker artifact must not be a symlink")
+    return path
+
+
+def _atomic_write(path: Path, payload: bytes, *, overwrite_identical: bool = False) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        if overwrite_identical and path.read_bytes() == payload:
+            return
+        raise FileExistsError(f"refusing to overwrite worker artifact {path.name!r}")
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if path.exists():
+            raise FileExistsError(f"worker artifact appeared during write: {path.name!r}")
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def _read_control(path: Path, model_type: type[_FrozenModel]) -> _FrozenModel:
+    if path.is_symlink() or not path.is_file():
+        raise ValueError(f"worker artifact {path.name!r} is unavailable")
+    if path.stat().st_size <= 0 or path.stat().st_size > _MAX_CONTROL_BYTES:
+        raise ValueError(f"worker artifact {path.name!r} has an invalid size")
+    payload = path.read_bytes()
+    model = model_type.model_validate_json(payload)
+    if payload != canonical_json_bytes(model) + b"\n":
+        raise ValueError(f"worker artifact {path.name!r} is not canonical")
+    return model
+
+
+def _load_bound_examples(request: MlxTeacherCaptureRequest) -> tuple[TokenizedTeacherExample, ...]:
+    payload = verified_dataset_bytes(request.plan, dataset_root=request.dataset_root)
+    examples = tuple(
+        TokenizedTeacherExample.model_validate(json.loads(line))
+        for line in payload.splitlines()
+    )
+    if not examples:
+        raise ValueError("teacher capture dataset must not be empty")
+    identifiers = [example.example_id for example in examples]
+    if len(identifiers) != len(set(identifiers)):
+        raise ValueError("teacher capture example_id values must be unique")
+    token_count = sum(len(example.target_token_ids) for example in examples)
+    if token_count != request.plan.capture.planned_token_count:
+        raise ValueError("dataset target-token count does not match the plan")
+    end = len(examples) if request.example_end is None else request.example_end
+    if request.example_start >= len(examples) or end > len(examples):
+        raise ValueError("requested example range is outside the bound dataset")
+    selected = examples[request.example_start:end]
+    selected_token_count = sum(len(example.target_token_ids) for example in selected)
+    if selected_token_count > _MAX_CAPTURE_ROWS:
+        raise ValueError("teacher capture exceeds the B1 row safety cap")
+    vocab_size = request.plan.capture.vocab_size
+    for example in examples:
+        all_ids = (*example.prompt_token_ids, *example.target_token_ids)
+        if any(token_id >= vocab_size for token_id in all_ids):
+            raise ValueError("teacher capture dataset contains an id outside the vocabulary")
+    return selected
+
+
+def _context_for_position(
+    example: TokenizedTeacherExample,
+    position: int,
+    request: MlxTeacherCaptureRequest,
+) -> tuple[int, ...]:
+    context = example.prompt_token_ids + example.target_token_ids[:position]
+    maximum = request.plan.capture.max_sequence_length
+    if len(context) <= maximum:
+        return context
+    truncation = request.plan.capture.truncation
+    if truncation == "none":
+        raise ValueError("teacher context exceeds max_sequence_length")
+    if truncation == "left":
+        return context[-maximum:]
+    return context[:maximum]
+
+
+def _logit_row(output: object, *, context_length: int, row_index: int, vocab_size: int):
+    logits = getattr(output, "logits", output)
+    shape = getattr(logits, "shape", None)
+    if shape is None or len(shape) != 3:
+        raise ValueError("MLX teacher must return rank-3 causal logits")
+    if shape[0] != 1 or shape[1] != context_length or shape[2] != vocab_size:
+        raise ValueError("MLX teacher logits shape does not match the capture input")
+    return logits[0, row_index, :]
+
+
+def _capture_examples_with_mlx(
+    request: MlxTeacherCaptureRequest,
+    examples: tuple[TokenizedTeacherExample, ...],
+) -> tuple[tuple[CaptureToken, ...], str, str]:
+    import mlx
+    import mlx.core as mx
+    import mlx_lm
+    from mlx_lm import load
+
+    mlx_version = _package_version("mlx", mlx)
+    mlx_lm_version = _package_version("mlx-lm", mlx_lm)
+    if mlx_lm_version != request.plan.capture.backend_version:
+        raise ValueError("installed MLX-LM version does not match capture.backend_version")
+    model, tokenizer = load(request.teacher_root)
+    verify_tokenizer_fingerprint(
+        request.plan,
+        tokenizer_root=request.tokenizer_root,
+        chat_template=getattr(tokenizer, "chat_template", "") or "",
+        renderer=f"mlx-lm@{mlx_lm_version}",
+    )
+    captures: list[CaptureToken] = []
+    try:
+        for example in examples:
+            final_context = example.prompt_token_ids + example.target_token_ids[:-1]
+            can_use_one_forward = len(final_context) <= request.plan.capture.max_sequence_length
+            if can_use_one_forward:
+                inputs = mx.array([final_context])
+                output = model(inputs)
+                for position, target in enumerate(example.target_token_ids):
+                    context = _context_for_position(example, position, request)
+                    row = _logit_row(
+                        output,
+                        context_length=len(final_context),
+                        row_index=len(example.prompt_token_ids) - 1 + position,
+                        vocab_size=request.plan.capture.vocab_size,
+                    )
+                    row = mx.astype(row, mx.float32)
+                    mx.eval(row)
+                    captures.append(
+                        build_teacher_expert_capture_token(
+                            example_id=example.example_id,
+                            position=position,
+                            context_token_ids=context,
+                            target_token_id=target,
+                            teacher_logits=row.tolist(),
+                            vocab_size=request.plan.capture.vocab_size,
+                            probability_policy=request.plan.probability_policy,
+                        )
+                    )
+            else:
+                for position, target in enumerate(example.target_token_ids):
+                    context = _context_for_position(example, position, request)
+                    inputs = mx.array([context])
+                    output = model(inputs)
+                    row = _logit_row(
+                        output,
+                        context_length=len(context),
+                        row_index=-1,
+                        vocab_size=request.plan.capture.vocab_size,
+                    )
+                    row = mx.astype(row, mx.float32)
+                    mx.eval(row)
+                    captures.append(
+                        build_teacher_expert_capture_token(
+                            example_id=example.example_id,
+                            position=position,
+                            context_token_ids=context,
+                            target_token_id=target,
+                            teacher_logits=row.tolist(),
+                            vocab_size=request.plan.capture.vocab_size,
+                            probability_policy=request.plan.probability_policy,
+                        )
+                    )
+    finally:
+        del model
+        del tokenizer
+        mx.clear_cache()
+    return tuple(captures), mlx_version, mlx_lm_version
+
+
+def _package_version(distribution: str, module: object) -> str:
+    try:
+        return version(distribution)
+    except PackageNotFoundError:
+        value = getattr(module, "__version__", None)
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"cannot determine {distribution} version") from None
+        return value
+
+
+def _run_worker(request_path: Path) -> None:
+    request = _read_control(request_path, MlxTeacherCaptureRequest)
+    assert isinstance(request, MlxTeacherCaptureRequest)
+    worker_root = request_path.parent
+    try:
+        verify_teacher_fingerprint(request.plan, teacher_root=request.teacher_root)
+        examples = _load_bound_examples(request)
+        captures, mlx_version, mlx_lm_version = _capture_examples_with_mlx(
+            request,
+            examples,
+        )
+        manifest = CaptureShardPublisher(
+            root=request.publication_root,
+            plan=request.plan,
+            shard_id=request.shard_id,
+            transaction_id=request.transaction_id,
+        ).publish(captures)
+        receipt = MlxTeacherWorkerReceipt(
+            schema=MLX_TEACHER_WORKER_RECEIPT_SCHEMA,
+            worker_pid=os.getpid(),
+            student_loaded=False,
+            plan_sha256=canonical_sha256(request.plan),
+            teacher_fingerprint_sha256=canonical_sha256(request.plan.teacher),
+            tokenizer_fingerprint_sha256=canonical_sha256(request.plan.tokenizer),
+            dataset_fingerprint_sha256=canonical_sha256(request.plan.dataset),
+            available_manifest_sha256=canonical_sha256(manifest),
+            row_count=manifest.row_count,
+            token_count=manifest.token_count,
+            mlx_version=mlx_version,
+            mlx_lm_version=mlx_lm_version,
+        )
+        _atomic_write(
+            _contained_path(worker_root, _WORKER_RECEIPT_NAME),
+            canonical_json_bytes(receipt) + b"\n",
+        )
+    except Exception as exc:
+        error = {
+            "error_type": type(exc).__name__,
+            "message": str(exc).replace("\x00", "")[:4096],
+        }
+        try:
+            _atomic_write(
+                _contained_path(worker_root, _ERROR_NAME),
+                canonical_json_bytes(error) + b"\n",
+            )
+        except Exception:
+            pass
+        raise
+
+
+def run_mlx_teacher_capture_process(
+    *,
+    plan: AutoDistillPlan,
+    teacher_root: str | os.PathLike[str],
+    tokenizer_root: str | os.PathLike[str],
+    dataset_root: str | os.PathLike[str],
+    publication_root: str | os.PathLike[str],
+    shard_id: str,
+    transaction_id: str,
+    example_start: int = 0,
+    example_end: int | None = None,
+    python_executable: str | os.PathLike[str] = sys.executable,
+    timeout_seconds: float = 3600.0,
+) -> MlxTeacherCaptureResult:
+    """Run capture in a fresh child and commit the result only after child exit."""
+
+    if isinstance(timeout_seconds, bool) or not isinstance(timeout_seconds, (int, float)):
+        raise TypeError("timeout_seconds must be a finite positive number")
+    if not 0.0 < float(timeout_seconds) <= 86_400.0:
+        raise ValueError("timeout_seconds must be in (0, 86400]")
+    publication = Path(os.path.realpath(publication_root))
+    request = MlxTeacherCaptureRequest(
+        schema=MLX_TEACHER_REQUEST_SCHEMA,
+        plan=plan,
+        teacher_root=os.path.realpath(teacher_root),
+        tokenizer_root=os.path.realpath(tokenizer_root),
+        dataset_root=os.path.realpath(dataset_root),
+        publication_root=os.path.realpath(publication),
+        shard_id=shard_id,
+        transaction_id=transaction_id,
+        example_start=example_start,
+        example_end=example_end,
+    )
+    worker_root = publication / ".workers" / transaction_id
+    if worker_root.exists():
+        raise FileExistsError("worker transaction already exists")
+    worker_root.mkdir(parents=True)
+    request_path = _contained_path(worker_root, _REQUEST_NAME)
+    _atomic_write(request_path, canonical_json_bytes(request) + b"\n")
+    command = [os.fspath(python_executable), "-m", __name__, "--request", os.fspath(request_path)]
+    process = subprocess.Popen(
+        command,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        process.wait(timeout=float(timeout_seconds))
+    except subprocess.TimeoutExpired as exc:
+        process.kill()
+        process.wait()
+        raise TimeoutError("MLX teacher worker exceeded timeout and was killed") from exc
+    if process.returncode != 0:
+        error_path = _contained_path(worker_root, _ERROR_NAME)
+        detail = ""
+        if error_path.is_file() and error_path.stat().st_size <= _MAX_CONTROL_BYTES:
+            detail = error_path.read_text(encoding="utf-8").strip()
+        raise RuntimeError(
+            f"MLX teacher worker exited with {process.returncode}: {detail[:4096]}"
+        )
+    receipt = _read_control(
+        _contained_path(worker_root, _WORKER_RECEIPT_NAME),
+        MlxTeacherWorkerReceipt,
+    )
+    assert isinstance(receipt, MlxTeacherWorkerReceipt)
+    if receipt.worker_pid != process.pid:
+        raise ValueError("worker receipt PID does not match the exited child")
+    manifest_path = publication / "shards" / shard_id / "manifest.available.json"
+    manifest = ShardManifest.model_validate_json(manifest_path.read_bytes())
+    if canonical_sha256(manifest) != receipt.available_manifest_sha256:
+        raise ValueError("worker receipt does not match the available shard")
+    receipt_bytes = canonical_json_bytes(receipt) + b"\n"
+    result = MlxTeacherCaptureResult(
+        schema=MLX_TEACHER_RESULT_SCHEMA,
+        worker_pid=process.pid,
+        worker_exit_code=0,
+        worker_exit_confirmed=True,
+        student_loaded=False,
+        worker_receipt_sha256=hashlib.sha256(receipt_bytes).hexdigest(),
+        available_manifest_sha256=receipt.available_manifest_sha256,
+        row_count=receipt.row_count,
+        token_count=receipt.token_count,
+    )
+    _atomic_write(
+        _contained_path(worker_root, _RESULT_NAME),
+        canonical_json_bytes(result) + b"\n",
+    )
+    return result
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--request", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = _parse_args(argv)
+    _run_worker(Path(arguments.request))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/soup_cli/autodistill/publisher.py
+++ b/src/soup_cli/autodistill/publisher.py
@@ -1,0 +1,364 @@
+"""Transactional publication of immutable AutoDistill capture shards."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Literal
+
+from soup_cli.autodistill.contract import (
+    ArtifactCorruptionError,
+    AutoDistillPlan,
+    CaptureToken,
+    PayloadDigest,
+    ShardManifest,
+    canonical_json_bytes,
+    canonical_sha256,
+    canonicalize_jsonl_bytes,
+    decide_resume,
+    ensure_shard_transition,
+    verify_payload_bytes,
+)
+
+PublicationState = Literal["staging", "complete", "verified", "available"]
+_STATES: tuple[PublicationState, ...] = ("staging", "complete", "verified", "available")
+_PAYLOAD_NAME = "capture.jsonl"
+
+
+def _contained_path(root: Path, *parts: str) -> Path:
+    root_real = os.path.realpath(root)
+    candidate = os.path.abspath(os.path.join(root_real, *parts))
+    candidate_real = os.path.realpath(candidate)
+    try:
+        contained = os.path.commonpath((root_real, candidate_real)) == root_real
+    except ValueError as exc:
+        raise ValueError("artifact path is outside the publication root") from exc
+    if not contained:
+        raise ValueError("artifact path is outside the publication root")
+    return Path(candidate)
+
+
+def _sync_directory(path: Path) -> None:
+    if os.name == "nt":
+        return
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _atomic_write(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_symlink():
+        raise ArtifactCorruptionError(f"refusing to replace symlink {path.name!r}")
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+        _sync_directory(path.parent)
+    finally:
+        if temporary_path.exists():
+            temporary_path.unlink()
+
+
+def _manifest_name(state: PublicationState) -> str:
+    return f"manifest.{state}.json"
+
+
+class CaptureShardPublisher:
+    """Advance one capture shard through a write-last manifest transaction."""
+
+    def __init__(
+        self,
+        *,
+        root: str | os.PathLike[str],
+        plan: AutoDistillPlan,
+        shard_id: str,
+        transaction_id: str,
+    ) -> None:
+        self.root = Path(os.path.realpath(root))
+        self.plan = plan
+        self.shard_id = shard_id
+        self.transaction_id = transaction_id
+        self.transaction_dir = _contained_path(self.root, ".transactions", transaction_id)
+        self.available_dir = _contained_path(self.root, "shards", shard_id)
+        self.quarantine_root = _contained_path(self.root, "quarantine")
+
+    def publish(
+        self,
+        captures: Sequence[CaptureToken],
+        *,
+        stop_after: PublicationState | None = None,
+    ) -> ShardManifest:
+        """Resume or publish exactly one immutable shard.
+
+        ``stop_after`` is an explicit interruption hook for tests and controllers;
+        every returned state is already committed by an atomic manifest.
+        """
+
+        if stop_after is not None and stop_after not in _STATES:
+            raise ValueError("unknown stop_after state")
+        payload = self._capture_payload(captures)
+        directory, manifest = self._inspect_existing()
+        if manifest is not None:
+            if not self._integrity_matches(directory, manifest, payload):
+                self._quarantine(directory, manifest)
+                raise ArtifactCorruptionError("existing transaction is corrupt or mismatched")
+            decision = decide_resume(
+                state=manifest.state,
+                payloads_valid=True,
+                fingerprints_match=True,
+            )
+            if decision == "reuse":
+                return manifest
+        else:
+            manifest = self._stage(payload, len(captures))
+            directory = self.transaction_dir
+        if stop_after == manifest.state:
+            return manifest
+
+        if manifest.state == "staging":
+            manifest = self._commit_state(directory, manifest, "complete")
+            if stop_after == "complete":
+                return manifest
+        if manifest.state == "complete":
+            self._verify_semantics(directory, manifest)
+            manifest = self._commit_state(directory, manifest, "verified")
+            if stop_after == "verified":
+                return manifest
+        if manifest.state == "verified":
+            manifest = self._make_available(directory, manifest)
+        return manifest
+
+    def _capture_payload(self, captures: Sequence[CaptureToken]) -> bytes:
+        rows = tuple(captures)
+        if not rows:
+            raise ValueError("a capture shard must contain at least one token row")
+        closed_examples: set[str] = set()
+        current_example: str | None = None
+        expected_position = 0
+        for row in rows:
+            if not isinstance(row, CaptureToken):
+                raise TypeError("captures must contain CaptureToken instances")
+            if row.trajectory_kind != "teacher_expert":
+                raise ValueError("Milestone B1 publishes teacher_expert rows only")
+            if row.vocab_size != self.plan.capture.vocab_size:
+                raise ValueError("capture vocabulary does not match plan")
+            if row.temperature != self.plan.probability_policy.temperature:
+                raise ValueError("capture temperature does not match plan")
+            if len(row.top_k_token_ids) != self.plan.probability_policy.top_k:
+                raise ValueError("capture top-k cardinality does not match plan")
+            if len(row.context_token_ids) > self.plan.capture.max_sequence_length:
+                raise ValueError("capture context exceeds plan max_sequence_length")
+            if row.example_id != current_example:
+                if row.example_id in closed_examples:
+                    raise ValueError("capture examples must form contiguous groups")
+                if current_example is not None:
+                    closed_examples.add(current_example)
+                current_example = row.example_id
+                expected_position = 0
+            if row.position != expected_position:
+                raise ValueError("capture positions must be contiguous and start at zero")
+            expected_position += 1
+        return b"".join(canonical_json_bytes(row) + b"\n" for row in rows)
+
+    def _stage(self, payload: bytes, row_count: int) -> ShardManifest:
+        if self.transaction_dir.exists() or self.available_dir.exists():
+            raise ArtifactCorruptionError("transaction target appeared while staging")
+        self.root.mkdir(parents=True, exist_ok=True)
+        plan_path = _contained_path(self.root, "plan.json")
+        plan_bytes = canonical_json_bytes(self.plan) + b"\n"
+        if plan_path.exists():
+            if plan_path.is_symlink() or plan_path.read_bytes() != plan_bytes:
+                raise ArtifactCorruptionError("publication root is bound to a different plan")
+        else:
+            _atomic_write(plan_path, plan_bytes)
+        self.transaction_dir.mkdir(parents=True)
+        payload_path = _contained_path(self.transaction_dir, _PAYLOAD_NAME)
+        _atomic_write(payload_path, payload)
+        payload_digest = PayloadDigest(
+            path=_PAYLOAD_NAME,
+            bytes=len(payload),
+            sha256=hashlib.sha256(payload).hexdigest(),
+            rows=row_count,
+            tokens=row_count,
+        )
+        manifest = ShardManifest(
+            schema="soup.autodistill.shard-manifest.v1",
+            shard_id=self.shard_id,
+            transaction_id=self.transaction_id,
+            state="staging",
+            plan_sha256=canonical_sha256(self.plan),
+            previous_manifest_sha256=None,
+            row_count=row_count,
+            token_count=row_count,
+            payloads=(payload_digest,),
+        )
+        self._write_manifest(self.transaction_dir, manifest)
+        return manifest
+
+    def _commit_state(
+        self,
+        directory: Path,
+        previous: ShardManifest,
+        state: Literal["complete", "verified"],
+    ) -> ShardManifest:
+        ensure_shard_transition(previous.state, state)
+        manifest = previous.model_copy(
+            update={
+                "state": state,
+                "previous_manifest_sha256": canonical_sha256(previous),
+            }
+        )
+        manifest = ShardManifest.model_validate(manifest.model_dump(by_alias=True))
+        self._write_manifest(directory, manifest)
+        return manifest
+
+    def _make_available(self, directory: Path, previous: ShardManifest) -> ShardManifest:
+        ensure_shard_transition(previous.state, "available")
+        self.available_dir.parent.mkdir(parents=True, exist_ok=True)
+        if directory == self.transaction_dir:
+            if self.available_dir.exists():
+                raise ArtifactCorruptionError("available shard path already exists")
+            os.replace(directory, self.available_dir)
+            _sync_directory(self.available_dir.parent)
+            directory = self.available_dir
+        elif directory != self.available_dir:
+            raise ArtifactCorruptionError("transaction is outside known publication paths")
+        manifest = previous.model_copy(
+            update={
+                "state": "available",
+                "previous_manifest_sha256": canonical_sha256(previous),
+            }
+        )
+        manifest = ShardManifest.model_validate(manifest.model_dump(by_alias=True))
+        self._write_manifest(directory, manifest)
+        return manifest
+
+    def _inspect_existing(self) -> tuple[Path, ShardManifest | None]:
+        directories = [path for path in (self.available_dir, self.transaction_dir) if path.exists()]
+        if len(directories) > 1:
+            raise ArtifactCorruptionError("duplicate transaction and available shard directories")
+        if not directories:
+            return self.transaction_dir, None
+        directory = directories[0]
+        if directory.is_symlink():
+            raise ArtifactCorruptionError("transaction directory must not be a symlink")
+        found: list[tuple[PublicationState, ShardManifest]] = []
+        for state in _STATES:
+            path = _contained_path(directory, _manifest_name(state))
+            if path.exists():
+                found.append((state, self._read_manifest(path)))
+        if not found:
+            raise ArtifactCorruptionError("transaction has no committed manifest")
+        self._verify_manifest_chain(found)
+        return directory, found[-1][1]
+
+    def _verify_manifest_chain(
+        self,
+        found: Sequence[tuple[PublicationState, ShardManifest]],
+    ) -> None:
+        expected_states = list(_STATES[: len(found)])
+        if [state for state, _ in found] != expected_states:
+            raise ArtifactCorruptionError("transaction manifest states are not contiguous")
+        previous: ShardManifest | None = None
+        for state, manifest in found:
+            if manifest.state != state:
+                raise ArtifactCorruptionError("manifest filename and state disagree")
+            if manifest.shard_id != self.shard_id or manifest.transaction_id != self.transaction_id:
+                raise ArtifactCorruptionError("manifest identity does not match publisher")
+            expected_previous = None if previous is None else canonical_sha256(previous)
+            if manifest.previous_manifest_sha256 != expected_previous:
+                raise ArtifactCorruptionError("manifest hash chain is broken")
+            if previous is not None and manifest.payloads != previous.payloads:
+                raise ArtifactCorruptionError("manifest transition changed payload commitments")
+            previous = manifest
+
+    def _integrity_matches(
+        self,
+        directory: Path,
+        manifest: ShardManifest,
+        expected_payload: bytes,
+    ) -> bool:
+        try:
+            if manifest.plan_sha256 != canonical_sha256(self.plan):
+                return False
+            plan_path = _contained_path(self.root, "plan.json")
+            if plan_path.is_symlink():
+                return False
+            if plan_path.read_bytes() != canonical_json_bytes(self.plan) + b"\n":
+                return False
+            payload_path = _contained_path(directory, _PAYLOAD_NAME)
+            if payload_path.is_symlink():
+                return False
+            payload = payload_path.read_bytes()
+            verify_payload_bytes(manifest, {_PAYLOAD_NAME: payload})
+            if payload != expected_payload:
+                return False
+            self._verify_semantics(directory, manifest)
+        except (OSError, TypeError, ValueError):
+            return False
+        return True
+
+    def _verify_semantics(self, directory: Path, manifest: ShardManifest) -> None:
+        payload = _contained_path(directory, _PAYLOAD_NAME).read_bytes()
+        if canonicalize_jsonl_bytes(payload) != payload:
+            raise ArtifactCorruptionError("capture payload is not canonical JSONL")
+        rows = tuple(
+            CaptureToken.model_validate(json.loads(line))
+            for line in payload.splitlines()
+        )
+        rebuilt = self._capture_payload(rows)
+        if rebuilt != payload:
+            raise ArtifactCorruptionError("capture payload semantic verification failed")
+        if len(rows) != manifest.row_count or len(rows) != manifest.token_count:
+            raise ArtifactCorruptionError("capture logical counts do not match manifest")
+        verify_payload_bytes(manifest, {_PAYLOAD_NAME: payload})
+
+    def _write_manifest(self, directory: Path, manifest: ShardManifest) -> None:
+        path = _contained_path(directory, _manifest_name(manifest.state))
+        if path.exists():
+            if path.read_bytes() != canonical_json_bytes(manifest) + b"\n":
+                raise ArtifactCorruptionError("refusing to overwrite a committed manifest")
+            return
+        _atomic_write(path, canonical_json_bytes(manifest) + b"\n")
+
+    def _read_manifest(self, path: Path) -> ShardManifest:
+        if path.is_symlink():
+            raise ArtifactCorruptionError("manifest must not be a symlink")
+        data = path.read_bytes()
+        try:
+            manifest = ShardManifest.model_validate_json(data)
+        except ValueError as exc:
+            raise ArtifactCorruptionError(f"invalid manifest {path.name!r}") from exc
+        if data != canonical_json_bytes(manifest) + b"\n":
+            raise ArtifactCorruptionError("manifest bytes are not canonical")
+        return manifest
+
+    def _quarantine(self, directory: Path, previous: ShardManifest) -> None:
+        self.quarantine_root.mkdir(parents=True, exist_ok=True)
+        target = _contained_path(
+            self.quarantine_root,
+            f"{self.shard_id}.{self.transaction_id}",
+        )
+        if target.exists():
+            raise ArtifactCorruptionError("quarantine target already exists")
+        os.replace(directory, target)
+        _sync_directory(self.quarantine_root)
+        quarantined = previous.model_copy(
+            update={
+                "state": "quarantined",
+                "previous_manifest_sha256": canonical_sha256(previous),
+            }
+        )
+        quarantined = ShardManifest.model_validate(quarantined.model_dump(by_alias=True))
+        self._write_manifest(target, quarantined)

--- a/tests/test_issue580_autodistill_capture.py
+++ b/tests/test_issue580_autodistill_capture.py
@@ -1,0 +1,176 @@
+"""Model-free trajectory capture tests for AutoDistill Milestone B1."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from soup_cli.autodistill.capture import (
+    TeacherExpertExample,
+    build_teacher_expert_capture_token,
+    capture_teacher_expert_trajectory,
+)
+from soup_cli.autodistill.contract import ProbabilityPolicy
+
+
+def _policy(*, top_k: int, temperature: float = 1.0) -> ProbabilityPolicy:
+    return ProbabilityPolicy(
+        name="topk_union_forced_tail.v1",
+        top_k=top_k,
+        forced_token_sources=("target", "student_sample"),
+        token_id_bytes=4,
+        log_probability_bytes=4,
+        tail_mass_bytes=8,
+        entropy_bytes=8,
+        temperature=temperature,
+        renormalize_selected=False,
+    )
+
+
+def _dense_log_softmax(logits: tuple[float, ...], temperature: float = 1.0) -> tuple[float, ...]:
+    scaled = tuple(value / temperature for value in logits)
+    maximum = max(scaled)
+    denominator = math.fsum(math.exp(value - maximum) for value in scaled)
+    normalizer = maximum + math.log(denominator)
+    return tuple(value - normalizer for value in scaled)
+
+
+def test_sparse_capture_forces_target_without_renormalizing_top_k():
+    logits = (4.0, 3.0, 2.0, -4.0)
+    token = build_teacher_expert_capture_token(
+        example_id="example-1",
+        position=0,
+        context_token_ids=(1,),
+        target_token_id=3,
+        teacher_logits=logits,
+        vocab_size=4,
+        probability_policy=_policy(top_k=2),
+    )
+    dense = _dense_log_softmax(logits)
+
+    assert token.top_k_token_ids == (0, 1)
+    assert token.forced_token_ids == (3,)
+    assert token.selected_token_ids == (0, 1, 3)
+    assert token.teacher_log_probabilities == pytest.approx((dense[0], dense[1], dense[3]))
+    assert token.tail_mass == pytest.approx(math.exp(dense[2]))
+    selected_mass = math.fsum(math.exp(value) for value in token.teacher_log_probabilities)
+    assert selected_mass + token.tail_mass == pytest.approx(1.0)
+
+
+def test_top_k_ties_are_broken_by_token_id_before_canonical_sorting():
+    token = build_teacher_expert_capture_token(
+        example_id="example-1",
+        position=0,
+        context_token_ids=(),
+        target_token_id=3,
+        teacher_logits=(2.0, 2.0, 2.0, 0.0),
+        vocab_size=4,
+        probability_policy=_policy(top_k=2),
+    )
+
+    assert token.top_k_token_ids == (0, 1)
+
+
+def test_dense_capture_matches_full_distribution_and_has_no_tail():
+    logits = (1.0, -2.0, 0.5)
+    token = build_teacher_expert_capture_token(
+        example_id="example-1",
+        position=0,
+        context_token_ids=(0,),
+        target_token_id=2,
+        teacher_logits=logits,
+        vocab_size=3,
+        probability_policy=_policy(top_k=3, temperature=0.5),
+    )
+
+    assert token.selected_token_ids == (0, 1, 2)
+    assert token.teacher_log_probabilities == pytest.approx(_dense_log_softmax(logits, 0.5))
+    assert token.tail_mass == 0.0
+
+
+def test_full_target_trajectory_records_each_autoregressive_context():
+    example = TeacherExpertExample(
+        example_id="example-1",
+        prompt_token_ids=(0, 1),
+        target_token_ids=(2, 3, 4),
+    )
+    rows = capture_teacher_expert_trajectory(
+        example=example,
+        teacher_logits_by_position=(
+            (0.0, 0.0, 3.0, 0.0, 0.0),
+            (0.0, 0.0, 0.0, 3.0, 0.0),
+            (0.0, 0.0, 0.0, 0.0, 3.0),
+        ),
+        vocab_size=5,
+        probability_policy=_policy(top_k=2),
+        max_sequence_length=8,
+        truncation="none",
+    )
+
+    assert [row.position for row in rows] == [0, 1, 2]
+    assert [row.context_token_ids for row in rows] == [(0, 1), (0, 1, 2), (0, 1, 2, 3)]
+    assert [row.target_token_id for row in rows] == [2, 3, 4]
+
+
+def test_trajectory_applies_declared_left_truncation_to_recorded_context():
+    rows = capture_teacher_expert_trajectory(
+        example=TeacherExpertExample(
+            example_id="example-1",
+            prompt_token_ids=(0, 1, 2),
+            target_token_ids=(3, 4),
+        ),
+        teacher_logits_by_position=((0.0,) * 5, (0.0,) * 5),
+        vocab_size=5,
+        probability_policy=_policy(top_k=1),
+        max_sequence_length=2,
+        truncation="left",
+    )
+
+    assert [row.context_token_ids for row in rows] == [(1, 2), (2, 3)]
+
+
+@pytest.mark.parametrize(
+    ("logits", "match"),
+    [
+        ((0.0, 1.0), "length must equal"),
+        ((0.0, math.inf, 1.0), "finite numbers"),
+    ],
+)
+def test_capture_rejects_invalid_teacher_logits(logits: tuple[float, ...], match: str):
+    with pytest.raises(ValueError, match=match):
+        build_teacher_expert_capture_token(
+            example_id="example-1",
+            position=0,
+            context_token_ids=(),
+            target_token_id=1,
+            teacher_logits=logits,
+            vocab_size=3,
+            probability_policy=_policy(top_k=1),
+        )
+
+
+def test_trajectory_rejects_missing_positions_and_undeclared_truncation():
+    example = TeacherExpertExample(
+        example_id="example-1",
+        prompt_token_ids=(0, 1),
+        target_token_ids=(2, 1),
+    )
+    with pytest.raises(ValueError, match="one teacher logit vector"):
+        capture_teacher_expert_trajectory(
+            example=example,
+            teacher_logits_by_position=((0.0, 0.0, 0.0),),
+            vocab_size=3,
+            probability_policy=_policy(top_k=1),
+            max_sequence_length=8,
+            truncation="none",
+        )
+    with pytest.raises(ValueError, match="exceeds max_sequence_length"):
+        capture_teacher_expert_trajectory(
+            example=example,
+            teacher_logits_by_position=((0.0, 0.0, 0.0),) * 2,
+            vocab_size=3,
+            probability_policy=_policy(top_k=1),
+            max_sequence_length=1,
+            truncation="none",
+        )

--- a/tests/test_issue580_autodistill_fingerprints.py
+++ b/tests/test_issue580_autodistill_fingerprints.py
@@ -99,6 +99,50 @@ def test_teacher_fingerprint_fails_closed_after_one_changed_byte(tmp_path):
         verify_teacher_fingerprint(plan, teacher_root=teacher_root)
 
 
+def test_teacher_weight_hashing_uses_bounded_streaming_reads(tmp_path, monkeypatch):
+    import soup_cli.autodistill.fingerprints as fingerprints
+
+    plan, teacher_root, _, _, _ = _local_plan(tmp_path)
+    weights_path = teacher_root / "model.safetensors"
+    original_open = Path.open
+    original_read_bytes = Path.read_bytes
+    read_sizes: list[int] = []
+
+    class BoundedReader:
+        def __init__(self, handle):
+            self.handle = handle
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return self.handle.__exit__(exc_type, exc_value, traceback)
+
+        def read(self, size=-1):
+            read_sizes.append(size)
+            return self.handle.read(size)
+
+    def guarded_open(path, *args, **kwargs):
+        handle = original_open(path, *args, **kwargs)
+        if path == weights_path and args and args[0] == "rb":
+            return BoundedReader(handle)
+        return handle
+
+    def guarded_read_bytes(path):
+        if path == weights_path:
+            raise AssertionError("weight shards must not use Path.read_bytes()")
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(fingerprints, "_HASH_CHUNK_BYTES", 4)
+    monkeypatch.setattr(Path, "open", guarded_open)
+    monkeypatch.setattr(Path, "read_bytes", guarded_read_bytes)
+
+    verify_teacher_fingerprint(plan, teacher_root=teacher_root)
+
+    assert len(read_sizes) > 1
+    assert set(read_sizes) == {4}
+
+
 def test_tokenizer_requires_exact_files_template_and_renderer(tmp_path):
     plan, _, tokenizer_root, _, template = _local_plan(tmp_path)
     with pytest.raises(ArtifactCorruptionError, match="chat template"):

--- a/tests/test_issue580_autodistill_fingerprints.py
+++ b/tests/test_issue580_autodistill_fingerprints.py
@@ -1,0 +1,140 @@
+"""Teacher-only input fingerprint verification for AutoDistill Milestone B1."""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+
+from soup_cli.autodistill.contract import ArtifactCorruptionError, AutoDistillPlan
+from soup_cli.autodistill.fingerprints import (
+    verify_dataset_fingerprint,
+    verify_teacher_fingerprint,
+    verify_tokenizer_fingerprint,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "autodistill" / "v1"
+
+
+def _sha(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _local_plan(tmp_path: Path) -> tuple[AutoDistillPlan, Path, Path, Path, str]:
+    teacher_root = tmp_path / "teacher"
+    tokenizer_root = tmp_path / "tokenizer"
+    dataset_root = tmp_path / "dataset"
+    teacher_root.mkdir()
+    tokenizer_root.mkdir()
+    dataset_root.mkdir()
+    config = b'{"model_type":"fixture"}\n'
+    weights = b"teacher-weights"
+    tokenizer = b'{"version":"1.0"}\n'
+    dataset = b'{ "answer": 2, "prompt": "1+1" }\r\n'
+    normalized = b'{"answer":2,"prompt":"1+1"}\n'
+    template = "{{ messages }}"
+    (teacher_root / "config.json").write_bytes(config)
+    (teacher_root / "model.safetensors").write_bytes(weights)
+    (tokenizer_root / "tokenizer.json").write_bytes(tokenizer)
+    (dataset_root / "prompts.jsonl").write_bytes(dataset)
+
+    payload = json.loads((FIXTURES / "plan.json").read_text(encoding="utf-8"))
+    payload["teacher"]["config_sha256"] = _sha(config)
+    payload["teacher"]["weights"] = [
+        {
+            "path": "model.safetensors",
+            "bytes": len(weights),
+            "sha256": _sha(weights),
+        }
+    ]
+    payload["tokenizer"]["files"] = [
+        {
+            "path": "tokenizer.json",
+            "bytes": len(tokenizer),
+            "sha256": _sha(tokenizer),
+        }
+    ]
+    payload["tokenizer"]["chat_template_sha256"] = _sha(template.encode())
+    payload["dataset"]["source_files"] = [
+        {
+            "path": "prompts.jsonl",
+            "bytes": len(dataset),
+            "sha256": _sha(dataset),
+        }
+    ]
+    payload["dataset"]["normalized_sha256"] = _sha(normalized)
+    payload["dataset"]["rows"] = 1
+    return (
+        AutoDistillPlan.model_validate(payload),
+        teacher_root,
+        tokenizer_root,
+        dataset_root,
+        template,
+    )
+
+
+def test_capture_inputs_verify_without_accepting_or_loading_a_student(tmp_path):
+    plan, teacher_root, tokenizer_root, dataset_root, template = _local_plan(tmp_path)
+
+    verify_teacher_fingerprint(plan, teacher_root=teacher_root)
+    verify_tokenizer_fingerprint(
+        plan,
+        tokenizer_root=tokenizer_root,
+        chat_template=template,
+        renderer=plan.tokenizer.renderer,
+    )
+    verify_dataset_fingerprint(plan, dataset_root=dataset_root)
+
+    assert "student" not in inspect.signature(verify_teacher_fingerprint).parameters
+
+
+def test_teacher_fingerprint_fails_closed_after_one_changed_byte(tmp_path):
+    plan, teacher_root, _, _, _ = _local_plan(tmp_path)
+    (teacher_root / "model.safetensors").write_bytes(b"teacher-weightX")
+
+    with pytest.raises(ArtifactCorruptionError, match="sha256 mismatch"):
+        verify_teacher_fingerprint(plan, teacher_root=teacher_root)
+
+
+def test_tokenizer_requires_exact_files_template_and_renderer(tmp_path):
+    plan, _, tokenizer_root, _, template = _local_plan(tmp_path)
+    with pytest.raises(ArtifactCorruptionError, match="chat template"):
+        verify_tokenizer_fingerprint(
+            plan,
+            tokenizer_root=tokenizer_root,
+            chat_template=template + " ",
+            renderer=plan.tokenizer.renderer,
+        )
+    with pytest.raises(ArtifactCorruptionError, match="renderer"):
+        verify_tokenizer_fingerprint(
+            plan,
+            tokenizer_root=tokenizer_root,
+            chat_template=template,
+            renderer="different-runtime",
+        )
+
+
+def test_dataset_verifies_source_bytes_normalized_hash_and_rows(tmp_path):
+    plan, _, _, dataset_root, _ = _local_plan(tmp_path)
+    verify_dataset_fingerprint(plan, dataset_root=dataset_root)
+    (dataset_root / "prompts.jsonl").write_text(
+        '{"answer":3,"prompt":"1+1"}\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ArtifactCorruptionError, match="byte count mismatch|sha256 mismatch"):
+        verify_dataset_fingerprint(plan, dataset_root=dataset_root)
+
+
+def test_fingerprint_verifier_rejects_symlinked_files(tmp_path):
+    plan, teacher_root, _, _, _ = _local_plan(tmp_path)
+    weights = teacher_root / "model.safetensors"
+    real_weights = teacher_root / "real-weights"
+    weights.rename(real_weights)
+    weights.symlink_to(real_weights)
+
+    with pytest.raises(ArtifactCorruptionError, match="is missing"):
+        verify_teacher_fingerprint(plan, teacher_root=teacher_root)

--- a/tests/test_issue580_autodistill_mlx_worker.py
+++ b/tests/test_issue580_autodistill_mlx_worker.py
@@ -18,6 +18,7 @@ from soup_cli.autodistill.contract import (
     CaptureToken,
     ShardManifest,
     build_plan_estimate,
+    canonical_json_bytes,
     canonicalize_jsonl_bytes,
 )
 from soup_cli.autodistill.mlx_worker import (
@@ -33,7 +34,12 @@ def _sha(payload: bytes) -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
-def _write_fake_mlx_runtime(root: Path, *, mlx_lm_version: str = _MLX_VERSION) -> Path:
+def _write_fake_mlx_runtime(
+    root: Path,
+    *,
+    mlx_lm_version: str = _MLX_VERSION,
+    parameter_dtypes: tuple[str, ...] = ("float32",),
+) -> Path:
     fake_root = root / "fake-runtime"
     mlx_root = fake_root / "mlx"
     mlx_lm_root = fake_root / "mlx_lm"
@@ -64,6 +70,10 @@ def clear_cache():
     _trace("clear_cache")
 """,
         encoding="utf-8",
+    )
+    parameter_entries = ", ".join(
+        f'"weight_{index}": self._Parameter("mlx.core.{dtype}")'
+        for index, dtype in enumerate(parameter_dtypes)
     )
     (mlx_lm_root / "__init__.py").write_text(
         f'''import os
@@ -100,10 +110,11 @@ class _Logits:
 
 class _Model:
     class _Parameter:
-        dtype = "mlx.core.float32"
+        def __init__(self, dtype):
+            self.dtype = dtype
 
     def parameters(self):
-        return {{"weight": self._Parameter()}}
+        return {{{parameter_entries}}}
 
     def __call__(self, inputs):
         _trace("forward:" + str(len(inputs[0])))
@@ -113,6 +124,15 @@ def load(model_path):
     _trace("load:" + model_path)
     return _Model(), _Tokenizer()
 ''',
+        encoding="utf-8",
+    )
+    (mlx_lm_root / "utils.py").write_text(
+        """from . import _Tokenizer, _trace
+
+def load_tokenizer(model_path):
+    _trace("load-tokenizer:" + model_path)
+    return _Tokenizer()
+""",
         encoding="utf-8",
     )
     return fake_root
@@ -261,6 +281,7 @@ def test_real_child_process_captures_full_trajectory_and_exits(monkeypatch, tmp_
         (publication_root / ".workers/transaction-0001/worker-receipt.json").read_bytes()
     )
     assert receipt["inference_dtype"] == "float32"
+    assert receipt["floating_parameter_dtypes"] == ["float32"]
     assert receipt["quantization"] == "none"
     persisted = MlxTeacherCaptureResult.model_validate_json(
         (publication_root / ".workers/transaction-0001/result.json").read_bytes()
@@ -278,6 +299,7 @@ def test_real_child_process_captures_full_trajectory_and_exits(monkeypatch, tmp_
     assert [row.context_token_ids for row in rows] == [(1, 2), (1, 2, 3), (1, 2, 3, 4)]
     events = trace.read_text(encoding="utf-8").splitlines()
     assert events.count(f"load:{teacher_root}") == 1
+    assert events.count(f"load-tokenizer:{tokenizer_root}") == 1
     assert [event for event in events if event.startswith("forward:")] == ["forward:4"]
     assert events.count("astype:float32") == 3
     assert events.count("eval") == 3
@@ -342,6 +364,47 @@ def test_declared_runtime_identity_must_match_loaded_teacher(
         )
 
     assert not (publication_root / "shards/shard-0001").exists()
+
+
+def test_quantized_teacher_records_declared_dtype_and_float32_auxiliaries(
+    monkeypatch,
+    tmp_path,
+):
+    plan, teacher_root, tokenizer_root, dataset_root = _local_plan(tmp_path)
+    config = {"model_type": "fixture", "quantization": {"bits": 4, "group_size": 64}}
+    config_bytes = canonical_json_bytes(config) + b"\n"
+    (teacher_root / "config.json").write_bytes(config_bytes)
+    active = {"quantization": config["quantization"]}
+    quantization = f"config-sha256:{_sha(canonical_json_bytes(active))}"
+    payload = plan.model_dump(mode="json", by_alias=True)
+    payload["teacher"]["config_sha256"] = _sha(config_bytes)
+    payload["capture"].update({"dtype": "bfloat16", "quantization": quantization})
+    plan = AutoDistillPlan.model_validate(payload)
+    fake_root = _write_fake_mlx_runtime(
+        tmp_path,
+        parameter_dtypes=("bfloat16", "float32"),
+    )
+    _runtime_environment(monkeypatch, tmp_path, fake_root)
+    publication_root = tmp_path / "publication"
+
+    run_mlx_teacher_capture_process(
+        plan=plan,
+        teacher_root=teacher_root,
+        tokenizer_root=tokenizer_root,
+        dataset_root=dataset_root,
+        publication_root=publication_root,
+        shard_id="shard-0001",
+        transaction_id="transaction-0001",
+        python_executable=sys.executable,
+        timeout_seconds=30,
+    )
+
+    receipt = json.loads(
+        (publication_root / ".workers/transaction-0001/worker-receipt.json").read_bytes()
+    )
+    assert receipt["inference_dtype"] == "bfloat16"
+    assert receipt["floating_parameter_dtypes"] == ["bfloat16", "float32"]
+    assert receipt["quantization"] == quantization
 
 
 def test_declared_left_truncation_uses_one_forward_per_exact_context(monkeypatch, tmp_path):
@@ -463,6 +526,28 @@ def test_changed_bound_dataset_fails_before_model_load(monkeypatch, tmp_path):
     assert not trace.exists()
 
 
+def test_changed_bound_tokenizer_fails_before_model_load(monkeypatch, tmp_path):
+    plan, teacher_root, tokenizer_root, dataset_root = _local_plan(tmp_path)
+    fake_root = _write_fake_mlx_runtime(tmp_path)
+    trace = _runtime_environment(monkeypatch, tmp_path, fake_root)
+    (tokenizer_root / "tokenizer.json").write_bytes(b'{"changed":true}\n')
+
+    with pytest.raises(RuntimeError, match="byte count mismatch|sha256 mismatch"):
+        run_mlx_teacher_capture_process(
+            plan=plan,
+            teacher_root=teacher_root,
+            tokenizer_root=tokenizer_root,
+            dataset_root=dataset_root,
+            publication_root=tmp_path / "publication",
+            shard_id="shard-0001",
+            transaction_id="transaction-0001",
+            python_executable=sys.executable,
+            timeout_seconds=30,
+        )
+
+    assert not trace.exists()
+
+
 def test_non_mlx_plan_is_refused_before_worker_directory_is_created(tmp_path):
     plan, teacher_root, tokenizer_root, dataset_root = _local_plan(tmp_path)
     payload = plan.model_dump(mode="json", by_alias=True)
@@ -484,7 +569,7 @@ def test_non_mlx_plan_is_refused_before_worker_directory_is_created(tmp_path):
     assert not publication_root.exists()
 
 
-def test_worker_ids_and_tokenizer_root_fail_closed_before_spawn(tmp_path):
+def test_worker_ids_fail_closed_before_spawn(tmp_path):
     plan, teacher_root, tokenizer_root, dataset_root = _local_plan(tmp_path)
     publication_root = tmp_path / "publication"
     with pytest.raises(ValidationError, match="transaction_id"):
@@ -497,17 +582,32 @@ def test_worker_ids_and_tokenizer_root_fail_closed_before_spawn(tmp_path):
             shard_id="shard-0001",
             transaction_id="../escape",
         )
-    other_tokenizer = tmp_path / "other-tokenizer"
-    other_tokenizer.mkdir()
-    with pytest.raises(ValidationError, match="tokenizer_root to equal teacher_root"):
-        run_mlx_teacher_capture_process(
-            plan=plan,
-            teacher_root=teacher_root,
-            tokenizer_root=other_tokenizer,
-            dataset_root=dataset_root,
-            publication_root=publication_root,
-            shard_id="shard-0001",
-            transaction_id="transaction-0001",
-        )
-
     assert not publication_root.exists()
+
+
+def test_canonical_tokenizer_can_be_loaded_from_a_separate_root(monkeypatch, tmp_path):
+    plan, teacher_root, tokenizer_root, dataset_root = _local_plan(tmp_path)
+    canonical_root = tmp_path / "canonical-tokenizer"
+    canonical_root.mkdir()
+    (canonical_root / "tokenizer.json").write_bytes(
+        (tokenizer_root / "tokenizer.json").read_bytes()
+    )
+    fake_root = _write_fake_mlx_runtime(tmp_path)
+    trace = _runtime_environment(monkeypatch, tmp_path, fake_root)
+
+    result = run_mlx_teacher_capture_process(
+        plan=plan,
+        teacher_root=teacher_root,
+        tokenizer_root=canonical_root,
+        dataset_root=dataset_root,
+        publication_root=tmp_path / "publication",
+        shard_id="shard-0001",
+        transaction_id="transaction-0001",
+        python_executable=sys.executable,
+        timeout_seconds=30,
+    )
+
+    assert result.student_loaded is False
+    events = trace.read_text(encoding="utf-8").splitlines()
+    assert events.count(f"load:{teacher_root}") == 1
+    assert events.count(f"load-tokenizer:{canonical_root}") == 1

--- a/tests/test_issue580_autodistill_mlx_worker.py
+++ b/tests/test_issue580_autodistill_mlx_worker.py
@@ -99,6 +99,12 @@ class _Logits:
         return _Row(values)
 
 class _Model:
+    class _Parameter:
+        dtype = "mlx.core.float32"
+
+    def parameters(self):
+        return {{"weight": self._Parameter()}}
+
     def __call__(self, inputs):
         _trace("forward:" + str(len(inputs[0])))
         return _Logits(len(inputs[0]))
@@ -251,6 +257,11 @@ def test_real_child_process_captures_full_trajectory_and_exits(monkeypatch, tmp_
     assert result.student_loaded is False
     assert result.worker_pid != os.getpid()
     assert result.row_count == result.token_count == 3
+    receipt = json.loads(
+        (publication_root / ".workers/transaction-0001/worker-receipt.json").read_bytes()
+    )
+    assert receipt["inference_dtype"] == "float32"
+    assert receipt["quantization"] == "none"
     persisted = MlxTeacherCaptureResult.model_validate_json(
         (publication_root / ".workers/transaction-0001/result.json").read_bytes()
     )
@@ -280,6 +291,44 @@ def test_runtime_version_mismatch_fails_before_publication(monkeypatch, tmp_path
     publication_root = tmp_path / "publication"
 
     with pytest.raises(RuntimeError, match="does not match capture.backend_version"):
+        run_mlx_teacher_capture_process(
+            plan=plan,
+            teacher_root=teacher_root,
+            tokenizer_root=tokenizer_root,
+            dataset_root=dataset_root,
+            publication_root=publication_root,
+            shard_id="shard-0001",
+            transaction_id="transaction-0001",
+            python_executable=sys.executable,
+            timeout_seconds=30,
+        )
+
+    assert not (publication_root / "shards/shard-0001").exists()
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("dtype", "bfloat16", "floating parameter dtypes"),
+        ("quantization", "q4", "quantization does not match"),
+    ],
+)
+def test_declared_runtime_identity_must_match_loaded_teacher(
+    monkeypatch,
+    tmp_path,
+    field,
+    value,
+    message,
+):
+    plan, teacher_root, tokenizer_root, dataset_root = _local_plan(tmp_path)
+    payload = plan.model_dump(mode="json", by_alias=True)
+    payload["capture"][field] = value
+    plan = AutoDistillPlan.model_validate(payload)
+    fake_root = _write_fake_mlx_runtime(tmp_path)
+    _runtime_environment(monkeypatch, tmp_path, fake_root)
+    publication_root = tmp_path / "publication"
+
+    with pytest.raises(RuntimeError, match=message):
         run_mlx_teacher_capture_process(
             plan=plan,
             teacher_root=teacher_root,

--- a/tests/test_issue580_autodistill_mlx_worker.py
+++ b/tests/test_issue580_autodistill_mlx_worker.py
@@ -1,0 +1,464 @@
+"""Process-isolated MLX teacher capture tests for AutoDistill Milestone B1."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import inspect
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from soup_cli.autodistill.contract import (
+    AutoDistillPlan,
+    CaptureToken,
+    ShardManifest,
+    build_plan_estimate,
+    canonicalize_jsonl_bytes,
+)
+from soup_cli.autodistill.mlx_worker import (
+    MlxTeacherCaptureResult,
+    run_mlx_teacher_capture_process,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "autodistill" / "v1"
+_MLX_VERSION = "0.31.0-test"
+
+
+def _sha(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _write_fake_mlx_runtime(root: Path, *, mlx_lm_version: str = _MLX_VERSION) -> Path:
+    fake_root = root / "fake-runtime"
+    mlx_root = fake_root / "mlx"
+    mlx_lm_root = fake_root / "mlx_lm"
+    mlx_root.mkdir(parents=True)
+    mlx_lm_root.mkdir()
+    (mlx_root / "__init__.py").write_text('__version__ = "0.30.0-test"\n', encoding="utf-8")
+    (mlx_root / "core.py").write_text(
+        """import os
+
+float32 = "float32"
+
+def _trace(event):
+    with open(os.environ["SOUP_TEST_MLX_TRACE"], "a", encoding="utf-8") as handle:
+        handle.write(event + "\\n")
+
+def array(value):
+    return value
+
+def astype(value, dtype):
+    assert dtype == float32
+    _trace("astype:float32")
+    return value
+
+def eval(value):
+    _trace("eval")
+
+def clear_cache():
+    _trace("clear_cache")
+""",
+        encoding="utf-8",
+    )
+    (mlx_lm_root / "__init__.py").write_text(
+        f'''import os
+
+__version__ = "{mlx_lm_version}"
+
+def _trace(event):
+    with open(os.environ["SOUP_TEST_MLX_TRACE"], "a", encoding="utf-8") as handle:
+        handle.write(event + "\\n")
+
+class _Tokenizer:
+    chat_template = "{{{{ messages }}}}"
+
+class _Row:
+    def __init__(self, values):
+        self._values = values
+
+    def tolist(self):
+        _trace("tolist")
+        return list(self._values)
+
+class _Logits:
+    def __init__(self, sequence_length, vocab_size=8):
+        self.shape = (1, sequence_length, vocab_size)
+        self._vocab_size = vocab_size
+
+    def __getitem__(self, key):
+        _, position, _ = key
+        if position < 0:
+            position += self.shape[1]
+        values = [float(token_id) / 10.0 for token_id in range(self._vocab_size)]
+        values[(position + 1) % self._vocab_size] += 3.0
+        return _Row(values)
+
+class _Model:
+    def __call__(self, inputs):
+        _trace("forward:" + str(len(inputs[0])))
+        return _Logits(len(inputs[0]))
+
+def load(model_path):
+    _trace("load:" + model_path)
+    return _Model(), _Tokenizer()
+''',
+        encoding="utf-8",
+    )
+    return fake_root
+
+
+def _local_plan(
+    tmp_path: Path,
+    *,
+    backend_version: str = _MLX_VERSION,
+    truncation: str = "none",
+    max_sequence_length: int = 16,
+) -> tuple[AutoDistillPlan, Path, Path, Path]:
+    teacher_root = tmp_path / "teacher"
+    tokenizer_root = tmp_path / "tokenizer"
+    dataset_root = tmp_path / "dataset"
+    teacher_root.mkdir()
+    tokenizer_root = teacher_root
+    dataset_root.mkdir()
+    config = b'{"model_type":"fixture"}\n'
+    weights = b"teacher-weights"
+    tokenizer = b'{"version":"1.0"}\n'
+    template = "{{ messages }}"
+    dataset = (
+        b'{"example_id":"example-1","prompt_token_ids":[1,2],'
+        b'"schema":"soup.autodistill.tokenized-teacher-example.v1",'
+        b'"target_token_ids":[3,4,5]}\n'
+    )
+    (teacher_root / "config.json").write_bytes(config)
+    (teacher_root / "model.safetensors").write_bytes(weights)
+    (teacher_root / "tokenizer.json").write_bytes(tokenizer)
+    (dataset_root / "prompts.jsonl").write_bytes(dataset)
+
+    payload = json.loads((FIXTURES / "plan.json").read_text(encoding="utf-8"))
+    payload["teacher"]["config_sha256"] = _sha(config)
+    payload["teacher"]["weights"] = [
+        {"path": "model.safetensors", "bytes": len(weights), "sha256": _sha(weights)}
+    ]
+    payload["tokenizer"].update(
+        {
+            "vocab_size": 8,
+            "chat_template_sha256": _sha(template.encode()),
+            "renderer": f"mlx-lm@{backend_version}",
+            "files": [
+                {"path": "tokenizer.json", "bytes": len(tokenizer), "sha256": _sha(tokenizer)}
+            ],
+        }
+    )
+    normalized = canonicalize_jsonl_bytes(dataset)
+    payload["dataset"].update(
+        {
+            "normalized_sha256": _sha(normalized),
+            "rows": 1,
+            "source_files": [
+                {"path": "prompts.jsonl", "bytes": len(dataset), "sha256": _sha(dataset)}
+            ],
+        }
+    )
+    payload["capture"].update(
+        {
+            "planned_token_count": 3,
+            "vocab_size": 8,
+            "backend": "mlx",
+            "backend_version": backend_version,
+            "dtype": "float32",
+            "max_sequence_length": max_sequence_length,
+            "truncation": truncation,
+        }
+    )
+    payload["probability_policy"].update(
+        {
+            "top_k": 3,
+            "log_probability_bytes": 4,
+            "tail_mass_bytes": 8,
+            "entropy_bytes": 8,
+        }
+    )
+    estimate = build_plan_estimate(
+        token_count=3,
+        vocab_size=8,
+        top_k=3,
+        max_forced_tokens_per_position=2,
+        token_id_bytes=4,
+        log_probability_bytes=4,
+        tail_mass_bytes=8,
+        entropy_bytes=8,
+    )
+    payload["estimate"] = estimate.model_dump(mode="json")
+    return AutoDistillPlan.model_validate(payload), teacher_root, tokenizer_root, dataset_root
+
+
+def _runtime_environment(monkeypatch, tmp_path: Path, fake_root: Path) -> Path:
+    trace = tmp_path / "mlx-trace.txt"
+    source_root = Path(__file__).parents[1] / "src"
+    existing = os.environ.get("PYTHONPATH", "")
+    entries = [os.fspath(fake_root), os.fspath(source_root)]
+    if existing:
+        entries.append(existing)
+    monkeypatch.setenv("PYTHONPATH", os.pathsep.join(entries))
+    monkeypatch.setenv("SOUP_TEST_MLX_TRACE", os.fspath(trace))
+    return trace
+
+
+def test_worker_module_is_import_light_and_has_no_student_input():
+    import soup_cli.autodistill.mlx_worker as module
+
+    tree = ast.parse(Path(module.__file__).read_text(encoding="utf-8"))
+    top_level_imports = {
+        alias.name.split(".", 1)[0]
+        for node in tree.body
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    top_level_imports.update(
+        node.module.split(".", 1)[0]
+        for node in tree.body
+        if isinstance(node, ast.ImportFrom) and node.module
+    )
+
+    assert not {"mlx", "mlx_lm", "torch", "transformers"} & top_level_imports
+    assert "student" not in inspect.signature(run_mlx_teacher_capture_process).parameters
+
+
+def test_real_child_process_captures_full_trajectory_and_exits(monkeypatch, tmp_path):
+    plan, teacher_root, tokenizer_root, dataset_root = _local_plan(tmp_path)
+    fake_root = _write_fake_mlx_runtime(tmp_path)
+    trace = _runtime_environment(monkeypatch, tmp_path, fake_root)
+    publication_root = tmp_path / "publication"
+
+    result = run_mlx_teacher_capture_process(
+        plan=plan,
+        teacher_root=teacher_root,
+        tokenizer_root=tokenizer_root,
+        dataset_root=dataset_root,
+        publication_root=publication_root,
+        shard_id="shard-0001",
+        transaction_id="transaction-0001",
+        python_executable=sys.executable,
+        timeout_seconds=30,
+    )
+
+    assert result.worker_exit_confirmed is True
+    assert result.student_loaded is False
+    assert result.worker_pid != os.getpid()
+    assert result.row_count == result.token_count == 3
+    persisted = MlxTeacherCaptureResult.model_validate_json(
+        (publication_root / ".workers/transaction-0001/result.json").read_bytes()
+    )
+    assert persisted == result
+    manifest = ShardManifest.model_validate_json(
+        (publication_root / "shards/shard-0001/manifest.available.json").read_bytes()
+    )
+    assert manifest.state == "available"
+    rows = tuple(
+        CaptureToken.model_validate_json(line)
+        for line in (publication_root / "shards/shard-0001/capture.jsonl").read_bytes().splitlines()
+    )
+    assert [row.position for row in rows] == [0, 1, 2]
+    assert [row.context_token_ids for row in rows] == [(1, 2), (1, 2, 3), (1, 2, 3, 4)]
+    events = trace.read_text(encoding="utf-8").splitlines()
+    assert events.count(f"load:{teacher_root}") == 1
+    assert [event for event in events if event.startswith("forward:")] == ["forward:4"]
+    assert events.count("astype:float32") == 3
+    assert events.count("eval") == 3
+    assert events[-1] == "clear_cache"
+
+
+def test_runtime_version_mismatch_fails_before_publication(monkeypatch, tmp_path):
+    plan, teacher_root, tokenizer_root, dataset_root = _local_plan(tmp_path)
+    fake_root = _write_fake_mlx_runtime(tmp_path, mlx_lm_version="different-version")
+    _runtime_environment(monkeypatch, tmp_path, fake_root)
+    publication_root = tmp_path / "publication"
+
+    with pytest.raises(RuntimeError, match="does not match capture.backend_version"):
+        run_mlx_teacher_capture_process(
+            plan=plan,
+            teacher_root=teacher_root,
+            tokenizer_root=tokenizer_root,
+            dataset_root=dataset_root,
+            publication_root=publication_root,
+            shard_id="shard-0001",
+            transaction_id="transaction-0001",
+            python_executable=sys.executable,
+            timeout_seconds=30,
+        )
+
+    assert not (publication_root / "shards/shard-0001").exists()
+
+
+def test_declared_left_truncation_uses_one_forward_per_exact_context(monkeypatch, tmp_path):
+    plan, teacher_root, tokenizer_root, dataset_root = _local_plan(
+        tmp_path,
+        truncation="left",
+        max_sequence_length=2,
+    )
+    fake_root = _write_fake_mlx_runtime(tmp_path)
+    trace = _runtime_environment(monkeypatch, tmp_path, fake_root)
+    publication_root = tmp_path / "publication"
+
+    run_mlx_teacher_capture_process(
+        plan=plan,
+        teacher_root=teacher_root,
+        tokenizer_root=tokenizer_root,
+        dataset_root=dataset_root,
+        publication_root=publication_root,
+        shard_id="shard-0001",
+        transaction_id="transaction-0001",
+        python_executable=sys.executable,
+        timeout_seconds=30,
+    )
+
+    rows = tuple(
+        CaptureToken.model_validate_json(line)
+        for line in (publication_root / "shards/shard-0001/capture.jsonl").read_bytes().splitlines()
+    )
+    assert [row.context_token_ids for row in rows] == [(1, 2), (2, 3), (3, 4)]
+    events = trace.read_text(encoding="utf-8").splitlines()
+    assert [event for event in events if event.startswith("forward:")] == [
+        "forward:2",
+        "forward:2",
+        "forward:2",
+    ]
+
+
+def test_worker_publishes_only_requested_example_shard_from_fully_bound_dataset(
+    monkeypatch,
+    tmp_path,
+):
+    plan, teacher_root, tokenizer_root, dataset_root = _local_plan(tmp_path)
+    first = (dataset_root / "prompts.jsonl").read_bytes()
+    second = (
+        b'{"example_id":"example-2","prompt_token_ids":[6],'
+        b'"schema":"soup.autodistill.tokenized-teacher-example.v1",'
+        b'"target_token_ids":[2,3]}\n'
+    )
+    dataset = first + second
+    (dataset_root / "prompts.jsonl").write_bytes(dataset)
+    payload = plan.model_dump(mode="json", by_alias=True)
+    payload["dataset"].update(
+        {
+            "normalized_sha256": _sha(canonicalize_jsonl_bytes(dataset)),
+            "rows": 2,
+            "source_files": [
+                {"path": "prompts.jsonl", "bytes": len(dataset), "sha256": _sha(dataset)}
+            ],
+        }
+    )
+    payload["capture"]["planned_token_count"] = 5
+    payload["estimate"] = build_plan_estimate(
+        token_count=5,
+        vocab_size=8,
+        top_k=3,
+        max_forced_tokens_per_position=2,
+        token_id_bytes=4,
+        log_probability_bytes=4,
+        tail_mass_bytes=8,
+        entropy_bytes=8,
+    ).model_dump(mode="json")
+    plan = AutoDistillPlan.model_validate(payload)
+    fake_root = _write_fake_mlx_runtime(tmp_path)
+    _runtime_environment(monkeypatch, tmp_path, fake_root)
+    publication_root = tmp_path / "publication"
+
+    result = run_mlx_teacher_capture_process(
+        plan=plan,
+        teacher_root=teacher_root,
+        tokenizer_root=tokenizer_root,
+        dataset_root=dataset_root,
+        publication_root=publication_root,
+        shard_id="shard-0002",
+        transaction_id="transaction-0002",
+        example_start=1,
+        example_end=2,
+        python_executable=sys.executable,
+        timeout_seconds=30,
+    )
+
+    assert result.row_count == result.token_count == 2
+    rows = tuple(
+        CaptureToken.model_validate_json(line)
+        for line in (publication_root / "shards/shard-0002/capture.jsonl").read_bytes().splitlines()
+    )
+    assert [row.example_id for row in rows] == ["example-2", "example-2"]
+    assert [row.context_token_ids for row in rows] == [(6,), (6, 2)]
+
+
+def test_changed_bound_dataset_fails_before_model_load(monkeypatch, tmp_path):
+    plan, teacher_root, tokenizer_root, dataset_root = _local_plan(tmp_path)
+    fake_root = _write_fake_mlx_runtime(tmp_path)
+    trace = _runtime_environment(monkeypatch, tmp_path, fake_root)
+    (dataset_root / "prompts.jsonl").write_bytes(b'{"changed":true}\n')
+
+    with pytest.raises(RuntimeError, match="byte count mismatch|sha256 mismatch"):
+        run_mlx_teacher_capture_process(
+            plan=plan,
+            teacher_root=teacher_root,
+            tokenizer_root=tokenizer_root,
+            dataset_root=dataset_root,
+            publication_root=tmp_path / "publication",
+            shard_id="shard-0001",
+            transaction_id="transaction-0001",
+            python_executable=sys.executable,
+            timeout_seconds=30,
+        )
+
+    assert not trace.exists()
+
+
+def test_non_mlx_plan_is_refused_before_worker_directory_is_created(tmp_path):
+    plan, teacher_root, tokenizer_root, dataset_root = _local_plan(tmp_path)
+    payload = plan.model_dump(mode="json", by_alias=True)
+    payload["capture"]["backend"] = "transformers"
+    wrong_plan = AutoDistillPlan.model_validate(payload)
+    publication_root = tmp_path / "publication"
+
+    with pytest.raises(ValidationError, match="capture.backend=mlx"):
+        run_mlx_teacher_capture_process(
+            plan=wrong_plan,
+            teacher_root=teacher_root,
+            tokenizer_root=tokenizer_root,
+            dataset_root=dataset_root,
+            publication_root=publication_root,
+            shard_id="shard-0001",
+            transaction_id="transaction-0001",
+        )
+
+    assert not publication_root.exists()
+
+
+def test_worker_ids_and_tokenizer_root_fail_closed_before_spawn(tmp_path):
+    plan, teacher_root, tokenizer_root, dataset_root = _local_plan(tmp_path)
+    publication_root = tmp_path / "publication"
+    with pytest.raises(ValidationError, match="transaction_id"):
+        run_mlx_teacher_capture_process(
+            plan=plan,
+            teacher_root=teacher_root,
+            tokenizer_root=tokenizer_root,
+            dataset_root=dataset_root,
+            publication_root=publication_root,
+            shard_id="shard-0001",
+            transaction_id="../escape",
+        )
+    other_tokenizer = tmp_path / "other-tokenizer"
+    other_tokenizer.mkdir()
+    with pytest.raises(ValidationError, match="tokenizer_root to equal teacher_root"):
+        run_mlx_teacher_capture_process(
+            plan=plan,
+            teacher_root=teacher_root,
+            tokenizer_root=other_tokenizer,
+            dataset_root=dataset_root,
+            publication_root=publication_root,
+            shard_id="shard-0001",
+            transaction_id="transaction-0001",
+        )
+
+    assert not publication_root.exists()

--- a/tests/test_issue580_autodistill_mlx_worker.py
+++ b/tests/test_issue580_autodistill_mlx_worker.py
@@ -306,6 +306,46 @@ def test_real_child_process_captures_full_trajectory_and_exits(monkeypatch, tmp_
     assert events[-1] == "clear_cache"
 
 
+def test_controller_rejects_available_manifest_not_bound_to_worker_receipt(
+    monkeypatch,
+    tmp_path,
+):
+    import soup_cli.autodistill.mlx_worker as worker_module
+
+    plan, teacher_root, tokenizer_root, dataset_root = _local_plan(tmp_path)
+    fake_root = _write_fake_mlx_runtime(tmp_path)
+    _runtime_environment(monkeypatch, tmp_path, fake_root)
+    publication_root = tmp_path / "publication"
+    original_read_control = worker_module._read_control
+
+    def tamper_after_receipt(path, model_type):
+        receipt = original_read_control(path, model_type)
+        manifest_path = publication_root / "shards/shard-0001/manifest.available.json"
+        manifest = ShardManifest.model_validate_json(manifest_path.read_bytes())
+        tampered = ShardManifest.model_validate(
+            manifest.model_copy(update={"plan_sha256": "f" * 64}).model_dump(
+                by_alias=True
+            )
+        )
+        manifest_path.write_bytes(canonical_json_bytes(tampered) + b"\n")
+        return receipt
+
+    monkeypatch.setattr(worker_module, "_read_control", tamper_after_receipt)
+
+    with pytest.raises(ValueError, match="receipt does not match the available shard"):
+        run_mlx_teacher_capture_process(
+            plan=plan,
+            teacher_root=teacher_root,
+            tokenizer_root=tokenizer_root,
+            dataset_root=dataset_root,
+            publication_root=publication_root,
+            shard_id="shard-0001",
+            transaction_id="transaction-0001",
+            python_executable=sys.executable,
+            timeout_seconds=30,
+        )
+
+
 def test_runtime_version_mismatch_fails_before_publication(monkeypatch, tmp_path):
     plan, teacher_root, tokenizer_root, dataset_root = _local_plan(tmp_path)
     fake_root = _write_fake_mlx_runtime(tmp_path, mlx_lm_version="different-version")

--- a/tests/test_issue580_autodistill_publisher.py
+++ b/tests/test_issue580_autodistill_publisher.py
@@ -17,6 +17,7 @@ from soup_cli.autodistill.contract import (
     AutoDistillPlan,
     CaptureToken,
     ShardManifest,
+    canonical_json_bytes,
     canonical_sha256,
 )
 from soup_cli.autodistill.publisher import CaptureShardPublisher
@@ -146,6 +147,93 @@ def test_publisher_rejects_duplicate_reordered_and_wrong_policy_rows(tmp_path):
     wrong_temperature = CaptureToken.model_validate(wrong_temperature_payload)
     with pytest.raises(ValueError, match="temperature does not match plan"):
         _publisher(root, plan).publish((wrong_temperature,))
+
+
+def test_publisher_rejects_student_rollout_at_teacher_only_boundary(tmp_path):
+    plan = _plan()
+    teacher_row = _captures(plan)[0]
+    payload = teacher_row.model_dump(by_alias=True)
+    payload.update(
+        {
+            "trajectory_kind": "student_rollout",
+            "target_token_id": None,
+            "student_sampled_token_id": teacher_row.target_token_id,
+        }
+    )
+    student_row = CaptureToken.model_validate(payload)
+
+    with pytest.raises(ValueError, match="teacher_expert rows only"):
+        _publisher(tmp_path / "capture-cache", plan).publish(
+            (student_row,), stop_after="staging"
+        )
+
+
+def test_publisher_constructor_rejects_shard_path_escape(tmp_path):
+    with pytest.raises(ValueError, match="outside the publication root"):
+        CaptureShardPublisher(
+            root=tmp_path / "capture-cache",
+            plan=_plan(),
+            shard_id="../../escaped",
+            transaction_id="transaction-0001",
+        )
+
+
+def test_resume_rejects_tampered_manifest_hash_chain(tmp_path):
+    plan = _plan()
+    rows = _captures(plan)
+    root = tmp_path / "capture-cache"
+    _publisher(root, plan).publish(rows, stop_after="complete")
+    path = root / ".transactions/transaction-0001/manifest.complete.json"
+    manifest = ShardManifest.model_validate_json(path.read_bytes())
+    tampered = ShardManifest.model_validate(
+        manifest.model_copy(
+            update={"previous_manifest_sha256": "f" * 64}
+        ).model_dump(by_alias=True)
+    )
+    path.write_bytes(canonical_json_bytes(tampered) + b"\n")
+
+    with pytest.raises(ArtifactCorruptionError, match="manifest hash chain is broken"):
+        _publisher(root, plan).publish(rows)
+
+
+def test_publisher_rejects_top_k_cardinality_that_disagrees_with_plan(tmp_path):
+    plan = _plan()
+    smaller_policy = plan.probability_policy.model_copy(
+        update={"top_k": plan.probability_policy.top_k - 1}
+    )
+    capture_plan = plan.model_copy(update={"probability_policy": smaller_policy})
+    wrong_top_k = _captures(capture_plan)[0]
+
+    with pytest.raises(ValueError, match="top-k cardinality does not match plan"):
+        _publisher(tmp_path / "capture-cache", plan).publish(
+            (wrong_top_k,), stop_after="staging"
+        )
+
+
+def test_publisher_rejects_context_longer_than_plan_limit(tmp_path):
+    plan = _plan()
+    row = _captures(plan)[0]
+    payload = row.model_dump(by_alias=True)
+    payload["context_token_ids"] = [1] * (plan.capture.max_sequence_length + 1)
+    long_context = CaptureToken.model_validate(payload)
+
+    with pytest.raises(ValueError, match="context exceeds plan max_sequence_length"):
+        _publisher(tmp_path / "capture-cache", plan).publish(
+            (long_context,), stop_after="staging"
+        )
+
+
+def test_publisher_rejects_vocabulary_size_that_disagrees_with_plan(tmp_path):
+    plan = _plan()
+    row = _captures(plan)[0]
+    payload = row.model_dump(by_alias=True)
+    payload["vocab_size"] = plan.capture.vocab_size + 1
+    wrong_vocabulary = CaptureToken.model_validate(payload)
+
+    with pytest.raises(ValueError, match="vocabulary does not match plan"):
+        _publisher(tmp_path / "capture-cache", plan).publish(
+            (wrong_vocabulary,), stop_after="staging"
+        )
 
 
 def test_plan_file_binds_publication_root_before_any_transaction(tmp_path):

--- a/tests/test_issue580_autodistill_publisher.py
+++ b/tests/test_issue580_autodistill_publisher.py
@@ -1,0 +1,167 @@
+"""Transactional shard publication tests for AutoDistill Milestone B1."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+from soup_cli.autodistill.capture import (
+    TeacherExpertExample,
+    capture_teacher_expert_trajectory,
+)
+from soup_cli.autodistill.contract import (
+    ArtifactCorruptionError,
+    AutoDistillPlan,
+    CaptureToken,
+    ShardManifest,
+    canonical_sha256,
+)
+from soup_cli.autodistill.publisher import CaptureShardPublisher
+
+FIXTURES = Path(__file__).parent / "fixtures" / "autodistill" / "v1"
+
+
+def _plan() -> AutoDistillPlan:
+    return AutoDistillPlan.model_validate_json((FIXTURES / "plan.json").read_bytes())
+
+
+def _captures(plan: AutoDistillPlan):
+    logits = [0.0] * plan.capture.vocab_size
+    logits[10] = 4.0
+    logits[11] = 3.0
+    return capture_teacher_expert_trajectory(
+        example=TeacherExpertExample(
+            example_id="example-1",
+            prompt_token_ids=(1, 2),
+            target_token_ids=(10, 12),
+        ),
+        teacher_logits_by_position=(logits, logits),
+        vocab_size=plan.capture.vocab_size,
+        probability_policy=plan.probability_policy,
+        max_sequence_length=plan.capture.max_sequence_length,
+        truncation=plan.capture.truncation,
+    )
+
+
+def _publisher(root: Path, plan: AutoDistillPlan) -> CaptureShardPublisher:
+    return CaptureShardPublisher(
+        root=root,
+        plan=plan,
+        shard_id="shard-0001",
+        transaction_id="transaction-0001",
+    )
+
+
+def _read_manifest(path: Path) -> ShardManifest:
+    return ShardManifest.model_validate_json(path.read_bytes())
+
+
+def test_transaction_resumes_every_committed_state_and_publishes_manifest_last(tmp_path):
+    plan = _plan()
+    rows = _captures(plan)
+    root = tmp_path / "capture-cache"
+    transaction = root / ".transactions" / "transaction-0001"
+    available = root / "shards" / "shard-0001"
+
+    staging = _publisher(root, plan).publish(rows, stop_after="staging")
+    assert staging.state == "staging"
+    assert transaction.is_dir()
+    assert not available.exists()
+
+    complete = _publisher(root, plan).publish(rows, stop_after="complete")
+    assert complete.state == "complete"
+    assert complete.previous_manifest_sha256 == canonical_sha256(staging)
+    assert not available.exists()
+
+    verified = _publisher(root, plan).publish(rows, stop_after="verified")
+    assert verified.state == "verified"
+    assert verified.previous_manifest_sha256 == canonical_sha256(complete)
+    assert not available.exists()
+
+    final = _publisher(root, plan).publish(rows)
+    assert final.state == "available"
+    assert final.previous_manifest_sha256 == canonical_sha256(verified)
+    assert not transaction.exists()
+    assert available.is_dir()
+    assert (available / "capture.jsonl").read_bytes().count(b"\n") == 2
+    assert _read_manifest(available / "manifest.available.json") == final
+
+    reused = _publisher(root, plan).publish(rows)
+    assert reused == final
+
+
+def test_corrupt_payload_is_quarantined_and_never_exposed_as_available(tmp_path):
+    plan = _plan()
+    rows = _captures(plan)
+    root = tmp_path / "capture-cache"
+    publisher = _publisher(root, plan)
+    publisher.publish(rows, stop_after="complete")
+    payload = root / ".transactions" / "transaction-0001" / "capture.jsonl"
+    payload.write_bytes(payload.read_bytes().replace(b'"example-1"', b'"example-X"', 1))
+
+    with pytest.raises(ArtifactCorruptionError, match="corrupt or mismatched"):
+        _publisher(root, plan).publish(rows)
+
+    quarantine = root / "quarantine" / "shard-0001.transaction-0001"
+    assert quarantine.is_dir()
+    assert (quarantine / "manifest.quarantined.json").is_file()
+    assert not (root / "shards" / "shard-0001").exists()
+    assert not (root / ".transactions" / "transaction-0001").exists()
+
+
+def test_resume_refuses_changed_rows_instead_of_mixing_transactions(tmp_path):
+    plan = _plan()
+    rows = _captures(plan)
+    root = tmp_path / "capture-cache"
+    _publisher(root, plan).publish(rows, stop_after="staging")
+    changed = tuple(
+        row.model_copy(update={"example_id": "example-2"})
+        for row in rows
+    )
+
+    with pytest.raises(ArtifactCorruptionError, match="corrupt or mismatched"):
+        _publisher(root, plan).publish(changed)
+
+    assert (root / "quarantine" / "shard-0001.transaction-0001").is_dir()
+
+
+def test_publisher_rejects_duplicate_reordered_and_wrong_policy_rows(tmp_path):
+    plan = _plan()
+    rows = _captures(plan)
+    root = tmp_path / "capture-cache"
+    reordered = (rows[1], rows[0])
+    with pytest.raises(ValueError, match="positions must be contiguous"):
+        _publisher(root, plan).publish(reordered)
+
+    wrong_temperature_payload = rows[0].model_dump(by_alias=True)
+    wrong_temperature_payload["temperature"] = 2.0
+    selected_mass = sum(
+        math.exp(value)
+        for value in wrong_temperature_payload["teacher_log_probabilities"]
+    )
+    wrong_temperature_payload["tail_mass"] = 1.0 - selected_mass
+    wrong_temperature = CaptureToken.model_validate(wrong_temperature_payload)
+    with pytest.raises(ValueError, match="temperature does not match plan"):
+        _publisher(root, plan).publish((wrong_temperature,))
+
+
+def test_plan_file_binds_publication_root_before_any_transaction(tmp_path):
+    plan = _plan()
+    rows = _captures(plan)
+    root = tmp_path / "capture-cache"
+    _publisher(root, plan).publish(rows, stop_after="staging")
+    payload = json.loads((FIXTURES / "plan.json").read_text(encoding="utf-8"))
+    payload["run_id"] = "different-run"
+    changed_plan = AutoDistillPlan.model_validate(payload)
+
+    other = CaptureShardPublisher(
+        root=root,
+        plan=changed_plan,
+        shard_id="shard-0002",
+        transaction_id="transaction-0002",
+    )
+    with pytest.raises(ArtifactCorruptionError, match="different plan"):
+        other.publish(_captures(changed_plan), stop_after="staging")


### PR DESCRIPTION
## Summary

Implements the narrow Milestone B1 slice claimed in #580, strictly on top of the merged
Milestone A contract:

- teacher-only MLX capture in a fresh subprocess, with no student model input or load;
- immutable teacher, canonical-tokenizer, and dataset byte verification;
- full supervised target trajectories using top-k union forced-target plus residual tail mass;
- transactional staging -> complete -> verified -> available shard publication;
- fail-closed corruption, resume, traversal, runtime-version, dtype, and quantization checks;
- a reproducible opt-in Apple Silicon hardware smoke script.

This PR does not add a task, CLI command, or SoupConfig field. It also does not add student
training, adaptive generation/allocation, cross-tokenizer ULD, or benchmark integration.

Refs #580.

## Boundary and artifact semantics

The controller writes a canonical request, starts a fresh Python worker, waits for the child to
exit, reopens the available manifest, and only then writes the final result. The request has no
student path; the Milestone A student fingerprint remains future-consumer metadata only.

The teacher model and canonical shared tokenizer can come from separate immutable roots. Only
the teacher model is loaded. This matters for otherwise token-compatible model pairs whose
native chat-template files differ. Tokenizer files are verified before model loading, and the
instantiated template plus exact mlx-lm renderer version are verified before publication.

Quantized checkpoints bind the active quantization config by canonical SHA-256. The worker
requires the declared base floating dtype, permits only float32 auxiliaries for a quantized
checkpoint, and records every observed floating parameter dtype in the child receipt.

## Validation

```text
95 passed in 9.69s
ruff check src/soup_cli/ tests/ scripts/autodistill_b1_hardware_smoke.py: PASS
git diff --check origin/main...HEAD: PASS
```

The focused tests cover deterministic trajectory capture, exact truncation contexts, runtime
isolation, separate tokenizer roots, pre-load byte verification, mixed-dtype quantized teachers,
transaction state transitions, interruption/resume, corruption quarantine, and import-light CLI
startup.

### Apple Silicon smoke

Hardware/runtime:

- MacBook Pro M4 Max, 128 GiB unified memory;
- MLX 0.32.0 and MLX-LM 0.31.3;
- teacher: `txgsync/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-oQ4e-mtp`;
- future student fingerprint: `nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16`;
- canonical tokenizer: tokenizer-only materialization of the Nano tokenizer;
- two target positions, repeated in two fresh workers.

Observed:

```text
run 1 capture time: 10.658 s
run 2 capture time: 10.749 s
student_loaded: false
observed floating dtypes: [bfloat16, float32]
capture.jsonl SHA-256 (both runs):
8097b731bbe8c67b4c5b00c74d9955162e555f03d9611bccdbfd183d835f6a8c
available manifest file SHA-256 (both runs):
b5b51da89165ea90e2a0926eb87f74c0b7c0af7bc1f35fd3131e8e3e2060c221
```

The workers exited, the scientific payload and manifest were byte-identical across runs, and
the local oMLX server reported zero loaded models after capture.

This smoke proves the capture and release boundary. It does not claim downstream student quality
or quantized-vs-BF16 logit equivalence; those require later controlled training and evaluation.

## Review focus

1. Is the B1 worker request/receipt boundary narrow enough before a public CLI exists?
2. Is a separately pinned canonical tokenizer root the preferred same-tokenizer interpretation?
3. Is the quantization identity and mixed-dtype receipt sufficiently explicit for later cache
   consumers?
4. Should the manual hardware smoke script remain in this PR or move to a later integration slice?
