### PR TITLE
fix(mlx): exercise display and tracker in benchmark harness

### DIFF
--- a/benchmarks/harness/mlx_sft_smoke.py
+++ b/benchmarks/harness/mlx_sft_smoke.py
@@ -14,6 +14,11 @@ machine is directly comparable to `benchmarks/run-m1-8gb-mlx-sft.md`.
 
 Requires Apple Silicon and ``pip install -e ".[mlx]"``.
 
+Attaches Soup's Rich display and a local experiment tracker, and refuses a run
+with no bridge metrics. The database stays beside the temporary artifacts;
+the bridge also emits its normal process-local SSE events. Timing includes
+display/tracker overhead, unlike the original published M1 measurements.
+
 Usage:
     python mlx_sft_smoke.py [model-id] [rows] [epochs]
 
@@ -89,6 +94,10 @@ class _Tee:
         for stream in self._streams:
             stream.flush()
 
+    def isatty(self):
+        # Rich must still recognise a terminal through the capture wrapper.
+        return getattr(self._streams[0], "isatty", lambda: False)()
+
 
 _TRAINED_TOKENS_RE = re.compile(r"Trained Tokens (\d+)")
 
@@ -128,8 +137,11 @@ def main() -> int:
     epochs = int(sys.argv[3]) if len(sys.argv) > 3 else 1
 
     import mlx.core as mx
+    from rich.console import Console
 
     from soup_cli.config.loader import load_config_from_string
+    from soup_cli.experiment.tracker import ExperimentTracker
+    from soup_cli.monitoring.display import TrainingDisplay
     from soup_cli.trainer.mlx_routing import resolve_trainer
 
     tmp = Path(tempfile.mkdtemp(prefix="mlx_smoke_"))
@@ -179,14 +191,37 @@ output: {out}
           f"mlx peak after load: {mx.get_peak_memory() / 1024**3:.3f} GB   "
           f"(includes first-time Hub download)")
 
-    mx.reset_peak_memory()
-    t0 = time.time()
     # mlx-lm prints its progress to stdout; tee it so the run stays readable
     # AND the trained-token counter is recoverable for the throughput line.
     buffer = io.StringIO()
-    with contextlib.redirect_stdout(_Tee(sys.stdout, buffer)):
-        result = trainer.train()
-    train_s = time.time() - t0
+    display = TrainingDisplay(cfg, device_name="Apple Silicon (MLX)")
+    # A benchmark must not populate the user's normal experiment database.
+    with contextlib.closing(ExperimentTracker(db_path=tmp / "experiments.db")) as tracker:
+        run_id = tracker.start_run(
+            cfg.model_dump(), device="mlx", device_name="Apple Silicon (MLX)", gpu_info={},
+        )
+        try:
+            mx.reset_peak_memory()
+            t0 = time.time()
+            with contextlib.redirect_stdout(_Tee(sys.stdout, buffer)):
+                result = trainer.train(display=display, tracker=tracker, run_id=run_id)
+            train_s = time.time() - t0
+            metrics = tracker.get_metrics(run_id)
+            if not metrics or display.current_step <= 0:
+                raise RuntimeError("MLX bridge received no display/tracker metrics")
+            tracker.finish_run(
+                run_id, initial_loss=result["initial_loss"], final_loss=result["final_loss"],
+                total_steps=result["total_steps"], duration_secs=result["duration_secs"],
+                output_dir=result["output_dir"],
+            )
+        except BaseException:
+            # Include Ctrl-C; the wrapper stops its display in its own finally.
+            tracker.fail_run(run_id)
+            raise
+    Console().print(
+        f"bridge        : {len(metrics)} metric reports saved to {tracker.db_path}",
+        markup=False,
+    )
     train_stdout = buffer.getvalue()
     print(f"train         : {train_s:.1f}s   "
           f"mlx peak during train: {mx.get_peak_memory() / 1024**3:.3f} GB")

--- a/benchmarks/harness/mlx_sft_smoke.py
+++ b/benchmarks/harness/mlx_sft_smoke.py
@@ -99,6 +99,7 @@ class _Tee:
         return getattr(self._streams[0], "isatty", lambda: False)()
 
 
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
 _TRAINED_TOKENS_RE = re.compile(r"Trained Tokens (\d+)")
 
 
@@ -111,10 +112,14 @@ def _final_trained_tokens(train_stdout: str) -> int | None:
     wrapper's result dict does not carry the count, so stdout is the only
     place it surfaces.
 
-    Returns None if the line is absent — the caller prints nothing rather
-    than inventing a figure.
+    Rich's Live/FileProxy wraps progress lines and inserts ANSI controls.
+    Normalise both before matching, or an intact earlier report can silently
+    win over the wrapped final counter at some terminal widths.
+
+    Returns None if the counter is absent; the caller reports unavailable.
     """
-    matches = _TRAINED_TOKENS_RE.findall(train_stdout)
+    flat = re.sub(r"\s+", " ", _ANSI_RE.sub("", train_stdout))
+    matches = _TRAINED_TOKENS_RE.findall(flat)
     return int(matches[-1]) if matches else None
 
 
@@ -218,10 +223,10 @@ output: {out}
             # Include Ctrl-C; the wrapper stops its display in its own finally.
             tracker.fail_run(run_id)
             raise
-    Console().print(
-        f"bridge        : {len(metrics)} metric reports saved to {tracker.db_path}",
-        markup=False,
-    )
+        Console().print(
+            f"bridge        : {len(metrics)} metric reports saved to {tracker.db_path}",
+            markup=False, highlight=False, soft_wrap=True,
+        )
     train_stdout = buffer.getvalue()
     print(f"train         : {train_s:.1f}s   "
           f"mlx peak during train: {mx.get_peak_memory() / 1024**3:.3f} GB")

--- a/benchmarks/run-m1-8gb-mlx-sft.md
+++ b/benchmarks/run-m1-8gb-mlx-sft.md
@@ -255,6 +255,17 @@ rather than reconstructed.
 
 ## Reproducing
 
+The current harness also exercises the Rich display and experiment-tracker
+bridge added in #665. It saves `experiments.db` beside the temporary artifacts,
+leaving the user's usual experiment database untouched, and fails if no display
+updates or tracker metrics arrive. The bridge emits its normal process-local
+SSE events too. No separate UI server is started.
+
+The measurements above predate this wiring; they have not been re-run with the
+bridge enabled. New runs include display/tracker overhead in the training wall
+time. Throughput still uses mlx-lm's cumulative trained-token count captured
+inside the stdout tee, not the display's iterations-per-second value.
+
 ```bash
 pip install -e ".[mlx]"
 python benchmarks/harness/mlx_sft_smoke.py mlx-community/Qwen2.5-0.5B-Instruct-4bit 48 1

--- a/changelog.d/0.74.0/23.fixed.md
+++ b/changelog.d/0.74.0/23.fixed.md
@@ -1,0 +1,9 @@
+- **The MLX SFT benchmark harness now exercises the display/tracker bridge
+  (Refs #23).** It passes a real Rich display and an artifact-local SQLite
+  tracker to the MLX wrapper, and rejects runs without display updates or
+  recorded metrics. Training stays inside the stdout tee so whole-run
+  throughput still comes from mlx-lm's trained-token counter. Regression
+  tests cover the wiring, terminal output, failure/interruption cleanup, and
+  disconnected telemetry. The stdout tee preserves terminal detection so the
+  Rich panel can refresh during an interactive run. The existing Apple Silicon measurements are
+  unchanged; a new hardware run with the bridge enabled remains outstanding.

--- a/changelog.d/0.74.0/703.fixed.md
+++ b/changelog.d/0.74.0/703.fixed.md
@@ -2,8 +2,10 @@
   (#703 by @Shutaru; Refs #23).** It passes a real Rich display and an artifact-local SQLite
   tracker to the MLX wrapper, and rejects runs without display updates or
   recorded metrics. Training stays inside the stdout tee so whole-run
-  throughput still comes from mlx-lm's trained-token counter. Regression
+  throughput still comes from mlx-lm's trained-token counter, with ANSI controls
+  and wrapped whitespace normalised before parsing the final report. Regression
   tests cover the wiring, terminal output, failure/interruption cleanup, and
   disconnected telemetry. The stdout tee preserves terminal detection so the
-  Rich panel can refresh during an interactive run. The existing Apple Silicon
+  Rich panel can refresh during an interactive run; all terminal widths from
+  20 to 200 are exercised by the regression test. The existing Apple Silicon
   measurements are unchanged; a new hardware run with the bridge enabled remains outstanding.

--- a/changelog.d/0.74.0/703.fixed.md
+++ b/changelog.d/0.74.0/703.fixed.md
@@ -1,9 +1,9 @@
 - **The MLX SFT benchmark harness now exercises the display/tracker bridge
-  (Refs #23).** It passes a real Rich display and an artifact-local SQLite
+  (#703 by @Shutaru; Refs #23).** It passes a real Rich display and an artifact-local SQLite
   tracker to the MLX wrapper, and rejects runs without display updates or
   recorded metrics. Training stays inside the stdout tee so whole-run
   throughput still comes from mlx-lm's trained-token counter. Regression
   tests cover the wiring, terminal output, failure/interruption cleanup, and
   disconnected telemetry. The stdout tee preserves terminal detection so the
-  Rich panel can refresh during an interactive run. The existing Apple Silicon measurements are
-  unchanged; a new hardware run with the bridge enabled remains outstanding.
+  Rich panel can refresh during an interactive run. The existing Apple Silicon
+  measurements are unchanged; a new hardware run with the bridge enabled remains outstanding.

--- a/tests/test_issue23_mlx_harness_bridge.py
+++ b/tests/test_issue23_mlx_harness_bridge.py
@@ -102,7 +102,7 @@ def harness_run(monkeypatch, tmp_path):
 
 @pytest.mark.parametrize(
     ("terminal_width", "force_terminal"),
-    [(None, False), (80, True), (40, True), (32, True), (80, None)],
+    [(None, False), *((width, True) for width in range(20, 201)), (80, None)],
 )
 def test_harness_drives_rich_and_persists_metrics_without_losing_throughput(
     harness_run, capsys, monkeypatch, terminal_width, force_terminal,
@@ -195,3 +195,39 @@ def test_tee_preserves_rich_terminal_detection(harness_run, is_terminal):
     buffer = io.StringIO()
     tee = harness_run.harness._Tee(output, buffer)
     assert Console(file=tee, force_terminal=None).is_terminal is is_terminal
+
+
+@pytest.mark.parametrize(
+    ("stdout", "expected"),
+    [
+        ("no cumulative counter\nTokens/sec 254.313\n", None),
+        ("Trained Tokens 0\n", 0),
+        ("Trained Tokens 222\nTrained Tokens 454\n", 454),
+        # The final report, not the earlier matching count, must win.
+        ("Trained Tokens 222\nTrained\nTokens\t  454\n", 454),
+        ("Trained Tokens 222\nTrained\x1b[0m Tokens \x1b[32m454\x1b[0m\n", 454),
+        ("Trained Tokens 999\nTrained\x1b[2K\nTokens\r\n\x1b[32m1000\x1b[0m\n", 1000),
+        ("Trained Tokens 222\nTrained \x1b[0m \nTokens \x1b[32m 454\n", 454),
+    ],
+)
+def test_token_parser_recovers_the_last_report(harness_run, stdout, expected):
+    assert harness_run.harness._final_trained_tokens(stdout) == expected
+
+
+def test_summary_prints_a_copyable_path_before_tracker_close(harness_run, monkeypatch, capsys):
+    state = harness_run
+    monkeypatch.setenv("COLUMNS", "20")
+    original_print = Console.print
+    summary_connections = []
+
+    def record_print(console, *args, **kwargs):
+        if args and isinstance(args[0], str) and args[0].startswith("bridge        :"):
+            summary_connections.append(state.trackers[0]._conn is not None)
+        return original_print(console, *args, **kwargs)
+
+    monkeypatch.setattr(Console, "print", record_print)
+    assert state.harness.main() == 0
+    summary = f"bridge        : 2 metric reports saved to {state.artifacts / 'experiments.db'}"
+    assert summary in capsys.readouterr().out.splitlines()
+    assert summary_connections == [True]
+    assert state.trackers[0]._conn is None

--- a/tests/test_issue23_mlx_harness_bridge.py
+++ b/tests/test_issue23_mlx_harness_bridge.py
@@ -1,0 +1,197 @@
+"""Run the benchmark entry point through the real MLX wrapper and Rich/SQLite bridge.
+
+Only MLX/model loading and host measurements are faked. These tests run without
+Apple Silicon; they do not establish real Metal performance or callback cadence.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sqlite3
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from rich.console import Console
+from rich.file_proxy import FileProxy
+
+from tests.test_issue634_mlx_resume import _FakeMlxModel, _install_fake_mlx
+
+
+@pytest.fixture
+def harness_run(monkeypatch, tmp_path):
+    import soup_cli.experiment.tracker as tracker_module
+    import soup_cli.monitoring.display as display_module
+    import soup_cli.utils.mlx as mlx_utils
+    import soup_cli.utils.train_event_buffer as event_buffer
+
+    # Exercise detection independently of the developer/CI terminal overrides.
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.delenv("TTY_COMPATIBLE", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+
+    path = Path(__file__).parents[1] / "benchmarks" / "harness" / "mlx_sft_smoke.py"
+    spec = importlib.util.spec_from_file_location("mlx_sft_smoke", path)
+    harness = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(harness)
+
+    _install_fake_mlx(monkeypatch)
+    core = sys.modules["mlx.core"]
+    core.reset_peak_memory = lambda: None
+    core.get_peak_memory = lambda: 512 * 1024**2
+    monkeypatch.setattr(mlx_utils, "load_mlx_model", lambda *a, **k: (_FakeMlxModel(), object()))
+    artifacts = tmp_path / "benchmark"
+    artifacts.mkdir()
+    monkeypatch.setattr(harness.tempfile, "mkdtemp", lambda **k: str(artifacts))
+    monkeypatch.setattr(harness, "host_mem", lambda: ("50%", "0 MB"))
+    clock = iter([0.0, 1.0, 10.0, 30.0, 40.0, 41.0])
+    monkeypatch.setattr(harness, "time", SimpleNamespace(time=lambda: next(clock)))
+    monkeypatch.setattr(sys, "argv", [str(path), harness.DEFAULT_MODEL, "10", "1"])
+
+    state = SimpleNamespace(
+        harness=harness, artifacts=artifacts, displays=[], trackers=[], reloads=[],
+        events=event_buffer.TrainEventBuffer(), fail=None, emit_reports=True, rich_redirects=[],
+    )
+    # Isolate the real SSE buffer, rather than pretending a recorder display
+    # or tracker=None suppresses it: the merged bridge gates only on display.
+    monkeypatch.setattr(event_buffer, "_GLOBAL_BUFFER", state.events)
+    original_display = display_module.TrainingDisplay
+    original_tracker = tracker_module.ExperimentTracker
+    state.display_class = original_display
+    state.tracker_class = original_tracker
+    monkeypatch.setattr(display_module, "console", Console(file=io.StringIO(), width=160))
+
+    def display_factory(*args, **kwargs):
+        display = original_display(*args, **kwargs)
+        state.displays.append(display)
+        return display
+
+    def tracker_factory(*args, **kwargs):
+        tracker = original_tracker(*args, **kwargs)
+        state.trackers.append(tracker)
+        return tracker
+
+    monkeypatch.setattr(display_module, "TrainingDisplay", display_factory)
+    monkeypatch.setattr(tracker_module, "ExperimentTracker", tracker_factory)
+
+    def train(**kwargs):
+        for step, loss, speed, tokens in [(5, 3.639, 0.432, 222), (10, 1.976, 5.481, 454)]:
+            state.rich_redirects.append(isinstance(sys.stdout, FileProxy))
+            # Match mlx-lm's stdout independently of its callback. Moving train
+            # outside the tee loses this counter despite a working bridge.
+            sys.stdout.write(
+                f"Iter {step}: Train loss {loss}, Learning Rate 1e-4, "
+                f"It/sec {speed}, Tokens/sec 254.313, Trained Tokens {tokens}, Peak mem 0.497 GB\n"
+            )
+            if state.emit_reports:
+                kwargs["training_callback"].on_train_loss_report({
+                    "iteration": step, "train_loss": loss, "learning_rate": 1e-4,
+                    "iterations_per_second": speed, "tokens_per_second": 254.313,
+                    "trained_tokens": tokens, "peak_memory": 0.497,
+                })
+            if state.fail:
+                raise state.fail
+        Path(kwargs["args"].adapter_file).write_bytes(b"fake adapter")
+
+    sys.modules["mlx_lm.tuner.trainer"].train = train
+    sys.modules["mlx_lm"].load = lambda *a, **k: state.reloads.append((a, k))
+    return state
+
+
+@pytest.mark.parametrize(
+    ("terminal_width", "force_terminal"),
+    [(None, False), (80, True), (40, True), (32, True), (80, None)],
+)
+def test_harness_drives_rich_and_persists_metrics_without_losing_throughput(
+    harness_run, capsys, monkeypatch, terminal_width, force_terminal,
+):
+    state = harness_run
+    if terminal_width is not None:
+        import soup_cli.monitoring.display as display_module
+
+        if force_terminal is None:
+            monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+        monkeypatch.setattr(
+            display_module, "console", Console(force_terminal=force_terminal, width=terminal_width),
+        )
+    assert state.harness.main() == 0
+    assert state.rich_redirects == [terminal_width is not None] * 2
+
+    display, = state.displays
+    assert (display.current_step, display.total_steps) == (10, 10)
+    assert display.loss == pytest.approx(1.976)
+    assert display.speed == pytest.approx(5.481)  # it/s, not the 254.313 tok/s
+    assert display._live is None
+
+    tracker, = state.trackers
+    assert tracker.db_path == state.artifacts / "experiments.db"
+    assert tracker._conn is None
+    with sqlite3.connect(tracker.db_path) as conn:
+        run_id, status, total_steps = conn.execute(
+            "SELECT run_id, status, total_steps FROM runs"
+        ).fetchone()
+        metrics = conn.execute(
+            "SELECT step, loss, speed FROM metrics WHERE run_id = ? ORDER BY step", (run_id,)
+        ).fetchall()
+    assert (status, total_steps) == ("completed", 10)
+    assert metrics == [(5, 3.639, 0.432), (10, 1.976, 5.481)]
+    assert [event.step for event in state.events.snapshot()] == [5, 10]
+    output = capsys.readouterr().out
+    assert "454 trained tokens / 20.0s, whole-run average" in output
+    assert "22.7 tok/s" in output
+    assert state.reloads == [((state.harness.DEFAULT_MODEL,), {
+        "adapter_path": str(state.artifacts / "out"),
+    })]
+
+
+@pytest.mark.parametrize("failure", [RuntimeError("training failed"), KeyboardInterrupt()])
+def test_harness_closes_display_and_records_failed_run(harness_run, failure):
+    state = harness_run
+    state.fail = failure
+    with pytest.raises(type(failure)):
+        state.harness.main()
+
+    display, = state.displays
+    tracker, = state.trackers
+    assert display._live is None
+    assert tracker._conn is None
+    with sqlite3.connect(tracker.db_path) as conn:
+        assert conn.execute("SELECT status FROM runs").fetchone() == ("failed",)
+    assert state.reloads == []
+
+
+def test_harness_refuses_success_when_the_bridge_receives_no_reports(harness_run):
+    state = harness_run
+    state.emit_reports = False
+    with pytest.raises(RuntimeError, match="bridge"):
+        state.harness.main()
+    tracker, = state.trackers
+    assert tracker._conn is None
+    with sqlite3.connect(tracker.db_path) as conn:
+        assert conn.execute("SELECT status FROM runs").fetchone() == ("failed",)
+
+
+@pytest.mark.parametrize("sink", ["display", "tracker"])
+def test_harness_refuses_success_when_one_bridge_sink_is_disconnected(
+    harness_run, monkeypatch, sink,
+):
+    if sink == "display":
+        monkeypatch.setattr(harness_run.display_class, "update", lambda *a, **k: None)
+    else:
+        monkeypatch.setattr(harness_run.tracker_class, "log_metrics", lambda *a, **k: None)
+    with pytest.raises(RuntimeError, match="bridge"):
+        harness_run.harness.main()
+
+
+@pytest.mark.parametrize("is_terminal", [True, False])
+def test_tee_preserves_rich_terminal_detection(harness_run, is_terminal):
+    class Output(io.StringIO):
+        def isatty(self):
+            return is_terminal
+
+    output = Output()
+    buffer = io.StringIO()
+    tee = harness_run.harness._Tee(output, buffer)
+    assert Console(file=tee, force_terminal=None).is_terminal is is_terminal


### PR DESCRIPTION
## What does this PR do?

Refs #23. This is the harness follow-up to #663 and #665, not a closure of the whole issue.

Thanks @Srinivasan8888 for the handoff and the stdout-tee pointer. The benchmark now passes a real `TrainingDisplay`, an `ExperimentTracker`, and its `run_id` into the merged MLX wrapper.

The tracker database lives beside the temporary benchmark artifacts, so the user's normal experiment history is untouched. A run fails if either display updates or tracker metrics are missing. Failed and interrupted training is recorded as failed, and the tracker connection is closed.

Training stays inside the stdout tee. The tee now forwards `isatty()` too: without that, Rich treats an interactive terminal as redirected output and the live panel does not refresh. The new tests cover automatic terminal detection as well as forced-terminal and redirected output, while checking that the cumulative token count still produces the same whole-run throughput.

The bridge keeps its normal process-local SSE behavior. No changes to the trainer, validation callbacks, CI workflows, or README badge are included.

## Review follow-up

The parser now strips ANSI controls before collapsing whitespace, so a word-wrapped final counter does not fall back to an earlier report. The real Rich/Live/FileProxy integration test covers every width from 20 through 200: **21/181 failed before this fix, 0/181 after**, using the committed two-report fixture. Parser controls also cover absent and zero counters, ANSI-only and whitespace-only changes, and the transition from 999 to 1000 tokens.

The summary is inside the tracker context and uses `Console.print(..., soft_wrap=True, markup=False, highlight=False)` to keep the database path copyable. Its test checks the complete line at 20 columns and verifies that the connection is still open when it is printed.

## Verification

Windows, Python 3.12:

- **331 passed** across the MLX, display, tracker, dispatch, and runtime-isolation tests, including **198 harness cases**.
- **211 passed** when re-running the harness and display-bridge tests with `FORCE_COLOR=1 TERM=xterm-256color` (overlaps the tests above).
- **17 passed** in `tests/test_issue487_changelog_fragments.py`.
- `ruff check src/soup_cli/ scripts/ tests/ benchmarks/` passes.
- Changelog fragment validation and `git diff --check` pass.
- A local in-memory mutation check rejected **18/18 targeted regressions**: omitted display/tracker/run ID, bypassed tee, default database, removed or weakened presence guard, missing failure status/connection cleanup, hidden terminal detection, removed/reordered ANSI and whitespace normalisation, use of an earlier count, wrapped summary output, and summary access after tracker close.

The new tests execute the real Soup wrapper, Rich display, SQLite tracker, and SSE buffer, with MLX/model loading and host measurements replaced by fixtures.

**No Apple Silicon run was performed here.** The existing M1 measurements are unchanged; the benchmark notes explain that new runs include display/tracker overhead. The full repository suite was not run locally and remains for CI. A fresh hardware run is still needed to measure the enabled bridge.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [x] Tests

## Checklist

- [x] `ruff check src/soup_cli/ scripts/ tests/` passes
- [ ] `pytest tests/ -v` passes (full suite pending CI; focused results above)
- [x] Updated the relevant benchmark reproduction notes
- [x] Added a changelog fragment

