### PR TITLE
test(log_level): pin the foreign-handler branch of setup_logging (#273)

### DIFF
--- a/changelog.d/0.73.3/631.fixed.md
+++ b/changelog.d/0.73.3/631.fixed.md
@@ -1,0 +1,8 @@
+- [#631](https://github.com/MakazhanAlpamys/Soup/pull/631) pins the last
+  open row of #273: the `74->73` branch of `setup_logging`, which was only
+  ever executed incidentally depending on ambient logger state (100% branch
+  coverage on one machine, 98% on another). Two hermetic tests now force the
+  state: a handler without the `_soup_log_tier` tag survives reconfiguration,
+  and a Soup handler with a stale tier is still removed. Dropping the
+  `is not None` guard fails both tests by name (mutation demonstrated and
+  reverted). `BrPart` 1 -> 0, for a reason rather than by luck.

--- a/tests/test_log_level.py
+++ b/tests/test_log_level.py
@@ -92,6 +92,63 @@ class TestSetupLogging:
             parse_log_level(42)  # type: ignore[arg-type]
 
 
+class TestIssue273ForeignHandlerContract:
+    """Deterministically pin the ``74->73`` branch of ``setup_logging`` (#273).
+
+    The branch is the loop-back edge taken when a handler on the ``soup``
+    logger carries **no** ``_soup_log_tier`` tag — a handler Soup did not
+    install. Whether ambient logger state happens to exercise it varies by
+    platform and test ordering, so these tests force the state explicitly:
+    an embedding application's handlers must survive reconfiguration, while
+    a Soup handler with a stale tier is still removed.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolate_soup_logger(self):
+        logger = logging.getLogger("soup")
+        saved_handlers = list(logger.handlers)
+        saved_level = logger.level
+        saved_propagate = logger.propagate
+        yield
+        for handler in list(logger.handlers):
+            logger.removeHandler(handler)
+        for handler in saved_handlers:
+            logger.addHandler(handler)
+        logger.setLevel(saved_level)
+        logger.propagate = saved_propagate
+
+    def test_foreign_handler_survives_reconfigure(self):
+        # Killing check: dropping the ``is not None`` guard in setup_logging
+        # removes this handler and fails this test by name.
+        foreign = logging.NullHandler()
+        assert not hasattr(foreign, "_soup_log_tier")
+
+        logger = logging.getLogger("soup")
+        logger.addHandler(foreign)
+        setup_logging(LogLevel.NORMAL)
+
+        assert foreign in logger.handlers
+
+    def test_stale_soup_handler_removed_with_foreign_present(self):
+        foreign = logging.NullHandler()
+        stale = logging.NullHandler()
+        stale._soup_log_tier = LogLevel.DEBUG  # type: ignore[attr-defined]
+
+        logger = logging.getLogger("soup")
+        logger.addHandler(foreign)
+        logger.addHandler(stale)
+        setup_logging(LogLevel.NORMAL)
+
+        assert stale not in logger.handlers
+        assert foreign in logger.handlers
+        tagged = [
+            handler for handler in logger.handlers
+            if getattr(handler, "_soup_log_tier", None) is not None
+        ]
+        assert len(tagged) == 1
+        assert tagged[0]._soup_log_tier == LogLevel.NORMAL  # type: ignore[attr-defined]
+
+
 class TestCliFlag:
     def test_log_level_help_visible(self):
         runner = CliRunner()

--- a/tests/test_log_level.py
+++ b/tests/test_log_level.py
@@ -70,11 +70,18 @@ class TestSetupLogging:
         assert logger.isEnabledFor(logging.DEBUG)
 
     def test_idempotent(self):
-        # Calling twice should not duplicate handlers
+        # Calling twice must neither duplicate handlers nor replace the
+        # existing one: same tier keeps the same handler object.
+        logger = setup_logging(LogLevel.NORMAL)
+        tagged = [
+            handler for handler in logger.handlers
+            if getattr(handler, "_soup_log_tier", None) == LogLevel.NORMAL
+        ]
+        assert len(tagged) == 1
+        n_handlers = len(logger.handlers)
         setup_logging(LogLevel.NORMAL)
-        n_handlers = len(logging.getLogger("soup").handlers)
-        setup_logging(LogLevel.NORMAL)
-        assert len(logging.getLogger("soup").handlers) == n_handlers
+        assert len(logger.handlers) == n_handlers
+        assert tagged[0] in logger.handlers
 
     def test_tier_change_replaces_handler(self):
         setup_logging(LogLevel.NORMAL)
@@ -109,6 +116,8 @@ class TestIssue273ForeignHandlerContract:
         saved_handlers = list(logger.handlers)
         saved_level = logger.level
         saved_propagate = logger.propagate
+        for handler in saved_handlers:
+            logger.removeHandler(handler)
         yield
         for handler in list(logger.handlers):
             logger.removeHandler(handler)


### PR DESCRIPTION
Closes the remaining row of #273 (claimed in [this comment](https://github.com/MakazhanAlpamys/Soup/issues/273#issuecomment-5490791363), with the offered-take silence stated there).

## What

Pins the `74->73` loop-back edge of `setup_logging` deterministically — the branch taken when the `soup` logger carries a handler **without** the `_soup_log_tier` tag. Measured on this machine before the change (Windows, Python 3.10.11, `tests/test_log_level.py` only):

```
src\soup_cli\utils\log_level.py      45      0     14      1    98%   74->73
15 passed
```

Same as the maintainer's run — the branch was not covered, only incidentally executed depending on ambient logger state.

## The tests (both directions, per the 2026-08-29 spec)

- `test_foreign_handler_survives_reconfigure` — a handler with no `_soup_log_tier` attached to the `soup` logger **survives** `setup_logging(NORMAL)`. This pins the real contract: Soup must not rip out logging handlers installed by an embedding application.
- `test_stale_soup_handler_removed_with_foreign_present` — a Soup handler with a stale tier is **removed** in the same pass, and exactly one NORMAL-tagged handler is rebuilt.

Both are hermetic: an autouse fixture snapshots the `soup` logger's handlers/level/propagate and restores them, which is also the missing-cleanup concern raised on the issue for this file.

## Mutation demo — shown, not asserted

Temporarily dropping the `is not None` guard in `log_level.py`:

```
FAILED tests/test_log_level.py::TestIssue273ForeignHandlerContract::test_foreign_handler_survives_reconfigure
FAILED tests/test_log_level.py::TestIssue273ForeignHandlerContract::test_stale_soup_handler_removed_with_foreign_present
2 failed in 1.24s
```

Both die by name; guard restored, `17 passed`.

## Post-fix BrPart figure, quoted per the ask

```
src\soup_cli\utils\log_level.py      45      0     14      0   100%
17 passed in 28.94s
```

`BrPart` is now 0 **for a reason** — the foreign handler forces the edge — not by luck of ambient state.

## Verification

- `ruff check src/soup_cli/ tests/` clean
- `tests/test_log_level.py` + `tests/test_v0402_part_b.py` + `tests/test_v0713.py` (every test matching `log_level or logging`): **122 passed, 2 pre-existing skips**
- No source change — `log_level.py` is untouched; the mutation was demonstrated and reverted
