### PR TITLE
fix(data): make `soup data validate` agree with the loader by running the converters

### DIFF
--- a/changelog.d/0.74.0/712.fixed.md
+++ b/changelog.d/0.74.0/712.fixed.md
@@ -1,0 +1,20 @@
+- **`soup data validate` green-lit rows that `load_dataset` then drops, because the
+  validator never ran the converters (#712 by @abdulwaarith0).**
+  `validate_and_stats` judged a row by top-level key presence against `FORMAT_SIGNATURES`,
+  while the loader runs `format_to_messages` and drops any row that returns `None`. Those
+  are different notions of "valid", so they disagreed two ways: the six formats absent from
+  `FORMAT_SIGNATURES` (`prm`, `pre_tokenized`, `input_output`, `video`, `multimodal`,
+  `raft`) skipped validation entirely and reported every row valid regardless of content,
+  and for the formats that were checked, key presence passed rows a converter drops on a
+  value — a null field, a non-dict message. `soup data validate` could report a file fully
+  valid that the loader could not load, moving the failure from validate time into the
+  middle of a training run. `valid_rows` is now computed by running the real conversion
+  path per row, so agreement is structural rather than a second, weaker check that drifts;
+  every format is covered, including the six that were skipped. When a row is dropped, the
+  converter's own reason is surfaced for the first few offenders (`row 3: chatml message
+  must be a dict`) so the report says which rows and why, not only a count. Exit-code
+  behaviour is unchanged: `validate` still exits 0 even at `0/N`, so the `soup ci init`
+  gate is unaffected; whether a `0/N` file should fail the gate is left to a separate
+  change. On the repo's own datasets this shifts 120 of 360 file-by-format verdicts, every
+  one an over-count on a file that genuinely has zero valid rows in that format, with no
+  exit code moved.

--- a/src/soup_cli/data/formats.py
+++ b/src/soup_cli/data/formats.py
@@ -77,6 +77,69 @@ def detect_format(data: list[dict]) -> str:
     )
 
 
+# Every format format_to_messages can convert. Kept as a module constant so
+# the plain and reason-returning entry points share one source of truth.
+VALID_FORMATS = (
+    "chatml", "alpaca", "sharegpt", "dpo", "kto", "llava", "sharegpt4v",
+    "plaintext", "embedding", "audio", "tool-calling",
+    # v0.42.0 Part A
+    "prm", "pre_tokenized", "input_output", "video", "multimodal",
+    # v0.62.0 Part A — RAFT (Retrieval-Augmented Fine-Tuning).
+    "raft",
+    # v0.71.32 — ASR (Whisper): {"audio": path, "text": transcript}.
+    "asr",
+)
+
+# A malformed row makes a converter raise one of these; the drop contract is
+# that format_to_messages turns them into a dropped row (None), which the
+# loader skips. Kept as a constant so validation drops rows on exactly the
+# same conditions the loader does, rather than a re-implementation that drifts.
+_DROP_EXCEPTIONS = (KeyError, TypeError, IndexError, ValueError)
+
+
+def _dispatch_conversion(row: dict, fmt: str) -> dict:
+    """Run the converter for ``fmt``, letting a malformed row raise.
+
+    Separated from :func:`format_to_messages` so callers that need the *reason*
+    a row was dropped (dataset validation) can catch the exception, rather than
+    only seeing the ``None`` that :func:`format_to_messages` returns.
+    """
+    if fmt == "chatml":
+        return _convert_chatml(row)
+    elif fmt == "alpaca":
+        return _convert_alpaca(row)
+    elif fmt == "sharegpt":
+        return _convert_sharegpt(row)
+    elif fmt == "dpo":
+        return _convert_dpo(row)
+    elif fmt == "kto":
+        return _convert_kto(row)
+    elif fmt == "plaintext":
+        return _convert_plaintext(row)
+    elif fmt == "embedding":
+        return _convert_embedding(row)
+    elif fmt == "audio":
+        return _convert_audio(row)
+    elif fmt == "tool-calling":
+        return _convert_tool_calling(row)
+    elif fmt == "prm":
+        return _convert_prm(row)
+    elif fmt == "pre_tokenized":
+        return _convert_pre_tokenized(row)
+    elif fmt == "input_output":
+        return _convert_input_output(row)
+    elif fmt == "video":
+        return _convert_video(row)
+    elif fmt == "multimodal":
+        return _convert_multimodal(row)
+    elif fmt == "raft":
+        return _convert_raft(row)
+    elif fmt == "asr":
+        return _convert_asr(row)
+    else:
+        return _convert_vision(row)
+
+
 def format_to_messages(row: dict, fmt: str) -> Optional[dict]:
     """Convert any format to normalized structure for training.
 
@@ -85,56 +148,34 @@ def format_to_messages(row: dict, fmt: str) -> Optional[dict]:
     - Vision formats: {"messages": [...], "image": "path"}
     - DPO format: {"prompt": ..., "chosen": ..., "rejected": ...}
     - KTO format: {"prompt": ..., "completion": ..., "label": bool}
+
+    A malformed row is dropped (returns ``None``) rather than raising, so one
+    bad line does not abort a whole dataset load.
     """
-    valid_formats = (
-        "chatml", "alpaca", "sharegpt", "dpo", "kto", "llava", "sharegpt4v",
-        "plaintext", "embedding", "audio", "tool-calling",
-        # v0.42.0 Part A
-        "prm", "pre_tokenized", "input_output", "video", "multimodal",
-        # v0.62.0 Part A — RAFT (Retrieval-Augmented Fine-Tuning).
-        "raft",
-        # v0.71.32 — ASR (Whisper): {"audio": path, "text": transcript}.
-        "asr",
-    )
-    if fmt not in valid_formats:
+    if fmt not in VALID_FORMATS:
         raise ValueError(f"Unknown format: {fmt}")
     try:
-        if fmt == "chatml":
-            return _convert_chatml(row)
-        elif fmt == "alpaca":
-            return _convert_alpaca(row)
-        elif fmt == "sharegpt":
-            return _convert_sharegpt(row)
-        elif fmt == "dpo":
-            return _convert_dpo(row)
-        elif fmt == "kto":
-            return _convert_kto(row)
-        elif fmt == "plaintext":
-            return _convert_plaintext(row)
-        elif fmt == "embedding":
-            return _convert_embedding(row)
-        elif fmt == "audio":
-            return _convert_audio(row)
-        elif fmt == "tool-calling":
-            return _convert_tool_calling(row)
-        elif fmt == "prm":
-            return _convert_prm(row)
-        elif fmt == "pre_tokenized":
-            return _convert_pre_tokenized(row)
-        elif fmt == "input_output":
-            return _convert_input_output(row)
-        elif fmt == "video":
-            return _convert_video(row)
-        elif fmt == "multimodal":
-            return _convert_multimodal(row)
-        elif fmt == "raft":
-            return _convert_raft(row)
-        elif fmt == "asr":
-            return _convert_asr(row)
-        else:
-            return _convert_vision(row)
-    except (KeyError, TypeError, IndexError, ValueError):
+        return _dispatch_conversion(row, fmt)
+    except _DROP_EXCEPTIONS:
         return None
+
+
+def format_to_messages_with_reason(
+    row: dict, fmt: str
+) -> tuple[Optional[dict], Optional[str]]:
+    """Like :func:`format_to_messages`, but also report why a row was dropped.
+
+    Returns ``(converted, None)`` for a good row, or ``(None, reason)`` for one
+    that :func:`format_to_messages` would drop, where ``reason`` is the
+    converter's own error message. This lets validation tell a user *which*
+    rows fail and *why*, using the exact same drop decision as the loader.
+    """
+    if fmt not in VALID_FORMATS:
+        raise ValueError(f"Unknown format: {fmt}")
+    try:
+        return _dispatch_conversion(row, fmt), None
+    except _DROP_EXCEPTIONS as exc:
+        return None, str(exc)
 
 
 def _require_str_content(value: object, field: str) -> str:

--- a/src/soup_cli/data/validator.py
+++ b/src/soup_cli/data/validator.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from typing import Optional
 
-from soup_cli.data.formats import FORMAT_SIGNATURES
+from soup_cli.data.formats import VALID_FORMATS, format_to_messages_with_reason
+
+# How many per-row drop reasons to surface in `issues`. Enough to make
+# `validate` actionable ("which rows and why") without flooding the output on a
+# file where every row is bad.
+_MAX_REASON_SAMPLES = 3
 
 
 def validate_and_stats(data: list[dict], expected_format: Optional[str] = None) -> dict:
@@ -38,20 +43,32 @@ def validate_and_stats(data: list[dict], expected_format: Optional[str] = None) 
     row_strs = [str(sorted(row.items())) for row in data]
     dup_count = len(row_strs) - len(set(row_strs))
 
-    # Validate format
+    # Validate format by running the real conversion path per row, so a row is
+    # counted invalid on exactly the conditions load_dataset would drop it. A
+    # key-presence check drifts from the converters (a row can have every
+    # required key and still be dropped, e.g. a null value or a non-dict
+    # message) and skips the formats absent from FORMAT_SIGNATURES entirely.
     issues = []
     valid_rows = len(data)
-    if expected_format and expected_format in FORMAT_SIGNATURES:
-        required = FORMAT_SIGNATURES[expected_format]
+    if expected_format and expected_format in VALID_FORMATS:
         invalid = 0
-        for row in data:
-            if not required.issubset(row.keys()):
-                invalid += 1
+        sample_reasons: list[str] = []
+        for idx, row in enumerate(data):
+            _, reason = format_to_messages_with_reason(row, expected_format)
+            if reason is None:
+                continue
+            invalid += 1
+            if len(sample_reasons) < _MAX_REASON_SAMPLES:
+                sample_reasons.append(f"row {idx}: {reason}")
         valid_rows = len(data) - invalid
         if invalid > 0:
             issues.append(
-                f"{invalid} rows missing required keys for '{expected_format}' format: {required}"
+                f"{invalid} rows fail to convert for '{expected_format}' format "
+                f"(load_dataset would drop them)"
             )
+            issues.extend(sample_reasons)
+            if invalid > len(sample_reasons):
+                issues.append(f"... and {invalid - len(sample_reasons)} more")
 
     if dup_count > 0:
         issues.append(f"{dup_count} duplicate rows found")

--- a/tests/test_issue695_validate_agrees_with_loader.py
+++ b/tests/test_issue695_validate_agrees_with_loader.py
@@ -1,0 +1,137 @@
+"""Regression tests for issue #695.
+
+`soup data validate` used to disagree with `load_dataset`: `validate_and_stats`
+validated a row by top-level key presence (`FORMAT_SIGNATURES`), while the loader
+runs `format_to_messages` and drops any row that returns `None`. Those are two
+different notions of "valid", so they drifted apart in two ways:
+
+1. Six formats are absent from `FORMAT_SIGNATURES` (`prm`, `pre_tokenized`,
+   `input_output`, `video`, `multimodal`, `raft`), so validation was skipped
+   entirely and every row was reported valid regardless of content.
+2. For the formats that were checked, key presence passed rows the converter
+   drops on a value (a null field, a non-dict message, ...).
+
+The fix computes `valid_rows` by running the real conversion path per row, so
+agreement is structural. These tests pin that: they assert `validate` and
+`load_dataset` agree on a *specific count*, not merely that some rows are
+flagged — a validator wrong in the other direction would pass the weaker form.
+"""
+
+import pytest
+
+from soup_cli.data.loader import _format_rows
+from soup_cli.data.validator import validate_and_stats
+
+# Each entry: (good_row, bad_row) where bad_row is a row the loader drops on
+# current `main`. The spread deliberately mixes:
+#   - value-level failures on FORMAT_SIGNATURES formats (alpaca/sharegpt null
+#     field) — key presence passes these, so they discriminate the fix,
+#   - a missing-key failure (chatml),
+#   - formats NOT in FORMAT_SIGNATURES (input_output/multimodal/video) — key
+#     presence skipped these entirely.
+FORMAT_CASES = {
+    "alpaca": (
+        {"instruction": "say hi", "output": "hello there"},
+        {"instruction": "x", "output": None},
+    ),
+    "sharegpt": (
+        {"conversations": [{"from": "human", "value": "hi there"}]},
+        {"conversations": [{"from": "human", "value": None}]},
+    ),
+    "chatml": (
+        {"messages": [{"role": "user", "content": "hi there"}]},
+        {"nope": "x"},
+    ),
+    "input_output": (
+        {"segments": [{"text": "hello there", "label": True}]},
+        {"segments": ["x"]},
+    ),
+    "multimodal": (
+        {"messages": [{"role": "u", "content": [{"type": "text", "text": "hi there"}]}]},
+        {"messages": ["hello"]},
+    ),
+    "video": (
+        {"video": "v.mp4", "messages": [{"role": "u", "content": "hi there"}]},
+        {"video": 123},
+    ),
+}
+
+# The formats that carried no FORMAT_SIGNATURES entry, so validation was skipped
+# for them entirely before this fix.
+SKIP_VALIDATION_FORMATS = [
+    "prm", "pre_tokenized", "input_output", "video", "multimodal", "raft",
+]
+
+
+class TestValidateAgreesWithLoader:
+    @pytest.mark.parametrize("fmt", list(FORMAT_CASES))
+    def test_valid_rows_equals_what_the_loader_keeps(self, fmt):
+        good, bad = FORMAT_CASES[fmt]
+        rows = [good] * 4 + [bad]
+
+        reported = validate_and_stats(rows, expected_format=fmt)["valid_rows"]
+        kept = len(_format_rows(rows, fmt))
+
+        # Structural agreement, on a specific count. A revert to key-presence
+        # validation reports 5 here (the bad row has its keys / is unchecked),
+        # while the loader keeps 4 — so both this equality and the == 4 fail.
+        assert reported == kept == 4
+
+    @pytest.mark.parametrize("fmt", list(FORMAT_CASES))
+    def test_all_good_file_is_fully_valid(self, fmt):
+        good, _ = FORMAT_CASES[fmt]
+        rows = [good] * 3
+
+        stats = validate_and_stats(rows, expected_format=fmt)
+        assert stats["valid_rows"] == 3
+        assert not any("fail to convert" in iss for iss in stats["issues"])
+
+
+class TestSkippedFormatsAreNowValidated:
+    """Defect 1: the six formats absent from FORMAT_SIGNATURES were never
+    validated, so a bad row was silently reported valid."""
+
+    def test_input_output_bad_row_is_counted_invalid(self):
+        rows = [{"segments": [{"text": "hello there", "label": True}]}] * 4
+        rows.append({"segments": ["not a dict"]})
+
+        stats = validate_and_stats(rows, expected_format="input_output")
+        # Before the fix this returned 5 (validation skipped for input_output).
+        assert stats["valid_rows"] == 4
+
+    @pytest.mark.parametrize("fmt", SKIP_VALIDATION_FORMATS)
+    def test_previously_skipped_format_now_matches_loader(self, fmt):
+        # A row that is missing everything is dropped by every converter, so
+        # this holds for all six without needing a per-format valid fixture.
+        rows = [{"definitely": "not valid for any format"}]
+        reported = validate_and_stats(rows, expected_format=fmt)["valid_rows"]
+        kept = len(_format_rows(rows, fmt))
+        assert reported == kept == 0
+
+
+class TestDropReasonIsSurfaced:
+    """The maintainer asked for 'which rows and why', not just a count."""
+
+    def test_reason_and_row_index_appear_in_issues(self):
+        rows = [
+            {"messages": [{"role": "u", "content": [{"type": "text", "text": "hi there"}]}]},
+            {"messages": ["hello"]},  # non-dict message -> dropped
+        ]
+        stats = validate_and_stats(rows, expected_format="multimodal")
+
+        assert stats["valid_rows"] == 1
+        # The converter's own message is shown, tied to the offending row.
+        assert any("multimodal message must be a dict" in iss for iss in stats["issues"])
+        assert any("row 1" in iss for iss in stats["issues"])
+
+    def test_reason_sample_is_capped_but_total_is_reported(self):
+        # 10 bad rows; the sample is capped but the full count is still stated.
+        rows = [{"messages": ["bad"]} for _ in range(10)]
+        stats = validate_and_stats(rows, expected_format="multimodal")
+
+        assert stats["valid_rows"] == 0
+        assert any("10 rows fail to convert" in iss for iss in stats["issues"])
+        # Capped sample + an "... and N more" line rather than 10 row lines.
+        row_lines = [iss for iss in stats["issues"] if iss.startswith("row ")]
+        assert len(row_lines) == 3
+        assert any("more" in iss for iss in stats["issues"])

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -65,14 +65,16 @@ def test_validate_format_alpaca_valid():
 
 
 def test_validate_format_alpaca_invalid():
-    """Rows missing required alpaca keys should be flagged."""
+    """Rows the converter would drop should be flagged, with the row and reason."""
     data = [
         {"instruction": "Q", "output": "A"},
         {"wrong_key": "Q2", "output": "A2"},  # missing 'instruction'
     ]
     stats = validate_and_stats(data, expected_format="alpaca")
     assert stats["valid_rows"] == 1
-    assert any("missing required keys" in iss for iss in stats["issues"])
+    assert any("fail to convert" in iss for iss in stats["issues"])
+    # The specific offending row is surfaced so `validate` is actionable.
+    assert any("row 1" in iss for iss in stats["issues"])
 
 
 def test_validate_short_samples():


### PR DESCRIPTION
Fixes #695.

## What was wrong

`validate_and_stats` judged a row by top-level key presence against `FORMAT_SIGNATURES`, while `load_dataset` runs `format_to_messages` and drops any row that returns `None`. Two different notions of "valid", so they disagreed two ways:

1. The six formats absent from `FORMAT_SIGNATURES` (`prm`, `pre_tokenized`, `input_output`, `video`, `multimodal`, `raft`) skipped validation entirely and reported every row valid regardless of content.
2. For the checked formats, key presence passed rows a converter drops on a *value* — a null field, a non-dict message.

So `soup data validate` could report a file fully valid that the loader then can't load, moving the failure from validate time into the middle of a training run.

## The fix

- `valid_rows` is computed by running the real conversion path per row (`format_to_messages_with_reason`), so agreement with the loader is **structural**, not a second check that drifts. Every format is covered, including the six that were skipped.
- When a row is dropped, the converter's own reason is surfaced for the first few offenders (`row 3: chatml message must be a dict`) plus `... and N more`, so the report says which rows and why.
- **Exit-code behaviour is unchanged**: `validate` still exits 0 even at `0/N`, so the `soup ci init` gate is unaffected. Whether `0/N` should fail the gate is a separate question, left out of this PR.
- `format_to_messages` gains a `with_reason` variant that shares one dispatch and one drop-exception set with it; `format_to_messages`'s own behaviour is unchanged.

## Measurements (as requested on the issue)

**Agreement.** Across 360 file×format combos over the repo's own datasets, `validate` and `load_dataset` now agree on the count in **all 360** (0 mismatches).

**Over-reach.** vs the old validator, 120 of 360 verdicts change — every one an over-count reduced to the loader's true count (`N -> 0` on a file that genuinely has zero valid rows in that format), all in the six formats that previously skipped validation. No exit code moves in any combo.

**Cost.** 50k rows, best of three: `alpaca` 0.20s, `chatml` 0.33s — on par with the old key-presence version (the per-row stats already dominate; conversion adds negligible overhead).

**Test bar.** Tests assert `validate` and `load_dataset` agree on a *specific count*, not merely that some rows are flagged. Reverting the validator to key presence fails 14 of the 21 new tests.

## Notes

- Built against current `main`; if #678 lands first the only overlap is a few lines in `validator.py`.
- `tests/test_validator.py::test_validate_format_alpaca_invalid` is updated from the old key-presence message to the new "fail to convert" message and now also asserts the surfaced row/reason — strictly stronger, no assertion removed.
