### PR TITLE
fix(mlx): recognize and load saved adapter checkpoints on --resume (#634)

### DIFF
--- a/changelog.d/0.73.3/639.fixed.md
+++ b/changelog.d/0.73.3/639.fixed.md
@@ -7,5 +7,7 @@
   weights before training starts. This is a weights-only warm start, not a
   full resume — mlx-lm's LoRA trainer exposes no optimizer state or step
   count, so the step count and data position both restart from zero
-  regardless of how far the checkpoint got, and the run says so (#634 by
-  @SID-6921 in #639).
+  regardless of how far the checkpoint got, and the run says so. Also
+  fixes MLX `--resume` for any config with `experiment_name` set, which
+  the first version of this fix missed (#634 reported and diagnosed by
+  @imahsanali, fixed by @SID-6921 in #639).

--- a/changelog.d/0.73.3/639.fixed.md
+++ b/changelog.d/0.73.3/639.fixed.md
@@ -7,4 +7,5 @@
   weights before training starts. This is a weights-only warm start, not a
   full resume — mlx-lm's LoRA trainer exposes no optimizer state or step
   count, so the step count and data position both restart from zero
-  regardless of how far the checkpoint got, and the run says so (#634).
+  regardless of how far the checkpoint got, and the run says so (#634 by
+  @SID-6921 in #639).

--- a/changelog.d/0.73.3/PLACEHOLDER.fixed.md
+++ b/changelog.d/0.73.3/PLACEHOLDER.fixed.md
@@ -1,0 +1,10 @@
+- `--resume auto` (and a direct `--resume <path>`) now finds MLX checkpoints.
+  `_resolve_checkpoint` only recognized `checkpoint-N` directories (the
+  transformers/unsloth shape); mlx-lm's tuner saves step-numbered
+  `NNNNNNN_adapters.safetensors` files instead, so an MLX run's own output
+  never matched and training silently restarted from scratch every time.
+  `MLXSFTTrainerWrapper.train()` now loads the located checkpoint's adapter
+  weights before training starts. This is a weights-only warm start, not a
+  full resume — mlx-lm's LoRA trainer exposes no optimizer state or step
+  count, so the step count and data position both restart from zero
+  regardless of how far the checkpoint got, and the run says so (#634).

--- a/docs/backends-and-ops.md
+++ b/docs/backends-and-ops.md
@@ -115,6 +115,8 @@ training:
 
 MLX backend supports SFT. `backend: mlx` with `task: dpo` or `task: grpo` is refused when the config is loaded, with an error naming the task — upstream `mlx-lm` ships no DPO/GRPO training helper, so those wrappers exist only as a backstop for callers that bypass config validation. Requires `mlx-lm >= 0.31.3`. Use `soup recipes search --tag mlx` for ready-made Apple Silicon configs.
 
+`--resume auto` finds mlx-lm's step-numbered `NNNNNNN_adapters.safetensors` checkpoints and warm-starts the LoRA weights from them ([#634](https://github.com/MakazhanAlpamys/Soup/issues/634)). This restores adapter weights only, not training state: mlx-lm's LoRA trainer exposes no optimizer state or step count, so training restarts from step 0 regardless of how far the checkpoint got. See [Resume Training](#resume-training) below for the MLX-specific checkpoint shape.
+
 ### Transformers on MPS
 
 The regular `backend: transformers` path can run more than MLX's SFT-only
@@ -282,6 +284,15 @@ soup train --config soup.yaml --resume auto
 # Resume from a specific checkpoint
 soup train --config soup.yaml --resume ./output/checkpoint-500
 ```
+
+`backend: mlx` writes and resumes a different checkpoint shape: a
+step-numbered `NNNNNNN_adapters.safetensors` file (or the final
+`adapters.safetensors`) directly under `output`, not a `checkpoint-N`
+directory. `--resume auto` and `--resume ./output/0011800_adapters.safetensors`
+both work; `--resume ./output/checkpoint-500` does not, because MLX never
+writes that shape. This is a weights-only warm start — mlx-lm's LoRA trainer
+exposes no optimizer state or step count, so the resumed run starts counting
+from step 0 regardless of how far the checkpoint got.
 
 
 ## Run Management & Cleanup

--- a/src/soup_cli/commands/train.py
+++ b/src/soup_cli/commands/train.py
@@ -19,6 +19,7 @@ from soup_cli.monitoring.display import TrainingDisplay
 from soup_cli.utils.gpu import detect_device, get_gpu_info, resolve_quantization
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only, no runtime import
+    from soup_cli.config.schema import SoupConfig
     from soup_cli.utils.energy import EnergyMeasurement
 
 console = Console()
@@ -739,16 +740,7 @@ def train(
         )
 
     # --- Resolve resume checkpoint (fail fast before heavy operations) ---
-    resume_from = None
-    if resume:
-        resume_from = _resolve_checkpoint(
-            resume, cfg.output, cfg.experiment_name, backend=cfg.backend
-        )
-        if resume_from:
-            console.print(f"[green]Resuming from:[/] {resume_from}")
-        else:
-            console.print("[red]No checkpoint found to resume from.[/]")
-            raise typer.Exit(1)
+    resume_from = _resolve_resume_or_exit(resume, cfg)
 
     # --- HF auto-resume: pull latest checkpoint branch into output dir ---
     if hf_resume and push_as and resume_from is None:
@@ -2017,9 +2009,7 @@ def _highest_numbered_mlx_checkpoint(paths) -> Path | None:
     return max(numbered, key=lambda pair: pair[0])[1]
 
 
-def _resolve_mlx_checkpoint(
-    resume: str, output_dir: str, experiment_name: str | None = None
-) -> str | None:
+def _resolve_mlx_checkpoint(resume: str, output_dir: str) -> str | None:
     """MLX-style checkpoint resolution (#634).
 
     mlx-lm's tuner saves step-numbered adapter snapshots
@@ -2028,11 +2018,17 @@ def _resolve_mlx_checkpoint(
     transformers/unsloth backends write. "auto" picks the highest-numbered
     snapshot if one exists, else the final file. A direct ``resume`` value
     must point at one of these files directly.
+
+    Takes no ``experiment_name``, unlike the transformers/unsloth resolver
+    below: ``mlx_sft.py``'s ``output_dir`` is always ``Path(cfg.output)``,
+    flat, never nested under it the way ``trainer/sft.py`` nests under
+    ``output_dir / cfg.experiment_name``. Nesting here would look inside a
+    directory MLX never writes to, and "auto" would report no checkpoint
+    found on every run that sets ``experiment_name`` — the exact symptom
+    #634 reported, reintroduced for a config the original fix didn't cover.
     """
     if resume.lower() == "auto":
         base = Path(output_dir)
-        if experiment_name:
-            base = base / experiment_name
 
         if not base.exists():
             return None
@@ -2054,7 +2050,11 @@ def _resolve_mlx_checkpoint(
 
 
 def _resolve_checkpoint(
-    resume: str, output_dir: str, experiment_name: str = None, *, backend: str = "transformers"
+    resume: str,
+    output_dir: str,
+    experiment_name: str | None = None,
+    *,
+    backend: str = "transformers",
 ) -> str | None:
     """Resolve the checkpoint path from --resume argument.
 
@@ -2066,7 +2066,7 @@ def _resolve_checkpoint(
     directories (#634) — the shape below never matches an MLX run's output.
     """
     if backend == "mlx":
-        return _resolve_mlx_checkpoint(resume, output_dir, experiment_name)
+        return _resolve_mlx_checkpoint(resume, output_dir)
 
     if resume.lower() == "auto":
         base = Path(output_dir)
@@ -2089,6 +2089,26 @@ def _resolve_checkpoint(
     if checkpoint_path.exists() and checkpoint_path.is_dir():
         return str(checkpoint_path)
     return None
+
+
+def _resolve_resume_or_exit(resume: str, cfg: "SoupConfig") -> str | None:
+    """Resolve ``--resume`` against ``cfg``, printing status and exiting on
+    failure. Extracted out of ``train()`` (#634 review) so the
+    ``backend=cfg.backend`` wiring — the entire seam the MLX checkpoint fix
+    depends on — is directly testable without invoking the rest of the
+    command, which needs real hardware/model loading this can be exercised
+    without. Returns ``None`` only when ``resume`` itself is falsy; a
+    ``resume`` value that fails to resolve exits rather than returning.
+    """
+    if not resume:
+        return None
+    resume_from = _resolve_checkpoint(resume, cfg.output, cfg.experiment_name, backend=cfg.backend)
+    if resume_from:
+        console.print(f"[green]Resuming from:[/] {resume_from}")
+    else:
+        console.print("[red]No checkpoint found to resume from.[/]")
+        raise typer.Exit(1)
+    return resume_from
 
 
 def _run_live_lr_sweep_or_synth(

--- a/src/soup_cli/commands/train.py
+++ b/src/soup_cli/commands/train.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -740,7 +741,9 @@ def train(
     # --- Resolve resume checkpoint (fail fast before heavy operations) ---
     resume_from = None
     if resume:
-        resume_from = _resolve_checkpoint(resume, cfg.output, cfg.experiment_name)
+        resume_from = _resolve_checkpoint(
+            resume, cfg.output, cfg.experiment_name, backend=cfg.backend
+        )
         if resume_from:
             console.print(f"[green]Resuming from:[/] {resume_from}")
         else:
@@ -1990,12 +1993,81 @@ def _resolve_deepspeed(deepspeed: str) -> str:
     raise typer.Exit(1)
 
 
-def _resolve_checkpoint(resume: str, output_dir: str, experiment_name: str = None) -> str:
+_MLX_CHECKPOINT_RE = re.compile(r"^(\d+)_adapters\.safetensors$")
+
+
+def _highest_numbered_mlx_checkpoint(paths) -> Path | None:
+    """Pick the highest step-numbered ``NNNNNNN_adapters.safetensors`` file.
+
+    ``max()`` over the parsed step number, not a sort over whatever order
+    the filesystem's ``iterdir()`` happened to enumerate — the enumeration
+    order isn't guaranteed, so picking the last element of a sort keyed
+    wrong could still coincidentally return the right answer on a given
+    filesystem. Order-independent by construction instead.
+    """
+    numbered: list[tuple[int, Path]] = []
+    for path in paths:
+        if not path.is_file():
+            continue
+        match = _MLX_CHECKPOINT_RE.match(path.name)
+        if match:
+            numbered.append((int(match.group(1)), path))
+    if not numbered:
+        return None
+    return max(numbered, key=lambda pair: pair[0])[1]
+
+
+def _resolve_mlx_checkpoint(
+    resume: str, output_dir: str, experiment_name: str | None = None
+) -> str | None:
+    """MLX-style checkpoint resolution (#634).
+
+    mlx-lm's tuner saves step-numbered adapter snapshots
+    (``NNNNNNN_adapters.safetensors``) plus a final ``adapters.safetensors``
+    with no step prefix — files, not the ``checkpoint-N`` directories the
+    transformers/unsloth backends write. "auto" picks the highest-numbered
+    snapshot if one exists, else the final file. A direct ``resume`` value
+    must point at one of these files directly.
+    """
+    if resume.lower() == "auto":
+        base = Path(output_dir)
+        if experiment_name:
+            base = base / experiment_name
+
+        if not base.exists():
+            return None
+
+        highest = _highest_numbered_mlx_checkpoint(base.iterdir())
+        if highest is not None:
+            return str(highest)
+
+        final = base / "adapters.safetensors"
+        if final.is_file():
+            return str(final)
+        return None
+
+    # Direct path to a specific adapter file
+    checkpoint_path = Path(resume)
+    if checkpoint_path.exists() and checkpoint_path.is_file():
+        return str(checkpoint_path)
+    return None
+
+
+def _resolve_checkpoint(
+    resume: str, output_dir: str, experiment_name: str = None, *, backend: str = "transformers"
+) -> str | None:
     """Resolve the checkpoint path from --resume argument.
 
     If resume == "auto", find the latest checkpoint in the output directory.
     Otherwise, treat it as a direct path to a checkpoint directory.
+
+    ``backend="mlx"`` dispatches to :func:`_resolve_mlx_checkpoint`, since MLX
+    writes step-numbered adapter files rather than ``checkpoint-N``
+    directories (#634) — the shape below never matches an MLX run's output.
     """
+    if backend == "mlx":
+        return _resolve_mlx_checkpoint(resume, output_dir, experiment_name)
+
     if resume.lower() == "auto":
         base = Path(output_dir)
         if experiment_name:

--- a/src/soup_cli/commands/train.py
+++ b/src/soup_cli/commands/train.py
@@ -211,7 +211,8 @@ def train(
         None,
         "--resume",
         "-r",
-        help="Resume from checkpoint: path to checkpoint dir, or 'auto' for latest",
+        help="Resume from checkpoint: path to checkpoint dir ('auto' for latest); "
+        "on the MLX backend, a path to a .safetensors adapter file instead",
     ),
     wandb: bool = typer.Option(
         False,
@@ -2032,7 +2033,7 @@ def _resolve_mlx_checkpoint(resume: str, output_dir: str) -> str | None:
     if resume.lower() == "auto":
         base = Path(output_dir)
 
-        if not base.exists():
+        if not base.is_dir():
             return None
 
         highest = _highest_numbered_mlx_checkpoint(base.iterdir())

--- a/src/soup_cli/commands/train.py
+++ b/src/soup_cli/commands/train.py
@@ -1991,11 +1991,13 @@ _MLX_CHECKPOINT_RE = re.compile(r"^(\d+)_adapters\.safetensors$")
 def _highest_numbered_mlx_checkpoint(paths) -> Path | None:
     """Pick the highest step-numbered ``NNNNNNN_adapters.safetensors`` file.
 
-    ``max()`` over the parsed step number, not a sort over whatever order
-    the filesystem's ``iterdir()`` happened to enumerate — the enumeration
-    order isn't guaranteed, so picking the last element of a sort keyed
-    wrong could still coincidentally return the right answer on a given
-    filesystem. Order-independent by construction instead.
+    ``max()`` over the parsed step number: not a sort over whatever order
+    the filesystem's ``iterdir()`` happened to enumerate (that order isn't
+    guaranteed), and not a comparison of the filenames as strings (that
+    would only agree with numeric order if every step number in a run
+    happened to be zero-padded to the same width, which nothing here
+    enforces). Keying on the parsed int makes both mistakes fail instead
+    of coincidentally still returning the right file.
     """
     numbered: list[tuple[int, Path]] = []
     for path in paths:

--- a/src/soup_cli/trainer/mlx_sft.py
+++ b/src/soup_cli/trainer/mlx_sft.py
@@ -28,6 +28,21 @@ from soup_cli.config.schema import SoupConfig
 console = Console()
 
 
+def _count_safetensors_tensors(path: str) -> int:
+    """Number of tensors declared in a ``.safetensors`` file's own header.
+
+    Parsed directly from the format (an 8-byte little-endian length prefix
+    followed by that many bytes of JSON metadata) rather than via mlx or
+    the ``safetensors`` package, so this runs on any machine regardless of
+    whether either is installed. ``__metadata__`` is the one header key
+    that isn't a tensor.
+    """
+    with open(path, "rb") as f:
+        header_len = int.from_bytes(f.read(8), "little")
+        header = json.loads(f.read(header_len))
+    return sum(1 for key in header if key != "__metadata__")
+
+
 #: What `target_modules: auto` means on MLX. peft resolves `auto` per
 #: architecture; mlx-lm has no equivalent, so the streamed-down default is
 #: attention Q/V — the modules `_apply_lora` has always actually trained.
@@ -189,8 +204,29 @@ class MLXSFTTrainerWrapper:
         from the saved iteration is a separate, harder claim — it needs a
         reproducible iteration order tied to training.seed/data_seed, which
         the MLX path does not thread yet (#353) — and is out of scope here.
+
+        ``strict=False`` means a checkpoint saved under a different
+        ``lora.r`` or ``target_modules`` drops every tensor in silence —
+        exactly the #392 failure mode this file's own
+        ``resolve_mlx_target_keys`` docstring records. What's checked here
+        is the narrower, MLX-independent half of that: the checkpoint FILE
+        itself declares at least one tensor before ``load_weights`` ever
+        runs, so an empty or corrupt checkpoint fails loudly instead of
+        producing a warm start from nothing that still prints two green
+        messages. Confirming that the declared tensors actually match this
+        model's LoRA-shaped parameter names — the other half — needs mlx
+        itself to introspect, which isn't available to verify here.
         """
-        console.print(f"[green]MLX: loading checkpoint weights from[/] {checkpoint_path}")
+        tensor_count = _count_safetensors_tensors(checkpoint_path)
+        if tensor_count == 0:
+            raise ValueError(
+                f"MLX checkpoint {checkpoint_path} declares no tensors; refusing "
+                "to warm-start from an empty or corrupt checkpoint file"
+            )
+        console.print(
+            f"[green]MLX: loading checkpoint weights from[/] {checkpoint_path} "
+            f"({tensor_count} tensors)"
+        )
         self.model.load_weights(checkpoint_path, strict=False)
 
     def train(self, display=None, tracker=None, run_id=None, resume_from_checkpoint=None) -> dict:

--- a/src/soup_cli/trainer/mlx_sft.py
+++ b/src/soup_cli/trainer/mlx_sft.py
@@ -174,15 +174,28 @@ class MLXSFTTrainerWrapper:
             },
         )
 
+    def _load_checkpoint_weights(self, checkpoint_path: str) -> None:
+        """Warm-start LoRA weights from a saved MLX checkpoint (#634).
+
+        Must run after ``_apply_lora`` — the saved file holds only the
+        LoRA-shaped tensors, which don't exist on the model until the linear
+        layers have been converted.
+
+        This restores adapter WEIGHTS only. mlx-lm's LoRA trainer exposes no
+        optimizer state and no step/iteration count, so it is a warm start,
+        not a resume of training state: the step count and data position
+        both restart from zero regardless of how far the checkpoint got.
+        Say so rather than implying a full resume. Replaying the dataset
+        from the saved iteration is a separate, harder claim — it needs a
+        reproducible iteration order tied to training.seed/data_seed, which
+        the MLX path does not thread yet (#353) — and is out of scope here.
+        """
+        console.print(f"[green]MLX: loading checkpoint weights from[/] {checkpoint_path}")
+        self.model.load_weights(checkpoint_path, strict=False)
+
     def train(self, display=None, tracker=None, run_id=None, resume_from_checkpoint=None) -> dict:
         """Run MLX training loop via mlx-lm (mlx-lm >= 0.31 API)."""
         del display, tracker, run_id  # accepted for CLI-contract parity
-
-        if resume_from_checkpoint is not None:
-            console.print(
-                "[yellow]MLX backend does not support --resume yet; "
-                "starting training from scratch.[/]"
-            )
 
         self._require_mlx()
 
@@ -201,6 +214,9 @@ class MLXSFTTrainerWrapper:
             )
 
         self._apply_lora(self.model)
+
+        if resume_from_checkpoint is not None:
+            self._load_checkpoint_weights(resume_from_checkpoint)
 
         batch_size = (
             int(cfg.training.batch_size)

--- a/src/soup_cli/trainer/mlx_sft.py
+++ b/src/soup_cli/trainer/mlx_sft.py
@@ -36,10 +36,29 @@ def _count_safetensors_tensors(path: str) -> int:
     the ``safetensors`` package, so this runs on any machine regardless of
     whether either is installed. ``__metadata__`` is the one header key
     that isn't a tensor.
+
+    ``path`` is untrusted here: the ``--resume`` direct-path branch accepts
+    any existing file, and ``--hf-resume`` can point at a directory. The
+    length prefix is bounded against the file's own size before it's used
+    to size a read, and every failure mode (garbage length, truncated or
+    non-JSON content, a directory instead of a file) collapses to one
+    ``ValueError`` naming the path, instead of a raw ``MemoryError``,
+    ``JSONDecodeError``, or ``IsADirectoryError`` reaching the caller.
     """
-    with open(path, "rb") as f:
-        header_len = int.from_bytes(f.read(8), "little")
-        header = json.loads(f.read(header_len))
+    try:
+        file_size = Path(path).stat().st_size
+        with open(path, "rb") as f:
+            header_len = int.from_bytes(f.read(8), "little")
+            if not 0 < header_len <= file_size:
+                raise ValueError(
+                    f"declared header length {header_len} is invalid for a "
+                    f"{file_size}-byte file"
+                )
+            header = json.loads(f.read(header_len))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            f"MLX checkpoint {path} is not a readable safetensors file: {exc}"
+        ) from exc
     return sum(1 for key in header if key != "__metadata__")
 
 

--- a/tests/test_issue634_mlx_resume.py
+++ b/tests/test_issue634_mlx_resume.py
@@ -15,19 +15,41 @@ the exact saved step. mlx-lm's LoRA trainer exposes no optimizer state and
 no step count, so this is a weights-only warm start, not a full resume —
 the docstring on ``_load_checkpoint_weights`` says so, on purpose.
 
-Caveat that matters more here than usual: MLX only runs on Apple Silicon,
-so the parts of this fix that call into mlx-lm's real training loop
-(``mlx_sft.MLXSFTTrainerWrapper.train()`` end to end) cannot be executed in
-this environment and are NOT covered by a running test below — only
-inspected at the source level. What IS executed and asserted: the
-checkpoint-path resolution (pure filesystem logic, no MLX import needed),
-and ``_load_checkpoint_weights`` in isolation against a fake model object
-duck-typing ``load_weights``.
+Caveat that still matters, even though most of this now runs: MLX only
+runs on Apple Silicon. ``TestTrainWiresCheckpointLoadingAfterLoraIsApplied``
+executes the real ``train()`` method body against minimal fake ``mlx`` /
+``mlx_lm`` modules registered in ``sys.modules`` — real control flow, real
+call ordering, not source-text inspection — but the fakes are stand-ins
+for real mlx-lm behaviour (LoRA conversion, the actual training loop,
+what ``load_weights(strict=False)`` does on a real tensor-shape mismatch),
+not a substitute for it. What genuinely cannot be verified here and is
+flagged as such rather than implied: an end-to-end train -> interrupt ->
+``--resume auto`` run against real mlx-lm.
 """
 
 from __future__ import annotations
 
-import inspect
+import json
+import sys
+import types
+
+import pytest
+
+
+def _write_fake_safetensors(path, tensor_names):
+    """A minimal but structurally real .safetensors file: the real 8-byte
+    length-prefixed JSON header format, with dummy F32 tensor data behind
+    it. Real enough for _count_safetensors_tensors to parse without mlx."""
+    header = {}
+    offset = 0
+    for name in tensor_names:
+        header[name] = {"dtype": "F32", "shape": [1], "data_offsets": [offset, offset + 4]}
+        offset += 4
+    header_bytes = json.dumps(header).encode("utf-8")
+    with open(path, "wb") as f:
+        f.write(len(header_bytes).to_bytes(8, "little"))
+        f.write(header_bytes)
+        f.write(b"\x00" * offset)
 
 
 def _mlx_wrapper(tmp_path, **training):
@@ -82,6 +104,41 @@ class TestHighestNumberedCheckpointIsOrderIndependent:
         from soup_cli.commands.train import _highest_numbered_mlx_checkpoint
 
         assert _highest_numbered_mlx_checkpoint([]) is None
+
+
+class TestMlxCheckpointResolutionIgnoresExperimentName:
+    """The review's second blocking finding: mlx_sft.py's output_dir is
+    always Path(cfg.output), flat — unlike trainer/sft.py, which nests
+    under output_dir / cfg.experiment_name. An MLX resolver that copies
+    that nesting looks in a directory MLX never writes to, and "auto"
+    reports no checkpoint found on every config that sets experiment_name
+    — the exact #634 symptom, for a config the original fix didn't cover."""
+
+    def test_auto_finds_the_checkpoint_when_experiment_name_is_set(self, tmp_path):
+        """MLX writes directly into output_dir regardless of
+        experiment_name, so the checkpoint sits at the top level even
+        though the config names an experiment."""
+        from soup_cli.commands.train import _resolve_checkpoint
+
+        (tmp_path / "0000300_adapters.safetensors").write_bytes(b"")
+
+        result = _resolve_checkpoint(
+            "auto", str(tmp_path), experiment_name="my-experiment", backend="mlx"
+        )
+        assert result == str(tmp_path / "0000300_adapters.safetensors")
+
+    def test_experiment_name_does_not_change_the_result(self, tmp_path):
+        """Same output dir, with and without experiment_name set — MLX's
+        resolution must not depend on it either way."""
+        from soup_cli.commands.train import _resolve_checkpoint
+
+        (tmp_path / "0000300_adapters.safetensors").write_bytes(b"")
+
+        with_name = _resolve_checkpoint(
+            "auto", str(tmp_path), experiment_name="my-experiment", backend="mlx"
+        )
+        without_name = _resolve_checkpoint("auto", str(tmp_path), backend="mlx")
+        assert with_name == without_name == str(tmp_path / "0000300_adapters.safetensors")
 
 
 class TestMlxCheckpointResolutionFindsStepNumberedFiles:
@@ -171,9 +228,41 @@ class TestNonMlxBackendsAreUnaffected:
         assert _resolve_checkpoint("auto", str(tmp_path), backend="mlx") is not None
 
 
+class TestCountSafetensorsTensors:
+    """The MLX-independent half of the #392-shaped post-load check: the
+    checkpoint FILE declares at least one tensor, parsed from the format's
+    own header — no mlx or safetensors package needed to check it."""
+
+    def test_counts_declared_tensors(self, tmp_path):
+        from soup_cli.trainer.mlx_sft import _count_safetensors_tensors
+
+        path = tmp_path / "adapters.safetensors"
+        _write_fake_safetensors(path, ["lora_a", "lora_b", "lora_c"])
+
+        assert _count_safetensors_tensors(str(path)) == 3
+
+    def test_empty_header_counts_zero(self, tmp_path):
+        from soup_cli.trainer.mlx_sft import _count_safetensors_tensors
+
+        path = tmp_path / "empty.safetensors"
+        _write_fake_safetensors(path, [])
+
+        assert _count_safetensors_tensors(str(path)) == 0
+
+    def test_metadata_key_is_not_counted_as_a_tensor(self, tmp_path):
+        from soup_cli.trainer.mlx_sft import _count_safetensors_tensors
+
+        path = tmp_path / "metadata_only.safetensors"
+        header_bytes = json.dumps({"__metadata__": {"format": "pt"}}).encode("utf-8")
+        path.write_bytes(len(header_bytes).to_bytes(8, "little") + header_bytes)
+
+        assert _count_safetensors_tensors(str(path)) == 0
+
+
 class TestLoadCheckpointWeights:
     """MLXSFTTrainerWrapper._load_checkpoint_weights, tested against a fake
-    model object — no real mlx/mlx-lm import is reachable here."""
+    model object and a real (minimal) .safetensors file — no real mlx/mlx-lm
+    import is reachable here."""
 
     def test_it_calls_load_weights_non_strict(self, tmp_path):
         calls = []
@@ -182,42 +271,227 @@ class TestLoadCheckpointWeights:
             def load_weights(self, path, strict=True):
                 calls.append((path, strict))
 
+        checkpoint = tmp_path / "0000100_adapters.safetensors"
+        _write_fake_safetensors(checkpoint, ["lora_a"])
+
         wrapper = _mlx_wrapper(tmp_path)
         wrapper.model = _FakeModel()
 
-        wrapper._load_checkpoint_weights("/some/0000100_adapters.safetensors")
+        wrapper._load_checkpoint_weights(str(checkpoint))
 
-        assert calls == [("/some/0000100_adapters.safetensors", False)]
+        assert calls == [(str(checkpoint), False)]
+
+    def test_empty_checkpoint_is_rejected_before_load_weights_runs(self, tmp_path):
+        calls = []
+
+        class _FakeModel:
+            def load_weights(self, path, strict=True):
+                calls.append((path, strict))
+
+        checkpoint = tmp_path / "0000100_adapters.safetensors"
+        _write_fake_safetensors(checkpoint, [])
+
+        wrapper = _mlx_wrapper(tmp_path)
+        wrapper.model = _FakeModel()
+
+        with pytest.raises(ValueError, match="no tensors"):
+            wrapper._load_checkpoint_weights(str(checkpoint))
+
+        assert calls == [], "load_weights must not run against an empty checkpoint"
+
+
+def _install_fake_mlx(monkeypatch):
+    """Register minimal fake ``mlx`` / ``mlx_lm`` modules in ``sys.modules``
+    so ``MLXSFTTrainerWrapper.train()`` runs for real, without Apple
+    Silicon or the real packages installed.
+
+    Covers exactly the surface ``train()`` touches: ``mlx.core`` (the
+    ``_require_mlx`` import probe), ``mlx.optimizers.AdamW``, and
+    ``mlx_lm.tuner``'s ``callbacks`` / ``datasets`` / ``trainer`` / ``utils``
+    submodules. This exercises the real method body — real control flow,
+    real call ordering — rather than asserting on its source text.
+    """
+    mlx = types.ModuleType("mlx")
+    mlx_core = types.ModuleType("mlx.core")
+    mlx_optimizers = types.ModuleType("mlx.optimizers")
+    mlx_optimizers.AdamW = lambda **kwargs: object()
+
+    mlx_lm = types.ModuleType("mlx_lm")
+    mlx_lm_tuner = types.ModuleType("mlx_lm.tuner")
+
+    mlx_lm_tuner_callbacks = types.ModuleType("mlx_lm.tuner.callbacks")
+
+    class _FakeTrainingCallback:
+        pass
+
+    mlx_lm_tuner_callbacks.TrainingCallback = _FakeTrainingCallback
+
+    mlx_lm_tuner_datasets = types.ModuleType("mlx_lm.tuner.datasets")
+    mlx_lm_tuner_datasets.CacheDataset = lambda rows: rows
+    mlx_lm_tuner_datasets.create_dataset = lambda rows, tokenizer, args: rows
+
+    mlx_lm_tuner_trainer = types.ModuleType("mlx_lm.tuner.trainer")
+
+    class _FakeTrainingArgs:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    mlx_lm_tuner_trainer.TrainingArgs = _FakeTrainingArgs
+
+    def _fake_train(**kwargs):
+        callback = kwargs.get("training_callback")
+        if callback is not None:
+            callback.on_train_loss_report({"train_loss": 0.5})
+
+    mlx_lm_tuner_trainer.train = _fake_train
+
+    mlx_lm_tuner_utils = types.ModuleType("mlx_lm.tuner.utils")
+    mlx_lm_tuner_utils.linear_to_lora_layers = lambda model, num_layers, config: None
+
+    fake_modules = {
+        "mlx": mlx,
+        "mlx.core": mlx_core,
+        "mlx.optimizers": mlx_optimizers,
+        "mlx_lm": mlx_lm,
+        "mlx_lm.tuner": mlx_lm_tuner,
+        "mlx_lm.tuner.callbacks": mlx_lm_tuner_callbacks,
+        "mlx_lm.tuner.datasets": mlx_lm_tuner_datasets,
+        "mlx_lm.tuner.trainer": mlx_lm_tuner_trainer,
+        "mlx_lm.tuner.utils": mlx_lm_tuner_utils,
+    }
+    for name, module in fake_modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+
+class _FakeMlxModel:
+    """Duck-types just what train() touches on the model: freeze(),
+    layers, and load_weights(). Records whether freeze() (part of
+    _apply_lora) ran before load_weights() — the real ordering
+    constraint, checked behaviourally instead of by source position."""
+
+    def __init__(self):
+        self.frozen = False
+        self.layers = []
+        self.load_weights_calls = []
+
+    def freeze(self):
+        self.frozen = True
+
+    def load_weights(self, path, strict=True):
+        self.load_weights_calls.append((path, strict, self.frozen))
 
 
 class TestTrainWiresCheckpointLoadingAfterLoraIsApplied:
-    """train() itself calls into real mlx-lm and cannot run without Apple
-    Silicon; inspected at the source level instead of executed. This is a
-    real limitation, not a substitute for running it — flagged as such in
-    the PR."""
+    """train() itself, executed for real against fake mlx/mlx_lm modules —
+    not inspected at the source level. Exercises the actual method body:
+    real branching on resume_from_checkpoint, real call ordering."""
 
-    def test_the_old_no_op_warning_is_gone(self):
-        from soup_cli.trainer.mlx_sft import MLXSFTTrainerWrapper
+    def _ready_wrapper(self, tmp_path):
+        wrapper = _mlx_wrapper(tmp_path, epochs=1, lr=1e-4, batch_size=1)
+        wrapper.model = _FakeMlxModel()
+        wrapper.tokenizer = object()
+        wrapper._dataset = {"train": [{"text": "hi"}], "val": []}
+        return wrapper
 
-        source = inspect.getsource(MLXSFTTrainerWrapper.train)
-        assert "does not support --resume yet" not in source
+    def test_checkpoint_weights_load_after_lora_is_applied(self, tmp_path, monkeypatch):
+        _install_fake_mlx(monkeypatch)
+        wrapper = self._ready_wrapper(tmp_path)
+        checkpoint = tmp_path / "0000100_adapters.safetensors"
+        _write_fake_safetensors(checkpoint, ["lora_a"])
 
-    def test_checkpoint_loading_is_called_after_lora_is_applied(self):
-        from soup_cli.trainer.mlx_sft import MLXSFTTrainerWrapper
+        wrapper.train(resume_from_checkpoint=str(checkpoint))
 
-        source = inspect.getsource(MLXSFTTrainerWrapper.train)
-        lora_pos = source.index("self._apply_lora(")
-        load_pos = source.index("self._load_checkpoint_weights(")
-        assert lora_pos < load_pos, (
-            "_load_checkpoint_weights must run after _apply_lora — the saved "
-            "file holds only LoRA-shaped tensors, which don't exist on the "
-            "model until the linear layers are converted"
+        assert wrapper.model.load_weights_calls == [(str(checkpoint), False, True)], (
+            "load_weights must run after freeze() (part of _apply_lora) — "
+            "the saved file holds only LoRA-shaped tensors, which don't "
+            "exist on the model until the linear layers are converted"
         )
 
-    def test_checkpoint_loading_is_skipped_when_none_is_given(self):
-        """No resume requested -> no _load_checkpoint_weights call, no
-        change in behaviour from before this fix."""
-        from soup_cli.trainer.mlx_sft import MLXSFTTrainerWrapper
+    def test_no_load_when_no_checkpoint_given(self, tmp_path, monkeypatch):
+        """#634's original bug: resume_from_checkpoint was accepted and
+        never read again. Proven behaviourally in both directions — this
+        test pins that omitting it does nothing, the one above pins that
+        supplying it does something."""
+        _install_fake_mlx(monkeypatch)
+        wrapper = self._ready_wrapper(tmp_path)
 
-        source = inspect.getsource(MLXSFTTrainerWrapper.train)
-        assert "if resume_from_checkpoint is not None:" in source
+        wrapper.train(resume_from_checkpoint=None)
+
+        assert wrapper.model.load_weights_calls == []
+
+
+class TestResumeWiringReachesTheBackendAwareResolver:
+    """The blocking gap from review: every other test above calls
+    _resolve_checkpoint directly with backend="mlx" already supplied, so
+    none of them exercise the actual seam between the CLI and the
+    resolver — the single keyword the whole fix hangs on. This does, via
+    _resolve_resume_or_exit, the function train() itself calls, with
+    _resolve_checkpoint replaced by a spy that records what it was called
+    with."""
+
+    def _cfg(self, tmp_path, backend):
+        from soup_cli.config.schema import DataConfig, SoupConfig, TrainingConfig
+
+        return SoupConfig(
+            base="meta-llama/Llama-3.1-8B-Instruct",
+            task="sft",
+            backend=backend,
+            data=DataConfig(train="./data/train.jsonl", format="chatml"),
+            training=TrainingConfig(),
+            output=str(tmp_path),
+        )
+
+    def test_mlx_backend_reaches_the_resolver_as_mlx(self, tmp_path, monkeypatch):
+        import soup_cli.commands.train as train_module
+
+        calls = []
+
+        def _spy(resume, output_dir, experiment_name=None, *, backend="transformers"):
+            calls.append(backend)
+            return str(tmp_path / "0000100_adapters.safetensors")
+
+        monkeypatch.setattr(train_module, "_resolve_checkpoint", _spy)
+
+        result = train_module._resolve_resume_or_exit("auto", self._cfg(tmp_path, "mlx"))
+
+        assert calls == ["mlx"], (
+            "the CLI must pass backend=cfg.backend through to _resolve_checkpoint - "
+            "dropping that keyword is the exact #634 regression this pins"
+        )
+        assert result == str(tmp_path / "0000100_adapters.safetensors")
+
+    def test_transformers_backend_reaches_the_resolver_as_transformers(
+        self, tmp_path, monkeypatch
+    ):
+        """Negative control: the default backend must still say so, not
+        "mlx" leaking in from a hardcoded value."""
+        import soup_cli.commands.train as train_module
+
+        calls = []
+
+        def _spy(resume, output_dir, experiment_name=None, *, backend="transformers"):
+            calls.append(backend)
+            return str(tmp_path / "checkpoint-100")
+
+        monkeypatch.setattr(train_module, "_resolve_checkpoint", _spy)
+
+        train_module._resolve_resume_or_exit("auto", self._cfg(tmp_path, "transformers"))
+
+        assert calls == ["transformers"]
+
+    def test_no_resume_requested_skips_the_resolver_entirely(self, tmp_path):
+        import soup_cli.commands.train as train_module
+
+        result = train_module._resolve_resume_or_exit(None, self._cfg(tmp_path, "mlx"))
+
+        assert result is None
+
+    def test_unresolvable_checkpoint_exits_rather_than_returning(self, tmp_path, monkeypatch):
+        import typer
+
+        import soup_cli.commands.train as train_module
+
+        monkeypatch.setattr(train_module, "_resolve_checkpoint", lambda *a, **k: None)
+
+        with pytest.raises(typer.Exit):
+            train_module._resolve_resume_or_exit("auto", self._cfg(tmp_path, "mlx"))

--- a/tests/test_issue634_mlx_resume.py
+++ b/tests/test_issue634_mlx_resume.py
@@ -30,6 +30,7 @@ flagged as such rather than implied: an end-to-end train -> interrupt ->
 from __future__ import annotations
 
 import json
+import re
 import sys
 import types
 
@@ -69,11 +70,18 @@ def _mlx_wrapper(tmp_path, **training):
 
 class TestHighestNumberedCheckpointIsOrderIndependent:
     """_highest_numbered_mlx_checkpoint picks by parsed step number via
-    max(), not by sorting whatever order the filesystem enumerated files in.
-    The list passed in here is explicit and adversarial — the highest step
-    is neither first nor last — so a key/sort mistake can't coincidentally
-    still return the right file the way it could if this only iterated a
-    real directory in on-disk order."""
+    max(), not by sorting whatever order the filesystem enumerated files in,
+    and not by comparing filenames as strings. The first test's list is
+    explicit and adversarial on ORDER — the highest step is neither first
+    nor last — so a key/sort mistake can't coincidentally still return the
+    right file the way it could if this only iterated a real directory in
+    on-disk order. That alone doesn't rule out a key/TYPE mistake though:
+    equal-width zero-padded numbers sort identically whether compared as
+    strings or as ints, so a regression that keyed by ``path.name`` instead
+    of the parsed int would pass an order-independence check built only from
+    padded names. The second test uses unpadded, different-width numbers
+    (99 vs 100) specifically because string order and numeric order disagree
+    there, which is what actually pins the key down to the parsed int."""
 
     def test_the_highest_step_wins_regardless_of_input_order(self, tmp_path):
         from soup_cli.commands.train import _highest_numbered_mlx_checkpoint
@@ -88,6 +96,22 @@ class TestHighestNumberedCheckpointIsOrderIndependent:
 
         result = _highest_numbered_mlx_checkpoint(paths)
         assert result == tmp_path / "0000300_adapters.safetensors"
+
+    def test_the_highest_step_wins_by_numeric_value_not_string_order(self, tmp_path):
+        """"100_adapters.safetensors" < "99_adapters.safetensors" as strings
+        (```"1" < "9"```) but 100 > 99 as integers. Only a key that parses
+        the digits to an int before comparing picks the right file here."""
+        from soup_cli.commands.train import _highest_numbered_mlx_checkpoint
+
+        names = ["99_adapters.safetensors", "100_adapters.safetensors"]
+        paths = []
+        for name in names:
+            path = tmp_path / name
+            path.write_bytes(b"")
+            paths.append(path)
+
+        result = _highest_numbered_mlx_checkpoint(paths)
+        assert result == tmp_path / "100_adapters.safetensors"
 
     def test_non_matching_files_are_ignored(self, tmp_path):
         from soup_cli.commands.train import _highest_numbered_mlx_checkpoint
@@ -258,6 +282,48 @@ class TestCountSafetensorsTensors:
 
         assert _count_safetensors_tensors(str(path)) == 0
 
+    def test_garbage_header_length_raises_value_error_not_memory_error(self, tmp_path):
+        """A non-safetensors file's first 8 bytes decode to an arbitrary
+        integer. Unbounded, that integer sizes a ``f.read()`` call and can
+        demand gigabytes from an 8-byte file. Bounded against the file's own
+        size, it must fail fast with a ``ValueError`` naming the path."""
+        from soup_cli.trainer.mlx_sft import _count_safetensors_tensors
+
+        path = tmp_path / "not_a_checkpoint.bin"
+        path.write_bytes((2**40).to_bytes(8, "little") + b"short")
+
+        with pytest.raises(ValueError, match=re.escape(str(path))):
+            _count_safetensors_tensors(str(path))
+
+    def test_truncated_json_raises_value_error(self, tmp_path):
+        from soup_cli.trainer.mlx_sft import _count_safetensors_tensors
+
+        path = tmp_path / "truncated.safetensors"
+        header_bytes = json.dumps({"lora_a": {"shape": [1]}}).encode("utf-8")
+        # Declare the full header length but only write half of it.
+        truncated = header_bytes[: len(header_bytes) // 2]
+        path.write_bytes(len(header_bytes).to_bytes(8, "little") + truncated)
+
+        with pytest.raises(ValueError, match=re.escape(str(path))):
+            _count_safetensors_tensors(str(path))
+
+    def test_directory_path_raises_value_error_not_is_a_directory_error(self, tmp_path):
+        from soup_cli.trainer.mlx_sft import _count_safetensors_tensors
+
+        directory = tmp_path / "adapters.safetensors"
+        directory.mkdir()
+
+        with pytest.raises(ValueError, match=re.escape(str(directory))):
+            _count_safetensors_tensors(str(directory))
+
+    def test_missing_file_raises_value_error_not_file_not_found_error(self, tmp_path):
+        from soup_cli.trainer.mlx_sft import _count_safetensors_tensors
+
+        missing = tmp_path / "does_not_exist.safetensors"
+
+        with pytest.raises(ValueError, match=re.escape(str(missing))):
+            _count_safetensors_tensors(str(missing))
+
 
 class TestLoadCheckpointWeights:
     """MLXSFTTrainerWrapper._load_checkpoint_weights, tested against a fake
@@ -418,6 +484,52 @@ class TestTrainWiresCheckpointLoadingAfterLoraIsApplied:
         wrapper.train(resume_from_checkpoint=None)
 
         assert wrapper.model.load_weights_calls == []
+
+
+class TestWriterAndResolverAgreeOnOutputDirWithExperimentName:
+    """The maintainer's own reproduction for the last blocking gap: nothing
+    ties _resolve_mlx_checkpoint's flat-output-dir assumption to what
+    mlx_sft.py's train() actually writes to disk — they were verified
+    separately, never against each other. This runs train() for real
+    against the fake mlx/mlx_lm harness, with the fake trainer.train()
+    writing an adapter file the way the real one does (to args.adapter_file,
+    which train() builds from output_dir alone), on a config that sets
+    experiment_name the way a real run would. It then resolves "auto"
+    against that same config through _resolve_checkpoint — the actual CLI
+    entry point, backend and experiment_name included — and asserts it
+    finds the file train() just wrote. If mlx_sft.py ever starts nesting
+    output under experiment_name the way the transformers/unsloth trainer
+    does, the write and the resolve would point at different directories
+    and this fails, instead of both sides silently drifting apart again."""
+
+    def test_resolver_finds_the_file_train_just_wrote(self, tmp_path, monkeypatch):
+        _install_fake_mlx(monkeypatch)
+
+        def _fake_train_that_saves_an_adapter(**kwargs):
+            args = kwargs["args"]
+            _write_fake_safetensors(args.adapter_file, ["lora_a"])
+
+        sys.modules["mlx_lm.tuner.trainer"].train = _fake_train_that_saves_an_adapter
+
+        wrapper = _mlx_wrapper(tmp_path, epochs=1, lr=1e-4, batch_size=1)
+        wrapper.config.experiment_name = "exp1"
+        wrapper.model = _FakeMlxModel()
+        wrapper.tokenizer = object()
+        wrapper._dataset = {"train": [{"text": "hi"}], "val": []}
+
+        wrapper.train()
+
+        from soup_cli.commands.train import _resolve_checkpoint
+
+        resolved = _resolve_checkpoint(
+            "auto", wrapper.config.output, wrapper.config.experiment_name, backend="mlx"
+        )
+
+        assert resolved == str(tmp_path / "adapters.safetensors"), (
+            "train() writes to output_dir flat and _resolve_mlx_checkpoint "
+            "reads output_dir flat - if either side starts nesting under "
+            "experiment_name without the other, resolution silently breaks"
+        )
 
 
 class TestResumeWiringReachesTheBackendAwareResolver:

--- a/tests/test_issue634_mlx_resume.py
+++ b/tests/test_issue634_mlx_resume.py
@@ -207,6 +207,18 @@ class TestMlxCheckpointResolutionFindsStepNumberedFiles:
         missing = tmp_path / "does-not-exist"
         assert _resolve_checkpoint("auto", str(missing), backend="mlx") is None
 
+    def test_auto_returns_none_when_output_dir_is_a_file(self, tmp_path):
+        """A misconfigured output path (a file, not a directory) must fail
+        the same way a missing one does. Before this guard, base.exists()
+        was true and base.iterdir() raised NotADirectoryError instead of
+        the graceful None every other missing/empty case returns."""
+        from soup_cli.commands.train import _resolve_checkpoint
+
+        not_a_dir = tmp_path / "output_is_actually_a_file"
+        not_a_dir.write_bytes(b"")
+
+        assert _resolve_checkpoint("auto", str(not_a_dir), backend="mlx") is None
+
     def test_direct_path_to_an_adapter_file_is_accepted(self, tmp_path):
         from soup_cli.commands.train import _resolve_checkpoint
 

--- a/tests/test_issue634_mlx_resume.py
+++ b/tests/test_issue634_mlx_resume.py
@@ -1,0 +1,223 @@
+"""#634 — MLX backend ignores saved adapter checkpoints on --resume.
+
+Two mechanical gaps, per the maintainer's own scoping on the issue:
+
+1. ``_resolve_checkpoint("auto", ...)`` only looks for ``checkpoint-N``
+   directories (the transformers/unsloth shape). mlx-lm's tuner writes
+   step-numbered ``NNNNNNN_adapters.safetensors`` FILES instead, so "auto"
+   resume never found them — this is the exact bug reproduction, confirmed
+   against the pre-fix function shape below.
+2. ``MLXSFTTrainerWrapper.train()`` accepted ``resume_from_checkpoint`` and
+   printed a warning that it does nothing with it.
+
+Deliberately NOT in scope, per the issue: resuming the dataset iterator to
+the exact saved step. mlx-lm's LoRA trainer exposes no optimizer state and
+no step count, so this is a weights-only warm start, not a full resume —
+the docstring on ``_load_checkpoint_weights`` says so, on purpose.
+
+Caveat that matters more here than usual: MLX only runs on Apple Silicon,
+so the parts of this fix that call into mlx-lm's real training loop
+(``mlx_sft.MLXSFTTrainerWrapper.train()`` end to end) cannot be executed in
+this environment and are NOT covered by a running test below — only
+inspected at the source level. What IS executed and asserted: the
+checkpoint-path resolution (pure filesystem logic, no MLX import needed),
+and ``_load_checkpoint_weights`` in isolation against a fake model object
+duck-typing ``load_weights``.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+def _mlx_wrapper(tmp_path, **training):
+    from soup_cli.config.schema import DataConfig, SoupConfig, TrainingConfig
+    from soup_cli.trainer.mlx_sft import MLXSFTTrainerWrapper
+
+    cfg = SoupConfig(
+        base="mlx-community/Llama-3.1-8B-Instruct-4bit",
+        task="sft",
+        backend="mlx",
+        data=DataConfig(train="./data/train.jsonl", format="chatml"),
+        training=TrainingConfig(**training),
+        output=str(tmp_path),
+    )
+    return MLXSFTTrainerWrapper(cfg)
+
+
+class TestHighestNumberedCheckpointIsOrderIndependent:
+    """_highest_numbered_mlx_checkpoint picks by parsed step number via
+    max(), not by sorting whatever order the filesystem enumerated files in.
+    The list passed in here is explicit and adversarial — the highest step
+    is neither first nor last — so a key/sort mistake can't coincidentally
+    still return the right file the way it could if this only iterated a
+    real directory in on-disk order."""
+
+    def test_the_highest_step_wins_regardless_of_input_order(self, tmp_path):
+        from soup_cli.commands.train import _highest_numbered_mlx_checkpoint
+
+        names = ["0000200_adapters.safetensors", "0000300_adapters.safetensors",
+                 "0000100_adapters.safetensors"]
+        paths = []
+        for name in names:
+            path = tmp_path / name
+            path.write_bytes(b"")
+            paths.append(path)
+
+        result = _highest_numbered_mlx_checkpoint(paths)
+        assert result == tmp_path / "0000300_adapters.safetensors"
+
+    def test_non_matching_files_are_ignored(self, tmp_path):
+        from soup_cli.commands.train import _highest_numbered_mlx_checkpoint
+
+        matching = tmp_path / "0000050_adapters.safetensors"
+        matching.write_bytes(b"")
+        other = tmp_path / "adapters.safetensors"
+        other.write_bytes(b"")
+
+        result = _highest_numbered_mlx_checkpoint([other, matching])
+        assert result == matching
+
+    def test_empty_input_returns_none(self):
+        from soup_cli.commands.train import _highest_numbered_mlx_checkpoint
+
+        assert _highest_numbered_mlx_checkpoint([]) is None
+
+
+class TestMlxCheckpointResolutionFindsStepNumberedFiles:
+    """_resolve_checkpoint / _resolve_mlx_checkpoint — no MLX import needed,
+    this is pure filesystem logic."""
+
+    def test_auto_picks_the_highest_numbered_snapshot(self, tmp_path):
+        from soup_cli.commands.train import _resolve_checkpoint
+
+        (tmp_path / "0000100_adapters.safetensors").write_bytes(b"")
+        (tmp_path / "0000300_adapters.safetensors").write_bytes(b"")
+        (tmp_path / "0000200_adapters.safetensors").write_bytes(b"")
+
+        result = _resolve_checkpoint("auto", str(tmp_path), backend="mlx")
+        assert result == str(tmp_path / "0000300_adapters.safetensors")
+
+    def test_auto_falls_back_to_the_final_adapter_file(self, tmp_path):
+        from soup_cli.commands.train import _resolve_checkpoint
+
+        (tmp_path / "adapters.safetensors").write_bytes(b"")
+
+        result = _resolve_checkpoint("auto", str(tmp_path), backend="mlx")
+        assert result == str(tmp_path / "adapters.safetensors")
+
+    def test_auto_prefers_numbered_snapshot_over_final_file(self, tmp_path):
+        from soup_cli.commands.train import _resolve_checkpoint
+
+        (tmp_path / "adapters.safetensors").write_bytes(b"")
+        (tmp_path / "0000050_adapters.safetensors").write_bytes(b"")
+
+        result = _resolve_checkpoint("auto", str(tmp_path), backend="mlx")
+        assert result == str(tmp_path / "0000050_adapters.safetensors")
+
+    def test_auto_returns_none_when_output_dir_is_empty(self, tmp_path):
+        from soup_cli.commands.train import _resolve_checkpoint
+
+        assert _resolve_checkpoint("auto", str(tmp_path), backend="mlx") is None
+
+    def test_auto_returns_none_when_output_dir_missing(self, tmp_path):
+        from soup_cli.commands.train import _resolve_checkpoint
+
+        missing = tmp_path / "does-not-exist"
+        assert _resolve_checkpoint("auto", str(missing), backend="mlx") is None
+
+    def test_direct_path_to_an_adapter_file_is_accepted(self, tmp_path):
+        from soup_cli.commands.train import _resolve_checkpoint
+
+        checkpoint = tmp_path / "0000042_adapters.safetensors"
+        checkpoint.write_bytes(b"")
+
+        result = _resolve_checkpoint(str(checkpoint), str(tmp_path), backend="mlx")
+        assert result == str(checkpoint)
+
+    def test_direct_path_to_a_missing_file_is_rejected(self, tmp_path):
+        from soup_cli.commands.train import _resolve_checkpoint
+
+        result = _resolve_checkpoint(
+            str(tmp_path / "nope.safetensors"), str(tmp_path), backend="mlx"
+        )
+        assert result is None
+
+
+class TestNonMlxBackendsAreUnaffected:
+    """Regression guard: the pre-existing transformers/unsloth directory
+    logic is untouched, and demonstrates the bug this issue reports — the
+    old (and still-default) code path genuinely cannot see MLX's files."""
+
+    def test_default_backend_still_resolves_checkpoint_directories(self, tmp_path):
+        from soup_cli.commands.train import _resolve_checkpoint
+
+        (tmp_path / "checkpoint-100").mkdir()
+        (tmp_path / "checkpoint-300").mkdir()
+        (tmp_path / "checkpoint-200").mkdir()
+
+        result = _resolve_checkpoint("auto", str(tmp_path))
+        assert result == str(tmp_path / "checkpoint-300")
+
+    def test_the_default_path_cannot_see_mlx_style_files(self, tmp_path):
+        """The #634 bug, reproduced directly: an MLX run's own output
+        resolves to nothing under the backend-unaware (default) path,
+        because _adapters.safetensors is a file, not a checkpoint-N dir."""
+        from soup_cli.commands.train import _resolve_checkpoint
+
+        (tmp_path / "0000300_adapters.safetensors").write_bytes(b"")
+
+        assert _resolve_checkpoint("auto", str(tmp_path)) is None
+        assert _resolve_checkpoint("auto", str(tmp_path), backend="mlx") is not None
+
+
+class TestLoadCheckpointWeights:
+    """MLXSFTTrainerWrapper._load_checkpoint_weights, tested against a fake
+    model object — no real mlx/mlx-lm import is reachable here."""
+
+    def test_it_calls_load_weights_non_strict(self, tmp_path):
+        calls = []
+
+        class _FakeModel:
+            def load_weights(self, path, strict=True):
+                calls.append((path, strict))
+
+        wrapper = _mlx_wrapper(tmp_path)
+        wrapper.model = _FakeModel()
+
+        wrapper._load_checkpoint_weights("/some/0000100_adapters.safetensors")
+
+        assert calls == [("/some/0000100_adapters.safetensors", False)]
+
+
+class TestTrainWiresCheckpointLoadingAfterLoraIsApplied:
+    """train() itself calls into real mlx-lm and cannot run without Apple
+    Silicon; inspected at the source level instead of executed. This is a
+    real limitation, not a substitute for running it — flagged as such in
+    the PR."""
+
+    def test_the_old_no_op_warning_is_gone(self):
+        from soup_cli.trainer.mlx_sft import MLXSFTTrainerWrapper
+
+        source = inspect.getsource(MLXSFTTrainerWrapper.train)
+        assert "does not support --resume yet" not in source
+
+    def test_checkpoint_loading_is_called_after_lora_is_applied(self):
+        from soup_cli.trainer.mlx_sft import MLXSFTTrainerWrapper
+
+        source = inspect.getsource(MLXSFTTrainerWrapper.train)
+        lora_pos = source.index("self._apply_lora(")
+        load_pos = source.index("self._load_checkpoint_weights(")
+        assert lora_pos < load_pos, (
+            "_load_checkpoint_weights must run after _apply_lora — the saved "
+            "file holds only LoRA-shaped tensors, which don't exist on the "
+            "model until the linear layers are converted"
+        )
+
+    def test_checkpoint_loading_is_skipped_when_none_is_given(self):
+        """No resume requested -> no _load_checkpoint_weights call, no
+        change in behaviour from before this fix."""
+        from soup_cli.trainer.mlx_sft import MLXSFTTrainerWrapper
+
+        source = inspect.getsource(MLXSFTTrainerWrapper.train)
+        assert "if resume_from_checkpoint is not None:" in source


### PR DESCRIPTION
## Summary

Closes the first two items of #634 (reported and diagnosed by @imahsanali — thanks for the clear repro) — checkpoint detection + weight loading. The third — replaying the dataset from the saved iteration — is out of scope, per the maintainer's own comment on the issue: it needs a reproducible iteration order tied to `training.seed`/`training.data_seed`, which the MLX path doesn't thread yet (#353).

`_resolve_checkpoint("auto", ...)` only recognized `checkpoint-N` directories — the transformers/unsloth shape. mlx-lm's tuner saves step-numbered `NNNNNNN_adapters.safetensors` files instead, so an MLX run's own output never matched, and `MLXSFTTrainerWrapper.train()` printed a warning and silently restarted from scratch on every `--resume`.

## What's here

- `_resolve_mlx_checkpoint` (dispatched via a new `backend=` kwarg on `_resolve_checkpoint`) finds the highest step-numbered snapshot, falling back to the final `adapters.safetensors`.
- The "pick highest" step is factored into `_highest_numbered_mlx_checkpoint`, selecting via `max()` over the parsed step number rather than sorting whatever order `iterdir()` enumerated files in. Worth flagging: my first draft sorted instead, and its own test didn't actually catch a broken sort key, because `sorted()` over `iterdir()`'s filesystem order coincidentally produced the right answer anyway. Caught that in my own verification pass before pushing — see the mutation notes below.
- `MLXSFTTrainerWrapper.train()` now loads the located checkpoint's weights via `_load_checkpoint_weights()`, called after `_apply_lora` (the saved file holds only LoRA-shaped tensors, which don't exist until the linear layers are converted). This replaces the old no-op warning.
- This is a weights-only warm start, not a full resume — mlx-lm's LoRA trainer exposes no optimizer state or step count, so the step count and data position both restart from zero regardless of how far the checkpoint got. Documented on the method rather than implied otherwise.
- One changelog fragment.

## Important caveat — please read before reviewing

**I don't have Apple Silicon hardware.** The checkpoint resolution (pure filesystem logic) and `_load_checkpoint_weights` (tested against a fake model object) are executed and verified below. The wiring inside `train()` that reaches real `mlx-lm` is inspected at the source level — call ordering relative to `_apply_lora`, the old warning text removed — but has not been run end to end on real hardware. Flagging this plainly rather than claiming more than I've actually verified. Happy to have this verified on real hardware before merge, same as #589/#597 were handled.

## Verification

- `ruff check src/soup_cli/ scripts/ tests/` — clean.
- `mypy` on both touched files — 12 pre-existing errors remain (confirmed via the unmodified file in place), none introduced by this diff. Fixing `_resolve_checkpoint`'s return-type annotation (needed anyway for the new `backend` param) incidentally cleaned up 3 pre-existing "None vs str" errors.
- 16 new tests, all passing. Full existing MLX + resume regression suite (145 tests) unaffected.
- **Mutation, twice over**: broke the checkpoint sort key — first version (a `sorted()` call) didn't fail any test, which is how I found my own test wasn't order-independent; refactored to the `max()`-based `_highest_numbered_mlx_checkpoint` with an explicit adversarially-ordered input list in the test, re-broke it, confirmed it now fails. Broke `_load_checkpoint_weights`'s call — its test fails. Reverted both, all 16 pass again.

## Update — second review round

Three more gaps from review, all fixed and mutation-verified:

- **Writer/resolver coupling**: nothing tied `_resolve_mlx_checkpoint`'s flat-output-dir assumption to what `mlx_sft.py`'s `train()` actually writes — verified separately, never against each other. Added a test that runs `train()` for real against the fake mlx-lm harness with `experiment_name` set, has the fake trainer write an adapter file the way the real one does, then resolves `"auto"` through `_resolve_checkpoint` and asserts it finds the file `train()` just wrote. Mutated `mlx_sft.py` to nest `output_dir` under `experiment_name` — only this test caught it, the other 30 stayed green.
- **Sort-key robustness**: the original order-independence test only used equal-width zero-padded filenames, so a mutation to key by `path.name` instead of the parsed int would have passed undetected — string and numeric order agree when widths match. Added `"99_adapters.safetensors"` vs `"100_adapters.safetensors"` (numeric 100 > 99, but `"100" < "99"` as strings), narrowed the docstring's claim to match, and confirmed the same key-type mutation now fails specifically that test.
- **`_count_safetensors_tensors` hardening**: the header-length prefix was read straight off an untrusted file with no bound and no error handling — a non-checkpoint file could demand an arbitrary read size, and a directory path (reachable via `--hf-resume`) hit a raw `IsADirectoryError`. Bounded the declared length against the file's actual size and wrapped the parse so every failure mode (garbage length, truncated/malformed JSON, directory, missing file) raises one `ValueError` naming the path. Reverted the bound/wrap to confirm the four new tests fail against the old code, then restored it.

31 tests total now, all passing. `ruff check` and `mypy` both clean on the touched files (mypy: same 12 pre-existing errors as the unmodified file, none introduced).
