### PR TITLE
fix(deps): declare the real torch floor and stop duplicating it in doctor (#636)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
           tests/test_issue571_qwen4_exp.py
           tests/test_plotext_compat.py
           tests/test_bugfixes.py::TestDiffModelLoading
+          tests/test_issue636_torch_floor.py
 
   test:
     strategy:

--- a/changelog.d/0.73.3/641.fixed.md
+++ b/changelog.d/0.73.3/641.fixed.md
@@ -1,0 +1,9 @@
+- [#641](https://github.com/MakazhanAlpamys/Soup/pull/641) declares the real
+  torch floor and removes its second copy. `[train]` said `torch>=2.3.0` while
+  requiring `transformers>=5.16.1`, whose own torch extra forces `torch>=2.5` —
+  the declared floor could never bind, and `soup doctor` carried its own
+  hardcoded copy on top. The extra now declares `torch>=2.5.0`, doctor reads
+  the floor from the installed `[train]` metadata (the #368 pattern, no literal
+  fallback), and a drift test pins the declaration against the installed
+  transformers' requirement so the two cannot separate silently again.
+  Closes #636.

--- a/changelog.d/0.73.3/641.fixed.md
+++ b/changelog.d/0.73.3/641.fixed.md
@@ -1,9 +1,13 @@
-- [#641](https://github.com/MakazhanAlpamys/Soup/pull/641) declares the real
-  torch floor and removes its second copy. `[train]` said `torch>=2.3.0` while
-  requiring `transformers>=5.16.1`, whose own torch extra forces `torch>=2.5` —
-  the declared floor could never bind, and `soup doctor` carried its own
-  hardcoded copy on top. The extra now declares `torch>=2.5.0`, doctor reads
-  the floor from the installed `[train]` metadata (the #368 pattern, no literal
-  fallback), and a drift test pins the declaration against the installed
-  transformers' requirement so the two cannot separate silently again.
+- **`[train]` now declares the torch floor that actually binds, and doctor's
+  copy is pinned to it (#636 by @umran666 in #641).**
+  `[train]` said `torch>=2.3.0` while requiring `transformers>=5.16.1`, whose
+  own torch extra forces `torch>=2.5` — the declared floor could never bind,
+  and `soup doctor` carried an unpinned second copy on top. The extra now
+  declares `torch>=2.5.0` with the reason stated beside it; doctor keeps a
+  literal that `tests/test_issue636_torch_floor.py` pins to the declaration,
+  and a drift guard compares the declared floor against the *declared*
+  transformers floor's real metadata on the `transformers-floor` CI job (which
+  installs exactly 5.16.1 under the constraints file), skipping with a reason
+  anywhere the installed transformers is a different release rather than
+  passing vacuously.
   Closes #636.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,13 @@ dependencies = [
 # v0.71.0 — heavy training stack. `pip install 'soup-cli[train]'` to fine-tune.
 # These were core dependencies through v0.70.0.
 train = [
-    # oQ/Qwen4 uses safetensors U32 plus torch.uint32, both supported from 2.3.
-    "torch>=2.3.0",
+    # The binding floor is transformers', not Soup's: the torch extra of
+    # 5.16.1 (the floor declared just below) requires torch>=2.5, so no
+    # installable [train] env can carry torch below 2.5 regardless of what
+    # is declared here (#636). oQ/Qwen4's uint32 need (2.3) is subsumed.
+    # tests/test_issue636_torch_floor.py pins this floor against the
+    # installed transformers' requirement so the two cannot drift silently.
+    "torch>=2.5.0",
     # 5.16.1 is the validated Qwen4-Exp floor: an outer `qwen4_exp` config
     # selects the text-only Qwen4ExpForCausalLM, and the patch release restores
     # tensor-parallel compatibility needed by large-model training. The v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,10 @@ train = [
     # 5.16.1 (the floor declared just below) requires torch>=2.5, so no
     # installable [train] env can carry torch below 2.5 regardless of what
     # is declared here (#636). oQ/Qwen4's uint32 need (2.3) is subsumed.
-    # tests/test_issue636_torch_floor.py pins this floor against the
-    # installed transformers' requirement so the two cannot drift silently.
+    # tests/test_issue636_torch_floor.py pins this floor against the declared
+    # transformers floor's own requirement (real metadata, on the
+    # transformers-floor CI job that installs exactly 5.16.1) and pins
+    # doctor's literal copy against this file, so neither can drift silently.
     "torch>=2.5.0",
     # 5.16.1 is the validated Qwen4-Exp floor: an outer `qwen4_exp` config
     # selects the text-only Qwen4ExpForCausalLM, and the patch release restores

--- a/src/soup_cli/commands/doctor.py
+++ b/src/soup_cli/commands/doctor.py
@@ -16,48 +16,13 @@ from soup_cli.utils.constants import GITHUB_URL
 console = Console()
 
 
-def _declared_train_floor(package: str) -> str:
-    """The ``>=`` floor soup-cli's ``[train]`` extra declares for *package*.
-
-    Read from installed metadata — the #368 pattern ``env_lock`` uses — so
-    doctor carries no second hardcoded copy to drift (#636). Returns ``"?"``
-    when the metadata is unreadable (e.g. a source tree without an install);
-    ``_version_ok`` treats an unparseable floor as OK, so the row degrades to
-    informational instead of enforcing a stale literal.
-    """
-    try:
-        from importlib.metadata import PackageNotFoundError
-        from importlib.metadata import requires as _requires
-
-        reqs = _requires("soup-cli")
-    except (PackageNotFoundError, ImportError):
-        return "?"
-    if not reqs:
-        return "?"
-    try:
-        from packaging.requirements import InvalidRequirement, Requirement
-        from packaging.utils import canonicalize_name
-    except ImportError:  # pragma: no cover - packaging is a declared core dep
-        return "?"
-    target = canonicalize_name(package)
-    for raw in reqs:
-        try:
-            req = Requirement(raw)
-        except InvalidRequirement:
-            continue
-        if canonicalize_name(req.name) != target:
-            continue
-        if req.marker is not None and not req.marker.evaluate({"extra": "train"}):
-            continue
-        floors = [spec.version for spec in req.specifier if spec.operator == ">="]
-        if floors:
-            return floors[0]
-    return "?"
-
-
 # Dependencies to check: (import_name, package_name, min_version, required)
 DEPS = [
-    ("torch", "torch", _declared_train_floor("torch"), True),
+    # The torch floor is declared once, in pyproject.toml's [train] extra.
+    # This literal is a copy, pinned to the declaration by
+    # tests/test_issue636_torch_floor.py — reading installed metadata instead
+    # would report the install's history, not the declaration (#636).
+    ("torch", "torch", "2.5.0", True),
     ("transformers", "transformers", "5.16.1", True),
     ("peft", "peft", "0.20.0", True),
     ("trl", "trl", "0.29.0", True),

--- a/src/soup_cli/commands/doctor.py
+++ b/src/soup_cli/commands/doctor.py
@@ -15,9 +15,49 @@ from soup_cli.utils.constants import GITHUB_URL
 
 console = Console()
 
+
+def _declared_train_floor(package: str) -> str:
+    """The ``>=`` floor soup-cli's ``[train]`` extra declares for *package*.
+
+    Read from installed metadata — the #368 pattern ``env_lock`` uses — so
+    doctor carries no second hardcoded copy to drift (#636). Returns ``"?"``
+    when the metadata is unreadable (e.g. a source tree without an install);
+    ``_version_ok`` treats an unparseable floor as OK, so the row degrades to
+    informational instead of enforcing a stale literal.
+    """
+    try:
+        from importlib.metadata import PackageNotFoundError
+        from importlib.metadata import requires as _requires
+
+        reqs = _requires("soup-cli")
+    except (PackageNotFoundError, ImportError):
+        return "?"
+    if not reqs:
+        return "?"
+    try:
+        from packaging.requirements import InvalidRequirement, Requirement
+        from packaging.utils import canonicalize_name
+    except ImportError:  # pragma: no cover - packaging is a declared core dep
+        return "?"
+    target = canonicalize_name(package)
+    for raw in reqs:
+        try:
+            req = Requirement(raw)
+        except InvalidRequirement:
+            continue
+        if canonicalize_name(req.name) != target:
+            continue
+        if req.marker is not None and not req.marker.evaluate({"extra": "train"}):
+            continue
+        floors = [spec.version for spec in req.specifier if spec.operator == ">="]
+        if floors:
+            return floors[0]
+    return "?"
+
+
 # Dependencies to check: (import_name, package_name, min_version, required)
 DEPS = [
-    ("torch", "torch", "2.3.0", True),
+    ("torch", "torch", _declared_train_floor("torch"), True),
     ("transformers", "transformers", "5.16.1", True),
     ("peft", "peft", "0.20.0", True),
     ("trl", "trl", "0.29.0", True),

--- a/tests/test_issue602_qwen4_ple_streaming.py
+++ b/tests/test_issue602_qwen4_ple_streaming.py
@@ -1058,9 +1058,9 @@ def test_qwen4_oq_torch_floor_matches_project_and_doctor():
         f"{torch_entries}"
     )
     assert next(item for item in DEPS if item[0] == "torch")[2] == "2.5.0", (
-        "`soup doctor` must report the same floor pyproject.toml declares, read "
-        "from the installed [train] metadata rather than a second hardcoded "
-        "copy (#636)"
+        "`soup doctor` keeps a literal copy of the torch floor; it must equal "
+        "the one pyproject.toml declares, pinned by "
+        "tests/test_issue636_torch_floor.py (#636)"
     )
 
 

--- a/tests/test_issue602_qwen4_ple_streaming.py
+++ b/tests/test_issue602_qwen4_ple_streaming.py
@@ -1051,13 +1051,16 @@ def test_qwen4_oq_torch_floor_matches_project_and_doctor():
     entries = re.findall(r'"([^"]+)"', block.group(1))
     torch_entries = [e for e in entries if e.split(">")[0].strip() == "torch"]
 
-    assert torch_entries == ["torch>=2.3.0"], (
+    assert torch_entries == ["torch>=2.5.0"], (
         "the `train` extra must declare exactly one torch floor, and it must be "
-        f"2.3.0 -- Qwen4/oQ needs uint32 support; found {torch_entries}"
+        "2.5.0 -- transformers 5.16.1's own torch extra forces torch>=2.5, "
+        "which subsumes Qwen4/oQ's uint32 need at 2.3 (#636); found "
+        f"{torch_entries}"
     )
-    assert next(item for item in DEPS if item[0] == "torch")[2] == "2.3.0", (
-        "`soup doctor` carries its own copy of the floor and it has drifted "
-        "from pyproject.toml (see #636)"
+    assert next(item for item in DEPS if item[0] == "torch")[2] == "2.5.0", (
+        "`soup doctor` must report the same floor pyproject.toml declares, read "
+        "from the installed [train] metadata rather than a second hardcoded "
+        "copy (#636)"
     )
 
 

--- a/tests/test_issue636_torch_floor.py
+++ b/tests/test_issue636_torch_floor.py
@@ -1,14 +1,23 @@
-"""The declared torch floor must be the binding one, declared in one place (#636).
+"""The declared torch floor must be the binding one, and doctor's copy pinned (#636).
 
 ``pyproject.toml [train]`` declared ``torch>=2.3.0`` while requiring
 ``transformers>=5.16.1``, whose own torch extra forces ``torch>=2.5`` — so the
-declared floor could never bind, and ``soup doctor`` carried a second hardcoded
+declared floor could never bind, and ``soup doctor`` carried an unpinned second
 copy of it. These tests pin both halves:
 
-* the pyproject floor is at least what the *installed* transformers' torch
-  extra requires (mutating pyproject back to 2.3.0 fails by name), and
-* doctor's torch row reads the declared floor from installed metadata rather
-  than a literal (re-hardcoding any literal in doctor.py fails by name).
+* the pyproject floor is at least what the *declared* transformers floor's own
+  torch extra requires. That requirement is read from real metadata only where
+  the installed transformers is exactly the declared floor — the
+  ``transformers-floor`` CI job installs precisely that release under
+  ``.github/constraints/transformers-floor.txt``. Anywhere else the check skips
+  with a reason instead of passing vacuously against whatever transformers
+  happens to be installed (an older one forces a lower floor, a newer one could
+  turn the repo red without any repo change).
+* the constraints file pins the declared transformers floor, so the metadata
+  check above can never silently validate a different release than the one
+  ``[train]`` declares.
+* doctor's torch literal equals the pyproject declaration — hermetic, repo text
+  against src literal, the pin that keeps the second copy honest.
 
 pyproject is parsed with regex rather than ``tomllib`` because ``tomllib`` is
 3.11+ and this repo supports 3.10 — the same convention as
@@ -25,7 +34,7 @@ from packaging.version import Version
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 PYPROJECT = ROOT / "pyproject.toml"
-DOCTOR_PY = ROOT / "src" / "soup_cli" / "commands" / "doctor.py"
+CONSTRAINTS = ROOT / ".github" / "constraints" / "transformers-floor.txt"
 
 
 def _train_extra_block() -> str:
@@ -45,63 +54,99 @@ def _declared_torch_floor() -> str:
     return match.group(1)
 
 
-def _transformers_torch_floor() -> str:
-    """The torch floor the *installed* transformers declares in its torch extra."""
-    from importlib.metadata import PackageNotFoundError
-    from importlib.metadata import requires as _requires
+def _declared_transformers_floor() -> str:
+    # No closing-quote anchor: the entry is "transformers>=5.16.1,<6.0.0".
+    match = re.search(r'"transformers\s*>=\s*([0-9][^",]*)', _train_extra_block())
+    assert match, "the [train] extra declares no transformers>= floor"
+    return match.group(1)
 
-    try:
-        reqs = _requires("transformers")
-    except PackageNotFoundError:
-        pytest.skip("transformers is not installed in this environment")
-    from packaging.requirements import Requirement
 
-    floors = []
-    for raw in reqs or []:
-        req = Requirement(raw)
-        if req.name.lower() != "torch":
-            continue
-        if req.marker is not None and not req.marker.evaluate({"extra": "torch"}):
-            continue
-        floors.extend(spec.version for spec in req.specifier if spec.operator == ">=")
-    assert floors, "installed transformers declares no torch>= floor"
-    return max(floors, key=Version)
+def _constraints_pins() -> dict[str, str]:
+    text = CONSTRAINTS.read_text(encoding="utf-8")
+    return dict(re.findall(r"^([A-Za-z0-9_-]+)==([^\s#]+)\s*$", text, re.M))
 
 
 class TestIssue636TorchFloor:
-    def test_declared_floor_meets_transformers_torch_requirement(self) -> None:
-        # Mutation check: setting pyproject back to torch>=2.3.0 fails this test
-        # by name — 2.3.0 is below the floor transformers itself forces.
+    def test_declared_floor_meets_the_declared_transformers_requirement(self) -> None:
+        # Mutation check: on the transformers-floor CI job — where the installed
+        # transformers IS the declared floor — setting pyproject back to
+        # torch>=2.3.0 fails this test by name, because 5.16.1's own torch
+        # extra requires >=2.5.
+        from importlib.metadata import PackageNotFoundError
+        from importlib.metadata import requires as _requires
+        from importlib.metadata import version as _version
+
+        from packaging.requirements import Requirement
+
+        declared_tf = Version(_declared_transformers_floor())
+        try:
+            installed_tf = Version(_version("transformers"))
+        except PackageNotFoundError:
+            pytest.skip(
+                "transformers is not installed; the guard runs against real "
+                "metadata on the transformers-floor CI job"
+            )
+        if installed_tf != declared_tf:
+            pytest.skip(
+                f"installed transformers {installed_tf} is not the declared "
+                f"floor {declared_tf}; comparing against a different release's "
+                f"metadata would validate the wrong requirement — the "
+                f"transformers-floor CI job installs exactly {declared_tf}"
+            )
+
+        floors = []
+        for raw in _requires("transformers") or []:
+            req = Requirement(raw)
+            if req.name.lower() != "torch":
+                continue
+            if req.marker is not None and not req.marker.evaluate({"extra": "torch"}):
+                continue
+            floors.extend(
+                spec.version for spec in req.specifier if spec.operator == ">="
+            )
+        assert floors, f"transformers {declared_tf} declares no torch>= floor"
+        required = Version(max(floors, key=Version))
+
         declared = Version(_declared_torch_floor())
-        required = Version(_transformers_torch_floor())
         assert declared >= required, (
-            f"pyproject [train] declares torch>={declared} but the installed "
-            f"transformers requires torch>={required}; the declared floor cannot "
-            f"bind and invites trust it does not deserve (#636)"
+            f"pyproject [train] declares torch>={declared} but its own declared "
+            f"transformers floor {declared_tf} requires torch>={required}; the "
+            f"declared floor cannot bind and invites trust it does not "
+            f"deserve (#636)"
         )
 
-    def test_doctor_torch_row_reads_the_declared_floor(self) -> None:
-        # Mutation check: re-hardcoding a literal floor in doctor.py's DEPS
-        # fails this test by name — the row must equal the metadata-derived
-        # floor, which is what _declared_train_floor returns at runtime.
-        from soup_cli.commands.doctor import DEPS, _declared_train_floor
+    def test_constraints_file_pins_the_declared_floors(self) -> None:
+        # Hermetic. The metadata guard above only runs where the installed
+        # transformers equals the declared floor, and the transformers-floor
+        # CI job creates that state from this constraints file — so the pin
+        # must be the declared floor, or the guard validates another release.
+        # The torch pin is the version that job actually installs beside it;
+        # the declared floor must not exceed it or the job cannot resolve.
+        pins = _constraints_pins()
+        assert pins.get("transformers") == _declared_transformers_floor(), (
+            "the transformers-floor CI job validates "
+            f"transformers=={pins.get('transformers')} but [train] declares "
+            f">={_declared_transformers_floor()} — move the pin with the "
+            "declaration or the drift guard checks the wrong release (#636)"
+        )
+        assert Version(_declared_torch_floor()) <= Version(pins["torch"]), (
+            f"[train] declares torch>={_declared_torch_floor()} but the floor "
+            f"job pins torch=={pins['torch']}, which would not satisfy it (#636)"
+        )
+
+    def test_doctor_torch_floor_matches_the_pyproject_declaration(self) -> None:
+        # Hermetic. doctor.py keeps a literal copy of the floor; this is the
+        # pin that keeps it honest — mutating either side alone fails here by
+        # name. Reading installed metadata instead was tried and rejected:
+        # dist-info records the install's history, so an editable checkout
+        # whose pyproject moved on reports a floor nobody declared, and an
+        # uninstalled source tree reports "?" which _version_ok treats as OK.
+        from soup_cli.commands.doctor import DEPS
 
         torch_rows = [row for row in DEPS if row[1] == "torch"]
         assert len(torch_rows) == 1, "expected exactly one torch row in DEPS"
-        floor = _declared_train_floor("torch")
-        if floor == "?":
-            pytest.skip("soup-cli metadata unreadable in this environment")
-        assert torch_rows[0][2] == floor, (
-            f"doctor.py's torch row declares {torch_rows[0][2]!r} but soup-cli's "
-            f"installed [train] metadata declares {floor!r} — doctor must read the "
-            f"declared floor, not carry its own copy (#636)"
-        )
-
-    def test_doctor_source_declares_no_torch_floor_literal(self) -> None:
-        # "Exactly one place in the repo declares it": the DEPS torch row must
-        # not contain a version literal again.
-        source = DOCTOR_PY.read_text(encoding="utf-8")
-        assert not re.search(r'\(\s*"torch"\s*,\s*"torch"\s*,\s*"[0-9]', source), (
-            "doctor.py hardcodes a torch floor literal in DEPS again; read it via "
-            "_declared_train_floor so pyproject stays the single declaration (#636)"
+        assert torch_rows[0][2] == _declared_torch_floor(), (
+            f"doctor.py checks torch>={torch_rows[0][2]} but pyproject.toml "
+            f"[train] declares torch>={_declared_torch_floor()} — doctor must "
+            f"report the declared floor (#636)"
         )

--- a/tests/test_issue636_torch_floor.py
+++ b/tests/test_issue636_torch_floor.py
@@ -1,0 +1,107 @@
+"""The declared torch floor must be the binding one, declared in one place (#636).
+
+``pyproject.toml [train]`` declared ``torch>=2.3.0`` while requiring
+``transformers>=5.16.1``, whose own torch extra forces ``torch>=2.5`` — so the
+declared floor could never bind, and ``soup doctor`` carried a second hardcoded
+copy of it. These tests pin both halves:
+
+* the pyproject floor is at least what the *installed* transformers' torch
+  extra requires (mutating pyproject back to 2.3.0 fails by name), and
+* doctor's torch row reads the declared floor from installed metadata rather
+  than a literal (re-hardcoding any literal in doctor.py fails by name).
+
+pyproject is parsed with regex rather than ``tomllib`` because ``tomllib`` is
+3.11+ and this repo supports 3.10 — the same convention as
+``tests/test_requires_python_bound.py``.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+from packaging.version import Version
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+PYPROJECT = ROOT / "pyproject.toml"
+DOCTOR_PY = ROOT / "src" / "soup_cli" / "commands" / "doctor.py"
+
+
+def _train_extra_block() -> str:
+    text = PYPROJECT.read_text(encoding="utf-8")
+    table = re.search(
+        r"^\[project\.optional-dependencies\]\s*$(.*?)^\[", text, re.M | re.S
+    )
+    assert table, "pyproject.toml has no [project.optional-dependencies] table"
+    train = re.search(r"^train\s*=\s*\[(.*?)^\]", table.group(1), re.M | re.S)
+    assert train, "no train = [...] array in [project.optional-dependencies]"
+    return train.group(1)
+
+
+def _declared_torch_floor() -> str:
+    match = re.search(r'"torch\s*>=\s*([0-9][^"]*)"', _train_extra_block())
+    assert match, "the [train] extra declares no torch>= floor"
+    return match.group(1)
+
+
+def _transformers_torch_floor() -> str:
+    """The torch floor the *installed* transformers declares in its torch extra."""
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import requires as _requires
+
+    try:
+        reqs = _requires("transformers")
+    except PackageNotFoundError:
+        pytest.skip("transformers is not installed in this environment")
+    from packaging.requirements import Requirement
+
+    floors = []
+    for raw in reqs or []:
+        req = Requirement(raw)
+        if req.name.lower() != "torch":
+            continue
+        if req.marker is not None and not req.marker.evaluate({"extra": "torch"}):
+            continue
+        floors.extend(spec.version for spec in req.specifier if spec.operator == ">=")
+    assert floors, "installed transformers declares no torch>= floor"
+    return max(floors, key=Version)
+
+
+class TestIssue636TorchFloor:
+    def test_declared_floor_meets_transformers_torch_requirement(self) -> None:
+        # Mutation check: setting pyproject back to torch>=2.3.0 fails this test
+        # by name — 2.3.0 is below the floor transformers itself forces.
+        declared = Version(_declared_torch_floor())
+        required = Version(_transformers_torch_floor())
+        assert declared >= required, (
+            f"pyproject [train] declares torch>={declared} but the installed "
+            f"transformers requires torch>={required}; the declared floor cannot "
+            f"bind and invites trust it does not deserve (#636)"
+        )
+
+    def test_doctor_torch_row_reads_the_declared_floor(self) -> None:
+        # Mutation check: re-hardcoding a literal floor in doctor.py's DEPS
+        # fails this test by name — the row must equal the metadata-derived
+        # floor, which is what _declared_train_floor returns at runtime.
+        from soup_cli.commands.doctor import DEPS, _declared_train_floor
+
+        torch_rows = [row for row in DEPS if row[1] == "torch"]
+        assert len(torch_rows) == 1, "expected exactly one torch row in DEPS"
+        floor = _declared_train_floor("torch")
+        if floor == "?":
+            pytest.skip("soup-cli metadata unreadable in this environment")
+        assert torch_rows[0][2] == floor, (
+            f"doctor.py's torch row declares {torch_rows[0][2]!r} but soup-cli's "
+            f"installed [train] metadata declares {floor!r} — doctor must read the "
+            f"declared floor, not carry its own copy (#636)"
+        )
+
+    def test_doctor_source_declares_no_torch_floor_literal(self) -> None:
+        # "Exactly one place in the repo declares it": the DEPS torch row must
+        # not contain a version literal again.
+        source = DOCTOR_PY.read_text(encoding="utf-8")
+        assert not re.search(r'\(\s*"torch"\s*,\s*"torch"\s*,\s*"[0-9]', source), (
+            "doctor.py hardcodes a torch floor literal in DEPS again; read it via "
+            "_declared_train_floor so pyproject stays the single declaration (#636)"
+        )


### PR DESCRIPTION
Closes #636 (claimed in [this comment](https://github.com/MakazhanAlpamys/Soup/issues/636#issuecomment-5503635641)).

> **Reworked after review** — the first cut had doctor read the floor from *installed* metadata and the drift test compare against whatever transformers happened to be installed. @MakazhanAlpamys reproduced both failure modes (stale editable dist-info printing `>=2.0.0`; the guard passing at `2.3.0` on any box below transformers 5.16.1). The design below is the review's endorsed "less clever" option: one literal in `src/`, pinned by tests, and a guard that only claims to run where it is meaningful. Review response: [comment](https://github.com/MakazhanAlpamys/Soup/pull/641#issuecomment-5506591314).

## What

**1. `[train]` declares the real floor** — `torch>=2.5.0`, matching what transformers 5.16.1's own torch extra forces (`torch>=2.5; extra == "torch"`, verified from real metadata; `.github/constraints/transformers-floor.txt` already pinned `torch==2.5.1` beside `transformers==5.16.1`, so CI validated 2.5 before this PR made the declaration match). The comment names transformers as the binding constraint; oQ/Qwen4's uint32 need (2.3) is subsumed. **Unchanged from the reviewed cut** — the review kept the number and its rationale.

**2. `soup doctor` keeps a single literal, pinned to the declaration.** `DEPS`'s torch row is `("torch", "torch", "2.5.0", True)` with a comment pointing at pyproject and the pinning tests. The metadata reader (`_declared_train_floor`) is gone: dist-info records the install's *history*, not the declaration — an editable checkout whose pyproject moved on printed a floor nobody declared, and an uninstalled source tree printed `>=?`, which `_version_ok` treats as OK (wrong in the unsafe direction). A literal cannot go stale in either direction; two independent tests keep it honest (below).

**3. Guards** (`tests/test_issue636_torch_floor.py`, regex-parsed pyproject per the `test_requires_python_bound.py` convention since `tomllib` is 3.11+):

- `test_declared_floor_meets_the_declared_transformers_requirement` — pyproject's torch floor >= the torch floor forced by the **declared** transformers floor (5.16.1), read from real metadata **only where installed == declared** — the `transformers-floor` CI job installs exactly that release under the constraints file. Anywhere else it **skips with a reason** (naming both versions) instead of passing vacuously: an older installed transformers forces a lower floor (the vacuity the review demonstrated), a newer one could turn the repo red with no repo change (the review's second-order hazard).
- `test_constraints_file_pins_the_declared_floors` — hermetic. The constraints file's `transformers==` pin must equal the declared floor (or the metadata guard validates a different release than `[train]` declares), and its `torch==` pin must satisfy the declared torch floor (or the floor job cannot resolve).
- `test_doctor_torch_floor_matches_the_pyproject_declaration` — hermetic. DEPS' literal equals the pyproject-declared floor, compared dynamically (unlike the #602 pin, which asserts both sides against literals — this one fails if *either* side moves alone). Replaces the tautological test the review flagged (it compared DEPS against the same call that built the row).
- The #602 pin (`test_qwen4_oq_torch_floor_matches_project_and_doctor`, updated in `70f3113` with the reason stated in [this comment](https://github.com/MakazhanAlpamys/Soup/pull/641#issuecomment-5504676555)) is hermetic again now that DEPS holds a literal.

## Mutations — shown, not asserted

Hermetic guards, run locally (each reverted after):

```
doctor literal 2.5.0 -> 2.3.0        FAILED ...::test_doctor_torch_floor_matches_the_pyproject_declaration
                                     FAILED ...::test_qwen4_oq_torch_floor_matches_project_and_doctor
pyproject floor 2.5.0 -> 2.3.0       FAILED (same two, by name)
constraints transformers pin -> 5.17 FAILED ...::test_constraints_file_pins_the_declared_floors
constraints torch pin -> 2.4.0       FAILED ...::test_constraints_file_pins_the_declared_floors
baseline                             3 passed, 1 skipped (local transformers is 5.13.0.dev0, skip names it)
```

The metadata guard's body cannot run on this box (installed != declared), so it was **simulated**: declared floor temporarily set to the installed 5.13.0.dev0, whose torch extra forces `>=2.4` —

```
floor 2.5.0, guard body runs         1 passed
floor 2.3.0 (below the forced 2.4)   1 failed  <- the #636 regression, caught by name
```

The simulation earned its keep: it caught a `Version`-vs-`str` `TypeError` in `max(floors, key=Version)` that would have reddened the `transformers-floor` job itself — the one place the guard really runs. Fixed before push.

## Verification

- `ruff check` clean; `tests/test_issue636_torch_floor.py` + the #602 pin + `test_cli_startup_is_light.py`: **37 passed, 1 skipped** (the named skip) in 27s.
- `soup doctor` import weight: the module-scope metadata call is gone; DEPS is literals only.
- The 10 `test_doctor.py` CLI-invocation failures and 7 `test_issue602` Qwen4 failures on this machine are pre-existing local-env breakage (torchao requires torch>=2.11 against installed 2.6.0; transformers 5.13.0.dev0 against a 5.16.1-floor repo) — identical with changes stashed, and all pass in CI.

## Scope note

doctor's other rows (`transformers>=5.16.1`, etc.) are the same duplication shape and remain unpinned — the issue names the torch row, so this PR stays on it. The pinning pattern (`test_doctor_torch_floor_matches_the_pyproject_declaration`) generalizes row-by-row if you want a follow-up.
