### PR TITLE
fix(tests): unbreak main — a credit assertion pinned to a released changelog fragment

### DIFF
--- a/tests/test_issue602_qwen4_ple_streaming.py
+++ b/tests/test_issue602_qwen4_ple_streaming.py
@@ -1156,9 +1156,21 @@ def test_qwen4_gate_record_and_changelog_are_discoverable_and_credited():
 
     root = Path(__file__).parents[1]
     benchmark_index = (root / "benchmarks" / "README.md").read_text(encoding="utf-8")
-    changelog = (root / "changelog.d" / "0.73.3" / "603.added.md").read_text(
-        encoding="utf-8"
-    )
+
+    # The credit moves at release time: `changelog.d/<baseline>/603.added.md`
+    # is ASSEMBLED into CHANGELOG.md and then deleted. Reading the fragment by
+    # a hard-coded path made this test pass only while 0.73.3 was unreleased,
+    # and it went red on every platform the moment v0.74.0 shipped. Search both
+    # homes so the assertion survives the boundary in either direction.
+    credit = "(#602 by @Amix29 in #603)"
+    haystacks = [(root / "CHANGELOG.md").read_text(encoding="utf-8")]
+    haystacks += [
+        fragment.read_text(encoding="utf-8")
+        for fragment in sorted((root / "changelog.d").rglob("603.*.md"))
+    ]
 
     assert "gate-qwen4-ple-m4-max.md" in benchmark_index
-    assert "(#602 by @Amix29 in #603)" in changelog
+    assert any(credit in text for text in haystacks), (
+        f"{credit!r} found in neither CHANGELOG.md nor any changelog.d/**/603.*.md; "
+        "the #602 credit has been lost, not merely relocated"
+    )


### PR DESCRIPTION
**`main` is red and every open PR in the repo inherits it.** This unblocks it. Test-only, one file.

Opening directly rather than claiming first, because the tree is broken for everyone — say the word if you would rather I had waited.

## The break

`main` at `f07e07ed release: v0.74.0` fails **all nine `test` matrix cells**. The two commits before the release are green:

```
33859364205  completed/FAILURE  f07e07ed  release: v0.74.0
33844139364  completed/success  e6ad7b81  docs(contributors): credit Nurkhan Esenbek's Lambda...
33844072910  completed/success  0405611a  feat(cloud): add the Lambda Cloud training backend
```

```
FAILED tests/test_issue602_qwen4_ple_streaming.py::test_qwen4_gate_record_and_changelog_are_discoverable_and_credited
FileNotFoundError: [Errno 2] No such file or directory: 'D:\a\Soup\Soup\changelog.d\0.73.3\603.added.md'
```

Reproduced locally on a clean `main` checkout — `1 failed in 0.20s`.

## Cause, and why it was inevitable

```python
changelog = (root / "changelog.d" / "0.73.3" / "603.added.md").read_text(encoding="utf-8")
assert "(#602 by @Amix29 in #603)" in changelog
```

The test reads a changelog **fragment** by hard-coded path. Fragments are assembled into `CHANGELOG.md` and **deleted at release** — that is the entire point of `changelog.d`. So the assertion held only while 0.73.3 was unreleased, and was guaranteed to break at whatever the next release turned out to be. **This is not a v0.74.0 problem**; any release would have fired it.

The credit was not lost, only relocated — `CHANGELOG.md:326`, verbatim.

## The fix

Search **both** homes, so the assertion survives the boundary in either direction instead of being correct on only one side:

```python
haystacks = [(root / "CHANGELOG.md").read_text(encoding="utf-8")]
haystacks += [f.read_text(encoding="utf-8") for f in sorted((root / "changelog.d").rglob("603.*.md"))]
assert any(credit in text for text in haystacks), ...
```

Verified in all three states, with a control so it is not vacuous:

| scenario | verdict |
|---|---|
| POST-release: credit in `CHANGELOG.md`, no fragment | **PASS** |
| PRE-release: credit in fragment only | **PASS** |
| **CONTROL:** credit absent from **both** → must fail | **FAIL** — guard has teeth |

`CHANGELOG.md` restored byte-identical after the run (md5 verified).

The failure message now says the credit "has been lost, not merely relocated", so the next person to see it red knows which of the two situations they are in.

## Swept for the same shape

Only one other test touches `changelog.d`:

```
tests/test_issue627_unknown_config_keys.py:476:  + sorted((root / "changelog.d").rglob("*.md"))
```

It uses `rglob`, which tolerates the directory being empty, so it is **not** exposed. No other test hard-codes a fragment path.

## Verification

```
$ .venv/bin/python -m pytest tests/test_issue602_qwen4_ple_streaming.py -q -o addopts=
35 passed

$ .venv/bin/python -m ruff check tests/
All checks passed!

$ git diff -- tests/ | grep -c "^-[^-]"
4
```

**Those 4 removed lines, accounted for:** the two-line hard-coded `read_text` call and the two original `assert` lines, replaced by the both-homes lookup and a message-carrying assertion. The `benchmark_index` assertion is unchanged. Nothing weakened — the test now fails in strictly more cases than before (it previously could not distinguish "credit lost" from "file moved"; it crashed either way).

## Note for the four PRs of mine that are red

#662, #663, #665, #668 are all failing on this and nothing else. I have already rebased them onto v0.74.0 and moved their changelog fragments to `changelog.d/0.74.0/`, per `validate_fragments`'s own instruction — they should go green once this lands.

https://claude.ai/code/session_014vWWFgXhj9y46pYCyEjfcy
