### PR TITLE
feat(recipes): add glm-5.1-grpo recipe (#275)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ src/soup_cli/
   experiment/         - SQLite experiment tracking
   eval/               - Eval platform (custom tasks, LLM judge, human eval, leaderboard)
   migrate/            - Config migration (LLaMA-Factory, Axolotl, Unsloth)
-  recipes/            - Ready-made configs for popular models (162 recipes)
+  recipes/            - Ready-made configs for popular models (163 recipes)
   autopilot/          - Zero-config decision engine (v0.25.0)
   registry/           - Model Registry (hashing, store, diff, attach) (v0.26.0 + v0.33.0)
   cans/               - Shareable .can artifact format + run/publish orchestrator (v0.26.0 + v0.33.0)

--- a/changelog.d/0.73.3/656.added.md
+++ b/changelog.d/0.73.3/656.added.md
@@ -1,0 +1,11 @@
+- **Added a ready-made `glm-5.1-grpo` recipe for zai-org/GLM-5.1
+  (#275 by @Srinivasan8888 in #656).** The base already shipped SFT (v0.71.24)
+  and DPO (#280 by @Osheun); this completes the trio with the reasoning shape
+  (`task: grpo`, `reasoning_train.jsonl`, `grpo_beta: 0.1`, `num_generations: 4`,
+  `reward_fn: accuracy`) over the 754B MoE geometry its siblings already use
+  (LoRA r32/a64, `batch_size: 1`, `gradient_accumulation_steps: 16`, 4-bit,
+  `moe_lora`, `gradient_checkpointing`, `max_length: 8192`) — deliberately not
+  the 30B GRPO template's r16/a32. `lr: 1e-5` is the value both conventions
+  agree on: 15 of 22 GRPO recipes and `glm-5.1-sft` alike. The recipe is not
+  trained — 754B is multi-node — so no hyperparameter here is a measured
+  recommendation. Catalog count 162 -> 163.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -152,7 +152,7 @@ soup migrate --from llamafactory config.yaml  Import config from LLaMA-Factory
 soup migrate --from axolotl config.yml        Import config from Axolotl
 soup migrate --from unsloth notebook.ipynb    Import config from Unsloth notebook
 soup migrate --from llamafactory c.yaml --dry-run  Preview without writing
-soup recipes list                             List all 162 ready-made recipes
+soup recipes list                             List all 163 ready-made recipes
 soup recipes show llama3.1-8b-sft            Print recipe YAML
 soup recipes use llama3.1-8b-sft             Copy recipe to soup.yaml
 soup recipes search "reasoning"              Search by keyword/task/size

--- a/docs/serving-and-export.md
+++ b/docs/serving-and-export.md
@@ -546,7 +546,7 @@ soup ui
 
 **Pages:**
 - **Dashboard** — view all experiment runs, loss charts, system info, multi-run comparison
-- **New Training** — create configs from templates or 162 ready-made recipes, validate, start training with live SSE log streaming and progress bar
+- **New Training** — create configs from templates or 163 ready-made recipes, validate, start training with live SSE log streaming and progress bar
 - **Data Explorer** — browse and inspect datasets (JSONL, JSON, CSV, Parquet)
 - **Model Chat** — chat with streaming responses, configurable temperature/top_p/max_tokens, system prompt, adapter selection, markdown rendering, chat export
 
@@ -555,7 +555,7 @@ soup ui
 - **Enhanced Metrics** — 2x2 chart grid (loss, LR, grad_norm, throughput) + GPU memory chart, eval results table
 - **Multi-Run Compare** — overlay loss curves from up to 5 runs side-by-side
 - **Chat Upgrade** — SSE streaming via proxy, typing indicator, cancel button, markdown renderer (bold, italic, code blocks), chat export as JSON
-- **Config Builder** — recipe dropdown (162 recipes), config schema API for dynamic form generation
+- **Config Builder** — recipe dropdown (163 recipes), config schema API for dynamic form generation
 
 **Security:** The Web UI generates a random auth token at startup (printed to console). All mutating endpoints (start/stop training, delete runs, inspect data, validate config) require `Authorization: Bearer <token>` header. CORS is restricted to the served origin. Data inspection is sandboxed to the working directory.
 

--- a/src/soup_cli/recipes/catalog.py
+++ b/src/soup_cli/recipes/catalog.py
@@ -48,7 +48,7 @@ def search_recipes(
 
 
 # ---------------------------------------------------------------------------
-# Recipe catalog (162 recipes)
+# Recipe catalog (163 recipes)
 # ---------------------------------------------------------------------------
 
 RECIPES: Dict[str, RecipeMeta] = {
@@ -4399,6 +4399,44 @@ training:
     target_modules: auto
   quantization: 4bit
   dpo_beta: 0.1
+  moe_lora: true
+  moe_aux_loss_coeff: 0.01
+  gradient_checkpointing: true
+
+output: ./output
+""",
+    ),
+    "glm-5.1-grpo": RecipeMeta(
+        model="zai-org/GLM-5.1",
+        task="grpo",
+        size="754B",
+        tags=("glm", "zai-org", "grpo", "reasoning", "moe", "large", "multi-gpu"),
+        description=(
+            "GLM 5.1 MoE GRPO reasoning training (MIT, 754B). "
+            "Multi-GPU / multi-node recommended."
+        ),
+        yaml_str="""\
+base: zai-org/GLM-5.1
+task: grpo
+
+data:
+  train: ./data/reasoning_train.jsonl
+  format: auto
+  max_length: 8192
+
+training:
+  epochs: 3
+  lr: 1e-5
+  batch_size: 1
+  gradient_accumulation_steps: 16
+  lora:
+    r: 32
+    alpha: 64
+    target_modules: auto
+  quantization: 4bit
+  grpo_beta: 0.1
+  num_generations: 4
+  reward_fn: accuracy
   moe_lora: true
   moe_aux_loss_coeff: 0.01
   gradient_checkpointing: true

--- a/tests/fixtures/recipe_config_snapshots.json
+++ b/tests/fixtures/recipe_config_snapshots.json
@@ -631,6 +631,20 @@
       "training.lr": 5e-06,
       "training.moe_lora": true
     },
+    "glm-5.1-grpo": {
+      "base": "zai-org/GLM-5.1",
+      "data.format": "auto",
+      "data.max_length": 8192,
+      "data.train": "./data/reasoning_train.jsonl",
+      "task": "grpo",
+      "training.batch_size": 1,
+      "training.gradient_accumulation_steps": 16,
+      "training.gradient_checkpointing": true,
+      "training.lora.alpha": 64,
+      "training.lora.r": 32,
+      "training.lr": 1e-05,
+      "training.moe_lora": true
+    },
     "glm-5.1-sft": {
       "base": "zai-org/GLM-5.1",
       "data.format": "auto",

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -381,6 +381,125 @@ class TestIssue280Glm51DpoRecipe:
         )
 
 
+class TestGlm51GrpoRecipe:
+    """Regression coverage for the glm-5.1-grpo recipe (#275).
+
+    GLM-5.1 shipped SFT (v0.71.24) and DPO (#280) but no reasoning variant.
+    The model id is pinned on two independent surfaces — ``RecipeMeta.model``
+    and the YAML ``base:`` — in two separate tests, so a mutation to either
+    one alone names the surface it broke, and an edit that repairs one while
+    forgetting the other cannot go green.
+    """
+
+    RECIPE = "glm-5.1-grpo"
+    MODEL = "zai-org/GLM-5.1"
+
+    def test_recipe_meta_pins_the_model_id(self) -> None:
+        """Surface 1: the catalog metadata, read without touching the YAML."""
+        from soup_cli.recipes.catalog import get_recipe
+
+        recipe = get_recipe(self.RECIPE)
+        assert recipe is not None, f"{self.RECIPE} is missing from the catalog"
+        assert recipe.model == self.MODEL
+        assert recipe.task == "grpo"
+
+    def test_yaml_base_pins_the_model_id(self) -> None:
+        """Surface 2: the YAML body, parsed directly rather than via ``.model``.
+
+        Deliberately does not read ``RecipeMeta.model`` — otherwise the two
+        surfaces would be one assertion wearing two hats.
+        """
+        import yaml
+
+        from soup_cli.recipes.catalog import get_recipe
+
+        recipe = get_recipe(self.RECIPE)
+        assert recipe is not None
+        parsed = yaml.safe_load(recipe.yaml_str)
+        assert parsed["base"] == self.MODEL
+        assert parsed["task"] == "grpo"
+
+    def test_recipe_loads_with_expected_grpo_moe_shape(self) -> None:
+        """The loaded config, not the source text — behaviour is what ships."""
+        from soup_cli.config.loader import load_config_from_string
+        from soup_cli.recipes.catalog import get_recipe
+
+        recipe = get_recipe(self.RECIPE)
+        assert recipe is not None
+        config = load_config_from_string(recipe.yaml_str)
+
+        assert config.base == self.MODEL
+        assert config.task == "grpo"
+        # Fields whose recipe value differs from its schema default: these are
+        # the ones a stripped line actually changes.
+        assert config.data.max_length == 8192
+        assert config.training.lr == 1e-5
+        assert config.training.batch_size == 1
+        assert config.training.gradient_accumulation_steps == 16
+        assert config.training.lora.r == 32
+        assert config.training.lora.alpha == 64
+        assert config.training.moe_lora is True
+        assert config.training.gradient_checkpointing is True
+        # Fields that match their schema default. Pinned as recipe intent, and
+        # reported as equivalent mutations in the PR body rather than counted
+        # as kills they are not.
+        assert config.training.grpo_beta == 0.1
+        assert config.training.num_generations == 4
+        assert config.training.reward_fn == "accuracy"
+        assert config.training.moe_aux_loss_coeff == 0.01
+
+    def test_show_and_use_recipe(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The CLI path a user actually takes, run rather than asserted about."""
+        show_result = runner.invoke(app, ["recipes", "show", self.RECIPE])
+        assert show_result.exit_code == 0
+        assert self.MODEL in strip_ansi(show_result.output)
+
+        monkeypatch.chdir(tmp_path)
+        use_result = runner.invoke(app, ["recipes", "use", self.RECIPE, "--yes"])
+        assert use_result.exit_code == 0
+        written = (tmp_path / "soup.yaml").read_text(encoding="utf-8")
+        assert self.MODEL in written
+        assert "task: grpo" in written
+
+    def test_glm51_task_variants_are_three_distinct_entries(self) -> None:
+        """The unregister direction: deleting a recipe is not the only way to break this.
+
+        All three GLM-5.1 variants must remain present, share one base, and
+        carry three different tasks — so silently repointing this recipe at a
+        sibling's task fails here rather than passing as "a recipe exists".
+        """
+        from soup_cli.recipes.catalog import RECIPES
+
+        variants = {"glm-5.1-sft": "sft", "glm-5.1-dpo": "dpo", self.RECIPE: "grpo"}
+        for name, task in variants.items():
+            assert name in RECIPES, f"{name} is missing from the catalog"
+            assert RECIPES[name].model == self.MODEL
+            assert RECIPES[name].task == task
+        assert len({RECIPES[n].task for n in variants}) == 3
+
+    def test_shares_base_and_size_with_its_glm51_siblings(self) -> None:
+        """``RecipeMeta.size`` was uncovered: mutating 754B -> 30B survived the
+        whole suite until this test existed.
+
+        Tying the three variants together is stronger than a bare literal — a
+        lone edit to one variant's size fails here, while a genuine correction
+        applied consistently to all three does not.
+        """
+        from soup_cli.recipes.catalog import get_recipe
+
+        grpo = get_recipe(self.RECIPE)
+        sft = get_recipe("glm-5.1-sft")
+        dpo = get_recipe("glm-5.1-dpo")
+        assert grpo is not None and sft is not None and dpo is not None
+
+        assert grpo.size == sft.size == dpo.size == "754B"
+        assert grpo.model == sft.model == dpo.model == self.MODEL
+
+
 class TestIssue271SmolLM3Recipe:
     """Regression coverage for the smollm3-3b-sft recipe (#271)."""
 
@@ -629,7 +748,7 @@ class TestV025NewRecipes:
             assert cfg.base == recipe.model
             assert cfg.task == recipe.task
 
-    def test_catalog_size_is_162(self):
+    def test_catalog_size_is_163(self):
         """Total catalog size — grew with each release.
 
         v0.25.0 shipped 43 recipes (29 + 9 Part A + 2 Part B tools + 3 Part E MLX).
@@ -655,10 +774,11 @@ class TestV025NewRecipes:
         Issue #276 added 1 (qwen3.5-35b-a3b-dpo) -> 160.
         Issue #281 added 1 (kimi-k2.6-grpo) -> 161.
         Task-variant for #275 added 1 (qwen3.5-9b-dpo) -> 162.
+        Task-variant for #275 added 1 (glm-5.1-grpo) -> 163.
         """
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 162
+        assert len(RECIPES) == 163
 
     def test_new_recipes_searchable(self):
         """Search returns the new recipes via keyword/task filter."""

--- a/tests/test_v07124.py
+++ b/tests/test_v07124.py
@@ -274,11 +274,11 @@ class TestCatalogCount:
 
         It had drifted through 116 -> 134 -> 137 -> 158 -> 162 without the name
         following, so the one thing a reader saw first was the one thing that
-        was false. The count itself is pinned by `test_catalog_size_is_162` in
+        was false. The count itself is pinned by `test_catalog_size_is_163` in
         `test_recipes.py` and by `test_recipe_count_is_synced.py`; this row is
         the milestone file's own copy and does not need the number twice.
         """
-        assert len(RECIPES) == 162
+        assert len(RECIPES) == 163
 
     def test_list_recipes_matches_dict(self) -> None:
         assert len(list_recipes()) == len(RECIPES)

--- a/tests/test_v07130.py
+++ b/tests/test_v07130.py
@@ -737,10 +737,10 @@ class TestRecipes:
         assert cfg.training.rollout_backend == "openenv"
         assert cfg.training.rollout_func.startswith("soup_cli.envs.")
 
-    def test_catalog_size_is_162(self):
+    def test_catalog_size_is_163(self):
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 162
+        assert len(RECIPES) == 163
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_v07132.py
+++ b/tests/test_v07132.py
@@ -950,7 +950,7 @@ class TestAsrRecipes:
         assert cfg.task == "sft"
         assert cfg.modality == "vision"
 
-    def test_catalog_size_is_162(self):
+    def test_catalog_size_is_163(self):
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 162
+        assert len(RECIPES) == 163


### PR DESCRIPTION
Adds `glm-5.1-grpo`, the reasoning task-variant for `zai-org/GLM-5.1`. Catalog 162 -> 163.

`Refs #275`. [Claimed](https://github.com/MakazhanAlpamys/Soup/issues/275#issuecomment-5529106580) before any code was written.

## Overlap and attribution

No claim comment existed for this recipe. `gh pr list --search glm --state all` returns #452 (`glm-5.1-dpo`, merged, by @Osheun) and nothing else touching GLM; no open PR touches `recipes/`, `catalog.py`, or GRPO. All six named children of #275 are closed — #276 (#615), #277 (#448), #278 (#422), #279, #280 (#452), #281. I checked PR **titles** rather than only issue threads, since #512 is the reason that rule exists.

**The shape is inherited, not invented.** The geometry is @Osheun's from #452; the MoE-GRPO task fields are from `qwen3-30b-a3b-reasoning-grpo`.

## Shape, and why

GLM-5.1 had SFT (v0.71.24) and DPO (#280) but no reasoning variant. Measured rather than picked by eye — the models at two-of-three:

```
zai-org/GLM-5.1                  ['dpo', 'sft']         missing=['grpo']
Qwen/Qwen3.5-35B-A3B             ['dpo', 'sft']         missing=['grpo']
deepseek-ai/DeepSeek-V4-Flash    ['grpo', 'sft']        missing=['dpo']
moonshotai/Kimi-K2.6             ['grpo', 'sft']        missing=['dpo']
Qwen/Qwen3.5-9B                  ['dpo','grpo','sft']   complete (#632)
```

GLM-5.1 is the one whose missing slot is *reasoning* rather than preference.

### Where each line came from

The two conventions **conflict** — the MoE-GRPO cohort uses LoRA r16/a32, the GLM-5.1 siblings use r32/a64. I followed #275's own rule ("the shipped SFT recipes are the copy-paste template"), with the GRPO templates supplying the task shape:

| line | source | note |
|---|---|---|
| `base`, `size: 754B`, tags | `glm-5.1-sft` / `glm-5.1-dpo` | same base model |
| `batch_size: 1`, `gradient_accumulation_steps: 16` | GLM-5.1 siblings | 754B geometry |
| **`lora r32/a64`** | GLM-5.1 siblings | **not** the 30B template's r16/a32 — both siblings use r32/a64 here |
| `moe_lora`, `moe_aux_loss_coeff`, `gradient_checkpointing`, `max_length: 8192` | GLM-5.1 siblings | |
| `task: grpo`, `reasoning_train.jsonl`, `grpo_beta`, `num_generations`, `reward_fn` | `qwen3-30b-a3b-reasoning-grpo` | the MoE-GRPO task shape |
| `lr: 1e-5`, `epochs: 3` | **both agree** | 15 of 22 GRPO recipes use 1e-5, as does `glm-5.1-sft`; the 1e-5/epochs-3 pairing holds across the cohort |

`lr` is the one place both axes agree, so it is not an outlier in either direction — the #632 lesson. The closest analogue overall is `kimi-k2.6-grpo` (1T MoE, 2026 family): same `lr`, `epochs`, `max_length`, `moe_lora`.

## Mutation table

Each mutation applied **only inside the `glm-5.1-grpo` entry** (sliced by dict key, so `  r: 32` cannot hit another recipe). `__pycache__` cleared every round — a stale `.pyc` fakes a restore when the edit is the same length. `catalog.py` md5-verified byte-identical after every round.

| # | mutation | verdict | named test that fails |
|---|---|---|---|
| 1 | `RecipeMeta.model` **alone** | KILLED | `TestGlm51GrpoRecipe::test_recipe_meta_pins_the_model_id` |
| 2 | YAML `base:` **alone** | KILLED | `TestGlm51GrpoRecipe::test_yaml_base_pins_the_model_id` |
| 3 | both model surfaces together | KILLED | `test_recipe_meta_pins_the_model_id` + 2 others |
| 4 | `RecipeMeta.task` alone | KILLED | `TestRecipeCatalog::test_recipe_tasks_match_yaml` |
| 5 | YAML `task:` alone | KILLED | `TestRecipeCatalog::test_recipe_tasks_match_yaml` |
| 6 | both task surfaces together | KILLED | `test_glm51_task_variants_are_three_distinct_entries` + 2 |
| 7 | `lora.r` 32 -> 16 | KILLED | `test_recipe_loads_with_expected_grpo_moe_shape` |
| 8 | `lora.alpha` 64 -> 32 | KILLED | `test_recipe_loads_with_expected_grpo_moe_shape` |
| 9 | `moe_lora` true -> false | KILLED | `test_recipe_loads_with_expected_grpo_moe_shape` |
| 10 | `gradient_checkpointing` true -> false | KILLED | `test_recipe_loads_with_expected_grpo_moe_shape` |
| 11 | `batch_size` 1 -> auto | KILLED | `test_recipe_loads_with_expected_grpo_moe_shape` |
| 12 | `gradient_accumulation_steps` 16 -> 4 | KILLED | `test_recipe_loads_with_expected_grpo_moe_shape` |
| 13 | `lr` 1e-5 -> 2e-5 | KILLED | `test_recipe_loads_with_expected_grpo_moe_shape` |
| 14 | `max_length` 8192 -> 2048 | KILLED | `test_recipe_loads_with_expected_grpo_moe_shape` |
| 15 | delete the whole entry | KILLED | `test_recipe_meta_pins_the_model_id` |
| 16 | **`size` 754B -> 30B** | **SURVIVED, then KILLED** | see below |

### The survivor that was a real gap

`RecipeMeta.size` had **no coverage anywhere in the suite** — mutating `754B -> 30B` passed everything. That is not an equivalent mutation, it is a hole, so I closed it rather than reporting it as acceptable:

```
[KILLED  ] size 754B -> 30B (was a SURVIVOR)
           -> TestGlm51GrpoRecipe::test_shares_base_and_size_with_its_glm51_siblings
```

The new test ties `size` across all three GLM-5.1 variants rather than pinning a bare literal, so a lone edit fails while a genuine correction applied consistently does not.

### Reported survivors — equivalent, and proved rather than asserted

Seven lines equal their schema default, so stripping them is behaviourally identical and **cannot** be killed. I am not manufacturing kills for them:

```
stripped line                    identical loaded config?   schema default
  epochs: 3                                          True   epochs = 3
  quantization: 4bit                                 True   quantization = '4bit'
  grpo_beta: 0.1                                     True   grpo_beta = 0.1
  num_generations: 4                                 True   num_generations = 4
  reward_fn: accuracy                                True   reward_fn = 'accuracy'
  moe_aux_loss_coeff: 0.01                           True   moe_aux_loss_coeff = 0.01
  target_modules: auto                               True   target_modules = 'auto'
```

Independent confirmation from the repo's own tooling: #640's delta encoder omitted **exactly these seven fields** from the recipe's snapshot delta, because they match the baseline. They are kept in the YAML for parity with the sibling recipes, which also spell them out.

I did not add a test pinning the YAML *source text* to kill them — that is the shape #621/#640 removed from this suite.

## Verification

```
$ .venv/bin/python -m pytest tests/test_recipes.py tests/test_v07124.py tests/test_v07130.py \
    tests/test_v07132.py tests/test_recipe_count_is_synced.py tests/test_issue621_recipe_snapshot.py \
    tests/test_issue427_qwen35_text_modality.py tests/test_issue477_qwen38_catalog.py \
    tests/test_cli_startup_is_light.py -q -o addopts=
690 passed, 1 skipped, 2 warnings in 23.53s

$ .venv/bin/python -m ruff check src/soup_cli/ scripts/ tests/
All checks passed!

$ git diff --check          # clean
$ git diff -- tests/ | grep -c "^-[^-]"
8
```

**Those 8 removed test lines, every one accounted for:** 3 × `def test_catalog_size_is_162` renamed to `_163`, 4 × `assert len(RECIPES) == 162` bumped to `163`, and 1 docstring line in `test_v07124.py` that names `test_catalog_size_is_162` by string (updated so the pointer stays true). Each is a 1:1 replacement. Net **+9 test methods**; nothing deleted or weakened.

### Run live, not only asserted on

```
$ soup recipes use glm-5.1-grpo --yes
✓ Recipe glm-5.1-grpo written to soup.yaml

$ soup recipes list | grep glm-5.1
│ glm-5.1-sft   │ zai-org/GLM-5.1 │ sft  │ 754B │ GLM 5.1 MoE SFT  │
│ glm-5.1-dpo   │ zai-org/GLM-5.1 │ dpo  │ 754B │ GLM 5.1 MoE DPO  │
│ glm-5.1-grpo  │ zai-org/GLM-5.1 │ grpo │ 754B │ GLM 5.1 MoE GRPO │
```

The written `soup.yaml` reloads through `load_config_from_string` -> `zai-org/GLM-5.1 | grpo | lora r32 | lr 1e-05`.

### Count sweep — 13 sites

`catalog.py` comment · 3 renamed `test_catalog_size_is_163` methods · 4 assertions · 1 docstring cross-reference · `CONTRIBUTING.md` · `docs/commands.md` · `docs/serving-and-export.md` (×2). Verified with `grep -rn "\b162\b"`; the remaining hits are all historical (`CHANGELOG.md`, `CONTRIBUTORS.md`, `changelog.d/` fragments) and correctly left alone.

Snapshot fixture regenerated via `scripts/generate_recipe_snapshot.py`: **14 insertions, 0 deletions** — one recipe block, nothing else moved.

## Scope limits

- **Not trained.** GLM-5.1 is 754B MoE, multi-node. I cannot run it and am not implying otherwise. No hyperparameter here is a measured recommendation — every value is inherited from a shipped sibling or the GRPO template, itemised above.
- **Base repo id verified as *resolving* only** — `https://huggingface.co/api/models/zai-org/GLM-5.1` returns HTTP 200. I did not download 754B of weights, so "the checkpoint trains under this config" is unverified.
- The `pytorch-smoke` and full-suite gates are CI's to run; locally I ran the targeted suites with `-o addopts=`, which skips the coverage gate.

Changelog fragment follows in a second push, once this PR has a number — deliberately not guessed, per #487 and the `583.added.md` collision.

https://claude.ai/code/session_014vWWFgXhj9y46pYCyEjfcy
