### PR TITLE
fix(mlx): wire gradient_accumulation_steps into the SFT TrainingArgs (#684)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ reproducing 70+ versions of notes.
 
 ## [Unreleased]
 
+### Fixed
+
+- **MLX SFT ignored `training.gradient_accumulation_steps` (#684).** The
+  wrapper built mlx-lm's `TrainingArgs` without a `grad_accumulation_steps`
+  kwarg, so mlx-lm's own dataclass default of 1 always applied regardless
+  of the configured value, silently changing the effective batch size and
+  optimizer-update cadence on every MLX run. The written
+  `adapter_config.json` also hardcoded `grad_accumulation_steps: 1`, so the
+  drift could not be detected from the output afterwards either. Both now
+  carry the value `training.gradient_accumulation_steps` actually resolves
+  to.
+
 ## [0.74.0] - 2026-09-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,18 +12,6 @@ reproducing 70+ versions of notes.
 
 ## [Unreleased]
 
-### Fixed
-
-- **MLX SFT ignored `training.gradient_accumulation_steps` (#684).** The
-  wrapper built mlx-lm's `TrainingArgs` without a `grad_accumulation_steps`
-  kwarg, so mlx-lm's own dataclass default of 1 always applied regardless
-  of the configured value, silently changing the effective batch size and
-  optimizer-update cadence on every MLX run. The written
-  `adapter_config.json` also hardcoded `grad_accumulation_steps: 1`, so the
-  drift could not be detected from the output afterwards either. Both now
-  carry the value `training.gradient_accumulation_steps` actually resolves
-  to.
-
 ## [0.74.0] - 2026-09-04
 
 ### Added

--- a/benchmarks/harness/mlx_sft_smoke.py
+++ b/benchmarks/harness/mlx_sft_smoke.py
@@ -169,6 +169,10 @@ training:
   epochs: {epochs}
   lr: 1e-4
   batch_size: 1
+  # Pinned: the schema default (4) would round `iters` down to a whole
+  # accumulation window (#696), moving the step count this harness reports
+  # out from under any published benchmark record that assumes 1:1 rows-to-iters.
+  gradient_accumulation_steps: 1
   lora:
     r: 8
     alpha: 16

--- a/changelog.d/0.74.0/696.fixed.md
+++ b/changelog.d/0.74.0/696.fixed.md
@@ -1,0 +1,18 @@
+- **MLX SFT ignored `training.gradient_accumulation_steps` (#696).** The wrapper built
+  mlx-lm's `TrainingArgs` without a `grad_accumulation_steps` kwarg, so mlx-lm's own
+  dataclass default of 1 always applied regardless of the configured value, silently
+  changing the effective batch size and optimizer-update cadence on every MLX run. The
+  written `adapter_config.json` also hardcoded `grad_accumulation_steps: 1`, so the drift
+  could not be detected from the output afterwards either. Both now carry the value
+  `training.gradient_accumulation_steps` actually resolves to. `iters` is also rounded
+  down to a whole number of accumulation groups (kept at a minimum of one group), because
+  mlx-lm only updates the optimizer on `it % accum == 0` and never flushes a trailing
+  partial group; without this a dataset smaller than the accumulation window trained for
+  zero optimizer updates.
+
+  **Anyone who never touched this field will see a different effective batch size after
+  upgrading.** `gradient_accumulation_steps` defaults to 4, so an MLX run that used to
+  update on every micro-batch now accumulates over 4 before updating: a 4x larger
+  effective batch size and roughly a quarter as many optimizer updates for the same
+  `iters`. This is the correct value for the schema default; a differently-converging run
+  after this upgrade is expected, not a regression.

--- a/changelog.d/0.74.0/696.fixed.md
+++ b/changelog.d/0.74.0/696.fixed.md
@@ -1,4 +1,4 @@
-- **MLX SFT ignored `training.gradient_accumulation_steps` (#696).** The wrapper built
+- **MLX SFT ignored `training.gradient_accumulation_steps` (#684 by @AmirF194 in #696).** The wrapper built
   mlx-lm's `TrainingArgs` without a `grad_accumulation_steps` kwarg, so mlx-lm's own
   dataclass default of 1 always applied regardless of the configured value, silently
   changing the effective batch size and optimizer-update cadence on every MLX run. The

--- a/src/soup_cli/trainer/mlx_sft.py
+++ b/src/soup_cli/trainer/mlx_sft.py
@@ -299,6 +299,7 @@ class MLXSFTTrainerWrapper:
         # Real eval cadence when a val split exists; otherwise the value is
         # irrelevant (val_dataset stays None and mlx-lm skips evaluation).
         steps_per_eval = max(1, iters // 4) if val_rows else max(1000, iters + 1)
+        grad_accumulation_steps = int(cfg.training.gradient_accumulation_steps)
         args = TrainingArgs(
             batch_size=batch_size,
             iters=iters,
@@ -307,6 +308,7 @@ class MLXSFTTrainerWrapper:
             steps_per_eval=steps_per_eval,
             steps_per_save=steps_per_save,
             adapter_file=str(output_dir / "adapters.safetensors"),
+            grad_accumulation_steps=grad_accumulation_steps,
         )
 
         train_dataset = CacheDataset(create_dataset(train_rows, self.tokenizer, args))
@@ -437,7 +439,7 @@ class MLXSFTTrainerWrapper:
                     )["lora_parameters"],
                     "mask_prompt": False,
                     "grad_checkpoint": False,
-                    "grad_accumulation_steps": 1,
+                    "grad_accumulation_steps": grad_accumulation_steps,
                 },
                 indent=2,
             )

--- a/src/soup_cli/trainer/mlx_sft.py
+++ b/src/soup_cli/trainer/mlx_sft.py
@@ -300,6 +300,15 @@ class MLXSFTTrainerWrapper:
         # irrelevant (val_dataset stays None and mlx-lm skips evaluation).
         steps_per_eval = max(1, iters // 4) if val_rows else max(1000, iters + 1)
         grad_accumulation_steps = int(cfg.training.gradient_accumulation_steps)
+        # mlx-lm updates the optimizer only when it % accum == 0 (trainer.py) and
+        # never flushes a partial group, so round iters down to a whole number of
+        # groups, keeping at least one group so a small dataset does not train
+        # for zero optimizer steps.
+        if grad_accumulation_steps > 1:
+            iters = max(
+                grad_accumulation_steps,
+                iters - (iters % grad_accumulation_steps),
+            )
         args = TrainingArgs(
             batch_size=batch_size,
             iters=iters,

--- a/tests/test_issue684_mlx_grad_accumulation.py
+++ b/tests/test_issue684_mlx_grad_accumulation.py
@@ -1,0 +1,162 @@
+"""#684: MLX SFT ignores gradient_accumulation_steps.
+
+MLXSFTTrainerWrapper.train() built mlx-lm's TrainingArgs without a
+grad_accumulation_steps kwarg, so mlx-lm's own dataclass default of 1
+always applied regardless of the validated schema field
+training.gradient_accumulation_steps (default 4, ge=1). The written
+adapter_config.json also hardcoded grad_accumulation_steps: 1 rather than
+reading back the effective value, so the drift could not even be detected
+from the output afterwards.
+
+Caveat that still matters: MLX only runs on Apple Silicon. Both tests here
+execute the real train() method body against minimal fake mlx / mlx_lm
+modules registered in sys.modules (the same harness
+test_issue634_mlx_resume.py uses) - real control flow, real call
+ordering, not source-text inspection - but the fakes stand in for real
+mlx-lm behaviour, not a substitute for an end-to-end run on real Metal.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+
+
+def _install_fake_mlx(monkeypatch):
+    """Register minimal fake ``mlx`` / ``mlx_lm`` modules in ``sys.modules``
+    so ``MLXSFTTrainerWrapper.train()`` runs for real, without Apple
+    Silicon or the real packages installed. Same harness as
+    test_issue634_mlx_resume.py's helper of the same name.
+    """
+    mlx = types.ModuleType("mlx")
+    mlx_core = types.ModuleType("mlx.core")
+    mlx_optimizers = types.ModuleType("mlx.optimizers")
+    mlx_optimizers.AdamW = lambda **kwargs: object()
+
+    mlx_lm = types.ModuleType("mlx_lm")
+    mlx_lm_tuner = types.ModuleType("mlx_lm.tuner")
+
+    mlx_lm_tuner_callbacks = types.ModuleType("mlx_lm.tuner.callbacks")
+
+    class _FakeTrainingCallback:
+        pass
+
+    mlx_lm_tuner_callbacks.TrainingCallback = _FakeTrainingCallback
+
+    mlx_lm_tuner_datasets = types.ModuleType("mlx_lm.tuner.datasets")
+    mlx_lm_tuner_datasets.CacheDataset = lambda rows: rows
+    mlx_lm_tuner_datasets.create_dataset = lambda rows, tokenizer, args: rows
+
+    mlx_lm_tuner_trainer = types.ModuleType("mlx_lm.tuner.trainer")
+
+    class _FakeTrainingArgs:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    mlx_lm_tuner_trainer.TrainingArgs = _FakeTrainingArgs
+
+    captured_calls = []
+
+    def _fake_train(**kwargs):
+        captured_calls.append(kwargs)
+        callback = kwargs.get("training_callback")
+        if callback is not None:
+            callback.on_train_loss_report({"train_loss": 0.5})
+
+    mlx_lm_tuner_trainer.train = _fake_train
+
+    mlx_lm_tuner_utils = types.ModuleType("mlx_lm.tuner.utils")
+    mlx_lm_tuner_utils.linear_to_lora_layers = lambda model, num_layers, config: None
+
+    fake_modules = {
+        "mlx": mlx,
+        "mlx.core": mlx_core,
+        "mlx.optimizers": mlx_optimizers,
+        "mlx_lm": mlx_lm,
+        "mlx_lm.tuner": mlx_lm_tuner,
+        "mlx_lm.tuner.callbacks": mlx_lm_tuner_callbacks,
+        "mlx_lm.tuner.datasets": mlx_lm_tuner_datasets,
+        "mlx_lm.tuner.trainer": mlx_lm_tuner_trainer,
+        "mlx_lm.tuner.utils": mlx_lm_tuner_utils,
+    }
+    for name, module in fake_modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    return captured_calls
+
+
+class _FakeMlxModel:
+    def __init__(self):
+        self.layers = []
+
+    def freeze(self):
+        pass
+
+    def load_weights(self, path, strict=True):
+        pass
+
+
+def _mlx_wrapper(tmp_path, **training):
+    from soup_cli.config.schema import DataConfig, SoupConfig, TrainingConfig
+    from soup_cli.trainer.mlx_sft import MLXSFTTrainerWrapper
+
+    cfg = SoupConfig(
+        base="mlx-community/Llama-3.1-8B-Instruct-4bit",
+        task="sft",
+        backend="mlx",
+        data=DataConfig(train="./data/train.jsonl", format="chatml"),
+        training=TrainingConfig(**training),
+        output=str(tmp_path),
+    )
+    wrapper = MLXSFTTrainerWrapper(cfg)
+    wrapper.model = _FakeMlxModel()
+    wrapper.tokenizer = object()
+    wrapper._dataset = {"train": [{"text": "hi"}], "val": []}
+    return wrapper
+
+
+class TestTrainingArgsCarriesTheConfiguredGradAccumulationSteps:
+    def test_configured_value_reaches_training_args(self, tmp_path, monkeypatch):
+        captured_calls = _install_fake_mlx(monkeypatch)
+        wrapper = _mlx_wrapper(
+            tmp_path, epochs=1, lr=1e-4, batch_size=1, gradient_accumulation_steps=6
+        )
+
+        wrapper.train()
+
+        assert len(captured_calls) == 1
+        args = captured_calls[0]["args"]
+        assert args.grad_accumulation_steps == 6, (
+            "TrainingArgs must carry the schema's gradient_accumulation_steps, "
+            "not mlx-lm's own dataclass default of 1"
+        )
+
+    def test_a_different_configured_value_is_not_a_coincidence(self, tmp_path, monkeypatch):
+        """Same assertion at a second value, so this cannot pass by
+        happening to match one hardcoded number."""
+        captured_calls = _install_fake_mlx(monkeypatch)
+        wrapper = _mlx_wrapper(
+            tmp_path, epochs=1, lr=1e-4, batch_size=1, gradient_accumulation_steps=2
+        )
+
+        wrapper.train()
+
+        args = captured_calls[0]["args"]
+        assert args.grad_accumulation_steps == 2
+
+
+class TestAdapterConfigJsonRecordsTheEffectiveValue:
+    def test_written_metadata_matches_the_configured_value(self, tmp_path, monkeypatch):
+        _install_fake_mlx(monkeypatch)
+        wrapper = _mlx_wrapper(
+            tmp_path, epochs=1, lr=1e-4, batch_size=1, gradient_accumulation_steps=8
+        )
+
+        wrapper.train()
+
+        adapter_config = json.loads((tmp_path / "adapter_config.json").read_text())
+        assert adapter_config["grad_accumulation_steps"] == 8, (
+            "adapter_config.json must record the value training actually used, "
+            "not a hardcoded 1 that can never reveal the drift after the fact"
+        )

--- a/tests/test_issue684_mlx_grad_accumulation.py
+++ b/tests/test_issue684_mlx_grad_accumulation.py
@@ -97,7 +97,7 @@ class _FakeMlxModel:
         pass
 
 
-def _mlx_wrapper(tmp_path, **training):
+def _mlx_wrapper(tmp_path, train_row_count=1, **training):
     from soup_cli.config.schema import DataConfig, SoupConfig, TrainingConfig
     from soup_cli.trainer.mlx_sft import MLXSFTTrainerWrapper
 
@@ -112,7 +112,7 @@ def _mlx_wrapper(tmp_path, **training):
     wrapper = MLXSFTTrainerWrapper(cfg)
     wrapper.model = _FakeMlxModel()
     wrapper.tokenizer = object()
-    wrapper._dataset = {"train": [{"text": "hi"}], "val": []}
+    wrapper._dataset = {"train": [{"text": "hi"}] * train_row_count, "val": []}
     return wrapper
 
 
@@ -160,3 +160,81 @@ class TestAdapterConfigJsonRecordsTheEffectiveValue:
             "adapter_config.json must record the value training actually used, "
             "not a hardcoded 1 that can never reveal the drift after the fact"
         )
+
+
+def _optimizer_updates(iters: int, accum: int) -> int:
+    """mlx-lm's own rule (mlx_lm/tuner/trainer.py): update only when
+    ``it % accum == 0`` for ``it`` in ``1..iters``, and never flush a
+    partial trailing group."""
+    return iters // accum
+
+
+class TestOptimizerUpdateCountIsNeverZeroOrSilentlyTruncated:
+    def test_a_dataset_smaller_than_the_accumulation_window_still_updates(
+        self, tmp_path, monkeypatch
+    ):
+        # rows=3, batch=1, epochs=1 -> raw iters=3, accum=4: upstream's
+        # it % accum == 0 rule never fires across 1..3, so main trains for
+        # zero optimizer updates on a schema default nobody had to opt into.
+        captured_calls = _install_fake_mlx(monkeypatch)
+        wrapper = _mlx_wrapper(
+            tmp_path,
+            train_row_count=3,
+            epochs=1,
+            lr=1e-4,
+            batch_size=1,
+            gradient_accumulation_steps=4,
+        )
+
+        wrapper.train()
+
+        written_iters = captured_calls[0]["args"].iters
+        assert _optimizer_updates(written_iters, 4) >= 1, (
+            "a dataset smaller than the accumulation window must still reach "
+            "at least one optimizer update, never train silently for zero"
+        )
+        adapter_config = json.loads((tmp_path / "adapter_config.json").read_text())
+        assert adapter_config["iters"] == written_iters
+
+    def test_a_trailing_partial_group_is_rounded_off_not_silently_dropped(
+        self, tmp_path, monkeypatch
+    ):
+        # rows=26, batch=1, epochs=1, accum=4 -> raw iters=26, which upstream
+        # would run as 6 full updates plus 2 accumulated-but-never-applied
+        # micro-batches. iters must come out as a whole multiple of accum so
+        # nothing is silently accumulated and dropped.
+        captured_calls = _install_fake_mlx(monkeypatch)
+        wrapper = _mlx_wrapper(
+            tmp_path,
+            train_row_count=26,
+            epochs=1,
+            lr=1e-4,
+            batch_size=1,
+            gradient_accumulation_steps=4,
+        )
+
+        wrapper.train()
+
+        written_iters = captured_calls[0]["args"].iters
+        assert written_iters % 4 == 0, (
+            "iters must be a whole number of accumulation groups; a trailing "
+            "partial group is accumulated by mlx-lm and never applied"
+        )
+        assert _optimizer_updates(written_iters, 4) == 6
+
+    def test_accumulation_disabled_leaves_iters_untouched(self, tmp_path, monkeypatch):
+        # accum=1 is today's behaviour (every micro-batch updates); the
+        # rounding must be a no-op here, not merely harmless by coincidence.
+        captured_calls = _install_fake_mlx(monkeypatch)
+        wrapper = _mlx_wrapper(
+            tmp_path,
+            train_row_count=26,
+            epochs=1,
+            lr=1e-4,
+            batch_size=1,
+            gradient_accumulation_steps=1,
+        )
+
+        wrapper.train()
+
+        assert captured_calls[0]["args"].iters == 26


### PR DESCRIPTION
Fixes #684

`MLXSFTTrainerWrapper.train()` built mlx-lm's `TrainingArgs` without a `grad_accumulation_steps` kwarg, so mlx-lm's own dataclass default of 1 always applied no matter what `training.gradient_accumulation_steps` was set to. The written `adapter_config.json` hardcoded the same value to 1 too, so there was no way to tell from the output that it had drifted.

Both now read the configured value once and pass it through to `TrainingArgs` and the metadata write.

Added `tests/test_issue684_mlx_grad_accumulation.py`, same fake-mlx harness as `test_issue634_mlx_resume.py` so it runs `train()` for real without Apple Silicon. Fails on main with `AttributeError: '_FakeTrainingArgs' object has no attribute 'grad_accumulation_steps'`, passes on the branch. Ran the full mlx-related suite (test_mlx_backend.py, test_mlx_dispatch.py, test_issue634_mlx_resume.py, etc.) plus `ruff check` clean.

Not run: an actual training loop on real Metal, no Apple Silicon here. The fix is at the same argument-construction level `_apply_lora`'s target-modules fix (#392) used for the same reason.
