### PR TITLE
test(batch-probe): cover the two branches #654 recorded as untested

### DIFF
--- a/tests/test_issue654_batch_probe_uncovered_branches.py
+++ b/tests/test_issue654_batch_probe_uncovered_branches.py
@@ -1,0 +1,176 @@
+"""#654 follow-ups — the two branches its merge comment recorded as uncovered.
+
+#654 fixed the CUDA batch probe to gate on a measured peak rather than on the
+absence of an ``OutOfMemoryError``, and recorded two things it did **not**
+cover. Both are closed here.
+
+**1. The graceful-degradation branch.** ``_probe_budget_bytes`` returns ``None``
+when the driver cannot answer ``mem_get_info``, and ``_probe`` then returns
+``True`` — deliberately keeping the pre-#649 exception-only criterion instead of
+inventing a budget. Nothing executed that path: the fake in
+``test_issue649_batch_probe_peak_gate.py`` builds ``mem_get_info`` as a lambda
+that cannot fail. Flipping the branch to ``False`` would make the probe refuse
+**every** batch on such a stack, down to ``_MIN_BATCH``, and no test would move.
+
+**2. The ``AcceleratorError`` contract.** ``_is_cuda_oom`` classifies torch's
+async-OOM spelling through ``isinstance(exc, RuntimeError)`` — it never names
+``AcceleratorError``. That is correct upstream, but the existing test's
+``_FakeAcceleratorError`` *also* subclasses ``RuntimeError``, so it passes
+whether or not the real class does, and proves nothing about torch.
+
+The merge comment reasoned that no CI cell could check the real assumption,
+because the author's box had torch 2.5.1. That does not follow: ``[dev]`` pulls
+``[train]``, which declares ``torch>=2.5.0`` — a floor, not a pin — so CI
+resolves the newest wheel. Measured in this repo's ``.venv``: torch 2.13.0,
+``AcceleratorError`` present, ``issubclass(..., RuntimeError)`` True. So the
+guard below **executes** rather than skips. Where the symbol is genuinely
+absent it skips with a stated reason rather than passing vacuously — the
+convention ``tests/test_issue636_torch_floor.py`` sets for environment-dependent
+checks.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from tests.test_issue649_batch_probe_peak_gate import (
+    GB,
+    _Model,
+    _probe_with,
+    _Tensor,
+)
+
+
+def _torch_without_mem_get_info(*, peak_allocated: int, raises: bool = True):
+    """A ``torch`` whose driver cannot answer ``mem_get_info``.
+
+    ``peak_allocated`` is deliberately set far ABOVE anything a budget could
+    be, so ``peak <= budget`` would be ``False`` if a budget were ever
+    computed. A ``True`` from the probe can then only have come from the
+    ``budget is None`` path — the test cannot pass for the wrong reason.
+    """
+    torch = types.ModuleType("torch")
+    cuda = types.ModuleType("torch.cuda")
+
+    class _FakeOOMError(Exception):
+        pass
+
+    cuda.OutOfMemoryError = _FakeOOMError
+    cuda.is_available = lambda: True
+    cuda.synchronize = lambda *a, **k: None
+    cuda.empty_cache = lambda: None
+    cuda.memory_allocated = lambda *a, **k: 0
+
+    if raises:
+        def mem_get_info(*a, **k):
+            # What a driver that cannot answer actually does.
+            raise RuntimeError("CUDA driver error: cannot query memory info")
+    else:
+        # The control: a driver that CAN answer, same peak, tiny budget.
+        def mem_get_info(*a, **k):
+            return (1 * GB, 4 * GB)
+
+    cuda.mem_get_info = mem_get_info
+    cuda.reset_peak_memory_stats = lambda *a, **k: None
+    cuda.max_memory_allocated = lambda *a, **k: peak_allocated
+    cuda.max_memory_reserved = lambda *a, **k: peak_allocated
+
+    torch.cuda = cuda
+    torch.long = "long"
+    torch.full = lambda *a, **k: _Tensor()
+    torch.ones_like = lambda *a, **k: _Tensor()
+    return torch
+
+
+class TestBudgetUnavailableKeepsTheExceptionOnlyCriterion:
+    """#654 follow-up 1: ``if budget is None: return True``."""
+
+    def test_probe_approves_when_the_driver_cannot_report_memory(self, monkeypatch):
+        """A driver that cannot answer must not turn into a refusal of everything.
+
+        The step completes and raises nothing, so the pre-#649 criterion says
+        "fits". The peak here is 999 GB — larger than any budget — so if the
+        gate were reached at all this would return False.
+        """
+        torch = _torch_without_mem_get_info(peak_allocated=999 * GB)
+        probe = _probe_with(monkeypatch, torch, model=_Model())
+
+        assert probe(8) is True
+
+    def test_control_same_peak_is_refused_when_the_driver_can_answer(self, monkeypatch):
+        """The control that makes the test above mean something.
+
+        Identical 999 GB peak; the only change is that ``mem_get_info`` works.
+        If this also returned True the first test would prove nothing about the
+        ``budget is None`` path.
+        """
+        torch = _torch_without_mem_get_info(peak_allocated=999 * GB, raises=False)
+        probe = _probe_with(monkeypatch, torch, model=_Model())
+
+        assert probe(8) is False
+
+
+class TestAcceleratorErrorInheritanceContract:
+    """#654 follow-up 2: the assumption ``_is_cuda_oom`` actually rides on."""
+
+    def test_real_torch_accelerator_error_subclasses_runtime_error(self):
+        """Pin the upstream contract against the INSTALLED torch, not a fake.
+
+        ``_is_cuda_oom`` never names ``AcceleratorError``; it catches it via
+        ``isinstance(exc, RuntimeError)``. If upstream ever reparents the class
+        the probe would propagate an async OOM instead of shrinking the batch,
+        and every fake-torch test would still pass. This is the only check in
+        the suite that would notice.
+        """
+        torch = pytest.importorskip("torch", reason="torch is not installed in this env")
+        acc = getattr(torch, "AcceleratorError", None)
+        if acc is None:
+            pytest.skip(
+                f"torch {torch.__version__} predates torch.AcceleratorError "
+                "(added in 2.8); nothing to pin here"
+            )
+
+        assert issubclass(acc, RuntimeError), (
+            f"torch {torch.__version__} AcceleratorError no longer subclasses "
+            f"RuntimeError (mro: {[c.__name__ for c in acc.__mro__]}). "
+            "batch_probe._is_cuda_oom classifies it by inheritance, so an async "
+            "CUDA OOM would now propagate out of the probe instead of being "
+            "reported as 'does not fit'."
+        )
+
+    def test_an_accelerator_error_outside_runtimeerror_would_propagate(self, monkeypatch):
+        """Demonstrate the consequence the guard above protects against.
+
+        This is what makes that guard load-bearing rather than decorative: with
+        a class that does NOT subclass ``RuntimeError``, the same 'out of
+        memory' text is not classified, and the probe raises instead of
+        returning False.
+        """
+        from soup_cli.utils.batch_probe import _is_cuda_oom
+
+        class _DetachedAcceleratorError(Exception):
+            """An AcceleratorError that is not a RuntimeError."""
+
+        torch = _torch_without_mem_get_info(peak_allocated=1 * GB, raises=False)
+        torch.AcceleratorError = _DetachedAcceleratorError
+
+        exc = _DetachedAcceleratorError("CUDA error: out of memory")
+        assert _is_cuda_oom(exc, torch) is False
+
+        # And end to end: the probe propagates rather than refusing the batch.
+        def step():
+            raise exc
+
+        probe = _probe_with(monkeypatch, torch, model=_Model(step))
+        with pytest.raises(_DetachedAcceleratorError, match="out of memory"):
+            probe(8)
+
+    def test_the_runtimeerror_spelling_is_still_classified(self, monkeypatch):
+        """Reject-everything control: the classifier has not simply stopped working."""
+        from soup_cli.utils.batch_probe import _is_cuda_oom
+
+        torch = _torch_without_mem_get_info(peak_allocated=1 * GB, raises=False)
+        assert _is_cuda_oom(RuntimeError("CUDA out of memory. Tried to allocate"), torch) is True
+        assert _is_cuda_oom(RuntimeError("an illegal memory access"), torch) is False


### PR DESCRIPTION
Closes both follow-ups recorded in #654's merge comment. **No source changes** — this adds tests only.

[Claimed on #654](https://github.com/MakazhanAlpamys/Soup/pull/654#issuecomment-5529972442) before writing anything, with right of first refusal offered to @YuriPerro, who found the defect.

## Overlap

No open issue or PR covers either follow-up; nothing in the open queue touches `batch_probe.py`. #649 is closed by #654.

## 1. The graceful-degradation branch

`_probe_budget_bytes` returns `None` when the driver cannot answer `mem_get_info`, and `_probe` then returns `True` — deliberately keeping the pre-#649 exception-only criterion rather than inventing a budget.

I verified the cause rather than taking it on trust. `tests/test_issue649_batch_probe_peak_gate.py:77` builds the fake as:

```python
cuda.mem_get_info = lambda *a, **k: (free_before, total)
```

which cannot fail, so `_probe_budget_bytes` never returns `None` and line 445-446 never executes.

The new fake raises instead, and reports a **999 GB peak** — larger than any budget could be — so if the gate were reached at all the probe would return `False`. A `True` can therefore only have come from the `budget is None` path. A control with the identical peak and a *working* `mem_get_info` returns `False`, so the first test cannot pass for the wrong reason.

## 2. The `AcceleratorError` contract — and a premise worth correcting

`_is_cuda_oom` never names `AcceleratorError`; it catches it via `isinstance(exc, RuntimeError)`. The existing `_FakeAcceleratorError` *also* subclasses `RuntimeError`, so that test passes whether or not the real class does — exactly as the merge comment says.

The merge comment then reasoned that **no CI cell could check the real assumption**, because the author's box had torch 2.5.1. That second half does not follow, and the difference matters:

```
pyproject: dev = ["soup-cli[train,...]", ...]   ->   train = ["torch>=2.5.0", ...]
```

`>=2.5.0` is a **floor, not a pin**, so `pip install -e ".[dev]"` resolves the newest wheel. Measured in this repo's own `.venv`:

```
torch 2.13.0
torch.AcceleratorError present: True
  mro: ['AcceleratorError', 'RuntimeError', 'Exception', 'BaseException', 'object']
  issubclass(RuntimeError): True
```

And @YuriPerro's own WDDM verification in #654 ran torch **2.14.0**. So the assumption is checkable in CI today, and the guard **executes rather than skips** — confirmed locally with `-rs`, 5 passed / 0 skipped.

Where the symbol is genuinely absent the test skips **with a stated reason** rather than passing vacuously, which is the convention `tests/test_issue636_torch_floor.py` sets for environment-dependent checks.

The failure message names the consequence rather than just the assertion, so whoever sees it red knows what broke:

> `torch X AcceleratorError no longer subclasses RuntimeError (mro: ...). batch_probe._is_cuda_oom classifies it by inheritance, so an async CUDA OOM would now propagate out of the probe instead of being reported as 'does not fit'.`

## Mutation table

Each mutation run against the **pre-existing** suite and the new file, so "this was uncovered" is measured rather than asserted:

| mutation | OLD suite | NEW file | named failure |
|---|---|---|---|
| `budget is None: return True` -> `False` | **SURVIVED** | KILLED | `test_probe_approves_when_the_driver_cannot_report_memory` |
| `budget is None` branch removed entirely | **SURVIVED** | KILLED | `test_probe_approves_when_the_driver_cannot_report_memory` |
| `_is_cuda_oom`: `RuntimeError` -> `Exception` | **SURVIVED** | KILLED | `test_an_accelerator_error_outside_runtimeerror_would_propagate` |
| `_is_cuda_oom`: drop the message check | KILLED | KILLED | already covered — **no new kill**, reported not counted |

`batch_probe.py` md5-verified byte-identical after every round; `__pycache__` cleared each time.

**The third row is beyond the two gaps the merge comment named.** Nothing pinned the classifier's *narrowness*: it could be broadened to `Exception` and no test would object, which would swallow the non-OOM errors its own docstring says "must propagate" (an illegal access, a device assert). That direction is now pinned.

## Verification

```
$ .venv/bin/python -m pytest tests/test_issue654_batch_probe_uncovered_branches.py \
    tests/test_issue649_batch_probe_peak_gate.py -q -o addopts=
15 passed

$ .venv/bin/python -m ruff check src/soup_cli/ scripts/ tests/
All checks passed!

$ git diff -- tests/ | grep -c "^-[^-]"
0
```

Zero deleted test lines, zero source changes. The cross-module import of the existing fakes follows the precedent in `tests/test_qwen35_streaming.py` and `tests/test_v05311.py` rather than duplicating ~100 lines of fake torch.

## Scope — one thing deliberately NOT done

I did not rewrite `_is_cuda_oom` to match `AcceleratorError` **by name** instead of by inheritance. That would make the classifier independent of upstream's class hierarchy — today the probe would propagate rather than shrink the batch if that hierarchy changed — but it is a **behaviour change to correct code**, and therefore yours to decide rather than mine to slip into a test PR. Say the word and it is a separate PR.

Consequence worth stating plainly: `test_an_accelerator_error_outside_runtimeerror_would_propagate` pins today's narrow classification. If you take the by-name change, that test changes with it — by design, since its job is to make the inheritance dependency visible.

## Limits

- Everything here runs against a fake torch except the contract guard, which reads the installed one. No GPU is required and none was used.
- I cannot verify behaviour on a torch that predates `AcceleratorError` (2.5.x) beyond confirming the test skips there with a reason.
- The WDDM behaviour itself is @YuriPerro's measurement, not mine; nothing in this PR re-measures it.

https://claude.ai/code/session_014vWWFgXhj9y46pYCyEjfcy
