### PR TITLE
fix(distill): refuse wasserstein/topk_align on tokenizers that disagree

### DIFF
--- a/changelog.d/0.74.0/704.fixed.md
+++ b/changelog.d/0.74.0/704.fixed.md
@@ -1,0 +1,9 @@
+- **`wasserstein`/`topk_align` cross-tokenizer distillation trained on logits the teacher
+  computed for the wrong text, with no visible failure (#704 by @AmirF194, closes #681).**
+  Both strategies forwarded the student's own `input_ids` straight to the teacher, clamped
+  into its vocab range to avoid an index error. Clamping does not translate tokens between
+  vocabularies, so a mismatched pair silently fed the teacher garbled or wrong text while
+  still reporting a finite, plausible-looking loss. `wasserstein`/`topk_align` now refuse a
+  tokenizer pair that isn't interchangeable at `setup()`, naming `wasserstein_aligned` (which
+  already re-tokenizes correctly) as the working alternative for genuinely different
+  tokenizers. The same-tokenizer fast path (e.g. two sizes in one family) is unaffected.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -310,7 +310,7 @@ soup data brain-rot <data.jsonl> [--strict]   Brain-rot detector — arXiv 2510.
 soup iterative-dpo --base-model <m> --reward-model <rm> --prompts <p.jsonl> --output-dir <out> --rounds N --pairs-per-round N [--plan-only]  Iterative DPO loop driver — LIVE sample→score→pair→train (v0.70.0; live v0.71.11)
 soup train --reward-hack-detector info_rm|rm_ensemble [--reward-hack-halt]  Reward-hacking detector for GRPO — LIVE callback (v0.70.0; live v0.71.11)
 soup train --reward-hack-mitigation off|log_only|kl_control|pid_lagrangian  Closed-loop reward-hacking auto-mitigation (detect → raise KL/β → rollback → early-stop); GRPO/PPO, requires --reward-hack-detector; PPO BETA (v0.71.26)
-soup train --uld-strategy wasserstein|topk_align [--uld-top-k N]  Cross-tokenizer ULD on task='distill' — LIVE W1/topk loss (v0.70.0; live v0.71.11)
+soup train --uld-strategy wasserstein_aligned  Cross-tokenizer ULD on task='distill' (different tokenizers) — LIVE (v0.71.18)
 soup train --minillm-enabled [--minillm-teacher-mix-ratio 0.3]  MiniLLM reverse-KL distillation — LIVE (v0.70.0; live v0.71.11)
 soup train --rl-checkpoint-save-every-steps N [--rl-checkpoint-keep-last N]  Mid-epoch checkpoint for GRPO/PPO — LIVE (v0.70.0; live v0.71.11)
 soup train --echo-trap-enabled [--echo-trap-threshold 0.6 --echo-trap-halt]  RAGEN echo-trap detector for GRPO — LIVE callback (v0.70.0; live v0.71.11)

--- a/docs/training.md
+++ b/docs/training.md
@@ -269,13 +269,18 @@ soup train --config soup.yaml \
 soup train --config grpo.yaml --reward-hack-mitigation kl_control   # raise KL, recover
 soup train --config grpo.yaml --reward-hack-mitigation log_only     # observe only, no action
 
-# Cross-tokenizer distillation — Llama -> Mistral, no shared vocab needed
+# Wasserstein-distance distillation between two models that SHARE a
+# tokenizer, e.g. two sizes in the same family (#681: wasserstein / topk_align
+# forward the student's token ids to the teacher unchanged, so the pair must
+# tokenize identically; for a genuinely different tokenizer see
+# wasserstein_aligned below).
 # (Universal Logit Distillation, Boizard et al. 2024 arXiv:2402.12030)
 soup train --config soup.yaml --uld-strategy wasserstein
 
-# Cross-tokenizer distillation for FULLY-DISJOINT tokenizers (v0.71.18) —
-# aligns student/teacher token sequences over decoded character spans, so you
-# can distill a GPT-2 BPE student from a Llama SentencePiece teacher.
+# Cross-tokenizer distillation for DIFFERENT tokenizers, e.g. Llama -> Mistral,
+# no shared vocab needed (v0.71.18). Aligns student/teacher token sequences
+# over decoded character spans, so you can distill a GPT-2 BPE student from a
+# Llama SentencePiece teacher.
 #   training:
 #     uld_strategy: wasserstein_aligned
 

--- a/src/soup_cli/trainer/distill.py
+++ b/src/soup_cli/trainer/distill.py
@@ -139,6 +139,38 @@ def _compute_distill_term(
     raise ValueError(f"Unknown divergence {divergence!r}")
 
 
+def _require_uld_id_compatible_tokenizers(
+    strategy: str, student_tokenizer: Any, teacher_tokenizer: Any
+) -> None:
+    """Refuse ``wasserstein`` / ``topk_align`` on tokenizers that disagree.
+
+    Both strategies forward the student's own ``input_ids`` straight to the
+    teacher (see the caller), which is only correct when a given id decodes
+    to the same text in both tokenizers. ``wasserstein_aligned`` handles the
+    general case by re-tokenizing and aligning; these two do not, so an
+    incompatible pair must fail here rather than train on logits the teacher
+    computed for the wrong text (#681).
+
+    Reuses :func:`soup_cli.utils.draft.same_tokenizer`, the same probe this
+    codebase already trusts to decide whether a draft tokenizer is
+    interchangeable with a target one for speculative decoding (#304).
+    """
+    from soup_cli.utils.draft import same_tokenizer
+
+    if strategy in ("wasserstein", "topk_align") and not same_tokenizer(
+        student_tokenizer, teacher_tokenizer
+    ):
+        raise ValueError(
+            f"training.uld_strategy={strategy!r} forwards the student's "
+            "token ids to the teacher unchanged, which only holds when the "
+            "two tokenizers are interchangeable. This student/teacher pair "
+            "is not, so the teacher would be conditioned on the wrong text "
+            "with no visible failure (a finite loss either way). Use "
+            "training.uld_strategy='wasserstein_aligned', which "
+            "re-tokenizes and aligns text for mismatched tokenizers."
+        )
+
+
 class DistillTrainerWrapper:
     """High-level wrapper for student/teacher distillation.
 
@@ -370,6 +402,15 @@ class DistillTrainerWrapper:
                     uld_teacher_tokenizer.pad_token = uld_teacher_tokenizer.eos_token
             else:
                 uld_teacher_tokenizer = None
+                # #681: wasserstein / topk_align reuse the student's ids as
+                # the teacher's, so fail before training starts if this pair
+                # can't support that.
+                _teacher_tok_for_check = AutoTokenizer.from_pretrained(
+                    tcfg.teacher_model, trust_remote_code=teacher_trc
+                )
+                _require_uld_id_compatible_tokenizers(
+                    tcfg.uld_strategy, self.tokenizer, _teacher_tok_for_check
+                )
             console.print(
                 f"[green]Cross-tokenizer ULD enabled[/] "
                 f"(strategy={tcfg.uld_strategy})"
@@ -479,7 +520,6 @@ class DistillTrainerWrapper:
         )
 
         teacher_ref = self.teacher
-        _teacher_vocab = teacher_vocab
         _uld_projection = uld_projection
         _minillm_cb = minillm_cb
         _sequence_mode = sequence_mode
@@ -617,17 +657,6 @@ class DistillTrainerWrapper:
                     for k, v in inputs.items()
                     if k != "labels"
                 }
-                # v0.71.11 #236 — when ULD bridges different vocabs, clamp the
-                # student token ids to the teacher's range so the (possibly
-                # smaller) teacher embedding never index-errors.
-                if (
-                    _uld_projection is not None
-                    and _teacher_vocab is not None
-                    and "input_ids" in teacher_inputs
-                ):
-                    teacher_inputs["input_ids"] = teacher_inputs[
-                        "input_ids"
-                    ].clamp(max=int(_teacher_vocab) - 1)
                 with torch.no_grad():
                     teacher_out = teacher_ref(**teacher_inputs)
                     teacher_logits = teacher_out.logits.to(student_logits.device)

--- a/tests/test_issue681_uld_id_compat.py
+++ b/tests/test_issue681_uld_id_compat.py
@@ -1,0 +1,184 @@
+"""Regression tests for #681.
+
+``wasserstein`` / ``topk_align`` forwarded the student's own ``input_ids``
+straight to the teacher, clamped into range. Clamping stops an index error
+but does not translate tokens between vocabularies, so an incompatible pair
+trained on logits the teacher computed for the wrong text, with a finite
+loss and no visible failure. ``wasserstein_aligned`` (#258) already handles
+mismatched tokenizers correctly by re-tokenizing and aligning; the fix here
+is to fail early for the two strategies that don't, using the same
+tokenizer-compatibility probe (#304's ``same_tokenizer``) this codebase
+already trusts for the analogous speculative-decoding question.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+
+class _FakeTok:
+    """Tiny stand-in tokenizer: reports a vocab size and encodes via a map."""
+
+    def __init__(self, vocab_size: int, encode_map: dict | None = None):
+        self.vocab_size = vocab_size
+        self._encode_map = encode_map or {}
+        self.pad_token = "<pad>"
+        self.eos_token = "<eos>"
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        return list(self._encode_map.get(text, [1, 2, 3]))
+
+
+class _FakeModel:
+    """Enough of an HF causal-LM to get DistillTrainerWrapper.setup() past
+    the student/teacher load without touching a real model or the network."""
+
+    def __init__(self, vocab_size: int):
+        self.config = types.SimpleNamespace(vocab_size=vocab_size)
+
+    def eval(self):
+        return self
+
+    def parameters(self):
+        return iter([])
+
+
+# ---------------------------------------------------------------------------
+# PART 1: the pure compatibility gate
+# ---------------------------------------------------------------------------
+class TestRequireUldIdCompatibleTokenizers:
+    def test_identical_tokenizer_passes_wasserstein(self):
+        from soup_cli.trainer.distill import _require_uld_id_compatible_tokenizers
+
+        tok = _FakeTok(32000)
+        _require_uld_id_compatible_tokenizers("wasserstein", tok, tok)
+
+    def test_identical_tokenizer_passes_topk_align(self):
+        from soup_cli.trainer.distill import _require_uld_id_compatible_tokenizers
+
+        tok = _FakeTok(32000)
+        _require_uld_id_compatible_tokenizers("topk_align", tok, tok)
+
+    def test_mismatched_ids_same_vocab_size_raises_for_wasserstein(self):
+        """The reporter's own repro shape: same-sized vocabs, different ids."""
+        from soup_cli.trainer.distill import _require_uld_id_compatible_tokenizers
+
+        probe = "The quick brown fox jumps over 13 lazy dogs."
+        student = _FakeTok(32000, {probe: [1, 6, 7]})
+        teacher = _FakeTok(32000, {probe: [1, 4, 4]})
+        with pytest.raises(ValueError, match="wasserstein_aligned"):
+            _require_uld_id_compatible_tokenizers("wasserstein", student, teacher)
+
+    def test_mismatched_ids_raises_for_topk_align(self):
+        from soup_cli.trainer.distill import _require_uld_id_compatible_tokenizers
+
+        probe = "The quick brown fox jumps over 13 lazy dogs."
+        student = _FakeTok(32000, {probe: [1, 6, 7]})
+        teacher = _FakeTok(32000, {probe: [1, 4, 4]})
+        with pytest.raises(ValueError, match="topk_align"):
+            _require_uld_id_compatible_tokenizers("topk_align", student, teacher)
+
+    def test_different_vocab_size_raises(self):
+        from soup_cli.trainer.distill import _require_uld_id_compatible_tokenizers
+
+        with pytest.raises(ValueError, match="wasserstein_aligned"):
+            _require_uld_id_compatible_tokenizers(
+                "wasserstein", _FakeTok(32000), _FakeTok(49152)
+            )
+
+    def test_wasserstein_aligned_is_not_gated(self):
+        """#258's own strategy re-tokenizes and aligns; it never reuses raw
+        ids, so a mismatched pair here must not raise."""
+        from soup_cli.trainer.distill import _require_uld_id_compatible_tokenizers
+
+        _require_uld_id_compatible_tokenizers(
+            "wasserstein_aligned", _FakeTok(32000), _FakeTok(49152)
+        )
+
+
+# ---------------------------------------------------------------------------
+# PART 2: wired into DistillTrainerWrapper.setup(), fails before training
+# starts rather than on the first batch.
+# ---------------------------------------------------------------------------
+class TestDistillSetupRejectsIncompatibleUld:
+    def _config(self, uld_strategy: str) -> "object":
+        from soup_cli.config.loader import load_config_from_string
+
+        top_k_line = "  uld_top_k: 4\n" if uld_strategy == "topk_align" else ""
+        yaml_text = (
+            "base: fake/student\n"
+            "task: distill\n"
+            "data:\n  train: data.jsonl\n  format: chatml\n"
+            "training:\n"
+            f"  teacher_model: fake/teacher\n"
+            f"  uld_strategy: {uld_strategy}\n"
+            f"{top_k_line}"
+            "output: ./out\n"
+        )
+        return load_config_from_string(yaml_text)
+
+    def _patch_model_loading(self, monkeypatch, student_tok, teacher_tok):
+        import peft
+        import transformers
+
+        from soup_cli.utils import peft_wiring
+
+        def _fake_tok(model_id, trust_remote_code=False, **kwargs):
+            return {"fake/student": student_tok, "fake/teacher": teacher_tok}[model_id]
+
+        def _fake_model(model_id, trust_remote_code=False, device_map=None, **kwargs):
+            return _FakeModel(vocab_size=student_tok.vocab_size)
+
+        monkeypatch.setattr(
+            transformers.AutoTokenizer, "from_pretrained", staticmethod(_fake_tok)
+        )
+        monkeypatch.setattr(
+            transformers.AutoModelForCausalLM,
+            "from_pretrained",
+            staticmethod(_fake_model),
+        )
+        monkeypatch.setattr(
+            peft_wiring, "resolve_lora_target_modules", lambda model, configured: ["q_proj"]
+        )
+        monkeypatch.setattr(peft_wiring, "apply_pre_lora_patches", lambda *a, **k: None)
+        monkeypatch.setattr(peft_wiring, "apply_post_lora_patches", lambda *a, **k: None)
+        monkeypatch.setattr(peft, "get_peft_model", lambda model, config: model)
+
+    @pytest.mark.parametrize("strategy", ["wasserstein", "topk_align"])
+    def test_setup_raises_before_training_on_mismatched_tokenizers(
+        self, monkeypatch, strategy
+    ):
+        pytest.importorskip("torch")
+        from soup_cli.trainer.distill import DistillTrainerWrapper
+
+        probe = "The quick brown fox jumps over 13 lazy dogs."
+        student_tok = _FakeTok(32000, {probe: [1, 6, 7]})
+        teacher_tok = _FakeTok(32000, {probe: [1, 4, 4]})
+        self._patch_model_loading(monkeypatch, student_tok, teacher_tok)
+
+        wrapper = DistillTrainerWrapper(self._config(strategy), device="cpu")
+        with pytest.raises(ValueError, match="wasserstein_aligned"):
+            wrapper.setup({})
+
+    def test_setup_does_not_raise_id_compat_error_on_identical_tokenizer(
+        self, monkeypatch
+    ):
+        """Same-tokenizer fast path (#258's own requirement): setup() must
+        get past the compatibility gate without our new error firing."""
+        pytest.importorskip("torch")
+        from soup_cli.trainer.distill import DistillTrainerWrapper
+
+        tok = _FakeTok(32000)
+        self._patch_model_loading(monkeypatch, tok, tok)
+
+        wrapper = DistillTrainerWrapper(self._config("wasserstein"), device="cpu")
+        try:
+            wrapper.setup({})
+        except ValueError as exc:
+            assert "wasserstein_aligned" not in str(exc)
+        except Exception:
+            # Dataset/Trainer construction needs a real dataset and output
+            # dir; only the tokenizer-compatibility gate is under test here.
+            pass


### PR DESCRIPTION
Went with the refusal you outlined in the issue rather than wiring in a translation, since `wasserstein_aligned` already does that correctly and the two loss kernels (full sorted distribution vs top-k) don't need per-token alignment, only a text-correct teacher input.

`_require_uld_id_compatible_tokenizers` loads the teacher tokenizer for `wasserstein`/`topk_align` at `setup()` and reuses `same_tokenizer` (#304's speculative-decoding probe: vocab size plus id agreement over a small probe corpus) rather than a new check. Raises before training starts, naming `wasserstein_aligned`. Removed the clamp since compatibility is now proven up front; it was the only thing referencing `teacher_vocab` in that closure, so that variable went too.

Updated the `docs/training.md` example: it recommended `--uld-strategy wasserstein` for Llama -> Mistral, which is exactly the pair this now rejects. Pointed it at `wasserstein_aligned` instead and moved the Llama -> Mistral line down to sit with it.

Tests reproduce your own repro shape (same vocab size, disjoint ids) against the pure check and against `DistillTrainerWrapper.setup()` directly, mocking only the model/tokenizer loading so the setup path itself is exercised, not just the helper. Confirmed both fail on `main` (the mismatched pair falls through to an unrelated `KeyError` well past where the fix now raises) and pass on this branch, for both `wasserstein` and `topk_align`, on Python 3.10/3.11/3.12. Added a same-tokenizer case so the fast path stays clear too.

I ran this against fake tokenizers with disjoint id maps, same as #304's own suite does for `same_tokenizer`, not against real Llama/Mistral checkpoints, so it's the same gap you flagged on your own comment.

Fixes #681
