### PR TITLE
test(ansi): normalise syntax-highlighted CLI output and guard the pattern (#633)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,21 @@
-"""Shared test fixtures."""
+"""Shared pytest fixtures and helpers."""
 
 import json
+import re
 from pathlib import Path
 
 import pytest
+
+#: Rich/Pygments emit SGR escapes *between* the tokens of one logical line, so a
+#: multi-token substring like "modality: text" is absent from raw output and
+#: yaml.safe_load rejects \x1b outright (#633). 38 test files had grown their
+#: own copy of this regex; new code should import this one.
+_ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def strip_ansi(text: "str | None") -> str:
+    """Return ``text`` with SGR escape sequences removed."""
+    return _ANSI_ESCAPE.sub("", text or "")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_cli_help_assertions_are_ansi_safe.py
+++ b/tests/test_cli_help_assertions_are_ansi_safe.py
@@ -252,3 +252,149 @@ def test_help_renders():
 
     def test_unparseable_source_does_not_explode(self):
         assert find_raw_help_assertions("def broken(:\n") == []
+
+
+# ---------------------------------------------------------------------------
+# #633 — the same hazard, on subcommands the `--help` scan never reaches.
+# ---------------------------------------------------------------------------
+
+#: Commands whose output is **syntax highlighted**. Rich renders these through
+#: Pygments, which emits SGR escapes *between* the tokens of one logical line:
+#: ``modality``, ``:`` and ``text`` are three tokens, so ``"modality: text"`` is
+#: not a substring of the rendered output and ``yaml.safe_load`` rejects
+#: ``\x1b``. Plain ``console.print`` output is not affected the same way -- an
+#: unstyled message is wrapped in escapes rather than split by them -- which is
+#: why only these commands are scanned and the suite's ~200 other raw-output
+#: assertions are correctly left alone.
+_HIGHLIGHTED_INVOCATIONS = (
+    re.compile(r'"recipes"\s*,\s*"show"'),
+    re.compile(r"'recipes'\s*,\s*'show'"),
+    re.compile(r'"mix"\s*,\s*"--(apply|optimize)"'),
+    re.compile(r"'mix'\s*,\s*'--(apply|optimize)'"),
+)
+
+_PARSES_OUTPUT = re.compile(r"(yaml\.safe_load|json\.loads)\s*\(")
+
+#: Broader than ``_RAW_OUTPUT_RE``, which anchors on the exact name
+#: ``result.output`` and therefore cannot match ``show_result.output`` -- ``_``
+#: is a word character, so ``\b`` never fires before ``result`` there. Real
+#: tests name their results ``show_result`` / ``use_result`` all the time.
+_ANY_RAW_OUTPUT_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\.(output|stdout)\b|readouterr\(\)")
+_STRING_LITERAL = re.compile(r'"([^"]{2,})"' + r"|'([^']{2,})'")
+
+
+def _is_multi_token(literal: str) -> bool:
+    """A literal that Pygments would split across tokens.
+
+    The hazard is YAML *structure*. ``modality: text`` is three tokens -- key,
+    punctuation, value -- with escapes between them, and ``train:`` is two. A
+    bare model id (``Qwen/Qwen3.8-27B``) is one token and survives raw, which is
+    why neighbouring assertions in the same file kept passing.
+
+    A plain message such as ``"validation failed"`` is also safe: Rich wraps an
+    unstyled string in escapes rather than splitting it, so requiring a colon
+    keeps the guard on the assertions that actually break rather than every
+    substring containing a space.
+    """
+    return ":" in literal
+
+
+def _assert_expression(line: str) -> str:
+    """Return the tested expression of an ``assert``, dropping its message.
+
+    ``assert "train:" in compact, result.output`` reads raw output only in the
+    *failure message*, which is harmless and in fact good practice. Scanning the
+    whole line would flag it, so the top-level comma is found (ignoring commas
+    inside brackets or strings) and everything after it discarded.
+    """
+    depth = 0
+    quote = ""
+    for index, char in enumerate(line):
+        if quote:
+            if char == quote and line[index - 1 : index] != "\\":
+                quote = ""
+            continue
+        if char in "\"'":
+            quote = char
+        elif char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+        elif char == "," and depth == 0:
+            return line[:index]
+    return line
+
+
+def find_unsafe_highlighted_assertions(source: str) -> list[tuple[int, str]]:
+    """Return ``(lineno, text)`` for unnormalised reads of highlighted output.
+
+    Scoped per test FUNCTION, like ``find_raw_help_assertions``: a function that
+    invokes a syntax-highlighted command and then either feeds raw output to a
+    parser or asserts a multi-token substring against it.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:  # pragma: no cover — a broken file fails its own tests
+        return []
+    lines = source.splitlines()
+    offenders: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not node.name.startswith("test"):
+            continue
+        end = node.end_lineno or node.lineno
+        body = lines[node.lineno - 1 : end]
+        joined = "\n".join(body)
+        if not any(pattern.search(joined) for pattern in _HIGHLIGHTED_INVOCATIONS):
+            continue
+
+        tainted: set[str] = set()
+        for offset, line in enumerate(body):
+            stripped = line.strip()
+            if stripped[:1] in {'"', "'"}:
+                # A source line that *is* a string literal -- the synthetic
+                # fixtures this guard's own tests are built from. Scanning them
+                # would flag the examples written to prove the guard works.
+                continue
+            if _looks_normalised(stripped):
+                # Record that this variable is safe, then move on.
+                match = _ASSIGN_RE.match(line)
+                if match:
+                    tainted.discard(match.group(1))
+                continue
+
+            match = _ASSIGN_RE.match(line)
+            if match and not stripped.startswith("assert"):
+                name, rhs = match.group(1), match.group(2)
+                derived = _ANY_RAW_OUTPUT_RE.search(rhs) or any(
+                    re.search(rf"\b{re.escape(var)}\b", rhs) for var in tainted
+                )
+                if derived:
+                    tainted.add(name)
+                    if _PARSES_OUTPUT.search(rhs):
+                        offenders.append((node.lineno + offset, stripped[:100]))
+                continue
+
+            reads_raw = _ANY_RAW_OUTPUT_RE.search(stripped)
+            reads_tainted = any(
+                re.search(rf"\b{re.escape(var)}\b", stripped) for var in tainted
+            )
+            if not (reads_raw or reads_tainted):
+                continue
+            if _PARSES_OUTPUT.search(stripped):
+                offenders.append((node.lineno + offset, stripped[:100]))
+                continue
+            if not stripped.startswith("assert"):
+                continue
+            expression = _assert_expression(stripped)
+            if not (
+                _ANY_RAW_OUTPUT_RE.search(expression)
+                or any(re.search(rf"\b{re.escape(var)}\b", expression) for var in tainted)
+            ):
+                continue
+            found = _STRING_LITERAL.search(expression)
+            literal = (found.group(1) or found.group(2)) if found else ""
+            if literal and _is_multi_token(literal):
+                offenders.append((node.lineno + offset, stripped[:100]))
+    return offenders

--- a/tests/test_issue330_mix_recipe_train_loadable.py
+++ b/tests/test_issue330_mix_recipe_train_loadable.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 from soup_cli.config.loader import load_config_from_string
 from soup_cli.utils.data_mix import MixOptimizationReport, render_mix_recipe_yaml
 
+from .conftest import strip_ansi
+
 
 def _make_files(tmp_path, names):
     for n in names:
@@ -112,7 +114,10 @@ def test_apply_cli_prints_dataset_list_shape_recipe(tmp_path, monkeypatch):
     # Rich wraps long lines to the console width, so compare with whitespace
     # collapsed rather than by exact line — "train:" must be followed by a
     # "-" list marker (the new shape), not directly by a path.
-    compact = "".join(result.output.split())
+    # #633: collapse whitespace AND strip ANSI. Rich splits "train:" across
+    # Pygments tokens when colour is enabled, so whitespace collapse alone --
+    # the fix that shipped here originally -- leaves escapes mid-token.
+    compact = "".join(strip_ansi(result.output).split())
     assert "train:" in compact, result.output
     after = compact[compact.index("train:") + len("train:"):]
     assert after.startswith("-"), result.output
@@ -165,7 +170,8 @@ def test_apply_cli_quotes_path_needing_quoting(tmp_path, monkeypatch):
     runner = CliRunner()
     result = runner.invoke(app, ["data", "mix", "--apply", "odd.yaml"])
     assert result.exit_code == 0, (result.output, repr(result.exception))
-    data_block = result.output[result.output.index("data:"):]
+    plain = strip_ansi(result.output)  # #633 -- \x1b is not valid YAML
+    data_block = plain[plain.index("data:"):]
     loaded = yaml.safe_load(data_block)
     assert loaded["data"]["train"] == "odd: name.jsonl"
 
@@ -230,7 +236,8 @@ def test_apply_handles_new_multi_dataset_recipe(tmp_path, monkeypatch):
     assert result.exit_code == 0, (result.output, repr(result.exception))
     result = runner.invoke(app, ["data", "mix", "--apply", "rec3.yaml"])
     assert result.exit_code == 0, (result.output, repr(result.exception))
-    data_block = result.output[result.output.index("data:"):]
+    plain = strip_ansi(result.output)  # #633 -- \x1b is not valid YAML
+    data_block = plain[plain.index("data:"):]
     from pathlib import Path
 
     import yaml

--- a/tests/test_issue477_qwen38_catalog.py
+++ b/tests/test_issue477_qwen38_catalog.py
@@ -9,6 +9,8 @@ from soup_cli.cli import app
 from soup_cli.config.loader import load_config_from_string
 from soup_cli.recipes.catalog import get_recipe, search_recipes
 
+from .conftest import strip_ansi
+
 runner = CliRunner()
 
 
@@ -44,7 +46,10 @@ def test_qwen38_27b_recipe_show_and_use(
     show_result = runner.invoke(app, ["recipes", "show", "qwen3.8-27b-sft"])
     assert show_result.exit_code == 0
     assert "Qwen/Qwen3.8-27B" in show_result.output
-    assert "modality: text" in show_result.output
+    # #633: "modality: text" spans three Pygments tokens, so escapes land
+    # inside it whenever colour is enabled. The model id above is one token and
+    # survives raw, which is why only this line broke.
+    assert "modality: text" in strip_ansi(show_result.output)
 
     monkeypatch.chdir(tmp_path)
     use_result = runner.invoke(

--- a/tests/test_issue633_ansi_in_highlighted_output.py
+++ b/tests/test_issue633_ansi_in_highlighted_output.py
@@ -1,0 +1,166 @@
+"""Syntax-highlighted CLI output must be normalised before it is read (#633).
+
+``soup recipes show`` and ``soup data mix --apply`` render YAML through Rich
+with Pygments highlighting. With colour enabled, escape sequences land *between
+the tokens of one logical line* -- ``modality`` / ``:`` / ``text`` are three
+tokens, so ``"modality: text"`` is not a substring of the rendered output, and
+``yaml.safe_load`` rejects ``\\x1b`` outright.
+
+CI never sees this: GitHub runners have no TTY and do not set ``FORCE_COLOR``,
+so Rich disables colour. It appears only for a contributor whose terminal forces
+colour, as three red tests on a clean checkout with no local changes.
+
+This is the failure mode ``test_cli_help_assertions_are_ansi_safe.py`` was
+written for after it "turned CI red everywhere else (it has, four times)". That
+guard only ever looks at functions containing ``--help``, so no other subcommand
+was covered.
+
+Note what does *not* break: a bare model id such as ``Qwen/Qwen3.5-9B`` is a
+single Pygments token, so no escape lands inside it. The distinction is between
+single-token and multi-token assertions, which is why this went unnoticed while
+neighbouring assertions in the same files kept passing.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from typer.testing import CliRunner
+
+from soup_cli.cli import app
+
+from .conftest import strip_ansi
+
+_ESC = re.compile(r"\x1b\[[0-9;]*m")
+
+
+class TestTheHelperItself:
+    def test_strip_ansi_removes_escapes(self) -> None:
+        assert strip_ansi("\x1b[1;32mmodality\x1b[0m: text") == "modality: text"
+
+    def test_strip_ansi_leaves_clean_text_alone(self) -> None:
+        assert strip_ansi("modality: text") == "modality: text"
+
+    def test_strip_ansi_tolerates_none(self) -> None:
+        assert strip_ansi(None) == ""
+
+
+class TestHighlightedOutputIsReadable:
+    """These fail without the fix whenever colour is forced."""
+
+    def _show(self, name: str) -> str:
+        runner = CliRunner(env={"FORCE_COLOR": "1", "TERM": "xterm-256color", "COLUMNS": "300"})
+        result = runner.invoke(app, ["recipes", "show", name])
+        assert result.exit_code == 0, result.output
+        return result.output
+
+    def test_the_hazard_is_real_and_this_test_reproduces_it(self) -> None:
+        """A control: without stripping, the multi-token assertion fails.
+
+        If Rich ever stops highlighting here the rest of this file would pass
+        vacuously, so the hazard itself is asserted rather than assumed.
+
+        The skip is tied to the hazard, not to the mere presence of escapes:
+        Rich colours the panel border even when it does not syntax-highlight the
+        body, so "some escape somewhere" is not evidence that the YAML is
+        tokenised. Environments that honour NO_COLOR land here legitimately.
+        """
+        raw = self._show("qwen3.8-27b-sft")
+        if "modality: text" in raw:
+            pytest.skip("YAML is not syntax-highlighted here; nothing to normalise")
+        assert _ESC.search(raw), "expected escapes if the literal is absent"
+        assert "modality: text" in strip_ansi(raw)
+
+    def test_multi_token_assertion_holds_after_stripping(self) -> None:
+        assert "modality: text" in strip_ansi(self._show("qwen3.8-27b-sft"))
+
+    def test_single_token_assertion_holds_either_way(self) -> None:
+        """Why the neighbouring assertions in the same file never broke."""
+        raw = self._show("qwen3.8-27b-sft")
+        assert "Qwen/Qwen3.8-27B" in raw
+        assert "Qwen/Qwen3.8-27B" in strip_ansi(raw)
+
+    def test_structural_yaml_substrings_hold_after_stripping(self) -> None:
+        """``recipes show`` renders inside a Panel, so stripping ANSI is
+        necessary but not sufficient to *parse* it -- the box borders remain.
+        Assert on structure rather than pretending the panel is a document;
+        ``data mix --apply`` is the unpanelled command whose output is parsed,
+        and that path is covered in test_issue330."""
+        plain = strip_ansi(self._show("qwen3.8-27b-sft"))
+        assert "base: Qwen/Qwen3.8-27B" in plain
+        assert "task: sft" in plain
+
+
+class TestTheGuardCoversHighlightedCommands:
+    """The scanner must reach subcommands other than ``--help``."""
+
+    def test_scanner_flags_a_parsed_raw_output_assertion(self) -> None:
+        from tests.test_cli_help_assertions_are_ansi_safe import (
+            find_unsafe_highlighted_assertions,
+        )
+
+        source = (
+            "def test_x():\n"
+            "    result = runner.invoke(app, ['recipes', 'show', 'r'])\n"
+            "    loaded = yaml.safe_load(result.output)\n"
+        )
+        assert find_unsafe_highlighted_assertions(source)
+
+    def test_scanner_flags_a_multi_token_assertion(self) -> None:
+        from tests.test_cli_help_assertions_are_ansi_safe import (
+            find_unsafe_highlighted_assertions,
+        )
+
+        source = (
+            "def test_x():\n"
+            "    result = runner.invoke(app, ['recipes', 'show', 'r'])\n"
+            "    assert 'modality: text' in result.output\n"
+        )
+        assert find_unsafe_highlighted_assertions(source)
+
+    def test_scanner_accepts_a_normalised_assertion(self) -> None:
+        from tests.test_cli_help_assertions_are_ansi_safe import (
+            find_unsafe_highlighted_assertions,
+        )
+
+        source = (
+            "def test_x():\n"
+            "    result = runner.invoke(app, ['recipes', 'show', 'r'])\n"
+            "    assert 'modality: text' in strip_ansi(result.output)\n"
+        )
+        assert not find_unsafe_highlighted_assertions(source)
+
+    def test_scanner_ignores_single_token_assertions(self) -> None:
+        """Single tokens are genuinely safe; flagging them would be noise."""
+        from tests.test_cli_help_assertions_are_ansi_safe import (
+            find_unsafe_highlighted_assertions,
+        )
+
+        source = (
+            "def test_x():\n"
+            "    result = runner.invoke(app, ['recipes', 'show', 'r'])\n"
+            "    assert 'Qwen/Qwen3.8-27B' in result.output\n"
+        )
+        assert not find_unsafe_highlighted_assertions(source)
+
+    def test_the_suite_has_no_unsafe_highlighted_assertions(self) -> None:
+        from pathlib import Path
+
+        from tests.test_cli_help_assertions_are_ansi_safe import (
+            find_unsafe_highlighted_assertions,
+        )
+
+        offenders: list[str] = []
+        tests_dir = Path(__file__).parent
+        for path in sorted(tests_dir.glob("test_*.py")):
+            source = path.read_text(encoding="utf-8", errors="replace")
+            for lineno, text in find_unsafe_highlighted_assertions(source):
+                offenders.append(f"{path.name}:{lineno}: {text}")
+        assert not offenders, (
+            "These read syntax-highlighted CLI output without stripping ANSI. "
+            "Rich splits one logical line across Pygments tokens, so a "
+            "multi-token substring is absent and yaml.safe_load rejects \\x1b. "
+            "Route it through strip_ansi() from tests/conftest.py:\n"
+            + "\n".join(offenders)
+        )


### PR DESCRIPTION
Fixes the three tests that fail on a **clean checkout** in any shell with `FORCE_COLOR` set, and extends the existing ANSI guard to the subcommands it never reached.

`Refs #633`.

## The bug

`soup recipes show` and `soup data mix --apply` render YAML through Rich with Pygments, which emits escapes **between the tokens of one logical line**. `modality`, `:` and `text` are three tokens, so `"modality: text"` is not a substring of the output, and `yaml.safe_load` rejects `\x1b` outright.

CI never sees it — runners have no TTY — so the symptom is three red tests on a fresh clone with no local changes, which reads as "I broke something". It cost me a stash-and-rerun to disprove while verifying #632.

This is the exact failure mode `test_cli_help_assertions_are_ansi_safe.py` was written for, after it "turned CI red everywhere else (it has, four times)". That scanner only inspects functions containing `--help`, so no other subcommand was covered.

Worth noting the #330 pair had already defended against the *other* rendering hazard — Rich wrapping long paths mid-token, via `CliRunner(env={"COLUMNS": "300"})`. Colour was the one that got missed.

## Scope, measured rather than guessed

My first instinct was "flag every unnormalised raw-output assertion". That would have landed **217 pre-existing offenders**, and a guard arriving with 217 violations is one people delete rather than obey.

Scoping to **syntax-highlighted commands** and to **literals containing a colon** — the YAML structure Pygments actually tokenises — flags exactly the assertions that break:

| population | count |
|---|---|
| any unnormalised raw-output assertion | 217 |
| raw output fed to a parser | 4 |
| **highlighted output + colon literal (the guard's scope)** | **3, all genuine** |

A plain message like `"validation failed"` is wrapped in escapes rather than split by them, and a bare model id is a single token — which is why neighbouring assertions in the same files kept passing.

## Two defects in my own guard, found by running it

- **It missed the #477 case entirely.** `_RAW_OUTPUT_RE` anchors on `result.output`, and `\b` never fires before `result` in `show_result.output` because `_` is a word character. The new scan uses a broader pattern.

  **The existing `--help` guard has the same blind spot.** I measured it before claiming a second bug: **0** current assertions hit it, so it is latent rather than live. Reported, not changed here — widening `_RAW_OUTPUT_RE` alters the older guard's behaviour and belongs in its own PR if you want it.

- **It flagged `assert "train:" in compact, result.output`**, where the raw read is in the failure *message* — which is good practice, not a defect. Only the assert expression is scanned now.

## Mutations — four, all killed

| Mutation | Result |
|---|---|
| `strip_ansi()` becomes a no-op | 6 fail |
| scanner returns nothing | 2 fail |
| the #477 fix reverted | 2 fail |
| **colon predicate widened back to any-space** | **1 fails** |

The last is the one I care about: widening re-flags the legitimate `"validation failed"` assertion, so the *narrowing itself* is pinned and cannot drift back into noise.

## Verified in both directions

A fix that only passes in one colour mode is not a fix:

```
FORCE_COLOR=3 TERM=xterm-256color   -> 15 passed
NO_COLOR=1 FORCE_COLOR= TERM=dumb   -> 14 passed, 1 skipped
```

The skip is the control, which correctly skips when there is no highlighting to normalise — and it skips on the **hazard's absence**, not on "no escapes anywhere", because Rich colours the panel border even when it does not highlight the body. I got that wrong first and it passed vacuously.

```
full suite    -> 19468 passed, 103 skipped, coverage 82.73% (floor 77%)
ruff          -> All checks passed
git diff -- tests/ | grep -c "^-[^-]"  -> 5
```

All five removed lines are rewrites in place: the conftest docstring, the three patched read sites, and the #477 assertion. No test deleted or weakened.

## Deliberately not in this PR

**38 test files define their own `_ANSI_RE` / `_strip_ansi` copy.** `strip_ansi` now lives in `tests/conftest.py` and new code should import it, but consolidating 38 files inside a bug fix is scope creep of exactly the kind splitting #619 out of #581 avoided. Happy to do it as its own PR — duplicated helpers are how this repo got #372, #392 and #424.