### PR TITLE
fix(monitoring): use max_memory_allocated to report peak GPU memory in live training panel

### DIFF
--- a/changelog.d/0.73.3/652.fixed.md
+++ b/changelog.d/0.73.3/652.fixed.md
@@ -1,0 +1,8 @@
+- **Live training panel now labels the GPU figure as `GPU peak:` and reads `max_memory_allocated()` instead of `memory_allocated()` (#650 by @YuriPerro in #652).**
+  `on_log` fired between steps, after activations and gradients were freed, so the
+  sampled `memory_allocated()` was the inter-step trough -- on the reproducing run
+  `5.8/15.9 GB` while `nvidia-smi` showed the device fully occupied.
+  The fix uses `max_memory_allocated()`, the lifetime peak, and changes the label
+  to `GPU peak:` so the figure is self-describing. `reset_peak_memory_stats()` is
+  intentionally not called here: that reset is process-global and would clobber the
+  grad-accum advisor's own peak reading at `callback.py:566`.

--- a/src/soup_cli/monitoring/callback.py
+++ b/src/soup_cli/monitoring/callback.py
@@ -174,7 +174,7 @@ class _SoupTrainerCallback_body:  # noqa: N801
             import torch
 
             if torch.cuda.is_available():
-                used = torch.cuda.memory_allocated() / (1024**3)
+                used = torch.cuda.max_memory_allocated() / (1024**3)
                 total = torch.cuda.get_device_properties(0).total_memory / (1024**3)
                 gpu_mem = f"{used:.1f}/{total:.1f} GB"
         except Exception:

--- a/src/soup_cli/monitoring/callback.py
+++ b/src/soup_cli/monitoring/callback.py
@@ -168,7 +168,11 @@ class _SoupTrainerCallback_body:  # noqa: N801
         if logs is None:
             return
 
-        # Try to get GPU memory
+        # Try to get GPU memory.
+        # Uses max_memory_allocated() to report peak allocated VRAM rather than the
+        # inter-step trough (#650). We deliberately do not call reset_peak_memory_stats()
+        # here because that reset is process-global and would clobber the grad-accum
+        # advisor's own peak reading at line 566 (#650 criterion 3).
         gpu_mem = ""
         try:
             import torch

--- a/src/soup_cli/monitoring/display.py
+++ b/src/soup_cli/monitoring/display.py
@@ -115,7 +115,7 @@ class TrainingDisplay:
         if self.speed > 0:
             lines.append(f"Speed: {self.speed:.2f} it/s")
         if self.gpu_mem:
-            lines.append(f"GPU:   {self.gpu_mem}")
+            lines.append(f"GPU peak: {self.gpu_mem}")
         if self.grad_norm > 0:
             lines.append(f"Grad:  {self.grad_norm:.4f}")
 

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -174,4 +174,3 @@ def test_on_log_gpu_memory_uses_max_allocated():
     mock_torch.cuda.max_memory_allocated.assert_called_once()
     display.update.assert_called_once()
     assert display.update.call_args.kwargs["gpu_mem"] == "8.0/16.0 GB"
-

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -152,3 +152,26 @@ def test_on_log_without_tracker():
     callback.on_log(_make_args(), _make_state(), MagicMock(), logs=logs)
 
     display.update.assert_called_once()
+
+
+def test_on_log_gpu_memory_uses_max_allocated():
+    """on_log should report peak VRAM via max_memory_allocated rather than current allocation."""
+    display = MagicMock()
+    callback = SoupTrainerCallback(display=display)
+    state = _make_state()
+
+    mock_torch = MagicMock()
+    mock_torch.cuda.is_available.return_value = True
+    mock_torch.cuda.max_memory_allocated.return_value = 8 * (1024**3)
+    mock_torch.cuda.memory_allocated.return_value = 2 * (1024**3)
+    props = MagicMock()
+    props.total_memory = 16 * (1024**3)
+    mock_torch.cuda.get_device_properties.return_value = props
+
+    with patch.dict("sys.modules", {"torch": mock_torch}):
+        callback.on_log(_make_args(), state, MagicMock(), logs={"loss": 1.0})
+
+    mock_torch.cuda.max_memory_allocated.assert_called_once()
+    display.update.assert_called_once()
+    assert display.update.call_args.kwargs["gpu_mem"] == "8.0/16.0 GB"
+

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -59,6 +59,8 @@ def test_display_render_panel():
     rendered = _render_to_str(panel)
     assert "62/100" in rendered
     assert "0.847" in rendered
+    # The panel label must identify the figure as a peak, not just "GPU:" (#650).
+    assert "GPU peak:" in rendered
 
 
 def test_display_render_zero_steps():


### PR DESCRIPTION
## Summary

Fixes #650.

on_log in \src/soup_cli/monitoring/callback.py\ previously read \	orch.cuda.memory_allocated()\ to build the GPU cell of the training display panel. Because \on_log\ fires between steps (after activations and gradients have been freed), the figure showed the trough allocation rather than actual peak memory consumption.

## Changes

1. **Peak allocation counter**: Replaced \	orch.cuda.memory_allocated()\ with \	orch.cuda.max_memory_allocated()\ in \on_log\. We deliberately do not call \eset_peak_memory_stats()\ here because that reset is process-global and would clobber the grad-accum advisor's own peak reading at \callback.py:566\ (#650 acceptance criterion 3).
2. **Display label**: Changed the panel readout in \src/soup_cli/monitoring/display.py\ from \GPU:\ to \GPU peak:\ so the metric is self-describing.
3. **Tests**:
   - Added unit test \	est_on_log_gpu_memory_uses_max_allocated\ in \	ests/test_callback.py\ asserting that peak allocated VRAM is reported over trough allocation.
   - Updated \	ests/test_display.py\ (\	est_display_render_panel\) asserting that the panel renders the \GPU peak:\ label.
4. **Changelog**: Added fragment \changelog.d/0.73.3/652.fixed.md\ crediting \(#650 by @YuriPerro in #652)\.

## Validation

- Verified all 16 tests in \	ests/test_callback.py\ and \	ests/test_display.py\ pass.
- Verified linting and formatting with \uff check\ and \uff format\.