### PR TITLE
fix(trainer): support lora.r=0 (full fine-tuning) on task=embedding (#700)

### DIFF
--- a/changelog.d/0.74.0/705.fixed.md
+++ b/changelog.d/0.74.0/705.fixed.md
@@ -1,0 +1,4 @@
+- Fixed `ValueError: Lora rank r must be > 0` when training embeddings with
+  `lora.r: 0` (full fine-tuning) on `task: embedding` (#700 by @kok-o in #705).
+  `_setup_transformers()` now skips PEFT wrapping when `r == 0`, and
+  `_EmbeddingTrainer` delegates `model` and `args` attributes.

--- a/src/soup_cli/config/schema.py
+++ b/src/soup_cli/config/schema.py
@@ -64,7 +64,7 @@ class LoraConfig(BaseModel):
         ge=0,
         description=(
             "LoRA rank. 0 = full fine-tuning: no adapter, every base "
-            "parameter trains (sft + transformers + text + "
+            "parameter trains (sft / embedding + transformers + text + "
             "quantization='none' only)."
         ),
     )
@@ -5023,9 +5023,9 @@ class SoupConfig(BaseModel):
         mutually exclusive with the LoRA feature flags and with the other two
         (each independently decides what trains).
 
-        Scoped to ``task='sft'`` ON PURPOSE. ``classifier`` / ``reranker`` /
-        ``cross_encoder`` (``classifier_lora``, v0.71.12 #146) and ``asr``
-        (``asr_lora``, v0.71.32) have gated LoRA behind their own opt-in flag
+        Scoped to ``task in ('sft', 'embedding')`` (#340, #700). ``classifier`` /
+        ``reranker`` / ``cross_encoder`` (``classifier_lora``, v0.71.12 #146) and
+        ``asr`` (``asr_lora``, v0.71.32) have gated LoRA behind their own opt-in flag
         for releases, so ``lora.r: 0`` already parses and is already harmless
         there; a blanket gate would break configs that work today. Tasks that
         do pass the rank straight to peft keep their existing behaviour
@@ -5033,7 +5033,7 @@ class SoupConfig(BaseModel):
         a new refusal this issue never measured.
         """
         tcfg = self.training
-        if tcfg.lora.r != 0 or self.task != "sft":
+        if tcfg.lora.r != 0 or self.task not in ("sft", "embedding"):
             return self
         if tcfg.stream_layers:
             # Streaming has its own, more specific refusal (the decoder lives
@@ -5044,7 +5044,7 @@ class SoupConfig(BaseModel):
             raise ValueError(
                 f"training.lora.r=0 (full fine-tuning) requires "
                 f"backend='transformers'; got backend={self.backend!r}. The "
-                f"full-FT branch is wired in the transformers SFT trainer."
+                f"full-FT branch is wired in the transformers SFT and embedding trainers."
             )
         if self.modality != "text":
             raise ValueError(

--- a/src/soup_cli/trainer/embedding.py
+++ b/src/soup_cli/trainer/embedding.py
@@ -12,8 +12,8 @@ from soup_cli.utils.gpu import (
     bf16_fp16_flags,
     estimate_batch_size,
     model_size_from_name,
+    resolve_base_load_dtype,
     resolve_device_map,
-    resolve_frozen_base_load_dtype,
 )
 from soup_cli.utils.mixed_precision import align_trainable_dtype_for_fp16
 from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
@@ -87,10 +87,15 @@ class EmbeddingTrainerWrapper:
         else:
             self._setup_transformers(cfg, tcfg)
 
-        trainable, total = self.model.get_nb_trainable_parameters()
-        pct = 100 * trainable / total
+        if tcfg.lora.r == 0:
+            trainable = sum(p.numel() for p in self.model.parameters() if p.requires_grad)
+            total = sum(p.numel() for p in self.model.parameters())
+        else:
+            trainable, total = self.model.get_nb_trainable_parameters()
+        pct = 100 * trainable / total if total > 0 else 0.0
+        label = "Full fine-tuning" if tcfg.lora.r == 0 else "LoRA applied"
         console.print(
-            f"[green]LoRA applied:[/] {trainable:,} trainable"
+            f"[green]{label}:[/] {trainable:,} trainable"
             f" / {total:,} total ({pct:.2f}%)"
         )
 
@@ -240,9 +245,13 @@ class EmbeddingTrainerWrapper:
 
         console.print(f"[dim]Loading model: {cfg.base}[/]")
         dev_map = resolve_device_map(self.device)
+        from soup_cli.trainer.sft import is_full_finetune
+
         model_kwargs = {
             "trust_remote_code": self._trust_remote_code, "device_map": dev_map,
-            "torch_dtype": resolve_frozen_base_load_dtype(self.device),
+            "torch_dtype": resolve_base_load_dtype(
+                self.device, full_finetune=is_full_finetune(tcfg)
+            ),
         }
         if quant_config_obj is not None:
             model_kwargs["quantization_config"] = quant_config_obj
@@ -253,28 +262,43 @@ class EmbeddingTrainerWrapper:
         if tcfg.quantization in ("4bit", "8bit", "mxfp4"):
             self.model = prepare_model_for_kbit_training(self.model)
 
-        from soup_cli.utils.peft_wiring import resolve_lora_target_modules
+        if tcfg.lora.r == 0:
+            # #700 — Full fine-tuning for embedding models (no PEFT adapter applied).
+            trainable = [
+                param for param in self.model.parameters() if param.requires_grad
+            ]
+            if not trainable:
+                raise ValueError(
+                    "training.lora.r=0 requests full fine-tuning but no "
+                    "parameter is trainable — check base model parameters, "
+                    "or set lora.r >= 1 to train an adapter instead. "
+                    "Refusing rather than running a no-op."
+                )
+            if hasattr(self.model, "enable_input_require_grads"):
+                self.model.enable_input_require_grads()
+        else:
+            from soup_cli.utils.peft_wiring import resolve_lora_target_modules
 
-        target_modules = resolve_lora_target_modules(self.model, tcfg.lora.target_modules)
+            target_modules = resolve_lora_target_modules(self.model, tcfg.lora.target_modules)
 
-        lora_config = LoraConfig(
-            r=tcfg.lora.r,
-            lora_alpha=tcfg.lora.alpha,
-            lora_dropout=tcfg.lora.dropout,
-            target_modules=target_modules,
-            task_type=TaskType.FEATURE_EXTRACTION,
-            bias="none",
-            use_dora=tcfg.lora.use_dora,
-            use_rslora=tcfg.lora.use_rslora,
-        )
-        # v0.40.6 #67 — surgical PEFT patches.
-        from soup_cli.utils.peft_wiring import (
-            apply_post_lora_patches,
-            apply_pre_lora_patches,
-        )
-        apply_pre_lora_patches(self.model, cfg.base)
-        self.model = get_peft_model(self.model, lora_config)
-        apply_post_lora_patches(self.model)
+            lora_config = LoraConfig(
+                r=tcfg.lora.r,
+                lora_alpha=tcfg.lora.alpha,
+                lora_dropout=tcfg.lora.dropout,
+                target_modules=target_modules,
+                task_type=TaskType.FEATURE_EXTRACTION,
+                bias="none",
+                use_dora=tcfg.lora.use_dora,
+                use_rslora=tcfg.lora.use_rslora,
+            )
+            # v0.40.6 #67 — surgical PEFT patches.
+            from soup_cli.utils.peft_wiring import (
+                apply_post_lora_patches,
+                apply_pre_lora_patches,
+            )
+            apply_pre_lora_patches(self.model, cfg.base)
+            self.model = get_peft_model(self.model, lora_config)
+            apply_post_lora_patches(self.model)
 
         # v0.35.0 #60 — multi-trainer wiring of v0.28.0 speed/memory features.
         # Embedding does not run cross-doc-mask paths; that flag no-ops.
@@ -544,3 +568,4 @@ class _EmbeddingTrainer:
     @property
     def args(self):
         return self._trainer.args
+

--- a/tests/test_issue491_frozen_base_load_dtype.py
+++ b/tests/test_issue491_frozen_base_load_dtype.py
@@ -5,9 +5,9 @@ PR #471 fixes ``SFTTrainerWrapper``: a frozen (LoRA) base keeps the
 checkpoint's own dtype instead of the HF default of upcasting every load to
 float32. The other trainer wrappers build the identical
 ``model_kwargs`` shape (``trust_remote_code`` + ``device_map`` + optional
-``quantization_config``) with the same gap. Pretraining now has a LISA
-full-fine-tuning branch and therefore uses the full-FT-aware resolver; the
-remaining wrappers always load a frozen LoRA base.
+``quantization_config``) with the same gap. Pretraining and embedding
+now have full-fine-tuning branches and therefore use the full-FT-aware
+resolver; the remaining wrappers always load a frozen LoRA base.
 
 ``TestResolveFrozenBaseLoadDtype`` pins the shared helper in isolation.
 ``TestWrapperModelKwargsCarryDtype`` proves the wiring for real: each
@@ -165,7 +165,7 @@ class TestWrapperModelKwargsCarryDtype:
         sentinel = object()
         resolver_name = (
             "resolve_base_load_dtype"
-            if class_name == "PretrainTrainerWrapper"
+            if class_name in ("PretrainTrainerWrapper", "EmbeddingTrainerWrapper")
             else "resolve_frozen_base_load_dtype"
         )
         with patch("transformers.AutoTokenizer.from_pretrained", return_value=fake_tokenizer), \

--- a/tests/test_issue700_embedding_lora_zero.py
+++ b/tests/test_issue700_embedding_lora_zero.py
@@ -1,0 +1,316 @@
+"""Tests for issue #700: task=embedding honours lora.r: 0 (full fine-tuning).
+
+Verifies that:
+1. lora.r: 0 on task: embedding trains without an adapter (no peft LoraConfig call).
+2. No raw peft ValueError ('r' should be a positive integer value) escapes.
+3. Real torch.nn.Module (without MagicMock) computes trainable parameters cleanly
+   and does not attempt to call get_nb_trainable_parameters() on bare base models.
+4. Console label displays "Full fine-tuning" instead of "LoRA applied".
+5. Schema validation rejects invalid combinations (quantization, backend, conflicting LoRA flags).
+6. _EmbeddingTrainer exposes model and args attributes.
+"""
+
+from unittest.mock import patch
+
+import pytest
+import torch
+import torch.nn as nn
+from pydantic import ValidationError
+
+from soup_cli.config.schema import SoupConfig
+from soup_cli.trainer.embedding import EmbeddingTrainerWrapper, _EmbeddingTrainer
+
+
+class DummyEmbeddingModel(nn.Module):
+    """Real torch.nn.Module imitating an embedding backbone without PEFT."""
+
+    def __init__(self, vocab_size=100, hidden_size=32):
+        super().__init__()
+        self.embeddings = nn.Embedding(vocab_size, hidden_size)
+        self.encoder = nn.Linear(hidden_size, hidden_size)
+
+    def forward(self, input_ids, attention_mask=None, **kwargs):
+        x = self.embeddings(input_ids)
+        x = self.encoder(x)
+        from types import SimpleNamespace
+
+        return SimpleNamespace(last_hidden_state=x)
+
+
+class DummyTokenizer:
+    """Minimal tokenizer for embedding tests."""
+
+    def __init__(self):
+        self.pad_token = "[PAD]"
+        self.eos_token = "[EOS]"
+
+    def __call__(self, texts, padding=True, truncation=True, max_length=128, return_tensors="pt"):
+        n = len(texts)
+        return {
+            "input_ids": torch.ones((n, 4), dtype=torch.long),
+            "attention_mask": torch.ones((n, 4), dtype=torch.long),
+        }
+
+    def save_pretrained(self, path):
+        pass
+
+
+class TestEmbeddingLoraZero:
+    """Test suite for issue #700."""
+
+    def test_schema_allows_embedding_with_lora_r_zero(self):
+        """lora.r: 0 with task=embedding and quantization='none' should validate clean."""
+        cfg = SoupConfig(
+            base="BAAI/bge-base-en-v1.5",
+            task="embedding",
+            data={"train": "./data.jsonl", "format": "embedding"},
+            training={"lora": {"r": 0}, "quantization": "none"},
+        )
+        assert cfg.training.lora.r == 0
+        assert cfg.task == "embedding"
+
+    def test_schema_rejects_quantization_with_lora_r_zero(self):
+        """lora.r: 0 requires quantization='none' (default '4bit' must be rejected)."""
+        with pytest.raises(ValidationError) as exc_info:
+            SoupConfig(
+                base="BAAI/bge-base-en-v1.5",
+                task="embedding",
+                data={"train": "./data.jsonl", "format": "embedding"},
+                training={"lora": {"r": 0}},  # quantization defaults to '4bit'
+            )
+        err = str(exc_info.value)
+        assert "lora.r=0" in err
+        assert "quantization='none'" in err
+
+    def test_schema_rejects_explicit_quantization_with_lora_r_zero(self):
+        """lora.r: 0 explicitly paired with quantization='8bit' must be rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            SoupConfig(
+                base="BAAI/bge-base-en-v1.5",
+                task="embedding",
+                data={"train": "./data.jsonl", "format": "embedding"},
+                training={"lora": {"r": 0}, "quantization": "8bit"},
+            )
+        err = str(exc_info.value)
+        assert "lora.r=0" in err
+        assert "quantization='none'" in err
+
+    def test_schema_rejects_unsloth_with_lora_r_zero(self):
+        """lora.r: 0 requires backend='transformers'."""
+        with pytest.raises(ValidationError) as exc_info:
+            SoupConfig(
+                base="BAAI/bge-base-en-v1.5",
+                task="embedding",
+                backend="unsloth",
+                data={"train": "./data.jsonl", "format": "embedding"},
+                training={"lora": {"r": 0}, "quantization": "none"},
+            )
+        err = str(exc_info.value)
+        assert "lora.r=0" in err
+        assert "backend='transformers'" in err
+
+    def test_schema_rejects_lora_feature_flags_with_lora_r_zero(self):
+        """lora.r: 0 is mutually exclusive with adapter-specific features like use_dora."""
+        with pytest.raises(ValidationError) as exc_info:
+            SoupConfig(
+                base="BAAI/bge-base-en-v1.5",
+                task="embedding",
+                data={"train": "./data.jsonl", "format": "embedding"},
+                training={"lora": {"r": 0, "use_dora": True}, "quantization": "none"},
+            )
+        err = str(exc_info.value)
+        assert "lora.r=0 means full fine-tuning" in err
+        assert "lora.use_dora" in err
+
+    def test_setup_transformers_skips_peft_when_r_is_zero(self):
+        """When lora.r is 0, peft.get_peft_model must NOT be called."""
+        cfg = SoupConfig(
+            base="BAAI/bge-base-en-v1.5",
+            task="embedding",
+            data={"train": "./data.jsonl", "format": "embedding"},
+            training={"lora": {"r": 0}, "quantization": "none"},
+        )
+        real_model = DummyEmbeddingModel()
+
+        with (
+            patch(
+                "transformers.AutoModel.from_pretrained", return_value=real_model
+            ) as mock_auto_model,
+            patch("transformers.AutoTokenizer.from_pretrained", return_value=DummyTokenizer()),
+            patch("peft.get_peft_model") as mock_get_peft,
+            patch("peft.LoraConfig") as mock_lora_cfg,
+        ):
+            wrapper = EmbeddingTrainerWrapper(cfg, device="cpu")
+            wrapper._setup_transformers(cfg, cfg.training)
+
+            # PEFT must NOT have been called
+            mock_lora_cfg.assert_not_called()
+            mock_get_peft.assert_not_called()
+
+            # Full fine-tuning must load at fp32 master weights (Blocking 2)
+            assert mock_auto_model.call_args[1]["torch_dtype"] == torch.float32
+
+            # The model is the original real PyTorch model (not a PeftModel)
+            assert wrapper.model is real_model
+            assert not hasattr(wrapper.model, "peft_config")
+
+    def test_setup_transformers_loads_fp32_for_full_finetune_and_frozen_for_lora(self):
+        """Full fine-tuning (r=0) pins torch.float32; LoRA (r>0) keeps frozen base dtype."""
+        real_model = DummyEmbeddingModel()
+        real_tok = DummyTokenizer()
+
+        # 1. Full fine-tuning (lora.r = 0) -> torch.float32
+        cfg_r0 = SoupConfig(
+            base="BAAI/bge-base-en-v1.5",
+            task="embedding",
+            data={"train": "./data.jsonl", "format": "embedding"},
+            training={"lora": {"r": 0}, "quantization": "none"},
+        )
+        with (
+            patch("transformers.AutoModel.from_pretrained", return_value=real_model) as mock_load,
+            patch("transformers.AutoTokenizer.from_pretrained", return_value=real_tok),
+        ):
+            wrapper0 = EmbeddingTrainerWrapper(cfg_r0, device="cpu")
+            wrapper0._setup_transformers(cfg_r0, cfg_r0.training)
+            assert mock_load.call_args[1]["torch_dtype"] == torch.float32
+
+        # 2. LoRA (lora.r = 4) -> 'auto' (frozen base load dtype on CPU)
+        cfg_r4 = SoupConfig(
+            base="BAAI/bge-base-en-v1.5",
+            task="embedding",
+            data={"train": "./data.jsonl", "format": "embedding"},
+            training={"lora": {"r": 4}, "quantization": "none"},
+        )
+        with (
+            patch("transformers.AutoModel.from_pretrained", return_value=real_model) as mock_load,
+            patch("transformers.AutoTokenizer.from_pretrained", return_value=real_tok),
+            patch("peft.get_peft_model", return_value=real_model),
+            patch(
+                "soup_cli.utils.peft_wiring.resolve_lora_target_modules",
+                return_value=["encoder"],
+            ),
+        ):
+            wrapper4 = EmbeddingTrainerWrapper(cfg_r4, device="cpu")
+            wrapper4._setup_transformers(cfg_r4, cfg_r4.training)
+            assert mock_load.call_args[1]["torch_dtype"] == "auto"
+
+    def test_setup_computes_trainable_params_on_real_module_without_peft_helper(self, capsys):
+        """Full fine-tuning prints 'Full fine-tuning' and computes params without PeftModel."""
+        cfg = SoupConfig(
+            base="BAAI/bge-base-en-v1.5",
+            task="embedding",
+            data={"train": "./data.jsonl", "format": "embedding"},
+            training={"lora": {"r": 0}, "quantization": "none", "batch_size": 2},
+        )
+        real_model = DummyEmbeddingModel()
+        real_tokenizer = DummyTokenizer()
+
+        # Notice: real_model does NOT have get_nb_trainable_parameters
+        assert not hasattr(real_model, "get_nb_trainable_parameters")
+
+        with (
+            patch("transformers.AutoModel.from_pretrained", return_value=real_model),
+            patch("transformers.AutoTokenizer.from_pretrained", return_value=real_tokenizer),
+        ):
+            wrapper = EmbeddingTrainerWrapper(cfg, device="cpu")
+            dataset = {
+                "train": [
+                    {"anchor": "query", "positive": "document"},
+                    {"anchor": "what is soup", "positive": "soup is a library"},
+                ]
+            }
+            # setup should complete without AttributeError
+            wrapper.setup(dataset)
+
+            assert wrapper.model is real_model
+            # Model and args should be accessible on wrapper.trainer
+            assert wrapper.trainer.model is real_model
+            assert wrapper.trainer.args is not None
+
+            # Verify console output says 'Full fine-tuning' and not 'LoRA applied'
+            out = capsys.readouterr().out
+            assert "Full fine-tuning" in out
+            assert "LoRA applied" not in out
+
+    def test_setup_raises_when_lora_r_positive_and_model_not_peft(self):
+        """When lora.r > 0, setup() calls get_nb_trainable_parameters and fails if not PeftModel."""
+        cfg = SoupConfig(
+            base="BAAI/bge-base-en-v1.5",
+            task="embedding",
+            data={"train": "./data.jsonl", "format": "embedding"},
+            training={"lora": {"r": 4}, "quantization": "none", "batch_size": 2},
+        )
+        real_model = DummyEmbeddingModel()  # lacks get_nb_trainable_parameters
+        real_tokenizer = DummyTokenizer()
+
+        with (
+            patch("transformers.AutoModel.from_pretrained", return_value=real_model),
+            patch("transformers.AutoTokenizer.from_pretrained", return_value=real_tokenizer),
+            patch("peft.get_peft_model", return_value=real_model),
+            patch(
+                "soup_cli.utils.peft_wiring.resolve_lora_target_modules",
+                return_value=["encoder"],
+            ),
+        ):
+            wrapper = EmbeddingTrainerWrapper(cfg, device="cpu")
+            dataset = {
+                "train": [
+                    {"anchor": "query", "positive": "document"},
+                ]
+            }
+            # Since real_model lacks get_nb_trainable_parameters, it must raise AttributeError
+            with pytest.raises(AttributeError, match="get_nb_trainable_parameters"):
+                wrapper.setup(dataset)
+
+    def test_embedding_trainer_delegates_model_and_args(self):
+        """_EmbeddingTrainer must expose model and args properties."""
+        model = DummyEmbeddingModel()
+        from transformers import TrainingArguments
+
+        args = TrainingArguments(output_dir="./tmp_test_output", report_to="none")
+
+        trainer = _EmbeddingTrainer(
+            model=model,
+            args=args,
+            train_dataset=[],
+            eval_dataset=None,
+            processing_class=DummyTokenizer(),
+            loss_type="contrastive",
+            margin=0.5,
+            pooling="mean",
+            temperature=0.05,
+            max_length=128,
+        )
+        # Must delegate model and args to the inner Trainer
+        assert trainer.model is model
+        assert trainer.args is args
+
+    def test_embedding_trainer_no_catchall_getattr_and_honest_deepspeed_guard(self):
+        """_EmbeddingTrainer has no catch-all __getattr__ and declines DeepSpeed guard honestly."""
+        from transformers import TrainingArguments
+
+        from soup_cli.utils.deepspeed import attach_empty_param_group_guard
+
+        model = DummyEmbeddingModel()
+        args = TrainingArguments(output_dir="./tmp_test_output", report_to="none")
+
+        trainer = _EmbeddingTrainer(
+            model=model,
+            args=args,
+            train_dataset=[],
+            eval_dataset=None,
+            processing_class=DummyTokenizer(),
+            loss_type="contrastive",
+            margin=0.5,
+            pooling="mean",
+            temperature=0.05,
+            max_length=128,
+        )
+
+        # No __getattr__ catch-all
+        assert "__getattr__" not in _EmbeddingTrainer.__dict__
+        assert not hasattr(trainer, "create_optimizer")
+
+        # Probing create_optimizer returns False instead of attaching guard to outer wrapper
+        assert attach_empty_param_group_guard(trainer) is False
+        assert not getattr(trainer, "_soup_empty_group_guard", False)


### PR DESCRIPTION
Fixes #700

## Description
When `task: embedding` is configured with `lora.r: 0` (full fine-tuning), `_setup_transformers()` previously passed `r=0` to `peft.LoraConfig`, causing a raw `ValueError: Lora rank r must be > 0`. Furthermore, full fine-tuning requires explicit `fp32` master weights rather than loading at the frozen-base checkpoint dtype.

## Changes
- **`src/soup_cli/config/schema.py`**: Allow `task in ('sft', 'embedding')` with `lora.r: 0` and `quantization: 'none'`.
- **`src/soup_cli/trainer/embedding.py`**:
  - In `_setup_transformers()`:
    - Skip PEFT wrapping when `lora.r == 0`, leaving the base model with trainable parameters.
    - Resolve base load dtype via `resolve_base_load_dtype(self.device, full_finetune=is_full_finetune(tcfg))`, correctly pinning `torch.float32` for full fine-tuning.
  - In `setup()`:
    - Explicitly check `if tcfg.lora.r == 0` before computing trainable parameters on the base model without `PeftModel`.
    - If `lora.r > 0` and the model lacks `get_nb_trainable_parameters`, fail loudly rather than masking the error.
    - Display `Full fine-tuning:` in the console log summary without duplicate lines.
  - Rebased onto #708: Removed `__getattr__` and inherited explicit `model` and `args` delegation on `_EmbeddingTrainer`, preserving honest guard decline behavior for `attach_empty_param_group_guard()`.
- **`tests/test_issue491_frozen_base_load_dtype.py`**:
  - Include `EmbeddingTrainerWrapper` alongside `PretrainTrainerWrapper` in the `resolve_base_load_dtype` resolver check, since embedding now also has full-FT support.
- **`tests/test_issue700_embedding_lora_zero.py`**:
  - Comprehensive unit/integration tests with real `torch.nn.Module` instances.
  - Verifies schema validation, PEFT bypass when `r=0`, dtype resolution (`float32` for full-FT vs. `auto` for LoRA), console summary labels, loud failure on unexpected non-PEFT model when `r>0`, property delegation, and absence of `__getattr__` (confirming `attach_empty_param_group_guard` honestly declines).

## Audit of Other Trainers (Acceptance Criterion 4)
Audited other trainers in `src/soup_cli/trainer/` for `lora.r: 0`:
- `classifier.py` and `sft.py` already support `lora.r: 0` / full fine-tuning.
- Other trainers (`asr`, `bco`, `distill`, `dpo`, `grpo`, `ipo`, `kto`, `online_dpo`, `orpo`, `ppo`, `pretrain`, `reward_model`, `simpo`, `stream_setup`) currently pass `r=tcfg.lora.r` directly to PEFT.
