### PR TITLE
fix(sweep): guard the empty grid, and test the #627 loader wiring by loading

### DIFF
--- a/changelog.d/0.73.3/643.fixed.md
+++ b/changelog.d/0.73.3/643.fixed.md
@@ -1,0 +1,9 @@
+- **`soup sweep` no longer crashes with an `IndexError` when the run grid is empty (#628 by @Srinivasan8888 in #643).**
+  The unknown-parameter precheck added in #628 reads `combinations[0]` to probe the grid, so
+  a `--max-runs` value that leaves no combinations — `--max-runs -1`, for instance — raised
+  `IndexError: list index out of range` from inside the guard rather than reaching the sweep.
+  Nonsense input either way, but the previous behaviour was an empty results table and exit 0,
+  and an unhandled traceback is a worse answer than that. The probe is skipped when the grid is
+  empty, restoring the old response. Bounding `--max-runs` at `ge=1` would reject the input
+  outright and is the better long-term fix; it is a pre-existing CLI contract change and is
+  left for its own change.

--- a/src/soup_cli/commands/sweep.py
+++ b/src/soup_cli/commands/sweep.py
@@ -121,14 +121,15 @@ def sweep(
     # still exit 0 -- an entirely invalid sweep that nothing downstream can
     # detect. Every combination carries the same parameter names, so one probe
     # built the way `_run_single` builds its config settles it for the grid.
-    probe = base_cfg.model_dump()
-    for key, val in combinations[0].items():
-        _set_nested_param(probe, key, val)
-    try:
-        _reject_unknown_sweep_params(probe)
-    except ValueError as exc:
-        console.print(f"[red]{exc}[/]")
-        raise typer.Exit(1) from exc
+    if combinations:
+        probe = base_cfg.model_dump()
+        for key, val in combinations[0].items():
+            _set_nested_param(probe, key, val)
+        try:
+            _reject_unknown_sweep_params(probe)
+        except ValueError as exc:
+            console.print(f"[red]{exc}[/]")
+            raise typer.Exit(1) from exc
 
     results = []
     best_loss = float("inf")

--- a/tests/test_issue627_unknown_config_keys.py
+++ b/tests/test_issue627_unknown_config_keys.py
@@ -648,6 +648,31 @@ class TestATypodSweepFailsTheCommandAndNotJustTheArm:
             "a per-arm failure table means the loop swallowed the guard"
         )
 
+    def test_an_empty_grid_does_not_crash_the_probe(self, tmp_path) -> None:
+        """The probe reads ``combinations[0]``, which an empty grid does not have.
+
+        ``--max-runs -1`` empties the grid. Before the guard this raised an
+        unhandled ``IndexError`` from inside the new precheck -- a regression
+        this PR introduced, found in the #628 review. Nonsense input either
+        way, but main printed an empty table and exited 0, and an unhandled
+        traceback is a worse answer than that. Bounding ``--max-runs`` at
+        ``ge=1`` would be the better fix and is pre-existing behaviour, so it
+        is left alone here.
+        """
+        from typer.testing import CliRunner
+
+        from soup_cli.cli import app
+
+        result = CliRunner().invoke(app, [
+            "sweep",
+            "--config", self._config(tmp_path),
+            "--param", "training.lr=1e-5",
+            "--max-runs", "-1",
+            "--yes",
+        ])
+        assert "IndexError" not in result.output, result.output
+        assert result.exit_code == 0, result.output
+
     def test_a_valid_sweep_reaches_the_first_arm(self, tmp_path) -> None:
         """Control: a precheck that refused every sweep would pass the above.
 
@@ -673,3 +698,119 @@ class TestATypodSweepFailsTheCommandAndNotJustTheArm:
         assert "--- Run 1/1" in result.output, (
             "the sweep never reached its first arm, so the precheck blocked it"
         )
+
+
+class TestTheLoaderIsActuallyWiredUp:
+    """The half every ``soup train`` user hits, tested through its callers.
+
+    The #628 review reverted both call sites in ``config/loader.py`` -- leaving
+    ``unknown_keys.py``, ``_report_unknown_keys`` and the import in place --
+    and the whole suite stayed green: 43 passed while a config carrying
+    ``quantizaton: none`` loaded silently, which is #627 restored exactly.
+
+    Nothing saw it because ``TestOneReportPerLoad`` calls ``_report_unknown_keys``
+    directly, and the construction-site scanner is a regex the surviving
+    top-level import satisfies on its own. The scanner is still worth having --
+    it catches a *fourth* call site appearing -- but it is not a test of these
+    two. Same shape as the ``inspect.getsource`` gap on the sweep side; this is
+    the third instance and the only user-visible one.
+
+    Each call site is exercised separately: they are separate branches with
+    separate contracts (``SystemExit`` for the CLI, ``ValueError`` for the
+    API/UI), and a test of one does not cover the other.
+    """
+
+    TYPOD = (
+        "base: test-model\n"
+        "data:\n"
+        "  train: ./data.jsonl\n"
+        "training:\n"
+        "  epochs: 1\n"
+        "  quantizaton: none\n"
+    )
+    CLEAN = (
+        "base: test-model\n"
+        "data:\n"
+        "  train: ./data.jsonl\n"
+        "training:\n"
+        "  epochs: 1\n"
+    )
+
+    @staticmethod
+    def _recording_console(monkeypatch) -> list:
+        """Record what the loader prints without matching against wrapped ANSI."""
+        from soup_cli.config import loader
+
+        printed: list[str] = []
+
+        def record(*args, **kwargs) -> None:
+            printed.append(str(args[0]) if args else "")
+
+        monkeypatch.setattr(loader.console, "print", record)
+        return printed
+
+    def test_load_config_from_string_reports_an_unknown_key(self, monkeypatch) -> None:
+        from soup_cli.config.loader import load_config_from_string
+
+        printed = self._recording_console(monkeypatch)
+        load_config_from_string(self.TYPOD)
+        joined = "\n".join(printed)
+        assert "quantizaton" in joined, "the API/UI call site never reported the typo"
+        assert "unknown config key" in joined
+        assert UNKNOWN_KEY_REJECTION_VERSION in joined, "the warning lost its deadline"
+
+    def test_load_config_from_string_is_silent_on_a_clean_config(self, monkeypatch) -> None:
+        """The control: wiring that warned on everything would pass the above."""
+        from soup_cli.config.loader import load_config_from_string
+
+        printed = self._recording_console(monkeypatch)
+        load_config_from_string(self.CLEAN)
+        assert printed == [], f"a clean config produced output: {printed}"
+
+    def test_load_config_reports_an_unknown_key(self, monkeypatch, tmp_path) -> None:
+        """The file call site is a separate branch from the string one."""
+        from soup_cli.config.loader import load_config
+
+        path = tmp_path / "soup.yaml"
+        path.write_text(self.TYPOD, encoding="utf-8")
+        printed = self._recording_console(monkeypatch)
+        load_config(path)
+        joined = "\n".join(printed)
+        assert "quantizaton" in joined, "the CLI call site never reported the typo"
+        assert "unknown config key" in joined
+
+    def test_load_config_is_silent_on_a_clean_config(self, monkeypatch, tmp_path) -> None:
+        from soup_cli.config.loader import load_config
+
+        path = tmp_path / "soup.yaml"
+        path.write_text(self.CLEAN, encoding="utf-8")
+        printed = self._recording_console(monkeypatch)
+        load_config(path)
+        assert printed == [], f"a clean config produced output: {printed}"
+
+    def test_the_string_call_site_refuses_under_error_severity(self, monkeypatch) -> None:
+        """Nothing else proves the v0.75 flip works, and a test will force it."""
+        from soup_cli.config import loader
+
+        monkeypatch.setattr(loader, "UNKNOWN_KEY_SEVERITY", "error")
+        with pytest.raises(ValueError, match="quantizaton"):
+            loader.load_config_from_string(self.TYPOD)
+
+    def test_the_file_call_site_refuses_under_error_severity(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        from soup_cli.config import loader
+
+        path = tmp_path / "soup.yaml"
+        path.write_text(self.TYPOD, encoding="utf-8")
+        self._recording_console(monkeypatch)
+        monkeypatch.setattr(loader, "UNKNOWN_KEY_SEVERITY", "error")
+        with pytest.raises(SystemExit):
+            loader.load_config(path)
+
+    def test_a_clean_config_still_loads_under_error_severity(self, monkeypatch) -> None:
+        """The control for the flip: refusing everything would pass the two above."""
+        from soup_cli.config import loader
+
+        monkeypatch.setattr(loader, "UNKNOWN_KEY_SEVERITY", "error")
+        assert loader.load_config_from_string(self.CLEAN).base == "test-model"


### PR DESCRIPTION
Follow-up to #628, which merged at `eac1a88` two minutes before your review of it landed. Both items in that review are here; neither is on main.

**Attribution: both findings are yours, from the #628 review.** I am carrying them, not discovering them. The `--dry-run` gap you filed as #642 is *not* here — you asked for it to be argued in its own thread, and I agree.

## 1. An `IndexError` I introduced is live on main

The probe I added in #628 reads `combinations[0]` unguarded, so a `--max-runs` that empties the grid crashes inside the precheck. As shipped:

```
$ soup sweep -c soup.yaml --param "training.lr=1e-5" --max-runs -1 --yes
Error: IndexError: list index out of range
EXIT=1
```

main previously printed an empty table and exited 0. `if combinations:` restores that:

```
$ soup sweep -c soup.yaml --param "training.lr=1e-5" --max-runs -1 --yes
EXIT=0        # empty table, no traceback
```

I took the minimal fix rather than bounding `--max-runs` at `ge=1`. Bounding it is the better fix, as you said, but it rejects input the CLI accepts today, and that contract change deserves its own argument. The test records the reasoning so it does not read as an oversight.

## 2. The loader wiring had no behavioural test

Your reversion — both `_report_unknown_keys` call sites removed, the helper, the import and `unknown_keys.py` untouched — left the suite green while a config carrying `quantizaton: none` loaded silently. Re-run against main with these tests added:

```
4 failed, 47 passed
FAILED TestTheLoaderIsActuallyWiredUp::test_load_config_from_string_reports_an_unknown_key
FAILED TestTheLoaderIsActuallyWiredUp::test_load_config_reports_an_unknown_key
FAILED TestTheLoaderIsActuallyWiredUp::test_the_string_call_site_refuses_under_error_severity
FAILED TestTheLoaderIsActuallyWiredUp::test_the_file_call_site_refuses_under_error_severity
```

Seven tests, covering all three of your asks:

| test | pins |
|---|---|
| `test_load_config_from_string_reports_an_unknown_key` | API/UI site warns, names the key, carries the deadline |
| `test_load_config_reports_an_unknown_key` | CLI/file site warns — a separate branch |
| `test_load_config_from_string_is_silent_on_a_clean_config` | **control** |
| `test_load_config_is_silent_on_a_clean_config` | **control** |
| `test_the_string_call_site_refuses_under_error_severity` | the v0.75 flip, `ValueError` |
| `test_the_file_call_site_refuses_under_error_severity` | the v0.75 flip, `SystemExit` |
| `test_a_clean_config_still_loads_under_error_severity` | **control for the flip** |

**The construction-site scanner stays.** You were right that it is not a test of these call sites and right that it is still worth having — it catches a *fourth* site appearing, which these seven cannot. The class docstring says so, so the next reader does not mistake one for the other.

## Mutations

`__pycache__` cleared between runs; a same-length edit otherwise restores from stale bytecode.

| # | Mutation | Result |
|---|---|---|
| M17 | only the `load_config` (CLI/file) site reverted | **killed** — the two file tests, and *only* those |
| M18 | only the `load_config_from_string` (API/UI) site reverted | **killed** — the two string tests, and *only* those |
| M19 | detector reports every config as carrying an unknown key | **killed** — both silence controls, the flip control, and the sweep control |
| M20 | `if combinations:` guard removed | **killed** — `test_an_empty_grid_does_not_crash_the_probe` |

M17/M18 are split deliberately: a future edit to one call site that forgets the other cannot pass. M19 is the answer to "without a control, a warn-on-everything wiring passes" — it fails four tests across both features.

## Verification

```
pytest tests/test_issue627_unknown_config_keys.py tests/test_sweep.py tests/test_config.py \
       tests/test_cli_startup_is_light.py tests/test_recipes.py -q -o addopts=
176 passed

ruff check src/soup_cli/ scripts/ tests/          ->  All checks passed!
git diff origin/main...HEAD -- tests/ | grep -c "^-[^-]"  ->  0
```

Live, through the CLI rather than the helper:

```
$ soup train --config typo.yaml --dry-run
Warning: unknown config key 'training.quantizaton' - did you mean 'quantization'
Soup v0.75 will reject unknown config keys instead of warning.
```

(The exit 1 after that is the absent dataset, downstream of this.)

## Scope limits

- **#642 is not here.** Your call, and I think the right one.
- **`"Not applied."` under `error` severity** and the **difflib short/long ranking** (`lr_rate` → `uld_strategy`) are still open and still not touched. They want follow-up issues; say the word and I will file them with the numbers.
- **`_nested_models` recursing into every `BaseModel` in a `Union`** — still latent, still no multi-model unions in the tree. Not touched; you called it a comment rather than a change.
- Changelog fragment follows in the next push, once this PR has a number.

https://claude.ai/code/session_01YVpZy3Xj4xF2baapkdmNF3