### PR TITLE
test(mlx): assert the smoke adapter LOADS, not merely that it exists (#23)

### DIFF
--- a/tests/test_smoke_train.py
+++ b/tests/test_smoke_train.py
@@ -108,13 +108,18 @@ output: {output_dir}
     return config_path
 
 
+#: The base the MLX smoke fixture trains. Named once so the fixture and the
+#: adapter-loadability assertion cannot drift onto different models.
+_MLX_SMOKE_BASE = "hf-internal-testing/tiny-random-LlamaForCausalLM"
+
+
 @pytest.fixture
 def mlx_sft_config_yaml(tmp_path: Path, tiny_train_data: Path) -> Path:
     """Create a one-step MLX SFT config with a public tiny Llama fixture."""
     config_path = tmp_path / "soup_mlx.yaml"
     output_dir = tmp_path / "output_mlx"
     config_path.write_text(
-        f"""base: hf-internal-testing/tiny-random-LlamaForCausalLM
+        f"""base: {_MLX_SMOKE_BASE}
 task: sft
 backend: mlx
 
@@ -234,6 +239,32 @@ def test_mlx_sft_smoke(mlx_sft_config_yaml: Path):
     output_dir = mlx_sft_config_yaml.parent / "output_mlx"
     assert (output_dir / "adapters.safetensors").exists()
     assert (output_dir / "adapter_config.json").exists()
+
+    # #23's "adapter file saved and loadable" criterion. Existence is not
+    # loadability, and the gap has a named failure mode here: per
+    # `resolve_mlx_target_keys`'s docstring (#392), a run could ship
+    # `{"keys": ["auto"]}`, `linear_to_lora_layers` would match nothing, and
+    # `load_weights(strict=False)` would drop every LoRA tensor IN SILENCE --
+    # leaving an adapter that exists, satisfies both assertions above, and
+    # produces generations bit-identical to the base model.
+    #
+    # So the check is that loading ATTACHES LoRA parameters, not merely that
+    # it does not raise. A dropped-tensor adapter loads perfectly happily.
+    from mlx.utils import tree_flatten
+    from mlx_lm import load
+
+    base_model, _ = load(_MLX_SMOKE_BASE)
+    tuned_model, _ = load(_MLX_SMOKE_BASE, adapter_path=str(output_dir))
+
+    base_keys = {key for key, _ in tree_flatten(base_model.parameters())}
+    tuned_keys = {key for key, _ in tree_flatten(tuned_model.parameters())}
+    lora_keys = {key for key in tuned_keys - base_keys if ".lora_" in key}
+
+    assert lora_keys, (
+        "the adapter loaded but attached no LoRA parameters: "
+        f"{len(base_keys)} params before, {len(tuned_keys)} after. That is the "
+        "#392 shape -- an adapter that exists and is inert."
+    )
 
 
 def test_dpo_smoke(dpo_config_yaml: Path):


### PR DESCRIPTION
Closes the last unmet acceptance criterion on #23 — *"adapter file saved and loadable"*. **Test-only, one file.**

Per [my status check on #23](https://github.com/MakazhanAlpamys/Soup/issues/23#issuecomment-5531000000), the other criteria are already met or obsolete: #394 put `mlx-smoke` on `macos-14` for **every PR** (stronger than the nightly this issue proposed), `README.md:28` already badges `ci.yml` which contains that job, and #665 closed the Rich callback item.

## The gap

`test_mlx_sft_smoke` asserted the two files exist and stopped:

```python
assert (output_dir / "adapters.safetensors").exists()
assert (output_dir / "adapter_config.json").exists()
```

**Existence is not loadability**, and the difference has a named failure mode in this repo already — `resolve_mlx_target_keys`'s own docstring, from #392:

> a default run trained Q/V and then shipped `{"keys": ["auto"]}`. `linear_to_lora_layers` matches nothing against that and `load_weights(strict=False)` drops every LoRA tensor **in silence**, leaving an adapter whose generations are bit-identical to the base model.

So an adapter can be written, be well-formed, carry 8 real tensors, satisfy both assertions — and be **inert**.

## The assertion, and why it is this one

Not "load does not raise" — a dropped-tensor adapter loads perfectly happily. The check is that loading **attaches** LoRA parameters:

```python
base_model, _  = load(_MLX_SMOKE_BASE)
tuned_model, _ = load(_MLX_SMOKE_BASE, adapter_path=str(output_dir))
lora_keys = {k for k in tuned_keys - base_keys if ".lora_" in k}
assert lora_keys, ...
```

Established empirically before writing it, rather than assumed: on a healthy run this base goes **21 params → 29**, with 12 new keys including `model.layers.0.self_attn.q_proj.lora_a` / `.lora_b`.

## Proof it has teeth

I injected the **actual #392 defect** — reverted `build_mlx_adapter_config` to write `{"keys": ["auto"]}` while `_apply_lora` still trains the resolved Q/V list — and measured which assertions notice:

| scenario | verdict |
|---|---|
| clean tree, WITH the loadability assertion | **PASS** |
| #392 bug injected, **OLD assertions only** | **PASS** — ships undetected |
| #392 bug injected, WITH the assertion | **FAIL** — caught |

```
AssertionError: the adapter loaded but attached no LoRA parameters:
21 params before, 21 after. That is the #392 shape -- an adapter that
exists and is inert.
```

Both `mlx_sft.py` and `test_smoke_train.py` restored **byte-identical** afterwards (md5 verified).

The failure message names the mechanism and prints the counts, so whoever sees it red does not have to rediscover #392 to understand it.

## Verified in the real job environment

Not the dev venv — **the dev venv cannot run this job.** Step 2 asserts `torch`, `trl`, `datasets`, `peft`, `accelerate`, `bitsandbytes` are *absent*, and `.[dev]` installs all six, which is exactly why #394 kept `mlx-smoke` out of the main matrix.

So I built a clean `.[mlx]`-only venv on Apple Silicon (Python 3.12, since system Python here is 3.9.6, below the floor) and ran all three job steps verbatim:

```
step 1: import mlx.core, mlx_lm     -> 0.32.2 0.31.3
step 2: PyTorch stack must be ABSENT -> PASS
step 3: pytest -o addopts= -m smoke -k mlx_sft_smoke -q tests/test_smoke_train.py
        1 passed, 2 deselected in 2.76s
```

**Cost:** 2.6–2.8 s for the whole test including the extra load, against ~4.3 s before on a cold HF cache. The assertion does not meaningfully change job runtime — it reuses the model the run already downloaded.

## Verification

```
$ .venv/bin/python -m ruff check src/soup_cli/ tests/
All checks passed!

$ git diff -- tests/ | grep -c "^-[^-]"
1
```

**That one removed line, accounted for:** the fixture's inline base id, replaced by the module constant `_MLX_SMOKE_BASE`. It is now named once so the fixture and this assertion cannot drift onto different models — a real risk, since the assertion loads the base a second time by name. No assertion deleted or weakened.

## Limits

- **Attachment, not correctness.** This proves LoRA parameters are present after load. It does not compare generations, check the weights are the trained ones, or evaluate quality.
- **`.lora_` is a naming assumption** about mlx-lm's `LoRALinear`. Verified against mlx-lm 0.31.3; if upstream renames those attributes this goes red, which is the correct direction for a guard.
- **Apple Silicon only**, like the job it lives in. It skips elsewhere via the existing `importorskip`.

No changelog fragment — test-only, matching #647 and #653.

https://claude.ai/code/session_014vWWFgXhj9y46pYCyEjfcy
