### PR TITLE
test(config): cover the non-string-key guard in the unknown-key walk (#627)

### DIFF
--- a/tests/test_issue627_unknown_config_keys.py
+++ b/tests/test_issue627_unknown_config_keys.py
@@ -156,6 +156,72 @@ class TestTheControl:
         find_unknown_config_keys(raw)  # must not raise
 
 
+class TestNonStringKeysAreSkippedNotCrashedOn:
+    """The ``isinstance(key, str)`` guard in ``_walk`` (#628), which had no test.
+
+    YAML permits non-string mapping keys. Without the guard the key reaches
+    ``difflib.get_close_matches``, which iterates it:
+
+        get_close_matches(1,    [...])  -> TypeError: 'int' object is not iterable
+        get_close_matches(True, [...])  -> TypeError: 'bool' object is not iterable
+
+    So a config carrying ``1:`` or ``true:`` would kill ``soup train --config``
+    with a bare TypeError raised from inside the unknown-key reporter — the
+    code whose whole purpose is to turn a confusing failure into an actionable
+    one. Measured as the single uncovered statement in ``unknown_keys.py``.
+    """
+
+    def test_python_collapses_true_and_one_into_one_key(self) -> None:
+        """Pin the fixture's own premise before relying on it.
+
+        ``True == 1`` in Python, so a mapping with both ``1:`` and ``true:``
+        holds ONE entry, not two. A test written without noticing this would
+        claim to cover two non-string key types while covering one.
+        """
+        import yaml
+
+        collapsed = yaml.safe_load("1: numeric\ntrue: boolean\n")
+        assert list(collapsed) == [1]
+        assert type(next(iter(collapsed))) is int
+
+    def test_a_numeric_key_does_not_raise(self) -> None:
+        doc = _raw(extra_training="1: numeric-key\nepochs: 3\n")
+        assert find_unknown_config_keys(doc) == []
+
+    def test_a_boolean_key_does_not_raise(self) -> None:
+        """Constructed directly: YAML would collapse ``true:`` onto ``1:``."""
+        doc = _raw(extra_training="epochs: 3\n")
+        doc["training"][True] = "boolean-key"
+        assert find_unknown_config_keys(doc) == []
+
+    def test_a_non_string_key_does_not_mask_a_real_unknown_key(self) -> None:
+        """The guard must ``continue``, not abort the loop.
+
+        This is the assertion that would survive a guard rewritten as an early
+        ``return``: the typo sits AFTER the non-string key in insertion order,
+        so it is only reported if the walk kept going.
+        """
+        doc = _raw(extra_training="1: numeric-key\nepocs: 3\n")
+        found = find_unknown_config_keys(doc)
+
+        assert [u.path for u in found] == ["training.epocs"]
+        assert "epochs" in found[0].suggestions
+
+    def test_a_non_string_key_nested_in_a_subsection_does_not_raise(self) -> None:
+        """``_walk`` recurses; the guard has to hold on the way down too."""
+        doc = _raw(extra_training="epochs: 3\n")
+        doc["training"]["lora"] = {2: "numeric-key", "r": 16, "alpah": 32}
+        found = find_unknown_config_keys(doc)
+
+        assert [u.path for u in found] == ["training.lora.alpah"]
+        assert "alpha" in found[0].suggestions
+
+    def test_control_string_keys_are_still_reported(self) -> None:
+        """Reject-everything control: the walk has not simply stopped working."""
+        doc = _raw(extra_training="epocs: 3\n")
+        assert [u.path for u in find_unknown_config_keys(doc)] == ["training.epocs"]
+
+
 class TestTheMessage:
     def test_message_names_the_path_and_the_suggestion(self) -> None:
         unknown = find_unknown_config_keys(


### PR DESCRIPTION
Covers the one uncovered statement in `config/unknown_keys.py` — the non-string-key guard I shipped in #628. **No source change**; the guard is correct, only its coverage was missing.

[Claimed on #627](https://github.com/MakazhanAlpamys/Soup/issues/627#issuecomment-5530288514) before writing anything. `Refs #627`.

## How it was found

Not by eye. A branch-coverage run over the full suite:

```
$ .venv/bin/python -m pytest tests/ -q -o addopts= --cov=soup_cli --cov-branch --cov-report=term-missing
19935 passed, 108 skipped ... TOTAL 74022 12672 28968 4607 81%   (25m27s)

src/soup_cli/config/unknown_keys.py    ...  miss=1  BrPart=1  97%   missing: 118
```

Line 118 is the `continue` in:

```python
for key, value in raw.items():
    if not isinstance(key, str):
        continue
```

Nothing in `tests/test_issue627_unknown_config_keys.py` had ever fed the walk a non-string key.

## Why it matters

YAML permits non-string mapping keys. Without the guard the key reaches `difflib.get_close_matches`, which iterates it:

```
difflib.get_close_matches(1,    [...])  -> TypeError: 'int' object is not iterable
difflib.get_close_matches(True, [...])  -> TypeError: 'bool' object is not iterable
```

So a config carrying `1:` or `true:` under any section would kill `soup train --config` with a bare `TypeError` **raised from inside the unknown-key reporter** — the code whose entire purpose is to turn a confusing failure into an actionable one. That is the #628 defect wearing different clothes.

## Mutation table

Each mutation run against the **pre-existing** classes in the file and against the new one, so "this was uncovered" is measured rather than asserted:

| mutation | PRE-EXISTING | NEW class |
|---|---|---|
| guard removed entirely | **SURVIVED** | KILLED |
| `continue` -> `return` (aborts the walk) | **SURVIVED** | KILLED |
| `isinstance(key, str)` -> `isinstance(key, object)` | **SURVIVED** | KILLED |

Named failures:

```
guard removed entirely
  test_a_numeric_key_does_not_raise
  test_a_boolean_key_does_not_raise
  test_a_non_string_key_does_not_mask_a_real_unknown_key
  test_a_non_string_key_nested_in_a_subsection_does_not_raise

continue -> return
  test_a_non_string_key_does_not_mask_a_real_unknown_key
  test_a_non_string_key_nested_in_a_subsection_does_not_raise
```

**The third row is reported, not counted.** `not isinstance(x, object)` is always `False`, so that mutation is behaviourally identical to removing the guard and produces the same four failures. One kill spelled two ways — I would rather say so than present three independent kills.

`unknown_keys.py` md5-verified byte-identical after every round; `__pycache__` cleared each time.

## Two details the tests pin deliberately

**`continue`, not `return`.** The mask test puts the typo *after* the non-string key in insertion order, so `training.epocs` is only reported if the walk kept going. A guard rewritten as an early `return` would silently stop reporting every key after the first non-string one — and would have passed a test that only checked "does not crash".

**`True == 1`.** `{1: ..., true: ...}` collapses to a **single** dict entry, so `yaml.safe_load("1: numeric\ntrue: boolean\n")` yields `[1]`, not two keys. A fixture written without noticing would claim to cover two non-string key types while covering one. `test_python_collapses_true_and_one_into_one_key` pins that premise before the other tests rely on it; the boolean case is therefore constructed directly rather than through YAML.

## Verification

```
$ .venv/bin/python -m pytest tests/test_issue627_unknown_config_keys.py tests/test_config.py \
    tests/test_cli_startup_is_light.py -q -o addopts=
91 passed

$ .venv/bin/python -m ruff check src/soup_cli/ scripts/ tests/
All checks passed!

$ git diff --stat -- src/ | wc -l
0
$ git diff -- tests/ | grep -c "^-[^-]"
0
```

## Measured but deliberately not taken

Recorded so they are findable rather than lost in a terminal. Both are the #273 shape — full statement coverage, one branch each:

- `monitoring/plugin_callback.py` `34->30` — an **enabled** plugin that exposes no hooks is never exercised.
- `utils/moe.py` `60->62` — a config object with no `__dict__` is never exercised.

Happy for anyone to take either; say the word if you would rather I fold them into this PR.

## Limits

- This pins the guard's behaviour, not a new capability. It changes nothing a working config does today.
- The crash it prevents is demonstrated at the `difflib` call rather than by shipping a broken build: the TypeError above is real output, but the end-to-end `soup train` path is only reached through `find_unknown_config_keys`, which is what the tests drive.

https://claude.ai/code/session_014vWWFgXhj9y46pYCyEjfcy
