### PR TITLE
fix(data): drop chatml/audio/video rows with a non-dict message

### DIFF
--- a/changelog.d/0.74.0/676.fixed.md
+++ b/changelog.d/0.74.0/676.fixed.md
@@ -1,0 +1,13 @@
+- **A non-dict message in a `chatml`, `audio`, or `video` row passed through verbatim instead of
+  dropping the row (#676).**
+  `_convert_chatml` returned `row["messages"]` as-is, and `_convert_audio` / `_convert_video`
+  copied the list after checking only its shape, so a row like `{"messages": ["hello"]}` — a bare
+  string where every message must be a dict — flowed into the training set untouched.
+  `format_to_messages` documents a drop contract: a malformed row returns `None` and is skipped,
+  so one bad line in a JSONL file never corrupts the dataset. These three converters silently
+  kept the malformed message instead. `chatml` is the default path for a bare
+  `{"messages": [...]}` row, which makes it the most-reachable case. The fix shares one
+  `_require_str_messages` validator across all three converters: a non-list `messages` or a
+  non-dict element raises `ValueError`, which the existing drop path already routes to `None`.
+  The loader-level behaviour is unchanged — `_format_rows` was already skipping `None` rows, the
+  converters were the ones not producing them.

--- a/src/soup_cli/data/formats.py
+++ b/src/soup_cli/data/formats.py
@@ -182,8 +182,8 @@ def _convert_sharegpt(row: dict) -> dict:
     return {"messages": messages}
 
 
-def _require_str_messages(row: dict, fmt: str) -> list[dict]:
-    """Validate ``row["messages"]`` is a list whose elements are all dicts.
+def _require_str_messages(messages: object, fmt: str) -> list[dict]:
+    """Validate a ``messages`` value is a list whose elements are all dicts.
 
     chatml, audio and video pass ``messages`` through verbatim, so a row
     like ``{"messages": ["hello"]}`` would otherwise flow into the training
@@ -191,7 +191,6 @@ def _require_str_messages(row: dict, fmt: str) -> list[dict]:
     Raising ``ValueError`` routes the row to ``format_to_messages``'s drop
     path, matching ``_convert_multimodal``'s element check (#676).
     """
-    messages = row["messages"]
     if not isinstance(messages, list):
         raise ValueError(f"{fmt} row 'messages' must be a list")
     for msg in messages:
@@ -202,7 +201,7 @@ def _require_str_messages(row: dict, fmt: str) -> list[dict]:
 
 def _convert_chatml(row: dict) -> dict:
     # Already in the right format
-    return {"messages": _require_str_messages(row, "chatml")}
+    return {"messages": _require_str_messages(row["messages"], "chatml")}
 
 
 def _convert_dpo(row: dict) -> dict:
@@ -291,7 +290,7 @@ def _convert_audio(row: dict) -> dict:
     audio = row["audio"]
     if not isinstance(audio, str) or not audio.strip():
         raise ValueError("Audio row must have a non-empty 'audio' field")
-    messages = _require_str_messages(row, "audio")
+    messages = _require_str_messages(row["messages"], "audio")
     if len(messages) < 1:
         raise ValueError("Audio row must have a 'messages' list with at least one message")
     return {"messages": messages, "audio": audio}
@@ -587,7 +586,7 @@ def _convert_video(row: dict) -> dict:
         raise ValueError("video row 'video' must not contain null bytes")
     if len(video) > 2048:
         raise ValueError("video row 'video' must be <= 2048 chars")
-    messages = _require_str_messages(row, "video")
+    messages = _require_str_messages(row.get("messages") or [], "video")
     return {"video": video, "messages": messages}
 
 

--- a/src/soup_cli/data/formats.py
+++ b/src/soup_cli/data/formats.py
@@ -182,9 +182,27 @@ def _convert_sharegpt(row: dict) -> dict:
     return {"messages": messages}
 
 
+def _require_str_messages(row: dict, fmt: str) -> list[dict]:
+    """Validate ``row["messages"]`` is a list whose elements are all dicts.
+
+    chatml, audio and video pass ``messages`` through verbatim, so a row
+    like ``{"messages": ["hello"]}`` would otherwise flow into the training
+    set as-is instead of being dropped like every other malformed row.
+    Raising ``ValueError`` routes the row to ``format_to_messages``'s drop
+    path, matching ``_convert_multimodal``'s element check (#676).
+    """
+    messages = row["messages"]
+    if not isinstance(messages, list):
+        raise ValueError(f"{fmt} row 'messages' must be a list")
+    for msg in messages:
+        if not isinstance(msg, dict):
+            raise ValueError(f"{fmt} message must be a dict")
+    return messages
+
+
 def _convert_chatml(row: dict) -> dict:
     # Already in the right format
-    return {"messages": row["messages"]}
+    return {"messages": _require_str_messages(row, "chatml")}
 
 
 def _convert_dpo(row: dict) -> dict:
@@ -273,8 +291,8 @@ def _convert_audio(row: dict) -> dict:
     audio = row["audio"]
     if not isinstance(audio, str) or not audio.strip():
         raise ValueError("Audio row must have a non-empty 'audio' field")
-    messages = row["messages"]
-    if not isinstance(messages, list) or len(messages) < 1:
+    messages = _require_str_messages(row, "audio")
+    if len(messages) < 1:
         raise ValueError("Audio row must have a 'messages' list with at least one message")
     return {"messages": messages, "audio": audio}
 
@@ -569,7 +587,7 @@ def _convert_video(row: dict) -> dict:
         raise ValueError("video row 'video' must not contain null bytes")
     if len(video) > 2048:
         raise ValueError("video row 'video' must be <= 2048 chars")
-    messages = row.get("messages") or []
+    messages = _require_str_messages(row, "video")
     return {"video": video, "messages": messages}
 
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -367,3 +367,21 @@ output: ./output_audio
         assert cfg.data.format == "audio"
         assert cfg.data.audio_dir == "./data/wav"
         assert cfg.output == "./output_audio"
+
+
+class TestAudioNonDictMessageDropped:
+    """#676 — a non-dict element in `messages` routes to the drop path."""
+
+    def test_audio_non_dict_message_returns_none(self):
+        from soup_cli.data.formats import format_to_messages
+
+        row = {"audio": "clip.wav", "messages": ["hello"]}
+        result = format_to_messages(row, "audio")
+        assert result is None
+
+    def test_audio_message_list_not_a_list_returns_none(self):
+        from soup_cli.data.formats import format_to_messages
+
+        row = {"audio": "clip.wav", "messages": "hello"}
+        result = format_to_messages(row, "audio")
+        assert result is None

--- a/tests/test_chatml_drop.py
+++ b/tests/test_chatml_drop.py
@@ -38,3 +38,14 @@ def test_video_valid_messages_still_convert():
 def test_video_messages_not_a_list_returns_none():
     result = format_to_messages({"video": "clip.mp4", "messages": 5}, "video")
     assert result is None
+
+
+def test_video_missing_messages_converts_with_empty_list():
+    """Pre-existing contract: video rows need no 'messages' key (#679 review)."""
+    result = format_to_messages({"video": "clip.mp4"}, "video")
+    assert result == {"video": "clip.mp4", "messages": []}
+
+
+def test_video_messages_null_converts_with_empty_list():
+    result = format_to_messages({"video": "clip.mp4", "messages": None}, "video")
+    assert result == {"video": "clip.mp4", "messages": []}

--- a/tests/test_chatml_drop.py
+++ b/tests/test_chatml_drop.py
@@ -1,0 +1,40 @@
+"""#676 — chatml and video converters honour the drop contract."""
+
+from soup_cli.data.formats import format_to_messages
+
+
+def test_chatml_non_dict_message_returns_none():
+    row = {"messages": ["hello"]}
+    result = format_to_messages(row, "chatml")
+    assert result is None
+
+
+def test_chatml_valid_messages_still_convert():
+    row = {"messages": [{"role": "user", "content": "hi"}]}
+    result = format_to_messages(row, "chatml")
+    assert result == {"messages": [{"role": "user", "content": "hi"}]}
+
+
+def test_chatml_messages_not_a_list_returns_none():
+    result = format_to_messages({"messages": "hello"}, "chatml")
+    assert result is None
+
+
+def test_video_non_dict_message_returns_none():
+    row = {"video": "clip.mp4", "messages": ["hello"]}
+    result = format_to_messages(row, "video")
+    assert result is None
+
+
+def test_video_valid_messages_still_convert():
+    row = {"video": "clip.mp4", "messages": [{"role": "user", "content": "hi"}]}
+    result = format_to_messages(row, "video")
+    assert result == {
+        "video": "clip.mp4",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+
+def test_video_messages_not_a_list_returns_none():
+    result = format_to_messages({"video": "clip.mp4", "messages": 5}, "video")
+    assert result is None


### PR DESCRIPTION
## Summary

`format_to_messages` documents a drop contract: a malformed row routes to the drop path and returns `None`, so one bad line in a JSONL file is skipped rather than corrupting the dataset. Three converters do not honour it — a non-dict element inside `messages` passes through verbatim:

```python
format_to_messages({"messages": ["hello"]}, "chatml")   # -> {'messages': ['hello']}
format_to_messages({"messages": ["hello"]}, "audio")    # -> {'messages': ['hello']}
format_to_messages({"messages": ["hello"]}, "video")    # -> {'messages': ['hello']}
```

Expected in each case is `None`. `chatml` is what `detect_format` returns for a bare `{"messages": [...]}` row, so it is the **default** path for the most common dataset shape.

## Fix

The three converters now share one `_require_str_messages` validator that raises `ValueError` for a non-list `messages` value or a non-dict element — which `format_to_messages`'s existing drop path already routes to `None`. Valid rows convert exactly as before. This mirrors the multimodal element check added in #670.

## Tests

Strong form throughout — asserting `result is None`, so replacing the raise with `continue` (keeping the malformed message) would fail them:

- `tests/test_chatml_drop.py` (new): non-dict element, non-list `messages`, and valid-row round-trips for both `chatml` and `video`
- `tests/test_audio.py`: non-dict element and non-list `messages` for `audio`
- All pre-existing audio conversion tests pass unchanged

Includes `changelog.d/0.74.0/676.fixed.md` per repo convention.

Fixes #676
