### PR TITLE
fix(distill): ULD loss respects the response-only label mask and causal shift

### DIFF
--- a/changelog.d/0.74.0/711.fixed.md
+++ b/changelog.d/0.74.0/711.fixed.md
@@ -1,0 +1,7 @@
+- The ULD distillation loss (`wasserstein` / `topk_align` / `wasserstein_aligned`)
+  ignored the response-only label mask and the causal shift the CE term already
+  applies, so under the default `train_on_responses_only` it optimized prompt
+  tokens and the shift-boundary position too (#682 by @MakazhanAlpamys, closes
+  #682 in #711). `uld_distill_loss` and `uld_aligned_loss` now take an optional
+  `labels` argument and mask on `labels != -100` after the same shift
+  `_compute_distill_term` uses.

--- a/changelog.d/0.74.0/711.fixed.md
+++ b/changelog.d/0.74.0/711.fixed.md
@@ -1,7 +1,7 @@
 - The ULD distillation loss (`wasserstein` / `topk_align` / `wasserstein_aligned`)
   ignored the response-only label mask and the causal shift the CE term already
   applies, so under the default `train_on_responses_only` it optimized prompt
-  tokens and the shift-boundary position too (#682 by @MakazhanAlpamys, closes
-  #682 in #711). `uld_distill_loss` and `uld_aligned_loss` now take an optional
+  tokens and the shift-boundary position too (#711 by @AmirF194, closes
+  #682). `uld_distill_loss` and `uld_aligned_loss` now take an optional
   `labels` argument and mask on `labels != -100` after the same shift
   `_compute_distill_term` uses.

--- a/src/soup_cli/trainer/distill.py
+++ b/src/soup_cli/trainer/distill.py
@@ -599,6 +599,7 @@ class DistillTrainerWrapper:
                         t_strings,
                         config=_uld_projection.config,
                         attention_mask=s_mask,
+                        labels=labels,
                     )
                     total = _CE_WEIGHT * ce_loss + _DISTILL_WEIGHT * distill_loss
                     return (total, outputs) if return_outputs else total
@@ -635,10 +636,13 @@ class DistillTrainerWrapper:
                 anchor = None
                 if _uld_projection is not None:
                     # v0.71.11 #236 — cross-tokenizer ULD distillation loss.
+                    # #682: pass labels so masking matches the CE term,
+                    # trained tokens only, not every attended position.
                     distill_loss = _uld_projection(
                         student_logits,
                         teacher_logits,
                         attention_mask=inputs.get("attention_mask"),
+                        labels=labels,
                     )
                 elif _minillm_cb is not None:
                     # v0.71.11 #237 — MiniLLM teacher-mixed reverse-KL +

--- a/src/soup_cli/utils/uld.py
+++ b/src/soup_cli/utils/uld.py
@@ -231,6 +231,7 @@ def uld_distill_loss(
     *,
     config: ULDConfig,
     attention_mask=None,
+    labels=None,
 ):
     """Cross-tokenizer ULD distillation loss (v0.71.11 #236).
 
@@ -247,7 +248,13 @@ def uld_distill_loss(
       Distils only on the high-probability subset.
 
     Differentiable w.r.t. the student logits (sort / topk both use
-    gather). Returns a scalar mean over the (masked) token positions.
+    gather). Returns a scalar mean over the (masked) token positions,
+    restricted to the trained tokens the same way
+    :func:`soup_cli.trainer.distill._compute_distill_term` restricts the
+    plain-KL path: ``labels != -100`` (post causal shift) when ``labels``
+    is given, else ``attention_mask``, else every position (#682: a
+    pure-padding mask let prompt tokens and the shift-boundary position
+    leak into the loss).
     """
     import torch
 
@@ -255,6 +262,18 @@ def uld_distill_loss(
         raise TypeError(
             f"config must be ULDConfig, got {type(config).__name__}"
         )
+
+    # Causal-LM alignment: logit position i predicts token i+1, the same
+    # shift the CE term applies. Drop the final logit and shift
+    # labels/attention_mask the same way so the mask below lines up.
+    if labels is not None or attention_mask is not None:
+        student_logits = student_logits[:, :-1, :]
+        teacher_logits = teacher_logits[:, :-1, :]
+        if labels is not None:
+            labels = labels[:, 1:]
+        if attention_mask is not None:
+            attention_mask = attention_mask[:, 1:]
+
     p_s = torch.softmax(student_logits, dim=-1)
     p_t = torch.softmax(teacher_logits, dim=-1)
 
@@ -274,11 +293,14 @@ def uld_distill_loss(
         t_sorted, _ = torch.sort(p_t, dim=-1, descending=True)
         per_pos = _sorted_w1(s_sorted, t_sorted)
 
-    if attention_mask is not None:
+    if labels is not None:
+        mask = (labels != -100).to(per_pos.dtype)
+    elif attention_mask is not None:
         mask = attention_mask.to(per_pos.dtype)
-        denom = mask.sum().clamp(min=1.0)
-        return (per_pos * mask).sum() / denom
-    return per_pos.mean()
+    else:
+        return per_pos.mean()
+    denom = mask.sum().clamp(min=1.0)
+    return (per_pos * mask).sum() / denom
 
 
 class ULDProjection:
@@ -298,12 +320,13 @@ class ULDProjection:
             )
         self.config = config
 
-    def __call__(self, student_logits, teacher_logits, *, attention_mask=None):
+    def __call__(self, student_logits, teacher_logits, *, attention_mask=None, labels=None):
         return uld_distill_loss(
             student_logits,
             teacher_logits,
             config=self.config,
             attention_mask=attention_mask,
+            labels=labels,
         )
 
 
@@ -449,6 +472,7 @@ def uld_aligned_loss(
     *,
     config: ULDConfig,
     attention_mask=None,
+    labels=None,
 ):
     """Wasserstein-1 ULD loss with token-sequence alignment (v0.71.18 #258).
 
@@ -472,6 +496,12 @@ def uld_aligned_loss(
             Must have at least ``B`` entries.
         config: a :class:`ULDConfig` (strategy ``wasserstein_aligned``).
         attention_mask: optional ``[B, Ts]`` student mask (1 = real token).
+        labels: optional ``[B, Ts]`` student labels (``-100`` = not
+            supervised). Same causal shift and masking as
+            :func:`uld_distill_loss` (#682): a student token list is decoded
+            from the UNSHIFTED sequence, so position ``i`` in it is raw
+            position ``i``, letting the shift below (which only drops the
+            tail) stay aligned with the per-position alignment computed here.
     """
     import torch
 
@@ -486,6 +516,16 @@ def uld_aligned_loss(
             f"{batch} entries (logit batch dim), got "
             f"{len(student_tokens)} / {len(teacher_tokens)}"
         )
+
+    # Same causal shift as uld_distill_loss: drop the final logit (nothing
+    # to predict) and shift labels/attention_mask so the mask lines up.
+    if labels is not None or attention_mask is not None:
+        student_logits = student_logits[:, :-1, :]
+        if labels is not None:
+            labels = labels[:, 1:]
+        if attention_mask is not None:
+            attention_mask = attention_mask[:, 1:]
+
     per_seq = []
     for b in range(batch):
         align = align_token_sequences(student_tokens[b], teacher_tokens[b])
@@ -501,10 +541,13 @@ def uld_aligned_loss(
         s_sorted, _ = torch.sort(p_s, dim=-1, descending=True)
         t_sorted, _ = torch.sort(p_t, dim=-1, descending=True)
         per_pos = _sorted_w1(s_sorted, t_sorted)  # [Ts]
-        if attention_mask is not None:
+        if labels is not None:
+            mask = (labels[b, :ts] != -100).to(per_pos.dtype)
+        elif attention_mask is not None:
             mask = attention_mask[b, :ts].to(per_pos.dtype)
-            denom = mask.sum().clamp(min=1.0)
-            per_seq.append((per_pos * mask).sum() / denom)
         else:
             per_seq.append(per_pos.mean())
+            continue
+        denom = mask.sum().clamp(min=1.0)
+        per_seq.append((per_pos * mask).sum() / denom)
     return torch.stack(per_seq).mean()

--- a/tests/test_issue682_uld_loss_label_mask.py
+++ b/tests/test_issue682_uld_loss_label_mask.py
@@ -1,0 +1,220 @@
+"""ULD loss must respect the response-only label mask and causal shift (#682).
+
+The SFT cross-entropy term (``_compute_distill_term`` / the CE branch in
+``DistillTrainerWrapper.setup``'s ``compute_loss``) restricts itself to
+``labels != -100`` after a causal shift (logit position i predicts token
+i+1), which excludes prompt tokens under ``train_on_responses_only`` (the
+default) and the final, unsupervisable position. The ULD branch
+(``wasserstein`` / ``topk_align`` / ``wasserstein_aligned``) received only
+``attention_mask``, so it trained on every attended position instead,
+including prompt tokens and the shift-boundary position the CE term
+explicitly drops.
+
+These tests pin the fix at the tensor level: a position excluded by the
+shifted label mask must not move the loss, and a supervised position must.
+Perturbations touch a SINGLE vocab entry, never a whole position vector:
+adding a constant to every logit at a position is a softmax no-op, which
+would make an "excluded position" assertion trivially true either way.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestUldDistillLossLabelMask:
+    def test_prompt_position_excluded_from_wasserstein_loss(self):
+        pytest.importorskip("torch")
+        import torch
+
+        from soup_cli.utils.uld import ULDConfig, uld_distill_loss
+
+        cfg = ULDConfig(strategy="wasserstein", student_vocab_size=6, teacher_vocab_size=6)
+        torch.manual_seed(0)
+        s = torch.randn(1, 4, 6)
+        t = torch.randn(1, 4, 6)
+        # Shift drops position 3; shifted labels = [-100, 5, 2], so position 0
+        # (predicting label index 1 == -100) is excluded and positions 1-2
+        # (predicting labels 5 and 2) are supervised.
+        labels = torch.tensor([[-100, -100, 5, 2]])
+
+        base = uld_distill_loss(s, t, config=cfg, labels=labels)
+
+        excluded = s.clone()
+        excluded[0, 0, 0] += 50.0  # position 0 predicts labels[1] == -100
+        assert torch.allclose(base, uld_distill_loss(excluded, t, config=cfg, labels=labels))
+
+        included = s.clone()
+        included[0, 1, 0] += 50.0  # position 1 predicts labels[2] == 5
+        assert not torch.allclose(base, uld_distill_loss(included, t, config=cfg, labels=labels))
+
+    def test_final_position_excluded_by_causal_shift(self):
+        pytest.importorskip("torch")
+        import torch
+
+        from soup_cli.utils.uld import ULDConfig, uld_distill_loss
+
+        cfg = ULDConfig(strategy="wasserstein", student_vocab_size=6, teacher_vocab_size=6)
+        torch.manual_seed(1)
+        s = torch.randn(1, 3, 6)
+        t = torch.randn(1, 3, 6)
+        labels = torch.tensor([[-100, 5, 2]])  # every real label is supervised
+
+        base = uld_distill_loss(s, t, config=cfg, labels=labels)
+        last = s.clone()
+        last[0, 2, 0] += 50.0  # last position predicts nothing; CE drops it too
+        assert torch.allclose(base, uld_distill_loss(last, t, config=cfg, labels=labels))
+
+        earlier = s.clone()
+        earlier[0, 1, 0] += 50.0  # position 1 predicts labels[2] == 2, kept
+        assert not torch.allclose(base, uld_distill_loss(earlier, t, config=cfg, labels=labels))
+
+    def test_topk_align_respects_the_same_mask(self):
+        pytest.importorskip("torch")
+        import torch
+
+        from soup_cli.utils.uld import ULDConfig, uld_distill_loss
+
+        cfg = ULDConfig(
+            strategy="topk_align", student_vocab_size=6, teacher_vocab_size=6, top_k=3
+        )
+        torch.manual_seed(2)
+        s = torch.randn(1, 4, 6)
+        t = torch.randn(1, 4, 6)
+        labels = torch.tensor([[-100, -100, 5, 2]])
+
+        base = uld_distill_loss(s, t, config=cfg, labels=labels)
+
+        excluded = s.clone()
+        excluded[0, 0, 0] += 50.0
+        assert torch.allclose(base, uld_distill_loss(excluded, t, config=cfg, labels=labels))
+
+        included = s.clone()
+        included[0, 1, 0] += 50.0
+        assert not torch.allclose(base, uld_distill_loss(included, t, config=cfg, labels=labels))
+
+    def test_fully_masked_batch_is_finite_and_zero(self):
+        pytest.importorskip("torch")
+        import torch
+
+        from soup_cli.utils.uld import ULDConfig, uld_distill_loss
+
+        cfg = ULDConfig(strategy="wasserstein", student_vocab_size=5, teacher_vocab_size=5)
+        s = torch.randn(1, 3, 5, requires_grad=True)
+        t = torch.randn(1, 3, 5)
+        labels = torch.full((1, 3), -100)
+
+        loss = uld_distill_loss(s, t, config=cfg, labels=labels)
+        assert torch.isfinite(loss)
+        assert loss.item() == pytest.approx(0.0)
+        loss.backward()
+        assert torch.all(s.grad == 0)
+
+    def test_no_labels_or_mask_keeps_prior_unmasked_behavior(self):
+        """No labels/attention_mask given: unchanged from before #682."""
+        pytest.importorskip("torch")
+        import torch
+
+        from soup_cli.utils.uld import ULDConfig, uld_distill_loss
+
+        cfg = ULDConfig(strategy="wasserstein", student_vocab_size=6, teacher_vocab_size=6)
+        torch.manual_seed(3)
+        s = torch.randn(1, 4, 6)
+        t = torch.randn(1, 4, 6)
+        with_last = uld_distill_loss(s, t, config=cfg)
+        # No shift applied, so perturbing the final position DOES move the
+        # loss when there is no labels/attention_mask to trigger the shift.
+        perturbed = s.clone()
+        perturbed[0, 3, 0] += 50.0
+        assert not torch.allclose(with_last, uld_distill_loss(perturbed, t, config=cfg))
+
+
+class TestUldAlignedLossLabelMask:
+    def test_aligned_strategy_applies_the_label_mask(self):
+        pytest.importorskip("torch")
+        import torch
+
+        from soup_cli.utils.uld import ULDConfig, uld_aligned_loss
+
+        cfg = ULDConfig(
+            strategy="wasserstein_aligned", student_vocab_size=5, teacher_vocab_size=5
+        )
+        torch.manual_seed(4)
+        s = torch.randn(1, 3, 5)
+        t = torch.randn(1, 3, 5)
+        tokens = [["a", "b", "c"]]  # identical decode -> exact offset alignment
+        # Shift drops raw position 2; shifted labels = [7, -100], so only
+        # raw position 0 (predicting raw label index 1 == 7) is supervised.
+        labels = torch.tensor([[-100, 7, -100]])
+
+        base = uld_aligned_loss(s, t, tokens, tokens, config=cfg, labels=labels)
+
+        included = s.clone()
+        included[0, 0, 0] += 50.0
+        assert not torch.allclose(
+            base, uld_aligned_loss(included, t, tokens, tokens, config=cfg, labels=labels)
+        )
+
+        excluded = s.clone()
+        excluded[0, 1, 0] += 50.0
+        assert torch.allclose(
+            base, uld_aligned_loss(excluded, t, tokens, tokens, config=cfg, labels=labels)
+        )
+
+    def test_attention_mask_only_still_shifts_and_masks(self):
+        """No labels: attention_mask alone still drops the final position."""
+        pytest.importorskip("torch")
+        import torch
+
+        from soup_cli.utils.uld import ULDConfig, uld_aligned_loss
+
+        cfg = ULDConfig(
+            strategy="wasserstein_aligned", student_vocab_size=5, teacher_vocab_size=5
+        )
+        torch.manual_seed(5)
+        s = torch.randn(1, 3, 5)
+        t = torch.randn(1, 3, 5)
+        tokens = [["a", "b", "c"]]
+        mask = torch.tensor([[1, 1, 0]])  # position 2 is padding
+
+        base = uld_aligned_loss(s, t, tokens, tokens, config=cfg, attention_mask=mask)
+        last = s.clone()
+        last[0, 2, 0] += 50.0  # dropped by the shift regardless of the mask
+        moved = uld_aligned_loss(last, t, tokens, tokens, config=cfg, attention_mask=mask)
+        assert torch.allclose(base, moved)
+
+    def test_fully_masked_batch_is_finite_and_zero(self):
+        pytest.importorskip("torch")
+        import torch
+
+        from soup_cli.utils.uld import ULDConfig, uld_aligned_loss
+
+        cfg = ULDConfig(
+            strategy="wasserstein_aligned", student_vocab_size=5, teacher_vocab_size=5
+        )
+        s = torch.randn(1, 3, 5, requires_grad=True)
+        t = torch.randn(1, 3, 5)
+        tokens = [["a", "b", "c"]]
+        labels = torch.full((1, 3), -100)
+
+        loss = uld_aligned_loss(s, t, tokens, tokens, config=cfg, labels=labels)
+        assert torch.isfinite(loss)
+        assert loss.item() == pytest.approx(0.0)
+
+
+class TestDistillPassesLabelsToUld:
+    """Wiring: both ULD call sites in compute_loss forward ``labels`` (#682)."""
+
+    def test_source_forwards_labels_to_both_uld_call_sites(self):
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parent.parent
+        src = (repo_root / "src/soup_cli/trainer/distill.py").read_text(encoding="utf-8")
+        # A bounded window, not split(")")[0]: the call's own arguments
+        # contain a closing paren (`inputs.get("attention_mask")`), so
+        # splitting on the first ")" cuts the window before "labels=labels".
+        window = 400
+        uld_at = src.index("distill_loss = _uld_projection(")
+        assert "labels=labels" in src[uld_at : uld_at + window]
+        aligned_at = src.index("distill_loss = uld_aligned_loss(")
+        assert "labels=labels" in src[aligned_at : aligned_at + window]


### PR DESCRIPTION
Threaded the response-only label mask through the ULD branch, plus the same causal shift the CE term already applies.

`uld_distill_loss` and `uld_aligned_loss` now take an optional `labels` argument. When given, they shift logits/labels the same way `_compute_distill_term` does (position i predicts token i+1, so the last position gets dropped) and mask on `labels != -100` instead of `attention_mask`. Both `compute_loss` call sites now pass `labels`. Attention-mask-only masking still works for callers with no labels, and no labels or mask at all keeps the old unmasked behavior, so this doesn't touch the non-distill paths.

For the aligned strategy: `s_strings`/`t_strings` are decoded from the unshifted sequence, so position i in them is raw position i, and the shift lines up with the alignment those strings already produced.

Added `tests/test_issue682_uld_loss_label_mask.py`. The key trick: perturbing a whole position vector by a constant is a softmax no-op, so the tests bump a single vocab logit instead, then check that only a supervised position moves the loss (checked for all three strategies, plus the final-position drop and a fully-masked batch staying finite at zero). Ran the existing ULD/distill suites (`test_v07111.py`, `test_v07118.py`, `test_v0700_part_b.py`) too, nothing broke.

I did not run the full `DistillTrainerWrapper.compute_loss` path with a real model (would need transformers/peft/datasets, which I left out of this scoped run), and I have not matched this numerically against the gradient trace you posted on GPU. The shift-and-mask math itself is the same as `_compute_distill_term`'s, which the wider suite already exercises end to end.

Fixes #682
