### PR TITLE
fix(recipes): repair Hugging Face repo IDs in MLX recipes (#661)

### DIFF
--- a/changelog.d/0.74.0/666.fixed.md
+++ b/changelog.d/0.74.0/666.fixed.md
@@ -1,0 +1,7 @@
+- Repaired non-existent Hugging Face repository IDs in MLX catalog recipes
+  (#661 by @kok-o in #666). `qwen3-8b-sft-mlx` previously pointed to
+  `mlx-community/Qwen3-8B-Instruct-4bit` (which huggingface_hub reports as
+  RepositoryNotFoundError); it now references `mlx-community/Qwen3-8B-4bit`.
+  `gemma3-9b-sft-mlx` is renamed to `gemma3-4b-sft-mlx` (user-visible rename;
+  the old 9B size does not exist upstream) pointing to
+  `mlx-community/gemma-3-4b-it-4bit` (size 4B, M1+ 16GB).

--- a/src/soup_cli/recipes/catalog.py
+++ b/src/soup_cli/recipes/catalog.py
@@ -1239,13 +1239,13 @@ output: ./output
 """,
     ),
     "qwen3-8b-sft-mlx": RecipeMeta(
-        model="mlx-community/Qwen3-8B-Instruct-4bit",
+        model="mlx-community/Qwen3-8B-4bit",
         task="sft",
         size="8B",
         tags=("qwen", "qwen3", "mlx", "apple-silicon", "sft"),
         description="Qwen 3 8B SFT on Apple Silicon via MLX (M2+ 16GB)",
         yaml_str="""\
-base: mlx-community/Qwen3-8B-Instruct-4bit
+base: mlx-community/Qwen3-8B-4bit
 task: sft
 backend: mlx
 
@@ -1267,14 +1267,14 @@ training:
 output: ./output
 """,
     ),
-    "gemma3-9b-sft-mlx": RecipeMeta(
-        model="mlx-community/gemma-3-9b-it-4bit",
+    "gemma3-4b-sft-mlx": RecipeMeta(
+        model="mlx-community/gemma-3-4b-it-4bit",
         task="sft",
-        size="9B",
+        size="4B",
         tags=("gemma", "gemma3", "mlx", "apple-silicon", "sft"),
-        description="Gemma 3 9B SFT on Apple Silicon via MLX (M2+ 16GB)",
+        description="Gemma 3 4B SFT on Apple Silicon via MLX (M1+ 16GB)",
         yaml_str="""\
-base: mlx-community/gemma-3-9b-it-4bit
+base: mlx-community/gemma-3-4b-it-4bit
 task: sft
 backend: mlx
 

--- a/tests/fixtures/recipe_config_snapshots.json
+++ b/tests/fixtures/recipe_config_snapshots.json
@@ -593,6 +593,15 @@
       "training.lora.r": 16,
       "training.lr": 1e-05
     },
+    "gemma3-4b-sft-mlx": {
+      "backend": "mlx",
+      "base": "mlx-community/gemma-3-4b-it-4bit",
+      "data.train": "./data/train.jsonl",
+      "training.batch_size": 2,
+      "training.lora.alpha": 32,
+      "training.lora.r": 16,
+      "training.lr": 0.0001
+    },
     "gemma3-9b-sft": {
       "base": "google/gemma-3-9b-it",
       "data.format": "auto",
@@ -600,15 +609,6 @@
       "training.lora.alpha": 32,
       "training.lora.r": 16,
       "training.lr": 0.0002
-    },
-    "gemma3-9b-sft-mlx": {
-      "backend": "mlx",
-      "base": "mlx-community/gemma-3-9b-it-4bit",
-      "data.train": "./data/train.jsonl",
-      "training.batch_size": 2,
-      "training.lora.alpha": 32,
-      "training.lora.r": 16,
-      "training.lr": 0.0001
     },
     "glm-4.6-sft": {
       "base": "THUDM/glm-4.6",
@@ -1628,7 +1628,7 @@
     },
     "qwen3-8b-sft-mlx": {
       "backend": "mlx",
-      "base": "mlx-community/Qwen3-8B-Instruct-4bit",
+      "base": "mlx-community/Qwen3-8B-4bit",
       "data.train": "./data/train.jsonl",
       "training.batch_size": 2,
       "training.lora.alpha": 32,

--- a/tests/test_mlx_backend.py
+++ b/tests/test_mlx_backend.py
@@ -223,14 +223,22 @@ class TestMLXRecipes:
 
         recipe = get_recipe("qwen3-8b-sft-mlx")
         assert recipe is not None
+        assert recipe.model == "mlx-community/Qwen3-8B-4bit"
         cfg = load_config_from_string(recipe.yaml_str)
+        assert cfg.base == "mlx-community/Qwen3-8B-4bit"
         assert cfg.backend == "mlx"
 
-    def test_gemma3_9b_sft_mlx(self):
+    def test_gemma3_4b_sft_mlx(self):
+        from soup_cli.config.loader import load_config_from_string
         from soup_cli.recipes.catalog import get_recipe
 
-        recipe = get_recipe("gemma3-9b-sft-mlx")
+        recipe = get_recipe("gemma3-4b-sft-mlx")
         assert recipe is not None
+        assert recipe.model == "mlx-community/gemma-3-4b-it-4bit"
+        assert recipe.size == "4B"
+        cfg = load_config_from_string(recipe.yaml_str)
+        assert cfg.base == "mlx-community/gemma-3-4b-it-4bit"
+        assert cfg.backend == "mlx"
 
     def test_mlx_dpo_config_rejected_at_load(self):
         """backend=mlx + task=dpo is rejected by the SoupConfig validator."""
@@ -268,6 +276,37 @@ output: ./output
 """
         with pytest.raises(ValueError, match="MLX backend only ships SFT"):
             load_config_from_string(yaml_str)
+
+
+class TestMlxRecipeRepoIds:
+    """Pin the repo id every shipped MLX recipe declares, on RecipeMeta.model
+    and YAML base: independently (#661). This does not check that the repo resolves.
+    """
+
+    MLX_RECIPES = [
+        ("llama3.1-8b-sft-mlx", "mlx-community/Llama-3.1-8B-Instruct-4bit"),
+        ("qwen3-8b-sft-mlx", "mlx-community/Qwen3-8B-4bit"),
+        ("gemma3-4b-sft-mlx", "mlx-community/gemma-3-4b-it-4bit"),
+    ]
+
+    @pytest.mark.parametrize("name,expected_repo", MLX_RECIPES)
+    def test_meta_model_matches_expected_repo(self, name: str, expected_repo: str):
+        from soup_cli.recipes.catalog import get_recipe
+
+        recipe = get_recipe(name)
+        assert recipe is not None, f"Recipe {name} missing from catalog"
+        assert recipe.model == expected_repo
+
+    @pytest.mark.parametrize("name,expected_repo", MLX_RECIPES)
+    def test_yaml_base_matches_expected_repo(self, name: str, expected_repo: str):
+        import yaml
+
+        from soup_cli.recipes.catalog import get_recipe
+
+        recipe = get_recipe(name)
+        assert recipe is not None
+        parsed = yaml.safe_load(recipe.yaml_str)
+        assert parsed["base"] == expected_repo
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Repairs the repository IDs for the MLX recipes in `src/soup_cli/recipes/catalog.py`.

`Fixes #661`. [Claimed](https://github.com/MakazhanAlpamys/Soup/issues/661#issuecomment-5538677387) before writing code.

## Overlap
- No other PR touches `qwen3-8b-sft-mlx` or `gemma3-9b-sft-mlx`.

## Root Cause & Changes

1. **`qwen3-8b-sft-mlx`:**
   - Previous repo ID `mlx-community/Qwen3-8B-Instruct-4bit` returned HTTP 401 / Not Found.
   - Qwen3 dropped the `-Instruct` suffix; the instruct model is just `Qwen3-8B`.
   - Updated to `mlx-community/Qwen3-8B-4bit` (HTTP 200 on Hub).

2. **`gemma3-9b-sft-mlx` -> `gemma3-4b-sft-mlx`:**
   - Gemma 3 has no 9B model size (sizes are 1b, 4b, 12b, 27b; 9B was Gemma 2 only).
   - Resolved to **`gemma3-4b-sft-mlx`** (`mlx-community/gemma-3-4b-it-4bit`, HTTP 200).
   - *Rationale:* MLX recipes target Apple Silicon laptops (8 GB / 16 GB), where 4B 4-bit runs comfortably without severe paging/pressure, while keeping the Gemma 3 family represented in the MLX catalog.
   - Updated size to `4B` and updated description.

## Mutation Testing

Tested against `TestMlxRecipeRepoIds`:

| # | mutation | verdict | named test |
|---|---|---|---|
| 1 | Qwen `RecipeMeta.model` alone | KILLED | `test_meta_model_matches_expected_repo` |
| 2 | Qwen YAML `base:` alone | KILLED | `test_yaml_base_matches_expected_repo` |
| 3 | Gemma `RecipeMeta.model` alone | KILLED | `test_meta_model_matches_expected_repo` |
| 4 | Gemma YAML `base:` alone | KILLED | `test_yaml_base_matches_expected_repo` |

## Verification

```
$ pytest tests/test_mlx_backend.py tests/test_issue621_recipe_snapshot.py -q -o addopts=
192 passed in 1.99s

$ ruff check src/soup_cli/ tests/
All checks passed!
```

- Live CLI: `soup recipes show qwen3-8b-sft-mlx` and `soup recipes show gemma3-4b-sft-mlx` render valid configs.
- Recipe config snapshot fixture regenerated additively.

Changelog fragment added in `changelog.d/0.74.0/666.fixed.md`.
