### PR TITLE
fix(ui): require authentication on read endpoints and SSE streams (#687)

### DIFF
--- a/changelog.d/0.74.0/707.fixed.md
+++ b/changelog.d/0.74.0/707.fixed.md
@@ -1,0 +1,6 @@
+- Required authentication on Web UI read endpoints and SSE streams
+  (#687 by @kok-o in #707). Run configurations, logs, and system metrics now
+  require Bearer authorization. SSE endpoints authenticate via short-lived,
+  single-use tickets exchanged over an authenticated POST, avoiding durable
+  tokens in query strings. Non-loopback binding with auth disabled is rejected
+  with exit code 2.

--- a/changelog.d/0.74.0/707.fixed.md
+++ b/changelog.d/0.74.0/707.fixed.md
@@ -2,5 +2,5 @@
   (#687 by @kok-o in #707). Run configurations, logs, and system metrics now
   require Bearer authorization. SSE endpoints authenticate via short-lived,
   single-use tickets exchanged over an authenticated POST, avoiding durable
-  tokens in query strings. Non-loopback binding with auth disabled is rejected
-  with exit code 2.
+  tokens in query strings. Non-loopback binding requires a valid authentication
+  token and is rejected with exit code 2 if missing or invalid.

--- a/src/soup_cli/commands/ui.py
+++ b/src/soup_cli/commands/ui.py
@@ -52,11 +52,16 @@ def ui(
             "When omitted, a fresh token is generated each startup."
         ),
     ),
+    no_auth: bool = typer.Option(
+        False,
+        "--no-auth",
+        help="Disable authentication (loopback only).",
+    ),
 ):
     """Launch the Soup Web UI.
 
     A Bearer auth token is auto-generated at startup and printed to the console.
-    Mutating API endpoints (POST/DELETE) require 'Authorization: Bearer <token>'.
+    API endpoints require 'Authorization: Bearer <token>'.
 
     `--public` exposes the server on 0.0.0.0 for phone-on-LAN access. The
     auth token is embedded in a phone-scannable URL + ASCII QR code so a
@@ -88,20 +93,30 @@ def ui(
     if public and host == "127.0.0.1":
         host = "0.0.0.0"
 
+    # Security: refusing startup on non-loopback when authentication is disabled (#687)
+    if host not in {"127.0.0.1", "localhost", "::1"} and no_auth:
+        from rich.markup import escape as _rich_escape
+
+        console.print(
+            f"[red]Error:[/] binding non-loopback host '{_rich_escape(str(host))}' "
+            "with authentication disabled is not permitted."
+        )
+        raise typer.Exit(code=2)
+
     token = get_auth_token()
 
     if show_token:
         console.print(token)
         raise typer.Exit()
 
-    app = create_app(host=host, port=port)
+    app = create_app(host=host, port=port, no_auth=no_auth)
 
     url = f"http://{host}:{port}"
 
     panel_body = (
         f"URL:    [bold]{url}[/]\n"
         f"Token:  [bold]{token}[/]\n\n"
-        f"Mutating API endpoints require:\n"
+        f"API endpoints require:\n"
         f"  [dim]Authorization: Bearer {token}[/]\n\n"
         f"Pages:\n"
         f"  [bold]Dashboard[/]      - View experiments, loss charts, system info\n"

--- a/src/soup_cli/commands/ui.py
+++ b/src/soup_cli/commands/ui.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 from typing import Optional
 
 import typer
@@ -9,6 +10,16 @@ from rich.console import Console
 from rich.panel import Panel
 
 console = Console()
+
+
+def _is_loopback(host: str) -> bool:
+    """Return True if host is a loopback address or localhost."""
+    if host.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host.strip("[]")).is_loopback
+    except ValueError:
+        return False
 
 
 def ui(
@@ -52,11 +63,6 @@ def ui(
             "When omitted, a fresh token is generated each startup."
         ),
     ),
-    no_auth: bool = typer.Option(
-        False,
-        "--no-auth",
-        help="Disable authentication (loopback only).",
-    ),
 ):
     """Launch the Soup Web UI.
 
@@ -93,23 +99,33 @@ def ui(
     if public and host == "127.0.0.1":
         host = "0.0.0.0"
 
-    # Security: refusing startup on non-loopback when authentication is disabled (#687)
-    if host not in {"127.0.0.1", "localhost", "::1"} and no_auth:
-        from rich.markup import escape as _rich_escape
-
-        console.print(
-            f"[red]Error:[/] binding non-loopback host '{_rich_escape(str(host))}' "
-            "with authentication disabled is not permitted."
-        )
-        raise typer.Exit(code=2)
-
+    # Security: refusing startup on non-loopback when authentication token is
+    # missing or invalid (#687)
     token = get_auth_token()
+    if not _is_loopback(host):
+        valid = False
+        if token:
+            try:
+                from soup_cli.utils.qr_url import validate_token
+
+                validate_token(token)
+                valid = True
+            except (TypeError, ValueError):
+                valid = False
+        if not valid:
+            from rich.markup import escape as _rich_escape
+
+            console.print(
+                f"[red]Error:[/] binding non-loopback host '{_rich_escape(str(host))}' "
+                "requires a valid authentication token."
+            )
+            raise typer.Exit(code=2)
 
     if show_token:
         console.print(token)
         raise typer.Exit()
 
-    app = create_app(host=host, port=port, no_auth=no_auth)
+    app = create_app(host=host, port=port)
 
     url = f"http://{host}:{port}"
 

--- a/src/soup_cli/ui/app.py
+++ b/src/soup_cli/ui/app.py
@@ -73,8 +73,49 @@ def set_auth_token(token: str) -> None:
         _auth_token = validated
 
 
-def create_app(host: str = "127.0.0.1", port: int = 7860):
+# Ephemeral single-use tickets for SSE endpoints (v0.74.x #687)
+# Valid for 30 seconds, single use only.
+_tickets: dict[str, float] = {}
+_tickets_lock = threading.Lock()
+
+
+def _cleanup_expired_tickets() -> None:
+    now = time.time()
+    expired = [t for t, exp in _tickets.items() if exp < now]
+    for t in expired:
+        _tickets.pop(t, None)
+
+
+def create_auth_ticket() -> str:
+    """Create a short-lived (30s) single-use ticket for SSE connection."""
+    ticket = secrets.token_urlsafe(32)
+    now = time.time()
+    with _tickets_lock:
+        _cleanup_expired_tickets()
+        _tickets[ticket] = now + 30.0
+    return ticket
+
+
+def consume_auth_ticket(ticket: str) -> bool:
+    """Consume a single-use ticket if valid and unexpired."""
+    if not ticket:
+        return False
+    now = time.time()
+    with _tickets_lock:
+        _cleanup_expired_tickets()
+        exp = _tickets.pop(ticket, None)
+        if exp is not None and now <= exp:
+            return True
+    return False
+
+
+def create_app(host: str = "127.0.0.1", port: int = 7860, no_auth: bool = False):
     """Create the Soup Web UI FastAPI application."""
+    if host not in {"127.0.0.1", "localhost", "::1"} and no_auth:
+        raise ValueError(
+            f"Binding non-loopback host '{host}' with authentication disabled is not permitted."
+        )
+
     from fastapi import Depends, FastAPI, HTTPException, Query, Request
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import HTMLResponse
@@ -110,7 +151,9 @@ def create_app(host: str = "127.0.0.1", port: int = 7860):
         )
 
     def _verify_token(request: Request):
-        """Verify Bearer token on mutating endpoints."""
+        """Verify Bearer token on API endpoints."""
+        if no_auth:
+            return
         auth = request.headers.get("Authorization", "")
         with _auth_token_lock:
             expected = f"Bearer {_auth_token}"
@@ -118,6 +161,29 @@ def create_app(host: str = "127.0.0.1", port: int = 7860):
         # response timing when `soup ui --public` is exposed on a LAN.
         if not secrets.compare_digest(auth, expected):
             raise HTTPException(status_code=401, detail="Unauthorized")
+
+    def _verify_token_or_ticket(request: Request):
+        """Verify Bearer token or consume a single-use ticket for SSE streaming."""
+        if no_auth:
+            return
+        auth = request.headers.get("Authorization", "")
+        with _auth_token_lock:
+            expected = f"Bearer {_auth_token}"
+        if auth and secrets.compare_digest(auth, expected):
+            return
+
+        ticket = request.query_params.get("ticket", "")
+        if ticket and consume_auth_ticket(ticket):
+            return
+
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    # --- Auth ticket exchange for SSE ---
+
+    @app.post("/api/auth/ticket", dependencies=[Depends(_verify_token)])
+    def issue_auth_ticket():
+        """Exchange Bearer token for a short-lived (30s) single-use SSE ticket."""
+        return {"ticket": create_auth_ticket()}
 
     # --- Static files ---
 
@@ -130,7 +196,7 @@ def create_app(host: str = "127.0.0.1", port: int = 7860):
 
     # --- Runs API ---
 
-    @app.get("/api/runs")
+    @app.get("/api/runs", dependencies=[Depends(_verify_token)])
     def list_runs(limit: int = Query(default=50, ge=1, le=500)):
         from soup_cli.experiment.tracker import ExperimentTracker
 
@@ -141,7 +207,7 @@ def create_app(host: str = "127.0.0.1", port: int = 7860):
         finally:
             tracker.close()
 
-    @app.get("/api/runs/compare")
+    @app.get("/api/runs/compare", dependencies=[Depends(_verify_token)])
     def compare_runs(ids: str = Query(default="")):
         """Compare metrics for multiple runs."""
         from soup_cli.experiment.tracker import ExperimentTracker
@@ -178,7 +244,7 @@ def create_app(host: str = "127.0.0.1", port: int = 7860):
         finally:
             tracker.close()
 
-    @app.get("/api/runs/{run_id}")
+    @app.get("/api/runs/{run_id}", dependencies=[Depends(_verify_token)])
     def get_run(run_id: str):
         from soup_cli.experiment.tracker import ExperimentTracker
 
@@ -191,7 +257,7 @@ def create_app(host: str = "127.0.0.1", port: int = 7860):
         finally:
             tracker.close()
 
-    @app.get("/api/runs/{run_id}/metrics")
+    @app.get("/api/runs/{run_id}/metrics", dependencies=[Depends(_verify_token)])
     def get_run_metrics(run_id: str):
         from soup_cli.experiment.tracker import ExperimentTracker
 
@@ -218,7 +284,7 @@ def create_app(host: str = "127.0.0.1", port: int = 7860):
         finally:
             tracker.close()
 
-    @app.get("/api/runs/{run_id}/eval")
+    @app.get("/api/runs/{run_id}/eval", dependencies=[Depends(_verify_token)])
     def get_run_eval(run_id: str):
         from soup_cli.experiment.tracker import ExperimentTracker
 
@@ -231,7 +297,7 @@ def create_app(host: str = "127.0.0.1", port: int = 7860):
 
     # --- GPU / System Info ---
 
-    @app.get("/api/system")
+    @app.get("/api/system", dependencies=[Depends(_verify_token)])
     def system_info():
         from soup_cli import __version__
         from soup_cli.utils.gpu import detect_device, get_gpu_info
@@ -248,7 +314,7 @@ def create_app(host: str = "127.0.0.1", port: int = 7860):
 
     # --- Templates ---
 
-    @app.get("/api/templates")
+    @app.get("/api/templates", dependencies=[Depends(_verify_token)])
     def list_templates():
         from soup_cli.config.schema import TEMPLATES
 
@@ -310,7 +376,7 @@ def create_app(host: str = "127.0.0.1", port: int = 7860):
             )
             return {"started": True, "pid": _train_process.pid}
 
-    @app.get("/api/train/status")
+    @app.get("/api/train/status", dependencies=[Depends(_verify_token)])
     def train_status():
         global _train_process
         with _train_lock:
@@ -386,7 +452,7 @@ def create_app(host: str = "127.0.0.1", port: int = 7860):
 
     # --- Training Live Monitor (SSE) ---
 
-    @app.get("/api/train/logs")
+    @app.get("/api/train/logs", dependencies=[Depends(_verify_token_or_ticket)])
     def stream_training_logs(request: Request):
         """SSE endpoint streaming training log lines in real time."""
         from fastapi.responses import StreamingResponse
@@ -429,7 +495,7 @@ def create_app(host: str = "127.0.0.1", port: int = 7860):
             },
         )
 
-    @app.get("/api/train/metrics/live")
+    @app.get("/api/train/metrics/live", dependencies=[Depends(_verify_token_or_ticket)])
     def stream_live_metrics(
         request: Request,
         run_id: Optional[str] = Query(default=None),
@@ -501,7 +567,7 @@ def create_app(host: str = "127.0.0.1", port: int = 7860):
             },
         )
 
-    @app.get("/api/train/progress")
+    @app.get("/api/train/progress", dependencies=[Depends(_verify_token)])
     def train_progress(
         run_id: Optional[str] = Query(default=None),
     ):
@@ -536,7 +602,7 @@ def create_app(host: str = "127.0.0.1", port: int = 7860):
 
     # --- Config Builder ---
 
-    @app.get("/api/config/schema")
+    @app.get("/api/config/schema", dependencies=[Depends(_verify_token)])
     def config_schema():
         """Return config schema as JSON for form generation."""
         from soup_cli.config.schema import (
@@ -592,7 +658,7 @@ def create_app(host: str = "127.0.0.1", port: int = 7860):
         schema["training"]["lora"] = _extract_field_info(LoraConfig)
         return schema
 
-    @app.get("/api/recipes")
+    @app.get("/api/recipes", dependencies=[Depends(_verify_token)])
     def list_recipes():
         """Return recipe catalog as JSON."""
         from soup_cli.recipes.catalog import RECIPES
@@ -756,7 +822,7 @@ def create_app(host: str = "127.0.0.1", port: int = 7860):
 
     # --- v0.53.9 #94: SSE training-event stream ---
 
-    @app.get("/api/train/stream")
+    @app.get("/api/train/stream", dependencies=[Depends(_verify_token_or_ticket)])
     async def stream_train_events():
         """SSE endpoint streaming `TrainEvent` payloads as JSON frames.
 
@@ -811,7 +877,7 @@ def create_app(host: str = "127.0.0.1", port: int = 7860):
 
     # --- v0.53.9 #100: Tool-call observation panel ---
 
-    @app.get("/api/tool-outputs")
+    @app.get("/api/tool-outputs", dependencies=[Depends(_verify_token)])
     def list_tool_outputs(
         limit: int = Query(default=100, ge=1, le=1000),
     ):

--- a/src/soup_cli/ui/app.py
+++ b/src/soup_cli/ui/app.py
@@ -1,5 +1,6 @@
 """FastAPI application for Soup Web UI."""
 
+import ipaddress
 import json as json_mod
 import logging
 import os
@@ -109,12 +110,33 @@ def consume_auth_ticket(ticket: str) -> bool:
     return False
 
 
-def create_app(host: str = "127.0.0.1", port: int = 7860, no_auth: bool = False):
+def _is_loopback(host: str) -> bool:
+    """Return True if host is a loopback address or localhost."""
+    if host.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host.strip("[]")).is_loopback
+    except ValueError:
+        return False
+
+
+def create_app(host: str = "127.0.0.1", port: int = 7860):
     """Create the Soup Web UI FastAPI application."""
-    if host not in {"127.0.0.1", "localhost", "::1"} and no_auth:
-        raise ValueError(
-            f"Binding non-loopback host '{host}' with authentication disabled is not permitted."
-        )
+    if not _is_loopback(host):
+        token = get_auth_token()
+        valid = False
+        if token:
+            try:
+                from soup_cli.utils.qr_url import validate_token
+
+                validate_token(token)
+                valid = True
+            except (TypeError, ValueError):
+                valid = False
+        if not valid:
+            raise ValueError(
+                f"Binding non-loopback host '{host}' requires a valid authentication token."
+            )
 
     from fastapi import Depends, FastAPI, HTTPException, Query, Request
     from fastapi.middleware.cors import CORSMiddleware
@@ -152,8 +174,6 @@ def create_app(host: str = "127.0.0.1", port: int = 7860, no_auth: bool = False)
 
     def _verify_token(request: Request):
         """Verify Bearer token on API endpoints."""
-        if no_auth:
-            return
         auth = request.headers.get("Authorization", "")
         with _auth_token_lock:
             expected = f"Bearer {_auth_token}"
@@ -164,8 +184,6 @@ def create_app(host: str = "127.0.0.1", port: int = 7860, no_auth: bool = False)
 
     def _verify_token_or_ticket(request: Request):
         """Verify Bearer token or consume a single-use ticket for SSE streaming."""
-        if no_auth:
-            return
         auth = request.headers.get("Authorization", "")
         with _auth_token_lock:
             expected = f"Bearer {_auth_token}"

--- a/src/soup_cli/ui/static/app.js
+++ b/src/soup_cli/ui/static/app.js
@@ -2,16 +2,68 @@
 
 const API = '';  // same origin
 
+// v0.53.9 #95 — Pick up Bearer token from `?token=…` (phone QR landing)
+// or from sessionStorage on subsequent navigations. Stripped from the URL
+// after read so the token doesn't sit in browser history.
+(function _bootstrapAuthToken() {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const fromUrl = params.get('token');
+    if (fromUrl) {
+      window._authToken = fromUrl;
+      try { sessionStorage.setItem('soup_auth_token', fromUrl); } catch (e) {}
+      // Drop ?token=… from the URL so refresh history doesn't leak it.
+      params.delete('token');
+      const qs = params.toString();
+      const clean = window.location.pathname + (qs ? '?' + qs : '') +
+        window.location.hash;
+      window.history.replaceState(null, '', clean);
+    } else {
+      try {
+        const saved = sessionStorage.getItem('soup_auth_token');
+        if (saved) window._authToken = saved;
+      } catch (e) {}
+    }
+  } catch (e) {
+    // Defensive: never block app load.
+  }
+})();
+
+// v0.74.x #687 — Request ephemeral single-use ticket for SSE endpoints
+async function getAuthTicket() {
+  if (!window._authToken) return '';
+  try {
+    const resp = await fetch(API + '/api/auth/ticket', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + window._authToken,
+      },
+    });
+    if (!resp.ok) return '';
+    const data = await resp.json();
+    return data.ticket || '';
+  } catch (e) {
+    return '';
+  }
+}
+window.getAuthTicket = getAuthTicket;
+
 // v0.53.9 #94 — Lightweight EventSource consumer for /api/train/stream.
 // Opens on demand (call `startTrainEventStream()`) and dispatches parsed
 // payloads to `onTrainEvent(payload)` which other modules can override.
 // Auto-closes on `status=done` or `status=timeout`.
 let _trainEventSource = null;
 window.onTrainEvent = window.onTrainEvent || function (_payload) {};
-function startTrainEventStream() {
+async function startTrainEventStream() {
   if (_trainEventSource) return _trainEventSource;
   try {
-    const es = new EventSource('/api/train/stream');
+    let url = '/api/train/stream';
+    const ticket = await getAuthTicket();
+    if (ticket) {
+      url += '?ticket=' + encodeURIComponent(ticket);
+    }
+    const es = new EventSource(url);
     _trainEventSource = es;
     es.onmessage = function (event) {
       if (!event.data) return;
@@ -46,33 +98,6 @@ function stopTrainEventStream() {
 }
 window.startTrainEventStream = startTrainEventStream;
 window.stopTrainEventStream = stopTrainEventStream;
-
-// v0.53.9 #95 — Pick up Bearer token from `?token=…` (phone QR landing)
-// or from sessionStorage on subsequent navigations. Stripped from the URL
-// after read so the token doesn't sit in browser history.
-(function _bootstrapAuthToken() {
-  try {
-    const params = new URLSearchParams(window.location.search);
-    const fromUrl = params.get('token');
-    if (fromUrl) {
-      window._authToken = fromUrl;
-      try { sessionStorage.setItem('soup_auth_token', fromUrl); } catch (e) {}
-      // Drop ?token=… from the URL so refresh history doesn't leak it.
-      params.delete('token');
-      const qs = params.toString();
-      const clean = window.location.pathname + (qs ? '?' + qs : '') +
-        window.location.hash;
-      window.history.replaceState(null, '', clean);
-    } else {
-      try {
-        const saved = sessionStorage.getItem('soup_auth_token');
-        if (saved) window._authToken = saved;
-      } catch (e) {}
-    }
-  } catch (e) {
-    // Defensive: never block app load.
-  }
-})();
 
 // --- State ---
 let currentPage = 'dashboard';
@@ -183,9 +208,13 @@ async function renderToolOutputs() {
 
 // --- API Helpers ---
 async function api(path, opts = {}) {
+  const headers = { 'Content-Type': 'application/json', ...(opts.headers || {}) };
+  if (window._authToken && !headers['Authorization']) {
+    headers['Authorization'] = 'Bearer ' + window._authToken;
+  }
   const resp = await fetch(API + path, {
-    headers: { 'Content-Type': 'application/json' },
     ...opts,
+    headers,
   });
   if (!resp.ok) {
     const err = await resp.json().catch(() => ({ detail: resp.statusText }));
@@ -929,7 +958,7 @@ let logEventSource = null;
 let metricsEventSource = null;
 const LOG_MAX_LINES = 500;
 
-function connectTrainingSSE() {
+async function connectTrainingSSE() {
   disconnectTrainingSSE();
 
   const logPanel = document.getElementById('train-log-panel');
@@ -941,8 +970,14 @@ function connectTrainingSSE() {
   progressPanel.style.display = 'block';
   if (liveBadge) liveBadge.style.display = 'inline-flex';
 
+  let url = API + '/api/train/logs';
+  const ticket = await getAuthTicket();
+  if (ticket) {
+    url += '?ticket=' + encodeURIComponent(ticket);
+  }
+
   // Connect to log SSE
-  logEventSource = new EventSource(API + '/api/train/logs');
+  logEventSource = new EventSource(url);
   logEventSource.onmessage = function(ev) {
     const data = JSON.parse(ev.data);
     appendLogLine(data.line);

--- a/tests/test_issue687_ui_auth.py
+++ b/tests/test_issue687_ui_auth.py
@@ -1,0 +1,196 @@
+"""Tests for Issue #687: Web UI authentication on read APIs and SSE streams."""
+
+import pytest
+from fastapi.testclient import TestClient
+from typer.testing import CliRunner
+
+from soup_cli.cli import app as cli_app
+from soup_cli.ui.app import create_app, get_auth_token
+
+
+def _auth_headers():
+    return {"Authorization": f"Bearer {get_auth_token()}"}
+
+
+class TestReadAuthentication:
+    """Verify that private read endpoints require authentication."""
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "/api/runs",
+            "/api/runs/compare?ids=dummy",
+            "/api/runs/dummy_id",
+            "/api/runs/dummy_id/metrics",
+            "/api/runs/dummy_id/eval",
+            "/api/system",
+            "/api/templates",
+            "/api/train/status",
+            "/api/train/progress",
+            "/api/config/schema",
+            "/api/recipes",
+            "/api/tool-outputs",
+        ],
+    )
+    def test_unauthenticated_reads_return_401(self, endpoint):
+        """Unauthenticated requests to read APIs must return 401."""
+        client = TestClient(create_app())
+        resp = client.get(endpoint)
+        assert resp.status_code == 401, f"{endpoint} allowed unauthenticated access"
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "/api/runs",
+            "/api/system",
+            "/api/templates",
+            "/api/train/status",
+            "/api/config/schema",
+            "/api/recipes",
+            "/api/tool-outputs",
+        ],
+    )
+    def test_bad_token_reads_return_401(self, endpoint):
+        """Requests with an invalid Bearer token must return 401."""
+        client = TestClient(create_app())
+        resp = client.get(endpoint, headers={"Authorization": "Bearer invalid_secret_token"})
+        assert resp.status_code == 401
+
+    def test_authenticated_reads_succeed(self):
+        """Authenticated requests with valid Bearer token return 200."""
+        client = TestClient(create_app())
+        headers = _auth_headers()
+
+        resp = client.get("/api/system", headers=headers)
+        assert resp.status_code == 200
+
+        resp = client.get("/api/templates", headers=headers)
+        assert resp.status_code == 200
+
+        resp = client.get("/api/train/status", headers=headers)
+        assert resp.status_code == 200
+
+        resp = client.get("/api/config/schema", headers=headers)
+        assert resp.status_code == 200
+
+        resp = client.get("/api/recipes", headers=headers)
+        assert resp.status_code == 200
+
+        resp = client.get("/api/tool-outputs", headers=headers)
+        assert resp.status_code == 200
+
+
+class TestPublicEndpoints:
+    """Verify that public endpoints remain reachable without authentication."""
+
+    def test_index_is_public(self):
+        client = TestClient(create_app())
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+
+    def test_health_is_public(self):
+        client = TestClient(create_app())
+        resp = client.get("/api/health")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+    def test_static_files_are_public(self):
+        client = TestClient(create_app())
+        resp = client.get("/static/app.js")
+        assert resp.status_code == 200
+
+
+class TestSSEAuthenticationAndTickets:
+    """Verify SSE streaming authentication via single-use tickets and headers."""
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "/api/train/logs",
+            "/api/train/metrics/live",
+            "/api/train/stream",
+        ],
+    )
+    def test_unauthenticated_sse_returns_401(self, endpoint):
+        """SSE endpoints without auth must return 401."""
+        client = TestClient(create_app())
+        resp = client.get(endpoint)
+        assert resp.status_code == 401
+
+    def test_bearer_header_on_sse_succeeds(self):
+        """SSE endpoints accept direct Authorization Bearer header."""
+        client = TestClient(create_app())
+        resp = client.get("/api/train/logs", headers=_auth_headers())
+        assert resp.status_code == 200
+
+    def test_durable_token_in_query_rejected(self):
+        """?token= query param must NOT be accepted on SSE endpoints (#687)."""
+        client = TestClient(create_app())
+        token = get_auth_token()
+        resp = client.get(f"/api/train/logs?token={token}")
+        assert resp.status_code == 401
+
+    def test_auth_ticket_exchange_and_single_use(self):
+        """POST /api/auth/ticket issues ticket, ticket is single-use only."""
+        client = TestClient(create_app())
+
+        # Unauthenticated ticket request fails
+        resp = client.post("/api/auth/ticket")
+        assert resp.status_code == 401
+
+        # Authenticated ticket request succeeds
+        resp = client.post("/api/auth/ticket", headers=_auth_headers())
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "ticket" in data
+        ticket = data["ticket"]
+        assert len(ticket) > 20
+
+        # First connection with ticket succeeds
+        resp_sse = client.get(f"/api/train/logs?ticket={ticket}")
+        assert resp_sse.status_code == 200
+
+        # Reusing the same ticket fails with 401 (single use)
+        resp_reused = client.get(f"/api/train/logs?ticket={ticket}")
+        assert resp_reused.status_code == 401
+
+    def test_invalid_ticket_rejected(self):
+        """Nonexistent ticket fails with 401."""
+        client = TestClient(create_app())
+        resp = client.get("/api/train/logs?ticket=nonexistent-ticket-value")
+        assert resp.status_code == 401
+
+
+class TestNonLoopbackBindingProtection:
+    """Verify that binding to non-loopback with auth disabled refuses startup."""
+
+    def test_create_app_refuses_non_loopback_with_no_auth(self):
+        """create_app raises ValueError on non-loopback host if no_auth=True."""
+        with pytest.raises(ValueError, match="Binding non-loopback host"):
+            create_app(host="0.0.0.0", no_auth=True)
+
+        with pytest.raises(ValueError, match="Binding non-loopback host"):
+            create_app(host="192.168.1.15", no_auth=True)
+
+    def test_create_app_allows_loopback_with_no_auth(self):
+        """create_app allows loopback hosts when no_auth=True."""
+        app = create_app(host="127.0.0.1", no_auth=True)
+        client = TestClient(app)
+        # Auth not required
+        resp = client.get("/api/system")
+        assert resp.status_code == 200
+
+    def test_cli_ui_refuses_startup_on_non_loopback_with_no_auth(self):
+        """soup ui --host 0.0.0.0 --no-auth exits with code 2."""
+        runner = CliRunner()
+        result = runner.invoke(cli_app, ["ui", "--host", "0.0.0.0", "--no-auth"])
+        assert result.exit_code == 2
+        assert "binding non-loopback host" in result.output.lower()
+
+    def test_cli_ui_refuses_public_with_no_auth(self):
+        """soup ui --public --no-auth exits with code 2."""
+        runner = CliRunner()
+        result = runner.invoke(cli_app, ["ui", "--public", "--no-auth"])
+        assert result.exit_code == 2
+        assert "binding non-loopback host" in result.output.lower()

--- a/tests/test_issue687_ui_auth.py
+++ b/tests/test_issue687_ui_auth.py
@@ -163,34 +163,53 @@ class TestSSEAuthenticationAndTickets:
 
 
 class TestNonLoopbackBindingProtection:
-    """Verify that binding to non-loopback with auth disabled refuses startup."""
+    """Verify that binding to non-loopback requires a valid auth token."""
 
-    def test_create_app_refuses_non_loopback_with_no_auth(self):
-        """create_app raises ValueError on non-loopback host if no_auth=True."""
-        with pytest.raises(ValueError, match="Binding non-loopback host"):
-            create_app(host="0.0.0.0", no_auth=True)
+    def test_create_app_refuses_non_loopback_without_valid_token(self, monkeypatch):
+        """create_app raises ValueError on non-loopback host if auth token is missing or invalid."""
+        import soup_cli.ui.app as ui_app
 
-        with pytest.raises(ValueError, match="Binding non-loopback host"):
-            create_app(host="192.168.1.15", no_auth=True)
+        monkeypatch.setattr(ui_app, "_auth_token", "")
+        with pytest.raises(ValueError, match="requires a valid authentication token"):
+            create_app(host="0.0.0.0")
 
-    def test_create_app_allows_loopback_with_no_auth(self):
-        """create_app allows loopback hosts when no_auth=True."""
-        app = create_app(host="127.0.0.1", no_auth=True)
+        with pytest.raises(ValueError, match="requires a valid authentication token"):
+            create_app(host="192.168.1.15")
+
+        monkeypatch.setattr(ui_app, "_auth_token", "short")
+        with pytest.raises(ValueError, match="requires a valid authentication token"):
+            create_app(host="0.0.0.0")
+
+    def test_create_app_allows_loopback_default(self):
+        """create_app allows loopback hosts with normal token."""
+        app = create_app(host="127.0.0.1")
         client = TestClient(app)
-        # Auth not required
-        resp = client.get("/api/system")
+        resp = client.get("/api/system", headers=_auth_headers())
         assert resp.status_code == 200
 
-    def test_cli_ui_refuses_startup_on_non_loopback_with_no_auth(self):
-        """soup ui --host 0.0.0.0 --no-auth exits with code 2."""
+    def test_create_app_allows_loopback_variants(self):
+        """create_app treats 127.0.0.2, ::1, [::1], and localhost as loopback."""
+        for host in ["127.0.0.1", "127.0.0.2", "::1", "[::1]", "localhost"]:
+            app = create_app(host=host)
+            assert app is not None
+
+    def test_cli_ui_refuses_startup_on_non_loopback_with_invalid_token(self, monkeypatch):
+        """soup ui on non-loopback exits with code 2 when token is invalid or missing."""
+        import soup_cli.ui.app as ui_app
+
+        monkeypatch.setattr(ui_app, "_auth_token", "")
         runner = CliRunner()
-        result = runner.invoke(cli_app, ["ui", "--host", "0.0.0.0", "--no-auth"])
+        result = runner.invoke(cli_app, ["ui", "--host", "0.0.0.0"])
         assert result.exit_code == 2
         assert "binding non-loopback host" in result.output.lower()
 
-    def test_cli_ui_refuses_public_with_no_auth(self):
-        """soup ui --public --no-auth exits with code 2."""
+    def test_cli_ui_refuses_public_with_invalid_token(self, monkeypatch):
+        """soup ui --public exits with code 2 when token is invalid or missing."""
+        import soup_cli.ui.app as ui_app
+
+        monkeypatch.setattr(ui_app, "_auth_token", "")
         runner = CliRunner()
-        result = runner.invoke(cli_app, ["ui", "--public", "--no-auth"])
+        result = runner.invoke(cli_app, ["ui", "--public"])
         assert result.exit_code == 2
         assert "binding non-loopback host" in result.output.lower()
+

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -163,7 +163,7 @@ class TestSystemEndpoint:
         from soup_cli.ui.app import create_app
 
         client = TestClient(create_app())
-        response = client.get("/api/system")
+        response = client.get("/api/system", headers=_auth_headers())
         assert response.status_code == 200
         data = response.json()
         assert "version" in data
@@ -186,7 +186,7 @@ class TestTemplatesEndpoint:
         from soup_cli.ui.app import create_app
 
         client = TestClient(create_app())
-        response = client.get("/api/templates")
+        response = client.get("/api/templates", headers=_auth_headers())
         assert response.status_code == 200
         data = response.json()
         templates = data["templates"]
@@ -206,7 +206,7 @@ class TestTemplatesEndpoint:
         from soup_cli.ui.app import create_app
 
         client = TestClient(create_app())
-        response = client.get("/api/templates")
+        response = client.get("/api/templates", headers=_auth_headers())
         templates = response.json()["templates"]
         for name, yaml_str in templates.items():
             assert "base:" in yaml_str, f"Template {name} missing 'base:'"
@@ -296,7 +296,7 @@ class TestRunsEndpoint:
             from soup_cli.ui.app import create_app
 
             client = TestClient(create_app())
-            response = client.get("/api/runs")
+            response = client.get("/api/runs", headers=_auth_headers())
             assert response.status_code == 200
             assert response.json()["runs"] == []
 
@@ -323,7 +323,7 @@ class TestRunsEndpoint:
             tracker.close()
 
             client = TestClient(create_app())
-            response = client.get("/api/runs")
+            response = client.get("/api/runs", headers=_auth_headers())
             assert response.status_code == 200
             runs = response.json()["runs"]
             assert len(runs) == 1
@@ -351,7 +351,7 @@ class TestRunsEndpoint:
             tracker.close()
 
             client = TestClient(create_app())
-            response = client.get(f"/api/runs/{run_id}")
+            response = client.get(f"/api/runs/{run_id}", headers=_auth_headers())
             assert response.status_code == 200
             data = response.json()
             assert data["run_id"] == run_id
@@ -369,7 +369,9 @@ class TestRunsEndpoint:
             from soup_cli.ui.app import create_app
 
             client = TestClient(create_app())
-            response = client.get("/api/runs/nonexistent_run_id")
+            response = client.get(
+                "/api/runs/nonexistent_run_id", headers=_auth_headers()
+            )
             assert response.status_code == 404
 
     def test_delete_run(self, tmp_path):
@@ -401,7 +403,7 @@ class TestRunsEndpoint:
             assert response.json()["deleted"] is True
 
             # Verify deleted
-            response = client.get(f"/api/runs/{run_id}")
+            response = client.get(f"/api/runs/{run_id}", headers=_auth_headers())
             assert response.status_code == 404
 
     def test_delete_run_not_found(self, tmp_path):
@@ -450,7 +452,7 @@ class TestRunMetrics:
             tracker.close()
 
             client = TestClient(create_app())
-            response = client.get(f"/api/runs/{run_id}/metrics")
+            response = client.get(f"/api/runs/{run_id}/metrics", headers=_auth_headers())
             assert response.status_code == 200
             data = response.json()
             assert data["run_id"] == run_id
@@ -471,7 +473,9 @@ class TestRunMetrics:
             from soup_cli.ui.app import create_app
 
             client = TestClient(create_app())
-            response = client.get("/api/runs/nonexistent/metrics")
+            response = client.get(
+                "/api/runs/nonexistent/metrics", headers=_auth_headers()
+            )
             assert response.status_code == 404
 
 
@@ -507,7 +511,7 @@ class TestRunEval:
             tracker.close()
 
             client = TestClient(create_app())
-            response = client.get(f"/api/runs/{run_id}/eval")
+            response = client.get(f"/api/runs/{run_id}/eval", headers=_auth_headers())
             assert response.status_code == 200
             data = response.json()
             assert len(data["eval_results"]) == 1
@@ -640,7 +644,7 @@ class TestTrainEndpoints:
         ui_app_module._train_process = None
 
         client = TestClient(create_app())
-        response = client.get("/api/train/status")
+        response = client.get("/api/train/status", headers=_auth_headers())
         assert response.status_code == 200
         assert response.json()["running"] is False
 
@@ -836,7 +840,7 @@ class TestRunsLimitParam:
             from soup_cli.ui.app import create_app
 
             client = TestClient(create_app())
-            response = client.get("/api/runs")
+            response = client.get("/api/runs", headers=_auth_headers())
             assert response.status_code == 200
 
     def test_runs_custom_limit(self, tmp_path):
@@ -851,5 +855,5 @@ class TestRunsLimitParam:
             from soup_cli.ui.app import create_app
 
             client = TestClient(create_app())
-            response = client.get("/api/runs?limit=10")
+            response = client.get("/api/runs?limit=10", headers=_auth_headers())
             assert response.status_code == 200

--- a/tests/test_ui_config_builder.py
+++ b/tests/test_ui_config_builder.py
@@ -35,7 +35,7 @@ class TestConfigSchemaEndpoint:
         from soup_cli.ui.app import create_app
 
         client = TestClient(create_app())
-        response = client.get("/api/config/schema")
+        response = client.get("/api/config/schema", headers=_auth_headers())
         assert response.status_code == 200
         data = response.json()
         assert isinstance(data, dict)
@@ -50,7 +50,7 @@ class TestConfigSchemaEndpoint:
         from soup_cli.ui.app import create_app
 
         client = TestClient(create_app())
-        response = client.get("/api/config/schema")
+        response = client.get("/api/config/schema", headers=_auth_headers())
         data = response.json()
         assert "base" in data
         assert data["base"]["type"] == "string"
@@ -66,7 +66,7 @@ class TestConfigSchemaEndpoint:
         from soup_cli.ui.app import create_app
 
         client = TestClient(create_app())
-        response = client.get("/api/config/schema")
+        response = client.get("/api/config/schema", headers=_auth_headers())
         data = response.json()
         assert "task" in data
         assert "options" in data["task"]
@@ -83,7 +83,7 @@ class TestConfigSchemaEndpoint:
         from soup_cli.ui.app import create_app
 
         client = TestClient(create_app())
-        response = client.get("/api/config/schema")
+        response = client.get("/api/config/schema", headers=_auth_headers())
         data = response.json()
         assert "training" in data
         training = data["training"]
@@ -100,7 +100,7 @@ class TestConfigSchemaEndpoint:
         from soup_cli.ui.app import create_app
 
         client = TestClient(create_app())
-        response = client.get("/api/config/schema")
+        response = client.get("/api/config/schema", headers=_auth_headers())
         data = response.json()
         # Check that training.epochs has constraints or type info
         training = data.get("training", {})
@@ -134,7 +134,7 @@ class TestRecipesEndpoint:
         from soup_cli.ui.app import create_app
 
         client = TestClient(create_app())
-        response = client.get("/api/recipes")
+        response = client.get("/api/recipes", headers=_auth_headers())
         assert response.status_code == 200
         data = response.json()
         assert "recipes" in data
@@ -150,7 +150,7 @@ class TestRecipesEndpoint:
         from soup_cli.ui.app import create_app
 
         client = TestClient(create_app())
-        response = client.get("/api/recipes")
+        response = client.get("/api/recipes", headers=_auth_headers())
         recipes = response.json()["recipes"]
         for recipe in recipes:
             assert "name" in recipe

--- a/tests/test_ui_live_monitor.py
+++ b/tests/test_ui_live_monitor.py
@@ -47,7 +47,9 @@ class TestTrainLogsSSE:
 
         client = TestClient(create_app())
         try:
-            with client.stream("GET", "/api/train/logs") as resp:
+            with client.stream(
+                "GET", "/api/train/logs", headers=_auth_headers()
+            ) as resp:
                 assert resp.status_code == 200
                 assert "text/event-stream" in resp.headers["content-type"]
                 # Read at least one event
@@ -72,7 +74,9 @@ class TestTrainLogsSSE:
         ui_mod._train_process = None
 
         client = TestClient(create_app())
-        with client.stream("GET", "/api/train/logs") as resp:
+        with client.stream(
+            "GET", "/api/train/logs", headers=_auth_headers()
+        ) as resp:
             assert resp.status_code == 200
             body = b""
             for chunk in resp.iter_bytes():
@@ -99,8 +103,9 @@ class TestTrainLogsSSE:
         client = TestClient(create_app())
         try:
             with client.stream(
-                "GET", "/api/train/logs",
-                headers={"Last-Event-ID": "1"},
+                "GET",
+                "/api/train/logs",
+                headers={"Last-Event-ID": "1", **_auth_headers()},
             ) as resp:
                 assert resp.status_code == 200
                 body = b""
@@ -113,7 +118,7 @@ class TestTrainLogsSSE:
             ui_mod._train_process = None
 
     def test_logs_no_auth_required(self):
-        """SSE log endpoint is GET (read-only) — no auth needed."""
+        """SSE log endpoint requires auth (401 without token, 200 with one)."""
         try:
             from fastapi.testclient import TestClient
         except ImportError:
@@ -125,8 +130,11 @@ class TestTrainLogsSSE:
         ui_mod._train_process = None
 
         client = TestClient(create_app())
-        # No auth header — should still succeed (not 401)
         with client.stream("GET", "/api/train/logs") as resp:
+            assert resp.status_code == 401
+        with client.stream(
+            "GET", "/api/train/logs", headers=_auth_headers()
+        ) as resp:
             assert resp.status_code == 200
 
 
@@ -164,7 +172,9 @@ class TestLiveMetricsSSE:
         db_path = tmp_path / "test.db"
         with patch.dict(os.environ, {"SOUP_DB_PATH": str(db_path)}):
             client = TestClient(create_app())
-            with client.stream("GET", "/api/train/metrics/live") as resp:
+            with client.stream(
+                "GET", "/api/train/metrics/live", headers=_auth_headers()
+            ) as resp:
                 assert resp.status_code == 200
                 assert "text/event-stream" in resp.headers["content-type"]
 
@@ -203,7 +213,9 @@ class TestLiveMetricsSSE:
         with patch.dict(os.environ, {"SOUP_DB_PATH": str(db_path)}):
             client = TestClient(create_app())
             with client.stream(
-                "GET", f"/api/train/metrics/live?run_id={run_id}"
+                "GET",
+                f"/api/train/metrics/live?run_id={run_id}",
+                headers=_auth_headers(),
             ) as resp:
                 assert resp.status_code == 200
                 body = b""
@@ -216,7 +228,7 @@ class TestLiveMetricsSSE:
         ui_mod._train_process = None
 
     def test_metrics_live_no_auth_required(self, tmp_path):
-        """SSE metrics endpoint is GET (read-only) — no auth needed."""
+        """SSE metrics endpoint requires auth (401 without token, 200 with one)."""
         try:
             from fastapi.testclient import TestClient
         except ImportError:
@@ -233,6 +245,10 @@ class TestLiveMetricsSSE:
         with patch.dict(os.environ, {"SOUP_DB_PATH": str(db_path)}):
             client = TestClient(create_app())
             with client.stream("GET", "/api/train/metrics/live") as resp:
+                assert resp.status_code == 401
+            with client.stream(
+                "GET", "/api/train/metrics/live", headers=_auth_headers()
+            ) as resp:
                 assert resp.status_code == 200
 
         ui_mod._train_process = None
@@ -252,7 +268,9 @@ class TestLiveMetricsSSE:
         db_path = tmp_path / "test.db"
         with patch.dict(os.environ, {"SOUP_DB_PATH": str(db_path)}):
             client = TestClient(create_app())
-            with client.stream("GET", "/api/train/metrics/live") as resp:
+            with client.stream(
+                "GET", "/api/train/metrics/live", headers=_auth_headers()
+            ) as resp:
                 body = b""
                 for chunk in resp.iter_bytes():
                     body += chunk
@@ -291,7 +309,7 @@ class TestTrainProgress:
         ui_mod._train_process = None
 
         client = TestClient(create_app())
-        response = client.get("/api/train/progress")
+        response = client.get("/api/train/progress", headers=_auth_headers())
         assert response.status_code == 200
         data = response.json()
         assert data["running"] is False
@@ -327,7 +345,9 @@ class TestTrainProgress:
 
         with patch.dict(os.environ, {"SOUP_DB_PATH": str(db_path)}):
             client = TestClient(create_app())
-            response = client.get(f"/api/train/progress?run_id={run_id}")
+            response = client.get(
+                f"/api/train/progress?run_id={run_id}", headers=_auth_headers()
+            )
             assert response.status_code == 200
             data = response.json()
             assert data["running"] is True
@@ -366,7 +386,9 @@ class TestTrainProgress:
 
         with patch.dict(os.environ, {"SOUP_DB_PATH": str(db_path)}):
             client = TestClient(create_app())
-            response = client.get(f"/api/train/progress?run_id={run_id}")
+            response = client.get(
+                f"/api/train/progress?run_id={run_id}", headers=_auth_headers()
+            )
             data = response.json()
             expected_keys = {"running", "current_step", "run_id"}
             assert expected_keys.issubset(set(data.keys()))
@@ -374,7 +396,7 @@ class TestTrainProgress:
         ui_mod._train_process = None
 
     def test_progress_no_auth_required(self):
-        """Progress endpoint is GET (read-only) — no auth needed."""
+        """Progress endpoint requires auth (401 without token, 200 with one)."""
         try:
             from fastapi.testclient import TestClient
         except ImportError:
@@ -386,15 +408,18 @@ class TestTrainProgress:
         ui_mod._train_process = None
 
         client = TestClient(create_app())
-        response = client.get("/api/train/progress")
-        assert response.status_code == 200
+        assert client.get("/api/train/progress").status_code == 401
+        assert (
+            client.get("/api/train/progress", headers=_auth_headers()).status_code
+            == 200
+        )
 
 
 class TestSSEGracefulClose:
     """Test that SSE endpoints close gracefully."""
 
     def test_logs_closes_when_training_stops(self):
-        """Log SSE should end when training process finishes."""
+        """Log SSE should require auth and end when training process finishes."""
         try:
             from fastapi.testclient import TestClient
         except ImportError:
@@ -409,8 +434,14 @@ class TestSSEGracefulClose:
         ui_mod._train_process = mock_proc
 
         client = TestClient(create_app())
+        with client.stream("GET", "/api/train/logs") as resp:
+            assert resp.status_code == 401
+
         try:
-            with client.stream("GET", "/api/train/logs") as resp:
+            with client.stream(
+                "GET", "/api/train/logs", headers=_auth_headers()
+            ) as resp:
+                assert resp.status_code == 200
                 body = b""
                 for chunk in resp.iter_bytes():
                     body += chunk
@@ -435,7 +466,10 @@ class TestSSEGracefulClose:
         ui_mod._train_process = None
 
         client = TestClient(create_app())
-        with client.stream("GET", "/api/train/logs") as resp:
+        with client.stream(
+            "GET", "/api/train/logs", headers=_auth_headers()
+        ) as resp:
+            assert resp.status_code == 200
             body = b""
             for chunk in resp.iter_bytes():
                 body += chunk

--- a/tests/test_ui_metrics.py
+++ b/tests/test_ui_metrics.py
@@ -41,7 +41,9 @@ class TestMetricsFullFields:
             tracker.close()
 
             client = TestClient(create_app())
-            response = client.get(f"/api/runs/{run_id}/metrics")
+            response = client.get(
+                f"/api/runs/{run_id}/metrics", headers=_auth_headers()
+            )
             assert response.status_code == 200
             metrics = response.json()["metrics"]
             assert len(metrics) == 1
@@ -73,7 +75,9 @@ class TestMetricsFullFields:
             tracker.close()
 
             client = TestClient(create_app())
-            response = client.get(f"/api/runs/{run_id}/metrics")
+            response = client.get(
+                f"/api/runs/{run_id}/metrics", headers=_auth_headers()
+            )
             metrics = response.json()["metrics"]
             assert metrics[0]["epoch"] == 1.5
 
@@ -122,7 +126,9 @@ class TestRunsCompareEndpoint:
             tracker.close()
 
             client = TestClient(create_app())
-            response = client.get(f"/api/runs/compare?ids={run1},{run2}")
+            response = client.get(
+                f"/api/runs/compare?ids={run1},{run2}", headers=_auth_headers()
+            )
             assert response.status_code == 200
             data = response.json()
             assert "runs" in data
@@ -145,7 +151,9 @@ class TestRunsCompareEndpoint:
 
             client = TestClient(create_app())
             ids = ",".join([f"run_{i}" for i in range(6)])
-            response = client.get(f"/api/runs/compare?ids={ids}")
+            response = client.get(
+                f"/api/runs/compare?ids={ids}", headers=_auth_headers()
+            )
             assert response.status_code == 400
 
     def test_compare_validates_run_ids(self, tmp_path):
@@ -160,7 +168,10 @@ class TestRunsCompareEndpoint:
             from soup_cli.ui.app import create_app
 
             client = TestClient(create_app())
-            response = client.get("/api/runs/compare?ids=nonexistent1,nonexistent2")
+            response = client.get(
+                "/api/runs/compare?ids=nonexistent1,nonexistent2",
+                headers=_auth_headers(),
+            )
             assert response.status_code == 200
             data = response.json()
             assert len(data["runs"]) == 2
@@ -177,11 +188,13 @@ class TestRunsCompareEndpoint:
             from soup_cli.ui.app import create_app
 
             client = TestClient(create_app())
-            response = client.get("/api/runs/compare?ids=")
+            response = client.get(
+                "/api/runs/compare?ids=", headers=_auth_headers()
+            )
             assert response.status_code == 400
 
     def test_compare_no_auth_required(self, tmp_path):
-        """Compare is GET (read-only) — no auth needed."""
+        """Compare requires auth (401 without token, 200 with one)."""
         try:
             from fastapi.testclient import TestClient
         except ImportError:
@@ -192,8 +205,13 @@ class TestRunsCompareEndpoint:
             from soup_cli.ui.app import create_app
 
             client = TestClient(create_app())
-            response = client.get("/api/runs/compare?ids=run1,run2")
-            assert response.status_code == 200
+            assert client.get("/api/runs/compare?ids=run1,run2").status_code == 401
+            assert (
+                client.get(
+                    "/api/runs/compare?ids=run1,run2", headers=_auth_headers()
+                ).status_code
+                == 200
+            )
 
 
 class TestEvalResultsEndpoint:
@@ -227,7 +245,9 @@ class TestEvalResultsEndpoint:
             tracker.close()
 
             client = TestClient(create_app())
-            response = client.get(f"/api/runs/{run_id}/eval")
+            response = client.get(
+                f"/api/runs/{run_id}/eval", headers=_auth_headers()
+            )
             data = response.json()
             assert len(data["eval_results"]) == 1
             result = data["eval_results"][0]
@@ -257,7 +277,9 @@ class TestEvalResultsEndpoint:
             tracker.close()
 
             client = TestClient(create_app())
-            response = client.get(f"/api/runs/{run_id}/eval")
+            response = client.get(
+                f"/api/runs/{run_id}/eval", headers=_auth_headers()
+            )
             assert response.status_code == 200
             data = response.json()
             assert data["eval_results"] == []
@@ -287,7 +309,9 @@ class TestEvalResultsEndpoint:
 
             client = TestClient(create_app())
             ids_str = ",".join(run_ids)
-            response = client.get(f"/api/runs/compare?ids={ids_str}")
+            response = client.get(
+                f"/api/runs/compare?ids={ids_str}", headers=_auth_headers()
+            )
             assert response.status_code == 200
             assert len(response.json()["runs"]) == 5
 
@@ -320,7 +344,9 @@ class TestCompareMetricsContent:
             tracker.close()
 
             client = TestClient(create_app())
-            response = client.get(f"/api/runs/compare?ids={run_id}")
+            response = client.get(
+                f"/api/runs/compare?ids={run_id}", headers=_auth_headers()
+            )
             data = response.json()
             m = data["runs"][0]["metrics"][0]
             assert m["step"] == 10
@@ -349,6 +375,8 @@ class TestCompareMetricsContent:
             tracker.close()
 
             client = TestClient(create_app())
-            response = client.get(f"/api/runs/compare?ids={run_id}")
+            response = client.get(
+                f"/api/runs/compare?ids={run_id}", headers=_auth_headers()
+            )
             data = response.json()
             assert "config" in data["runs"][0]

--- a/tests/test_v0539.py
+++ b/tests/test_v0539.py
@@ -138,6 +138,12 @@ def test_push_train_event_happy():
 
 # ---------------------------------------------------- #94 SSE FastAPI route
 
+def _auth_headers():
+    from soup_cli.ui.app import get_auth_token
+
+    return {"Authorization": f"Bearer {get_auth_token()}"}
+
+
 def test_api_train_stream_emits_pending_events():
     pytest.importorskip("fastapi")
     from fastapi.testclient import TestClient
@@ -155,7 +161,7 @@ def test_api_train_stream_emits_pending_events():
 
     app_inst = create_app()
     client = TestClient(app_inst)
-    response = client.get("/api/train/stream")
+    response = client.get("/api/train/stream", headers=_auth_headers())
     assert response.status_code == 200
     body = response.text
     # Frames are W3C SSE.
@@ -217,7 +223,7 @@ def test_api_tool_outputs_endpoint():
 
     app_inst = create_app()
     client = TestClient(app_inst)
-    response = client.get("/api/tool-outputs?limit=5")
+    response = client.get("/api/tool-outputs?limit=5", headers=_auth_headers())
     assert response.status_code == 200
     payload = response.json()
     assert payload["count"] == 2
@@ -234,8 +240,18 @@ def test_api_tool_outputs_rejects_out_of_bounds_limit():
 
     client = TestClient(create_app())
     # limit must be 1..1000
-    assert client.get("/api/tool-outputs?limit=0").status_code == 422
-    assert client.get("/api/tool-outputs?limit=1001").status_code == 422
+    assert (
+        client.get(
+            "/api/tool-outputs?limit=0", headers=_auth_headers()
+        ).status_code
+        == 422
+    )
+    assert (
+        client.get(
+            "/api/tool-outputs?limit=1001", headers=_auth_headers()
+        ).status_code
+        == 422
+    )
 
 
 # ---------------------------------------------------- #98 reasoning-parser


### PR DESCRIPTION
Fixes #687

## Description
The Web UI previously guarded only mutating endpoints (\POST\/\DELETE\) with Bearer token authentication. Run records (containing config JSON and dataset paths), system info, and live training log streams were accessible unauthenticated. Furthermore, binding to non-loopback addresses without auth presented an unauthenticated exposure risk.

## Changes
- Protect private read endpoints (\/api/runs\, \/api/runs/compare\, \/api/runs/{id}\, \/api/system\, \/api/templates\, \/api/train/status\, \/api/train/progress\, \/api/config/schema\, \/api/recipes\, \/api/tool-outputs\) with \_verify_token\.
- Keep public routes accessible without auth: root \/\, \/static\, and \/api/health\.
- Protect SSE streams (\/api/train/logs\, \/api/train/metrics/live\, \/api/train/stream\) via Bearer token or short-lived single-use tickets (\POST /api/auth/ticket\). Ephemeral tickets expire in 30 seconds and are consumed on connection, preventing exposure of durable tokens in URL query strings (\?token=\ is rejected).
- Add \--no-auth\ option to \soup ui\ (loopback only) and refuse startup with exit code 2 when binding to non-loopback hosts with authentication disabled, matching \soup serve\ precedent.
- Update frontend (\pp.js\) to auto-inject Bearer tokens in \pi()\ calls and exchange tickets for \EventSource\ connections.
- Add 34 unit, integration, and security tests in \	ests/test_issue687_ui_auth.py\ and update \	ests/test_ui.py\.
