### PR TITLE
fix(batch-probe): gate the CUDA probe on the measured peak, not only on OutOfMemoryError (#649)

### DIFF
--- a/changelog.d/0.73.3/654.fixed.md
+++ b/changelog.d/0.73.3/654.fixed.md
@@ -1,0 +1,16 @@
+- **The CUDA batch probe now refuses on a measured peak, not only on a raise
+  (#649 by @YuriPerro in #654).**
+  Under the WDDM driver (native Windows, WSL2) the allocator spills to host
+  memory instead of raising `OutOfMemoryError`, so `make_cuda_probe_fn`'s only
+  fit criterion, "the step did not throw", approved a batch 16 that ran an
+  order of magnitude slower in shared memory and `pick_batch_size` cached it.
+  The probe now reads `max_memory_allocated` after the synthetic step and
+  refuses when it exceeds what this process can reach on the device
+  (`mem_get_info` free plus what it already holds), mirroring the counter and
+  basis `decide_measured_fit` documents for layer streaming; an OOM surfacing
+  at a synchronize point as `AcceleratorError` / `RuntimeError("out of
+  memory")` is classified as OOM instead of propagating as misconfiguration;
+  and the cache key carries a version tag so entries written by the old probe
+  are ignored. The WDDM case is covered by a mocked-torch test that needs no
+  GPU, with a fitting control beside it.
+  Closes #649.

--- a/docs/performance-and-quantization.md
+++ b/docs/performance-and-quantization.md
@@ -675,6 +675,8 @@ training:
 
 Replaces the static memory formula with a real try-halve-then-double-to-ceiling loop. Picked size is cached at `~/.soup/batch_cache.json` keyed on `(model, max_length, quantization, lora_r, gpu_name, gpu_memory_gb)` so repeat runs short-circuit.
 
+A candidate is refused when the step raises an out-of-memory error **or** when it completes with a measured peak (`max_memory_allocated`) above the VRAM this process can reach. The second check exists for the WDDM driver (native Windows and WSL2), where the allocator spills to host memory instead of raising: the step finishes, an order of magnitude slower, and without the measurement the probe would approve a batch that does not fit and cache it (#649). Cache entries written before that check carry a different key and are ignored.
+
 
 ## Multi-GPU / DeepSpeed / FSDP
 
@@ -815,7 +817,7 @@ training:
   auto_batch_size_strategy: probe
 ```
 
-For each candidate size `B`, the probe runs ONE forward + backward + step on a synthetic batch of `B` sequences of length `max_length`. On `torch.cuda.OutOfMemoryError` it halves; otherwise it doubles up to `4 × static_estimate`. The picked size is cached per `(model, max_length, quantization, lora_r, gpu)` tuple in `~/.soup/batch_cache.json` so subsequent runs skip the probe.
+For each candidate size `B`, the probe runs ONE forward + backward + step on a synthetic batch of `B` sequences of length `max_length`. On an out-of-memory error, or on a measured peak above what this process can reach on the device (the WDDM spill case, #649), it halves; otherwise it doubles up to `4 × static_estimate`. The picked size is cached per `(model, max_length, quantization, lora_r, gpu)` tuple in `~/.soup/batch_cache.json` so subsequent runs skip the probe.
 
 CPU sessions and `auto_batch_size_strategy: static` skip the probe. Synthetic batch tensors are freed before the backward pass so peak VRAM reflects the realistic training step. SFT-only this release — non-SFT trainers fall back to the static estimate.
 

--- a/src/soup_cli/utils/batch_probe.py
+++ b/src/soup_cli/utils/batch_probe.py
@@ -25,6 +25,9 @@ from typing import Any, Callable, Optional
 # Stay safe — never go below 1; never run forever.
 _MIN_BATCH = 1
 _DEFAULT_MAX_DOUBLINGS = 8
+# Folded into every cache key. "v2" = probe gates on the measured peak (#649);
+# keys without it were written by the exception-only probe and are ignored.
+_CACHE_KEY_VERSION = "v2"
 
 ProbeFn = Callable[[int], bool]
 
@@ -149,7 +152,13 @@ def make_cache_key(
     gpu_name: str,
     gpu_memory_gb: int,
 ) -> str:
-    """Stable string key for the cache. Hashed for filesystem safety."""
+    """Stable string key for the cache. Hashed for filesystem safety.
+
+    ``_CACHE_KEY_VERSION`` is folded into the hash so an entry written by an
+    older probe is simply never found. Bumped in #649: the exception-only probe
+    approved batches that spilled to host memory under WDDM and cached them, and
+    a cached wrong answer is recomputed by nobody.
+    """
     for name, value in (
         ("max_length", max_length),
         ("lora_r", lora_r),
@@ -159,6 +168,7 @@ def make_cache_key(
             raise ValueError(f"{name} must be an int (got {type(value).__name__})")
     raw = "|".join(
         [
+            _CACHE_KEY_VERSION,
             str(base),
             str(max_length),
             str(quantization),
@@ -293,6 +303,42 @@ def pick_batch_size(
 # ---------------------------------------------------------------------------
 
 
+def _is_cuda_oom(exc: BaseException, torch: Any) -> bool:
+    """Is ``exc`` the device running out of memory, in any of torch's spellings?
+
+    The allocator raises ``torch.cuda.OutOfMemoryError``. An OOM that surfaces
+    later at a synchronize point does not: torch >= 2.8 raises
+    ``torch.AcceleratorError("CUDA error: out of memory")`` and older releases a
+    plain ``RuntimeError`` with the same text. #649 observed the second form
+    under WDDM, where the allocator had already spilled instead of raising.
+    Anything else (an illegal access, a device assert) is not a fit answer and
+    must propagate.
+    """
+    oom_cls = getattr(torch.cuda, "OutOfMemoryError", None)
+    if oom_cls is not None and isinstance(exc, oom_cls):
+        return True
+    return isinstance(exc, RuntimeError) and "out of memory" in str(exc).lower()
+
+
+def _probe_budget_bytes(torch: Any, device: str) -> Optional[int]:
+    """Bytes this process can reach on ``device``: what it holds plus what is free.
+
+    ``mem_get_info()`` is a device-level driver query, so it excludes VRAM held
+    by other processes (the streaming pre-flight relies on the same reading,
+    see :func:`~soup_cli.utils.layer_stream.resolve_available_vram_bytes`).
+    Under WDDM it reports physical VRAM: the allocator's own warning in #649
+    read ``free: 0`` while the step kept going in host memory. Returns ``None``
+    when the driver cannot answer, in which case the caller keeps the
+    exception-only criterion rather than inventing a budget.
+    """
+    try:
+        free, _total = torch.cuda.mem_get_info(device)
+        held = torch.cuda.memory_allocated(device)
+        return int(free) + int(held)
+    except Exception:  # noqa: BLE001 — a driver that cannot answer is not a fit answer
+        return None
+
+
 def make_cuda_probe_fn(
     model: Any,
     tokenizer: Any,
@@ -304,9 +350,23 @@ def make_cuda_probe_fn(
 
     Returns a closure that, given a candidate batch size ``B``, runs ONE
     forward + backward step on a synthetic batch of ``B`` sequences of
-    length ``max_length``. Returns ``True`` on success, ``False`` on
-    :class:`torch.cuda.OutOfMemoryError`. Other exceptions propagate so
-    misconfiguration surfaces.
+    length ``max_length``. Returns ``False`` when the step raises an OOM in
+    any of torch's spellings (:func:`_is_cuda_oom`) OR when it completes with
+    a measured peak above what this process can reach on the device. Other
+    exceptions propagate so misconfiguration surfaces.
+
+    The second criterion is the #649 fix. Under WDDM (native Windows, WSL2)
+    the allocator does not raise when dedicated VRAM runs out; it spills to
+    host memory and the step completes an order of magnitude slower, so "did
+    not throw" is not "fits". The gate reads ``max_memory_allocated`` after
+    the step, deliberately not ``max_memory_reserved``: reserved runs
+    1.08-1.41x allocated and gating on it refuses configurations that run
+    (measured for :func:`~soup_cli.utils.layer_stream.decide_measured_fit`,
+    which this mirrors). The threshold is the budget from
+    :func:`_probe_budget_bytes`, not a fraction of it: the probe's peak
+    already runs above the real step (12.5-14.3% in the streaming
+    measurements), which is the direction that makes an exact comparison
+    safe.
 
     Returns ``None`` on non-CUDA devices, when torch is unavailable, when
     ``cuda.is_available()`` is False, or when any of the inputs is missing
@@ -361,6 +421,11 @@ def make_cuda_probe_fn(
         except (AttributeError, RuntimeError):
             pass
         try:
+            # Budget and peak reset BEFORE the step: `synchronize()` here can
+            # surface an earlier async OOM, which the handler below classifies.
+            torch.cuda.synchronize()
+            budget = _probe_budget_bytes(torch, device)
+            torch.cuda.reset_peak_memory_stats(device)
             ids = torch.full(
                 (batch_size, max_length), pad_id, dtype=torch.long, device=device,
             )
@@ -368,19 +433,24 @@ def make_cuda_probe_fn(
             labels = ids.clone()
             outputs = model(input_ids=ids, attention_mask=attn, labels=labels)
             loss = getattr(outputs, "loss", None)
-            if loss is None:
+            if loss is not None:
+                # Drop intermediate tensor refs BEFORE backward so peak VRAM
+                # reflects the realistic training step (matches v0.35.0 policy).
+                del ids, attn, labels, outputs
+                loss.backward()
+            else:
                 # Last resort — generic signal we got past forward.
                 del ids, attn, labels, outputs
-                torch.cuda.synchronize()
-                return True
-            # Drop intermediate tensor refs BEFORE backward so peak VRAM
-            # reflects the realistic training step (matches v0.35.0 policy).
-            del ids, attn, labels, outputs
-            loss.backward()
             torch.cuda.synchronize()
-            return True
-        except torch.cuda.OutOfMemoryError:
-            return False
+            if budget is None:
+                return True
+            peak = int(torch.cuda.max_memory_allocated(device))
+            # Completed is not fitted (WDDM spill, #649): refuse on the peak.
+            return peak <= budget
+        except Exception as exc:  # noqa: BLE001 — classified, not swallowed
+            if _is_cuda_oom(exc, torch):
+                return False
+            raise
         finally:
             try:
                 model.zero_grad(set_to_none=True)

--- a/tests/test_issue649_batch_probe_peak_gate.py
+++ b/tests/test_issue649_batch_probe_peak_gate.py
@@ -1,0 +1,231 @@
+"""#649 — the CUDA batch probe must refuse on a MEASURED peak, not only on a raise.
+
+Under the WDDM driver (native Windows, WSL2) the CUDA allocator does not raise
+``OutOfMemoryError`` when dedicated VRAM is exhausted: it spills into host
+memory and the step completes. ``make_cuda_probe_fn`` used "the step did not
+throw" as its entire fit criterion, so it approved a batch that did not fit and
+``pick_batch_size`` wrote that answer to ``~/.soup/batch_cache.json``.
+
+Every test here runs with a fake ``torch`` in ``sys.modules`` — the WDDM case
+has to be testable without WDDM, and the whole file must pass with no GPU.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+import types
+
+import pytest
+
+GB = 1024**3
+
+
+class _FakeOOMError(Exception):
+    """Stand-in for ``torch.cuda.OutOfMemoryError``."""
+
+
+class _FakeAcceleratorError(RuntimeError):
+    """Stand-in for ``torch.AcceleratorError`` (torch >= 2.8 spelling)."""
+
+
+class _Tensor:
+    def clone(self):
+        return _Tensor()
+
+
+class _Loss:
+    def backward(self):
+        return None
+
+
+class _Outputs:
+    loss = _Loss()
+
+
+class _Model:
+    def __init__(self, step=None):
+        self._step = step
+
+    def zero_grad(self, set_to_none=True):
+        return None
+
+    def __call__(self, **kwargs):
+        if self._step is not None:
+            self._step()
+        return _Outputs()
+
+
+class _Tokenizer:
+    pad_token_id = 0
+
+    def __len__(self):
+        return 32000
+
+
+def _fake_torch(*, peak_allocated: int, allocated_before: int, free_before: int, total: int):
+    """A ``torch`` whose CUDA counters report the given picture around one step."""
+    torch = types.ModuleType("torch")
+    cuda = types.ModuleType("torch.cuda")
+    state = {"peak_reset": False}
+
+    cuda.OutOfMemoryError = _FakeOOMError
+    cuda.is_available = lambda: True
+    cuda.synchronize = lambda *a, **k: None
+    cuda.empty_cache = lambda: None
+    cuda.memory_allocated = lambda *a, **k: allocated_before
+    cuda.mem_get_info = lambda *a, **k: (free_before, total)
+
+    def reset_peak_memory_stats(*a, **k):
+        state["peak_reset"] = True
+
+    def max_memory_allocated(*a, **k):
+        # Before a reset the counter would carry a stale, possibly higher, peak
+        # from an earlier probe; the gate must reset before it measures.
+        assert state["peak_reset"], "probe read max_memory_allocated without resetting the peak"
+        return peak_allocated
+
+    cuda.reset_peak_memory_stats = reset_peak_memory_stats
+    cuda.max_memory_allocated = max_memory_allocated
+    cuda.max_memory_reserved = lambda *a, **k: int(peak_allocated * 1.3)
+
+    class _Props:
+        total_memory = total
+
+    cuda.get_device_properties = lambda *a, **k: _Props()
+
+    torch.cuda = cuda
+    torch.long = "long"
+    torch.full = lambda *a, **k: _Tensor()
+    torch.ones_like = lambda *a, **k: _Tensor()
+    torch.AcceleratorError = _FakeAcceleratorError
+    return torch
+
+
+def _probe_with(monkeypatch, torch, model=None):
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    from soup_cli.utils.batch_probe import make_cuda_probe_fn
+
+    probe = make_cuda_probe_fn(model or _Model(), _Tokenizer(), max_length=512, device="cuda")
+    assert probe is not None
+    return probe
+
+
+class TestMeasuredPeakGate:
+    def test_step_that_completes_but_peaks_over_budget_is_refused(self, monkeypatch):
+        """The WDDM case: nothing raised, the peak says it did not fit."""
+        torch = _fake_torch(
+            peak_allocated=21 * GB,  # spilled: more than the card has
+            allocated_before=6 * GB,
+            free_before=9 * GB,
+            total=16 * GB,
+        )
+        probe = _probe_with(monkeypatch, torch)
+        assert probe(16) is False
+
+    def test_step_under_budget_is_still_approved(self, monkeypatch):
+        """Control: a fix that refuses everything is not a fix."""
+        torch = _fake_torch(
+            peak_allocated=12 * GB,
+            allocated_before=6 * GB,
+            free_before=9 * GB,
+            total=16 * GB,
+        )
+        probe = _probe_with(monkeypatch, torch)
+        assert probe(8) is True
+
+    def test_budget_is_what_this_process_can_reach_not_the_whole_card(self, monkeypatch):
+        """Another process holds 5 GB: peak 13 GB on a 16 GB card does NOT fit."""
+        torch = _fake_torch(
+            peak_allocated=13 * GB,
+            allocated_before=6 * GB,
+            free_before=5 * GB,  # 6 (ours) + 5 (free) = 11 GB reachable
+            total=16 * GB,
+        )
+        probe = _probe_with(monkeypatch, torch)
+        assert probe(8) is False
+
+    def test_peak_exactly_at_budget_fits(self, monkeypatch):
+        torch = _fake_torch(
+            peak_allocated=15 * GB,
+            allocated_before=6 * GB,
+            free_before=9 * GB,
+            total=16 * GB,
+        )
+        probe = _probe_with(monkeypatch, torch)
+        assert probe(8) is True
+
+    def test_gate_uses_allocated_not_reserved(self, monkeypatch):
+        """Reserved runs 1.08-1.41x allocated (layer_stream.decide_measured_fit);
+        the fake reports reserved at 1.3x so a gate on reserved would refuse
+        this fitting step."""
+        torch = _fake_torch(
+            peak_allocated=14 * GB,  # reserved fake = 18.2 GB > 15 GB budget
+            allocated_before=6 * GB,
+            free_before=9 * GB,
+            total=16 * GB,
+        )
+        probe = _probe_with(monkeypatch, torch)
+        assert probe(8) is True
+
+
+class TestSynchronizeOOMSpelling:
+    def test_accelerator_error_out_of_memory_counts_as_oom(self, monkeypatch):
+        """WDDM's eventual failure is ``AcceleratorError: CUDA error: out of
+        memory`` from ``cuStreamSynchronize``, not ``OutOfMemoryError``."""
+        torch = _fake_torch(
+            peak_allocated=1 * GB, allocated_before=1 * GB, free_before=9 * GB, total=16 * GB
+        )
+
+        def step():
+            raise _FakeAcceleratorError("CUDA error: out of memory")
+
+        probe = _probe_with(monkeypatch, torch, model=_Model(step))
+        assert probe(8) is False
+
+    def test_runtime_error_out_of_memory_counts_as_oom(self, monkeypatch):
+        """Older torch spells the same failure as a plain RuntimeError."""
+        torch = _fake_torch(
+            peak_allocated=1 * GB, allocated_before=1 * GB, free_before=9 * GB, total=16 * GB
+        )
+
+        def step():
+            raise RuntimeError("CUDA out of memory. Tried to allocate 560.00 MiB")
+
+        probe = _probe_with(monkeypatch, torch, model=_Model(step))
+        assert probe(8) is False
+
+    def test_other_accelerator_error_propagates(self, monkeypatch):
+        """An illegal memory access is misconfiguration, not a fit answer."""
+        torch = _fake_torch(
+            peak_allocated=1 * GB, allocated_before=1 * GB, free_before=9 * GB, total=16 * GB
+        )
+
+        def step():
+            raise _FakeAcceleratorError("CUDA error: an illegal memory access was encountered")
+
+        probe = _probe_with(monkeypatch, torch, model=_Model(step))
+        with pytest.raises(_FakeAcceleratorError, match="illegal memory access"):
+            probe(8)
+
+
+class TestCacheKeyInvalidatesOldProbe:
+    def test_key_differs_from_the_pre_649_key_for_the_same_tuple(self):
+        """Entries written by the exception-only probe must not survive: the
+        pre-#649 key was sha256 of the bare tuple, and a poisoned
+        ``batch_cache.json`` has no other way to be noticed."""
+        from soup_cli.utils.batch_probe import make_cache_key
+
+        args = ("Qwen/Qwen2.5-1.5B-Instruct", 512, "none", 16, "NVIDIA GeForce RTX 5080", 15)
+        old_raw = "|".join(str(a) for a in args)
+        old_key = hashlib.sha256(old_raw.encode("utf-8")).hexdigest()[:32]
+        assert make_cache_key(*args) != old_key
+
+    def test_key_is_still_stable_and_still_32_hex(self):
+        from soup_cli.utils.batch_probe import make_cache_key
+
+        a = make_cache_key("m", 2048, "4bit", 64, "gpu", 80)
+        b = make_cache_key("m", 2048, "4bit", 64, "gpu", 80)
+        assert a == b
+        assert len(a) == 32
+        int(a, 16)


### PR DESCRIPTION
Closes #649.

## What

1. `make_cuda_probe_fn` now refuses a candidate whose **measured peak** after the synthetic step exceeds what this process can reach on the device, in addition to refusing on a raise. Under WDDM (native Windows, WSL2) the allocator spills to host memory instead of raising, so "the step did not throw" was the entire fit criterion and it approved a batch that did not fit.
   - Counter: `max_memory_allocated`, deliberately not `max_memory_reserved`. Reserved runs 1.08-1.41x allocated and gating on it refuses configurations that run; this is the basis `layer_stream.decide_measured_fit` already documents, and the probe mirrors it rather than picking a fraction.
   - Threshold: `mem_get_info()[0] + memory_allocated()` read before the step (what this process holds plus what is free), compared exactly. The probe's peak already runs above the real step, which is the direction that makes an exact comparison safe. When the driver cannot answer, the probe keeps the exception-only criterion rather than inventing a budget.
2. OOM raised at a synchronize point is classified as OOM: `torch.AcceleratorError("CUDA error: out of memory")` (torch >= 2.8) and the older `RuntimeError` spelling. This is the exception WDDM eventually raises (#649 reproduction, second row). An `AcceleratorError` with any other message still propagates.
3. Cache key carries a version tag (`v2`), so entries written by the exception-only probe are never found again. No migration code: a poisoned `batch_cache.json` simply stops matching.
4. `docs/performance-and-quantization.md`: the OOM-probe section states the WDDM behaviour in both places it describes the loop.

## Tests

`tests/test_issue649_batch_probe_peak_gate.py`, fake `torch` in `sys.modules`, no GPU:

| test | mutation it catches |
|---|---|
| step completes, peak 21 GB on a 16 GB card → `False` | removing the peak gate (the WDDM case) |
| step completes under budget → `True` | a gate that refuses everything |
| peak 13 GB, 5 GB free + 6 GB held → `False` | gating on `total_memory` instead of reachable bytes |
| peak == budget → `True` | an off-by-one / strict comparison |
| reserved 1.3x over budget, allocated under → `True` | gating on reserved |
| `AcceleratorError("... out of memory")` → `False` | not classifying the synchronize spelling |
| `RuntimeError("CUDA out of memory ...")` → `False` | same, older torch |
| `AcceleratorError("illegal memory access")` → raises | swallowing non-OOM device errors |
| key for the same tuple != pre-#649 sha256 | forgetting the cache bump |

The fake asserts `reset_peak_memory_stats` was called before `max_memory_allocated` is read, so a stale peak from an earlier candidate cannot leak into the decision.

## Verification

- `ruff check src/soup_cli/ scripts/ tests/` clean.
- `tests/test_batch_probe.py` (31) + the new file (10) pass; full suite result to be posted below.
- Live WDDM run on the reporting box (RTX 5080 16 GB, WSL2) pending: I will post the probe's decision for the batch 16 case from #649 before marking ready for review.

## Scope limits

- The probe's speed under WDDM is out of scope (#325 / #395); this PR changes only its decision.
- The panel readout that hid the peak is #650.
- `mem_get_info` cannot see a per-process cap (`set_per_process_memory_fraction`, MIG); the streaming pre-flight has an override for that and the batch probe does not grow one here.