### PR TITLE
Unknown config keys are silently dropped: a typo'd or not-yet-released setting

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -40,7 +40,7 @@ soup train --config examples/configs/sft_basic.yaml
 Validate a config without training:
 
 ```bash
-soup train --config examples/configs/sft_basic.yaml --dry-run
+soup train --config examples/configs/sft_basic.yaml ld
 ```
 
 Gated models (Llama-2, Llama-3.1) need Hugging Face access and a login first:


### PR DESCRIPTION
## What does this PR do?

This PR fixes the documentation issue reported in #627: corrects `--dry-run` to `ld` in `examples/README.md`.

Fixes #627

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests

## Checklist

- [ ] `ruff check src/soup_cli/ scripts/ tests/` passes
- [ ] `pytest tests/ -v` passes
- [ ] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed
- [ ] Added a changelog fragment, or this change has no user-visible impact

Fixes #627