### PR TITLE
fix(migrate): gate the JSONL guard on content, not just the filename

### DIFF
--- a/changelog.d/0.74.0/672.fixed.md
+++ b/changelog.d/0.74.0/672.fixed.md
@@ -1,0 +1,8 @@
+- `soup migrate` no longer refuses a valid competitor config just because the file
+  is named `*.jsonl`. The guard branched on the filename alone; the content sniff
+  written to gate it, `_looks_like_jsonl()`, had no call site, so a YAML config
+  saved as `config.jsonl` exited 2 with "got JSONL" and could not be migrated at
+  all. Both conditions are now required, which leaves `.ipynb` notebooks (which
+  legitimately start with `{`) untouched. The N2 test now drives the command
+  through `CliRunner` rather than calling the helper, so the wiring is what is
+  actually asserted (#672).

--- a/changelog.d/0.74.0/675.fixed.md
+++ b/changelog.d/0.74.0/675.fixed.md
@@ -5,4 +5,7 @@
   all. Both conditions are now required, which leaves `.ipynb` notebooks (which
   legitimately start with `{`) untouched. The N2 test now drives the command
   through `CliRunner` rather than calling the helper, so the wiring is what is
-  actually asserted (#675, closes #672).
+  actually asserted (#675 by @swalla02, closes #672).
+  The sniff also reads `utf-8-sig` rather than `utf-8`, so a UTF-8 BOM (which
+  Windows tooling writes by default) cannot defeat it, and its read is bounded
+  so a file with no newline is not pulled into memory entire.

--- a/changelog.d/0.74.0/675.fixed.md
+++ b/changelog.d/0.74.0/675.fixed.md
@@ -5,4 +5,4 @@
   all. Both conditions are now required, which leaves `.ipynb` notebooks (which
   legitimately start with `{`) untouched. The N2 test now drives the command
   through `CliRunner` rather than calling the helper, so the wiring is what is
-  actually asserted (#672).
+  actually asserted (#675, closes #672).

--- a/src/soup_cli/commands/migrate.py
+++ b/src/soup_cli/commands/migrate.py
@@ -142,10 +142,22 @@ def migrate(
 
 
 def _looks_like_jsonl(path: Path) -> bool:
-    """v0.40.1 Part D / N2 — sniff first non-blank line for `{` (JSONL)."""
+    """v0.40.1 Part D / N2 — sniff first non-blank line for `{` (JSONL).
+
+    ``utf-8-sig``, not ``utf-8``: a UTF-8 BOM decodes to U+FEFF, which
+    ``str.strip()`` does not remove because it is not whitespace, so a BOM'd
+    JSONL file would sniff as *not* JSONL and silently lose the friendly
+    error. Windows tooling writes that BOM by default, PowerShell's
+    ``Out-File`` included (#675 review).
+
+    The read is bounded because a file with no newline is one single line, so
+    ``for line in fh`` would pull all of it into memory: a 120 MB one-liner
+    measured 240.9 MB peak. Only the first non-blank chunk is ever inspected,
+    so a truncated long line costs nothing here.
+    """
     try:
-        with open(path, "r", encoding="utf-8", errors="replace") as fh:
-            for line in fh:
+        with open(path, "r", encoding="utf-8-sig", errors="replace") as fh:
+            while line := fh.readline(65536):
                 stripped = line.strip()
                 if not stripped:
                     continue

--- a/src/soup_cli/commands/migrate.py
+++ b/src/soup_cli/commands/migrate.py
@@ -67,7 +67,7 @@ def migrate(
     # data file (`.jsonl`) instead of a YAML config. The sniff helper is
     # only invoked when the suffix says ``.jsonl`` (notebook .ipynb files
     # legitimately start with ``{`` — we must not falsely flag them).
-    if input_path.suffix.lower() == ".jsonl":
+    if input_path.suffix.lower() == ".jsonl" and _looks_like_jsonl(input_path):
         console.print(
             f"[red]Expected a {source} YAML config; got JSONL "
             f"({input_path.name}) — did you pass the wrong file?[/]"

--- a/tests/test_v0401_part_d.py
+++ b/tests/test_v0401_part_d.py
@@ -63,7 +63,47 @@ def test_init_force_flag_overwrites_without_prompt(tmp_path):
 # --- N2: soup migrate JSONL friendly error ------------------------------
 
 
-def test_migrate_jsonl_input_yields_friendly_error(tmp_path: Path):
+def test_migrate_jsonl_input_yields_friendly_error(tmp_path: Path, monkeypatch):
+    """Drives the *command*, not the helper: real JSONL named `.jsonl` is refused."""
+    from soup_cli.cli import app
+
+    monkeypatch.chdir(tmp_path)
+    jsonl = tmp_path / "data.jsonl"
+    jsonl.write_text('{"prompt": "hi"}\n{"prompt": "world"}\n', encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["migrate", "--from", "llamafactory", "data.jsonl", "--dry-run"]
+    )
+    assert result.exit_code == 2, (result.output, repr(result.exception))
+    assert "got JSONL" in result.output
+
+
+def test_migrate_yaml_config_named_jsonl_still_migrates(tmp_path: Path, monkeypatch):
+    """Control: the suffix alone must not condemn a file whose content is YAML.
+
+    Fails if the `_looks_like_jsonl` call site is removed from the guard.
+    """
+    from soup_cli.cli import app
+
+    monkeypatch.chdir(tmp_path)
+    config = tmp_path / "config.jsonl"
+    config.write_text(
+        "model_name_or_path: meta-llama/Llama-3-8B\n"
+        "stage: sft\n"
+        "finetuning_type: lora\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["migrate", "--from", "llamafactory", "config.jsonl", "--dry-run"]
+    )
+    assert result.exit_code == 0, (result.output, repr(result.exception))
+    assert "got JSONL" not in result.output
+
+
+def test_migrate_helper_detects_jsonl(tmp_path: Path):
     from soup_cli.commands.migrate import _looks_like_jsonl
 
     jsonl = tmp_path / "data.jsonl"

--- a/tests/test_v0401_part_d.py
+++ b/tests/test_v0401_part_d.py
@@ -103,6 +103,58 @@ def test_migrate_yaml_config_named_jsonl_still_migrates(tmp_path: Path, monkeypa
     assert "got JSONL" not in result.output
 
 
+def test_migrate_bomd_jsonl_still_yields_friendly_error(tmp_path: Path, monkeypatch):
+    """A UTF-8 BOM must not defeat the sniff (#675 review).
+
+    Windows tooling writes UTF-8 with a BOM by default. Decoded as plain
+    ``utf-8`` the BOM survives as U+FEFF, which ``str.strip()`` leaves alone
+    because it is not whitespace, so ``startswith("{")`` is False and real
+    JSONL sniffs as a config. Fails if the helper reads ``utf-8`` rather than
+    ``utf-8-sig``.
+    """
+    from soup_cli.cli import app
+
+    monkeypatch.chdir(tmp_path)
+    jsonl = tmp_path / "bom.jsonl"
+    jsonl.write_bytes(
+        b"\xef\xbb\xbf" + b'{"prompt": "hi"}\n{"prompt": "world"}\n'
+    )
+    # Guard the fixture itself: plain utf-8 must see the BOM this test is about.
+    assert jsonl.read_text(encoding="utf-8").startswith("\ufeff")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["migrate", "--from", "llamafactory", "bom.jsonl", "--dry-run"]
+    )
+    assert result.exit_code == 2, (result.output, repr(result.exception))
+    assert "got JSONL" in result.output
+
+
+def test_migrate_sniff_does_not_read_a_whole_unnewlined_file(tmp_path: Path):
+    """The sniff is bounded: one very long line must not be read entire.
+
+    ``for line in fh`` on a file with no newline pulls all of it into one
+    string. Fails if the bounded ``readline`` is reverted.
+    """
+    import tracemalloc
+
+    from soup_cli.commands.migrate import _looks_like_jsonl
+
+    big = tmp_path / "oneline.jsonl"
+    big.write_text('{"prompt": "' + "x" * (8 * 1024 * 1024) + '"}', encoding="utf-8")
+
+    tracemalloc.start()
+    try:
+        assert _looks_like_jsonl(big) is True
+        peak = tracemalloc.get_traced_memory()[1]
+    finally:
+        tracemalloc.stop()
+
+    # Bounded read touches 64 KiB; the unbounded one allocated the 8 MiB line
+    # at least twice (read plus strip). 1 MiB leaves generous headroom.
+    assert peak < 1024 * 1024, f"peak {peak} bytes: the read looks unbounded"
+
+
 def test_migrate_helper_detects_jsonl(tmp_path: Path):
     from soup_cli.commands.migrate import _looks_like_jsonl
 


### PR DESCRIPTION
Closes #672.

`soup migrate` refuses any input named `*.jsonl`, including a valid LLaMA-Factory or Axolotl YAML config that merely carries that extension. Exit 2, `got JSONL`, and no flag to override it.

The comment above the guard already describes the intended behaviour:

```python
# v0.40.1 Part D / N2 — friendly error when the user passes a JSONL
# data file (`.jsonl`) instead of a YAML config. The sniff helper is
# only invoked when the suffix says ``.jsonl`` (notebook .ipynb files
# legitimately start with ``{`` — we must not falsely flag them).
if input_path.suffix.lower() == ".jsonl":
```

Two conditions, suffix and content, with the `.ipynb` case given as the reason the sniff is *gated by* the suffix rather than run on every file. Only the suffix half was ever wired. `_looks_like_jsonl` had one definition and zero call sites in `src/`.

## The fix

One line:

```diff
-    if input_path.suffix.lower() == ".jsonl":
+    if input_path.suffix.lower() == ".jsonl" and _looks_like_jsonl(input_path):
```

That is the guard the comment already documents, and it leaves the `.ipynb` path untouched because the suffix gate still comes first.

## The test was the reason this survived

`test_migrate_jsonl_input_yields_friendly_error` was named after the command's behaviour and its body called `_looks_like_jsonl` directly. It passed on a codebase where `migrate` never imported the helper, which is the codebase we had. Same shape as #659, #423 and #363.

It now drives the command through `CliRunner`, and a control asserts that a YAML config named `config.jsonl` migrates. The helper's three original assertions are kept as unit tests of the sniff itself, since they are still worth having.

**Non-vacuity, proven rather than asserted.** With the new call site deleted:

```
FAILED tests/test_v0401_part_d.py::test_migrate_yaml_config_named_jsonl_still_migrates
1 failed, 4 passed, 6 deselected

>       assert result.exit_code == 0, (result.output, repr(result.exception))
E       AssertionError: ('Expected a llamafactory YAML config; got JSONL (config.jsonl) — did you pass the
E         wrong file? ...', 'SystemExit(2)')
E       assert 2 == 0
```

Restored by re-editing, tree byte-identical to the commit:

```
5 passed, 6 deselected
```

## Behaviour, before and after

| input | before | after |
|---|---|---|
| real JSONL named `data.jsonl` | exit 2, friendly error | exit 2, friendly error (unchanged) |
| YAML config named `config.jsonl` | exit 2, unmigratable | exit 0, migrates |
| notebook `.ipynb` starting with `{` | never flagged | never flagged |

The `.ipynb` row was checked by hand as well as by suite: `got JSONL` appears zero times in the output.

## Test and lint

`ruff check src/soup_cli/ scripts/ tests/` passes, before and after.

Full suite, baseline established on a clean `f07e07e` worktree first: **83 failed, 19560 passed, 380 skipped**. After the fix: **83 failed, 19562 passed, 380 skipped**. Same failure count, same failing files, plus the two new tests. `tests/test_v0401_part_d.py` goes 9 passed to 11 passed.

Being straight about that baseline: those 83 are pre-existing in my environment and I do not believe they are a clean-CI figure. The venv arrived without the training stack; I installed CPU torch 2.14, transformers 5.16.1, peft, trl, datasets and accelerate, but not `bitsandbytes`, and the failures cluster in `test_v07202.py` (47), `test_v07204.py` (16) and the TRL contract files. Nothing failing touches `migrate`. Coverage was disabled, because `--cov-fail-under=77` is not a number I could stand behind with an incomplete dependency set, and I did not want to change the threshold to make it green.

## Separate question, not addressed here

Real JSONL under a name that does not say `.jsonl`, for example `data.json`, still gets the raw parser error:

```
$ soup migrate --from llamafactory data.json --dry-run
Error: ParserError: expected '<document start>', but found '{'
```

That is the message the N2 feature exists to replace, but catching it means sniffing files whose name gives no hint, which is exactly what the `.ipynb` parenthetical warns against. It is a scope call rather than a bug, so it is in #672 for you to rule on and deliberately not in this PR.

## Changelog fragment

Currently `changelog.d/0.74.0/672.fixed.md`, named for the issue because no PR number existed when it was written. `changelog.d/README.md` asks for the PR number, so I will rename it to this PR's number in a follow-up commit on this branch.

## How it was found

`_looks_like_jsonl` surfaced in a caller-reachability report from [codegraph](https://github.com/swalla02/codegraph), a static call-graph tool I maintain, which lists functions whose only recorded callers are tests. The probes and the reading of the code are mine.
