### PR TITLE
feat(recipes): add qwen3.5-9b-dpo recipe (#275)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ src/soup_cli/
   experiment/         - SQLite experiment tracking
   eval/               - Eval platform (custom tasks, LLM judge, human eval, leaderboard)
   migrate/            - Config migration (LLaMA-Factory, Axolotl, Unsloth)
-  recipes/            - Ready-made configs for popular models (161 recipes)
+  recipes/            - Ready-made configs for popular models (162 recipes)
   autopilot/          - Zero-config decision engine (v0.25.0)
   registry/           - Model Registry (hashing, store, diff, attach) (v0.26.0 + v0.33.0)
   cans/               - Shareable .can artifact format + run/publish orchestrator (v0.26.0 + v0.33.0)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -152,7 +152,7 @@ soup migrate --from llamafactory config.yaml  Import config from LLaMA-Factory
 soup migrate --from axolotl config.yml        Import config from Axolotl
 soup migrate --from unsloth notebook.ipynb    Import config from Unsloth notebook
 soup migrate --from llamafactory c.yaml --dry-run  Preview without writing
-soup recipes list                             List all 161 ready-made recipes
+soup recipes list                             List all 162 ready-made recipes
 soup recipes show llama3.1-8b-sft            Print recipe YAML
 soup recipes use llama3.1-8b-sft             Copy recipe to soup.yaml
 soup recipes search "reasoning"              Search by keyword/task/size

--- a/docs/serving-and-export.md
+++ b/docs/serving-and-export.md
@@ -536,7 +536,7 @@ soup ui
 
 **Pages:**
 - **Dashboard** — view all experiment runs, loss charts, system info, multi-run comparison
-- **New Training** — create configs from templates or 161 ready-made recipes, validate, start training with live SSE log streaming and progress bar
+- **New Training** — create configs from templates or 162 ready-made recipes, validate, start training with live SSE log streaming and progress bar
 - **Data Explorer** — browse and inspect datasets (JSONL, JSON, CSV, Parquet)
 - **Model Chat** — chat with streaming responses, configurable temperature/top_p/max_tokens, system prompt, adapter selection, markdown rendering, chat export
 
@@ -545,7 +545,7 @@ soup ui
 - **Enhanced Metrics** — 2x2 chart grid (loss, LR, grad_norm, throughput) + GPU memory chart, eval results table
 - **Multi-Run Compare** — overlay loss curves from up to 5 runs side-by-side
 - **Chat Upgrade** — SSE streaming via proxy, typing indicator, cancel button, markdown renderer (bold, italic, code blocks), chat export as JSON
-- **Config Builder** — recipe dropdown (161 recipes), config schema API for dynamic form generation
+- **Config Builder** — recipe dropdown (162 recipes), config schema API for dynamic form generation
 
 **Security:** The Web UI generates a random auth token at startup (printed to console). All mutating endpoints (start/stop training, delete runs, inspect data, validate config) require `Authorization: Bearer <token>` header. CORS is restricted to the served origin. Data inspection is sandboxed to the working directory.
 

--- a/src/soup_cli/recipes/catalog.py
+++ b/src/soup_cli/recipes/catalog.py
@@ -48,7 +48,7 @@ def search_recipes(
 
 
 # ---------------------------------------------------------------------------
-# Recipe catalog (161 recipes)
+# Recipe catalog (162 recipes)
 # ---------------------------------------------------------------------------
 
 RECIPES: Dict[str, RecipeMeta] = {
@@ -3944,6 +3944,36 @@ training:
   grpo_beta: 0.1
   num_generations: 4
   reward_fn: accuracy
+
+output: ./output
+""",
+    ),
+    "qwen3.5-9b-dpo": RecipeMeta(
+        model="Qwen/Qwen3.5-9B",
+        task="dpo",
+        size="9B",
+        tags=("qwen", "qwen3.5", "dpo", "alignment", "preference"),
+        description="Qwen 3.5 9B DPO alignment (Apache-2.0)",
+        yaml_str="""\
+base: Qwen/Qwen3.5-9B
+task: dpo
+modality: text
+
+data:
+  train: ./data/preference_train.jsonl
+  format: dpo
+  max_length: 4096
+
+training:
+  epochs: 3
+  lr: 5e-6
+  batch_size: auto
+  lora:
+    r: 16
+    alpha: 32
+    target_modules: auto
+  quantization: 4bit
+  dpo_beta: 0.1
 
 output: ./output
 """,

--- a/tests/test_issue427_qwen35_text_modality.py
+++ b/tests/test_issue427_qwen35_text_modality.py
@@ -15,6 +15,7 @@ EXPECTED_QWEN35_TEXT_RECIPES = {
     "qwen3.5-4b-pretrain",
     "qwen3.5-9b-sft",
     "qwen3.5-9b-grpo",
+    "qwen3.5-9b-dpo",
     "qwen3.5-27b-sft",
     "qwen3.5-35b-a3b-sft",
     "qwen3.5-35b-a3b-dpo",

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -518,6 +518,64 @@ class TestIssue281KimiK26GrpoRecipe:
         )
 
 
+class TestQwen35NineBDpoRecipe:
+    """Coverage for the qwen3.5-9b-dpo recipe (#275 task-variant)."""
+
+    def test_recipe_loads_with_expected_dpo_shape(self) -> None:
+        from soup_cli.config.loader import load_config_from_string
+        from soup_cli.recipes.catalog import get_recipe
+
+        recipe = get_recipe("qwen3.5-9b-dpo")
+        assert recipe is not None
+        # Surface 1: the metadata. Pinned separately from the YAML below so an
+        # edit to one that forgets the other cannot pass -- the guard the
+        # maintainer named as deciding #512.
+        assert recipe.model == "Qwen/Qwen3.5-9B"
+        assert recipe.task == "dpo"
+
+        config = load_config_from_string(recipe.yaml_str)
+        # Surface 2: the YAML `base:`.
+        assert config.base == "Qwen/Qwen3.5-9B"
+        assert config.task == "dpo"
+        assert config.data.format == "dpo"
+        assert config.training.dpo_beta == 0.1
+        # Every DPO recipe in the catalog uses 5e-6; this one is not an outlier.
+        assert config.training.lr == 5e-6
+        assert config.training.lora.r == 16
+        assert config.training.lora.alpha == 32
+        assert config.training.quantization == "4bit"
+
+    def test_completes_the_task_trio_for_this_base(self) -> None:
+        """#275 is about DPO/GRPO/pretrain variants of the shipped SFT recipes."""
+        from soup_cli.recipes.catalog import RECIPES
+
+        tasks = {r.task for r in RECIPES.values() if r.model == "Qwen/Qwen3.5-9B"}
+        assert {"sft", "grpo", "dpo"} <= tasks
+
+    def test_shares_base_and_size_with_its_sft_sibling(self) -> None:
+        from soup_cli.recipes.catalog import get_recipe
+
+        dpo, sft = get_recipe("qwen3.5-9b-dpo"), get_recipe("qwen3.5-9b-sft")
+        assert dpo is not None and sft is not None
+        assert dpo.model == sft.model
+        assert dpo.size == sft.size
+        assert dpo.task != sft.task
+
+    def test_show_and_use_recipe(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        show_result = runner.invoke(app, ["recipes", "show", "qwen3.5-9b-dpo"])
+        assert show_result.exit_code == 0
+        assert "Qwen/Qwen3.5-9B" in show_result.output
+
+        monkeypatch.chdir(tmp_path)
+        use_result = runner.invoke(app, ["recipes", "use", "qwen3.5-9b-dpo", "--yes"])
+        assert use_result.exit_code == 0
+        assert "Qwen/Qwen3.5-9B" in (tmp_path / "soup.yaml").read_text(encoding="utf-8")
+
+
 # ---------------------------------------------------------------------------
 # Part A: v0.25.0 new model recipes (Llama 4, Qwen 3, Gemma 3, DeepSeek V3)
 # ---------------------------------------------------------------------------
@@ -565,7 +623,7 @@ class TestV025NewRecipes:
             assert cfg.base == recipe.model
             assert cfg.task == recipe.task
 
-    def test_catalog_size_is_161(self):
+    def test_catalog_size_is_162(self):
         """Total catalog size — grew with each release.
 
         v0.25.0 shipped 43 recipes (29 + 9 Part A + 2 Part B tools + 3 Part E MLX).
@@ -590,10 +648,11 @@ class TestV025NewRecipes:
         Issue #271 added 1 (smollm3-3b-sft) -> 159.
         Issue #276 added 1 (qwen3.5-35b-a3b-dpo) -> 160.
         Issue #281 added 1 (kimi-k2.6-grpo) -> 161.
+        Task-variant for #275 added 1 (qwen3.5-9b-dpo) -> 162.
         """
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 161
+        assert len(RECIPES) == 162
 
     def test_new_recipes_searchable(self):
         """Search returns the new recipes via keyword/task filter."""

--- a/tests/test_v07124.py
+++ b/tests/test_v07124.py
@@ -270,7 +270,7 @@ class TestGlm5RepoIdFix:
 
 class TestCatalogCount:
     def test_total_recipe_count_is_158(self) -> None:
-        assert len(RECIPES) == 161
+        assert len(RECIPES) == 162
 
     def test_list_recipes_matches_dict(self) -> None:
         assert len(list_recipes()) == len(RECIPES)

--- a/tests/test_v07130.py
+++ b/tests/test_v07130.py
@@ -737,10 +737,10 @@ class TestRecipes:
         assert cfg.training.rollout_backend == "openenv"
         assert cfg.training.rollout_func.startswith("soup_cli.envs.")
 
-    def test_catalog_size_is_161(self):
+    def test_catalog_size_is_162(self):
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 161
+        assert len(RECIPES) == 162
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_v07132.py
+++ b/tests/test_v07132.py
@@ -950,7 +950,7 @@ class TestAsrRecipes:
         assert cfg.task == "sft"
         assert cfg.modality == "vision"
 
-    def test_catalog_size_is_161(self):
+    def test_catalog_size_is_162(self):
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 161
+        assert len(RECIPES) == 162


### PR DESCRIPTION
Adds the DPO task-variant for `Qwen/Qwen3.5-9B` under #275's "more variants beyond this list" line. Claimed the specific recipe on the tracking issue first, per your coordination note on #379.

`Refs #275` — the tracking issue stays open for the remaining families.

## Why this recipe

Measured rather than picked by eye. Of the 2026 families in the catalog:

```
Qwen/Qwen3.5-9B            ['grpo', 'sft']    <- no preference variant
Qwen/Qwen3.5-35B-A3B       ['dpo', 'sft']     (#276, merged as #615)
deepseek-ai/DeepSeek-V4-Flash  ['grpo','sft']
zai-org/GLM-5.1            ['dpo', 'sft']
...16 more models carrying SFT only
```

Qwen3.5-9B already had two of the three tasks #275 is about, so DPO completes the trio on the mid-size model of the family with the largest catalog presence. All six named children of #275 are now done (#276→#615, #277, #278, #279, #280, #281→#614); no open issue or PR mentioned `9b-dpo`.

## Shape

The `qwen2.5-7b-dpo` DPO half — `format: dpo`, `lr: 5e-6`, `dpo_beta: 0.1`, `preference_train.jsonl` — with the SFT sibling's geometry: LoRA r16/a32, 4-bit, `max_length: 4096`.

`lr: 5e-6` matches **all 11** existing DPO recipes. Noting it because #512 used `1e-5` for its recipe, which would have made it the family's only outlier.

## The modality contract, handled up front this time

#275 says to copy `qwen2.5-7b-dpo`, which carries **no `modality:` line**. `test_issue427_qwen35_text_modality.py` holds every Qwen3.5/3.6/3.8 recipe to an explicit `modality: text` and its family audit fails on any unregistered sibling — so a literal copy ships a recipe that escapes the decoder-only contract. Credit to @kok-o, who hit this first on #512; I hit it independently on #276. Here it was designed in rather than discovered.

## Mutations — six, all killed

| Mutation | Result |
|---|---|
| **`RecipeMeta.model` alone → wrong id** | **4 fail** |
| **YAML `base:` alone → wrong id** | **3 fail** |
| `modality: text` removed | 1 fails (family audit) |
| `format: dpo` → `auto` | 1 fails |
| `lr` 5e-6 → 1e-5 | 1 fails |
| entry deleted entirely | 7 fail |

The first two are the guard you named as deciding #512: each id surface fails **on its own**, so an edit that repairs one and forgets the other cannot pass.

## Verification

```
pytest tests/ -k "recipe"                          -> 2015 passed, 17561 deselected
ruff check src/soup_cli/ scripts/ tests/            -> All checks passed
git diff -- tests/ | grep -c "^-[^-]"              -> 7   (all count-bump sites)
```

The 7 removed test lines are the `161 → 162` bumps: four `assert len(RECIPES) == 161` and three `test_catalog_size_is_161` renames. No test deleted or weakened. `Qwen/Qwen3.5-9B` resolves on the Hub (HTTP 200); `recipes show` / `recipes use` were both run live.

## One thing worth reporting separately

While verifying I found that three existing tests fail on a **clean main** in a shell with `FORCE_COLOR` set — `test_issue330_mix_recipe_train_loadable.py` (×2) and `test_issue477_qwen38_catalog.py` — because `rich` emits ANSI into `recipes show` output that the assertions then parse as YAML. Nothing to do with this PR; I confirmed it by stashing. Filing it on its own rather than bundling.