### PR TITLE
feat(ci): resolve every recipe model id on a schedule (#677)

### DIFF
--- a/.github/workflows/recipe-repo-ids.yml
+++ b/.github/workflows/recipe-repo-ids.yml
@@ -1,0 +1,43 @@
+# Recipe repo-id resolution (#677).
+#
+# The catalog names a Hugging Face repo in two places per recipe --
+# `RecipeMeta.model` and the YAML `base:` -- and nothing checked that either
+# resolves. #661 found two that did not, both shipped and released:
+# `validate-recipes` parses the YAML through the real schema, and a nonexistent
+# repo id is a perfectly well-formed string.
+#
+# Deliberately NOT a pull-request gate. Resolving 160+ ids on every PR would
+# make an unrelated docs change depend on Hub availability and rate limits, and
+# a job that goes red for reasons unrelated to the diff is one people learn to
+# re-run rather than read. Repos disappear on a timescale of months, so weekly
+# finds it long before a user does.
+name: recipe repo ids
+
+on:
+  schedule:
+    # Mondays, 07:00 UTC -- an hour after dependency-drift so the two do not
+    # contend for the same Hub rate limit.
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  resolve:
+    name: resolve every recipe model id anonymously
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install the catalog and the Hub client only
+        # Not `.[dev]`: this needs the recipe catalog and huggingface_hub, not
+        # the PyTorch stack. A lighter install is also a faster scheduled job.
+        run: pip install -e . huggingface-hub pyyaml
+      - name: Resolve
+        # No HF_TOKEN in scope, deliberately and by omission: a token would
+        # resolve gated repos as EXISTS and hide the very case this guards.
+        # The script also refuses to run if one is set.
+        run: python scripts/check_recipe_repo_ids.py

--- a/.github/workflows/recipe-repo-ids.yml
+++ b/.github/workflows/recipe-repo-ids.yml
@@ -11,6 +11,12 @@
 # a job that goes red for reasons unrelated to the diff is one people learn to
 # re-run rather than read. Repos disappear on a timescale of months, so weekly
 # finds it long before a user does.
+#
+# Measured cost, 2026-09-06, unauthenticated against the live Hub:
+#   165 recipes / 330 surfaces / 118 unique ids after de-duplication (64% saved)
+#   29.8 s wall clock, 239 ms median, 340 ms p95, 0 rate limits
+# De-duplication matters because gated bases are shared: 18 unique gated ids
+# cover 68 of the 330 surfaces. Without it the sweep is ~83 s.
 name: recipe repo ids
 
 on:
@@ -20,6 +26,7 @@ on:
     - cron: "0 7 * * 1"
   workflow_dispatch:
 
+# Never add a pull_request trigger here.
 permissions:
   contents: read
 

--- a/scripts/check_recipe_repo_ids.py
+++ b/scripts/check_recipe_repo_ids.py
@@ -80,6 +80,7 @@ def classify_repo(
     repo_id: str,
     *,
     not_found: type[BaseException],
+    gated: type[BaseException] | None = None,
     attempts: int = _DEFAULT_ATTEMPTS,
     backoff: float = _DEFAULT_BACKOFF,
 ) -> RepoCheck:
@@ -91,11 +92,26 @@ def classify_repo(
 
     A ``RepositoryNotFoundError`` is a definite answer and is **not** retried;
     retrying it would burn the attempt budget that transient failures need.
+
+    ``gated`` **must** be caught before ``not_found``, because
+    ``GatedRepoError`` is a *subclass* of ``RepositoryNotFoundError`` in
+    ``huggingface_hub``::
+
+        GatedRepoError MRO: GatedRepoError -> RepositoryNotFoundError -> ...
+
+    Ordered the other way, ``except not_found`` swallows the gated answer and
+    every gated repo classifies MISSING -- the exact failure that gets a guard
+    like this muted. It does not show up in a live sweep today because the Hub
+    currently serves gated *metadata* anonymously, so those ids take the
+    returning path and ``info.gated`` is read instead. One org changing
+    metadata visibility would flip them all to the raising path.
     """
     last_detail = ""
     for attempt in range(1, max(1, attempts) + 1):
         try:
             info = api.model_info(repo_id)
+        except (gated or ()) as exc:  # MUST precede not_found -- see docstring
+            return RepoCheck(repo_id, Status.GATED, str(exc)[:200])
         except not_found as exc:
             return RepoCheck(repo_id, Status.MISSING, str(exc)[:200])
         except Exception as exc:  # noqa: BLE001 -- anything else may be transient
@@ -127,6 +143,7 @@ def check_surfaces(
     *,
     api: Any,
     not_found: type[BaseException],
+    gated: type[BaseException] | None = None,
     attempts: int = _DEFAULT_ATTEMPTS,
     backoff: float = _DEFAULT_BACKOFF,
 ) -> dict[str, RecipeReport]:
@@ -136,7 +153,8 @@ def check_surfaces(
     def _check(repo_id: str) -> RepoCheck:
         if repo_id not in cache:
             cache[repo_id] = classify_repo(
-                api, repo_id, not_found=not_found, attempts=attempts, backoff=backoff
+                api, repo_id, not_found=not_found, gated=gated,
+                attempts=attempts, backoff=backoff,
             )
         return cache[repo_id]
 
@@ -215,11 +233,29 @@ def format_report(report: dict[str, RecipeReport]) -> str:
     return "\n".join(lines)
 
 
-def main() -> int:
-    from huggingface_hub.errors import RepositoryNotFoundError
+def main(
+    *,
+    not_found: type[BaseException] | None = None,
+    gated: type[BaseException] | None = None,
+) -> int:
+    """Resolve the catalog and return a process exit code.
+
+    The exception classes are injectable for the same reason ``classify_repo``
+    takes them: it keeps the exit-code contract testable without the Hub, and
+    without constructing real ``huggingface_hub`` errors (which need a live
+    response object). Defaults are the real classes.
+    """
+    if not_found is None or gated is None:
+        from huggingface_hub.errors import GatedRepoError, RepositoryNotFoundError
+
+        not_found = not_found or RepositoryNotFoundError
+        gated = gated or GatedRepoError
 
     report = check_surfaces(
-        collect_recipe_repo_ids(), api=_anonymous_api(), not_found=RepositoryNotFoundError
+        collect_recipe_repo_ids(),
+        api=_anonymous_api(),
+        not_found=not_found,
+        gated=gated,
     )
     print(format_report(report))
     # Exit non-zero ONLY for genuinely missing repos. An unverified run is not a

--- a/scripts/check_recipe_repo_ids.py
+++ b/scripts/check_recipe_repo_ids.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Resolve every shipped recipe's Hugging Face repo id, anonymously (#677).
+
+The catalog names a repo in two independent places per recipe -- ``RecipeMeta.model``
+and the YAML ``base:`` -- and until now nothing checked that either resolves.
+#661 found two that did not; both had shipped and been released, because
+``validate-recipes`` parses the YAML through the real schema and a nonexistent
+repo id is a perfectly well-formed string.
+
+Three things this deliberately does NOT do, each of which would make the guard
+worse than nothing:
+
+**It does not treat a status code as evidence.** An invented repo id returns the
+same ``401`` from the Hub API as a real private one -- the mistake made in #661
+before that report was worth filing. The authoritative signal is
+``huggingface_hub``'s ``RepositoryNotFoundError``.
+
+**It does not report gated repos.** A gated repo (``meta-llama/*``, ``google/gemma-*``)
+resolves for an authorised user and refuses an anonymous one. Reporting those
+would fire forever on correct recipes, and a guard that cries wolf gets muted.
+``model_info`` exposes ``gated``; this reads it rather than inferring.
+
+**It does not report a transient failure as a missing repo.** Timeouts, 5xx and
+rate limits classify as UNVERIFIED -- "could not check" -- after retries. A bad
+minute at the Hub must not become a bug report.
+
+Run by ``.github/workflows/recipe-repo-ids.yml`` on a schedule. Never on pull
+requests: 163 network calls per PR would make every unrelated change depend on
+Hub availability.
+"""
+
+from __future__ import annotations
+
+import enum
+import os
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any
+
+_DEFAULT_ATTEMPTS = 3
+_DEFAULT_BACKOFF = 2.0
+
+
+class Status(enum.Enum):
+    """Four outcomes, not two. Collapsing GATED or UNVERIFIED into MISSING is
+    what turns this from a guard into noise."""
+
+    EXISTS = "exists"
+    GATED = "gated"
+    MISSING = "missing"
+    UNVERIFIED = "unverified"
+
+
+@dataclass(frozen=True)
+class RepoCheck:
+    repo_id: str
+    status: Status
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class SurfacePair:
+    """The two places a recipe names its model. Both are checked because #666's
+    mutation testing showed the snapshot guard sees only the YAML half, so a
+    wrong ``RecipeMeta.model`` slips past everything else."""
+
+    meta_model: str
+    yaml_base: str
+
+
+@dataclass(frozen=True)
+class RecipeReport:
+    meta: RepoCheck
+    yaml: RepoCheck
+
+
+def classify_repo(
+    api: Any,
+    repo_id: str,
+    *,
+    not_found: type[BaseException],
+    attempts: int = _DEFAULT_ATTEMPTS,
+    backoff: float = _DEFAULT_BACKOFF,
+) -> RepoCheck:
+    """Resolve one repo id into exactly one :class:`Status`.
+
+    ``not_found`` is injected rather than imported at module scope so the
+    classification logic is testable without ``huggingface_hub`` installed and
+    without touching the network.
+
+    A ``RepositoryNotFoundError`` is a definite answer and is **not** retried;
+    retrying it would burn the attempt budget that transient failures need.
+    """
+    last_detail = ""
+    for attempt in range(1, max(1, attempts) + 1):
+        try:
+            info = api.model_info(repo_id)
+        except not_found as exc:
+            return RepoCheck(repo_id, Status.MISSING, str(exc)[:200])
+        except Exception as exc:  # noqa: BLE001 -- anything else may be transient
+            last_detail = f"{type(exc).__name__}: {str(exc)[:160]}"
+            if attempt < attempts:
+                time.sleep(backoff * attempt)
+            continue
+        if getattr(info, "gated", False):
+            return RepoCheck(repo_id, Status.GATED, "gated; resolves for an authorised user")
+        return RepoCheck(repo_id, Status.EXISTS, "")
+    return RepoCheck(repo_id, Status.UNVERIFIED, last_detail)
+
+
+def collect_recipe_repo_ids() -> dict[str, SurfacePair]:
+    """Both model-id surfaces for every recipe in the shipped catalog."""
+    import yaml as _yaml
+
+    from soup_cli.recipes.catalog import RECIPES
+
+    out: dict[str, SurfacePair] = {}
+    for name, meta in RECIPES.items():
+        parsed = _yaml.safe_load(meta.yaml_str) or {}
+        out[name] = SurfacePair(meta_model=meta.model, yaml_base=parsed.get("base", ""))
+    return out
+
+
+def check_surfaces(
+    surfaces: dict[str, Any],
+    *,
+    api: Any,
+    not_found: type[BaseException],
+    attempts: int = _DEFAULT_ATTEMPTS,
+    backoff: float = _DEFAULT_BACKOFF,
+) -> dict[str, RecipeReport]:
+    """Resolve every surface, caching by id so a shared base is fetched once."""
+    cache: dict[str, RepoCheck] = {}
+
+    def _check(repo_id: str) -> RepoCheck:
+        if repo_id not in cache:
+            cache[repo_id] = classify_repo(
+                api, repo_id, not_found=not_found, attempts=attempts, backoff=backoff
+            )
+        return cache[repo_id]
+
+    report: dict[str, RecipeReport] = {}
+    for name, pair in surfaces.items():
+        if isinstance(pair, SurfacePair):
+            meta_id, yaml_id = pair.meta_model, pair.yaml_base
+        else:                       # a plain (meta, yaml) tuple, used by tests
+            meta_id, yaml_id = pair
+        report[name] = RecipeReport(meta=_check(meta_id), yaml=_check(yaml_id))
+    return report
+
+
+def missing_only(report: dict[str, RecipeReport]) -> list[str]:
+    """Recipes with a genuinely nonexistent id on either surface."""
+    return sorted(
+        name for name, rec in report.items()
+        if Status.MISSING in (rec.meta.status, rec.yaml.status)
+    )
+
+
+def unverified_only(report: dict[str, RecipeReport]) -> list[str]:
+    """Recipes the Hub could not answer for. Reported separately, never as
+    missing, and never a failure on their own."""
+    return sorted(
+        name for name, rec in report.items()
+        if Status.MISSING not in (rec.meta.status, rec.yaml.status)
+        and Status.UNVERIFIED in (rec.meta.status, rec.yaml.status)
+    )
+
+
+def _anonymous_api():
+    """A Hub client with authentication explicitly off.
+
+    ``HF_TOKEN`` in the environment would silently resolve gated repos as
+    EXISTS, so the guard would go quiet exactly where a wrong id is most likely
+    to hide. Refusing is better than reporting a result that means something
+    different from what it says.
+    """
+    from huggingface_hub import HfApi
+
+    for var in ("HF_TOKEN", "HUGGING_FACE_HUB_TOKEN", "HUGGINGFACEHUB_API_TOKEN"):
+        if os.environ.get(var):
+            raise SystemExit(
+                f"{var} is set. This check must run anonymously: a token turns "
+                "every gated repo into EXISTS and hides the case the guard is for."
+            )
+    return HfApi(token=False)
+
+
+def format_report(report: dict[str, RecipeReport]) -> str:
+    missing, unverified = missing_only(report), unverified_only(report)
+    counts: dict[Status, int] = {s: 0 for s in Status}
+    for rec in report.values():
+        for check in (rec.meta, rec.yaml):
+            counts[check.status] += 1
+
+    lines = [
+        f"checked {len(report)} recipes / {sum(counts.values())} surfaces",
+        "  " + "  ".join(f"{s.value}={counts[s]}" for s in Status),
+        "",
+    ]
+    if missing:
+        lines.append(f"MISSING — {len(missing)} recipe(s) name a repo that does not exist:")
+        for name in missing:
+            rec = report[name]
+            for label, check in (("RecipeMeta.model", rec.meta), ("YAML base:", rec.yaml)):
+                if check.status is Status.MISSING:
+                    lines.append(f"  {name}: {label} -> {check.repo_id}")
+    else:
+        lines.append("MISSING — none")
+    if unverified:
+        lines += ["", f"COULD NOT CHECK — {len(unverified)} recipe(s), not a failure:"]
+        lines += [f"  {name}: {report[name].meta.detail or report[name].yaml.detail}"
+                  for name in unverified]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    from huggingface_hub.errors import RepositoryNotFoundError
+
+    report = check_surfaces(
+        collect_recipe_repo_ids(), api=_anonymous_api(), not_found=RepositoryNotFoundError
+    )
+    print(format_report(report))
+    # Exit non-zero ONLY for genuinely missing repos. An unverified run is not a
+    # failure: making it one would mean a Hub outage reads as a broken catalog.
+    return 1 if missing_only(report) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_issue677_recipe_repo_id_guard.py
+++ b/tests/test_issue677_recipe_repo_id_guard.py
@@ -21,6 +21,8 @@ classification logic is pinned without depending on Hub availability.
 
 from __future__ import annotations
 
+import pytest
+
 
 class _NotFoundError(Exception):
     """Stand-in for huggingface_hub.errors.RepositoryNotFoundError."""
@@ -102,14 +104,64 @@ class TestClassification:
 
         assert len(api.calls) == 1
 
-    def test_negative_control_an_invented_id_is_missing(self):
-        """The acceptance criterion: the checker must be provably able to fail."""
+    def test_a_gated_repo_that_raises_is_still_gated(self):
+        """`GatedRepoError` SUBCLASSES `RepositoryNotFoundError`, so
+        `except not_found` swallows it and every gated repo classifies MISSING
+        unless the gated handler comes first.
+
+        The other gated test pins the path where `model_info` *returns* with
+        `info.gated` truthy. A live sweep only exercises that path today,
+        because the Hub currently serves gated metadata anonymously -- which is
+        why this went unnoticed in a run that otherwise looked complete.
+        """
         from scripts.check_recipe_repo_ids import Status, classify_repo
 
-        api = _FakeApi({"zz-invented/does-not-exist-xyz": _NotFoundError("404")})
-        result = classify_repo(api, "zz-invented/does-not-exist-xyz", not_found=_NotFoundError)
+        class _GatedError(_NotFoundError):      # the real subclass relationship
+            pass
 
-        assert result.status is Status.MISSING
+        api = _FakeApi({"meta-llama/Llama-3.1-8B-Instruct": _GatedError("gated")})
+        result = classify_repo(
+            api, "meta-llama/Llama-3.1-8B-Instruct",
+            not_found=_NotFoundError, gated=_GatedError, attempts=1, backoff=0,
+        )
+
+        assert result.status is Status.GATED, (
+            "a raising gated repo classified MISSING: the gated handler must "
+            "precede not_found, since GatedRepoError subclasses it"
+        )
+
+    def test_the_real_hub_classes_are_still_subclassed_that_way(self):
+        """Pin the upstream fact the ordering depends on, against the installed
+        library, so an un-nesting upstream says so rather than going stale."""
+        hub_errors = pytest.importorskip("huggingface_hub.errors")
+
+        assert issubclass(hub_errors.GatedRepoError, hub_errors.RepositoryNotFoundError), (
+            "GatedRepoError no longer subclasses RepositoryNotFoundError; the "
+            "except-ordering in classify_repo was written for that relationship"
+        )
+
+    def test_negative_control_an_invented_id_is_missing(self):
+        """The acceptance criterion: the checker must be provably able to fail.
+
+        Independent of `test_repository_not_found_is_missing` rather than a
+        restatement of it -- this drives the id through the whole pipeline
+        (collector shape, `check_surfaces`, `missing_only`), so a checker that
+        classified correctly but reported nothing would still fail here.
+        """
+        from scripts.check_recipe_repo_ids import check_surfaces, missing_only
+
+        api = _FakeApi({
+            "real/model": _Info(),
+            "zz-invented/does-not-exist-xyz": _NotFoundError("404"),
+        })
+        report = check_surfaces(
+            {"fine": ("real/model", "real/model"),
+             "broken": ("zz-invented/does-not-exist-xyz",
+                        "zz-invented/does-not-exist-xyz")},
+            api=api, not_found=_NotFoundError,
+        )
+
+        assert missing_only(report) == ["broken"]
 
 
 class TestBothSurfacesAreCovered:
@@ -182,27 +234,210 @@ class TestReporting:
 
 
 class TestTheWorkflow:
-    """Constraint 3: it must not run in the PR matrix."""
+    """Constraint 3: it must not run in the PR matrix.
 
-    def _workflow(self):
+    Parses the triggers rather than scanning the file for the substring, which
+    fired on correct code: adding the comment "Never add a pull_request trigger
+    here." failed the old version. A guard that goes red on a correct change is
+    one that gets deleted — the #404 lesson. Follows the in-repo precedent at
+    tests/test_recipes_v031.py, which reads `parsed.get(True) or parsed.get("on")`
+    because YAML parses a bare `on:` key as the boolean True.
+    """
+
+    def _triggers(self):
         from pathlib import Path
+
+        import yaml
 
         path = Path(__file__).parents[1] / ".github/workflows/recipe-repo-ids.yml"
         assert path.is_file(), "the scheduled workflow is missing"
-        return path.read_text(encoding="utf-8")
+        parsed = yaml.safe_load(path.read_text(encoding="utf-8"))
+        triggers = parsed.get(True) or parsed.get("on")
+        assert isinstance(triggers, dict), f"unexpected trigger shape: {triggers!r}"
+        return triggers
 
     def test_it_is_scheduled(self):
-        assert "schedule:" in self._workflow()
-        assert "cron:" in self._workflow()
+        triggers = self._triggers()
+        assert "schedule" in triggers
+        assert any("cron" in entry for entry in triggers["schedule"])
 
     def test_it_can_be_run_by_hand(self):
-        assert "workflow_dispatch:" in self._workflow()
+        assert "workflow_dispatch" in self._triggers()
 
     def test_it_does_not_run_on_pull_requests(self):
-        """Asserted rather than trusted: 163 network calls per PR would make
-        every unrelated change depend on Hub availability."""
-        text = self._workflow()
-        assert "pull_request" not in text, (
-            "this job must never be a PR gate — a docs PR going red because the "
-            "Hub had a bad minute trains people to re-run rather than to read"
+        """163 network calls per PR would make every unrelated change depend on
+        Hub availability. `pull_request_target` and `push` are checked too —
+        either would put this on the critical path just as effectively."""
+        triggers = self._triggers()
+        for forbidden in ("pull_request", "pull_request_target", "push"):
+            assert forbidden not in triggers, (
+                f"{forbidden!r} would put this sweep on the critical path of "
+                "unrelated changes"
+            )
+
+    def test_it_asks_for_no_write_permissions(self):
+        from pathlib import Path
+
+        import yaml
+
+        path = Path(__file__).parents[1] / ".github/workflows/recipe-repo-ids.yml"
+        perms = yaml.safe_load(path.read_text(encoding="utf-8")).get("permissions", {})
+        assert perms == {"contents": "read"}, (
+            f"a read-only check must not hold write scopes: {perms!r}"
+        )
+
+
+class TestTheAnonymousClient:
+    """`_anonymous_api()` — untested, and it is the guard on the guard."""
+
+    @pytest.mark.parametrize(
+        "var", ["HF_TOKEN", "HUGGING_FACE_HUB_TOKEN", "HUGGINGFACEHUB_API_TOKEN"]
+    )
+    def test_it_refuses_when_a_token_is_in_scope(self, monkeypatch, var):
+        """A token resolves gated repos as EXISTS, so the guard goes quiet
+        exactly where a wrong id is most likely to hide. Refusing beats
+        returning a result that means something different from what it says."""
+        from scripts.check_recipe_repo_ids import _anonymous_api
+
+        monkeypatch.setenv(var, "hf_notarealtoken")
+        with pytest.raises(SystemExit, match=var):
+            _anonymous_api()
+
+    def test_the_client_it_returns_has_authentication_off(self, monkeypatch):
+        """`token=False` also neutralises a cached ~/.cache/huggingface/token,
+        which the env-var check alone would miss."""
+        pytest.importorskip("huggingface_hub")
+        from scripts.check_recipe_repo_ids import _anonymous_api
+
+        for var in ("HF_TOKEN", "HUGGING_FACE_HUB_TOKEN", "HUGGINGFACEHUB_API_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
+
+        assert _anonymous_api().token is False
+
+
+class TestTheExitCode:
+    """Requirement 7 — "fails the job" — and the property that a Hub outage
+    must NOT fail it. Both were asserted only in a code comment."""
+
+    def _run_main(self, monkeypatch, answers, surfaces):
+        import scripts.check_recipe_repo_ids as mod
+
+        monkeypatch.setattr(mod, "_anonymous_api", lambda: _FakeApi(answers))
+        monkeypatch.setattr(mod, "collect_recipe_repo_ids", lambda: surfaces)
+        monkeypatch.setattr(mod, "_DEFAULT_ATTEMPTS", 1)
+        monkeypatch.setattr(mod, "_DEFAULT_BACKOFF", 0)
+
+        class _GatedError(_NotFoundError):
+            pass
+
+        return mod.main(not_found=_NotFoundError, gated=_GatedError)
+
+    def test_main_returns_1_when_a_repo_is_missing(self, monkeypatch):
+        code = self._run_main(
+            monkeypatch,
+            {"bad/gone": _NotFoundError("404")},
+            {"r": ("bad/gone", "bad/gone")},
+        )
+        assert code == 1, "a missing repo must fail the scheduled job"
+
+    def test_main_returns_0_when_everything_resolves(self, monkeypatch):
+        code = self._run_main(
+            monkeypatch, {"ok/real": _Info()}, {"r": ("ok/real", "ok/real")}
+        )
+        assert code == 0
+
+    def test_an_unverified_only_run_does_not_fail(self, monkeypatch):
+        """The load-bearing property. If a timeout fails the job, a bad minute
+        at the Hub reads as a broken catalog and the guard gets muted."""
+        code = self._run_main(
+            monkeypatch,
+            {"flaky/one": TimeoutError("read timed out")},
+            {"r": ("flaky/one", "flaky/one")},
+        )
+        assert code == 0, "a Hub outage must not read as a broken catalog"
+
+
+class TestTheReport:
+    """`format_report` — every line of it was uncovered."""
+
+    def _report(self):
+        from scripts.check_recipe_repo_ids import check_surfaces
+
+        api = _FakeApi({
+            "ok/real": _Info(),
+            "bad/gone": _NotFoundError("404"),
+            "flaky/one": TimeoutError("read timed out"),
+        })
+        return check_surfaces(
+            {"good-recipe": ("ok/real", "ok/real"),
+             "broken-recipe": ("bad/gone", "ok/real"),
+             "flaky-recipe": ("flaky/one", "ok/real")},
+            api=api, not_found=_NotFoundError, attempts=1, backoff=0,
+        )
+
+    def test_it_names_the_broken_recipe_and_the_surface(self):
+        from scripts.check_recipe_repo_ids import format_report
+
+        text = format_report(self._report())
+        assert "broken-recipe" in text, "a report that omits the name is unusable"
+        assert "RecipeMeta.model" in text, "the reader must know WHICH surface"
+        assert "bad/gone" in text
+
+    def test_it_does_not_name_a_healthy_recipe_as_missing(self):
+        """Reject-everything control."""
+        from scripts.check_recipe_repo_ids import format_report
+
+        missing_section = format_report(self._report()).split("COULD NOT CHECK")[0]
+        assert "good-recipe" not in missing_section
+
+    def test_it_reports_could_not_check_separately(self):
+        from scripts.check_recipe_repo_ids import format_report
+
+        text = format_report(self._report())
+        assert "COULD NOT CHECK" in text
+        assert "flaky-recipe" in text.split("COULD NOT CHECK")[1]
+
+
+class TestTheProductionCollectorPath:
+    """Every other test feeds plain tuples, so `check_surfaces`' real
+    `SurfacePair` branch — the one production uses — was uncovered."""
+
+    def test_real_surface_pairs_flow_through_check_surfaces(self):
+        from scripts.check_recipe_repo_ids import (
+            Status,
+            check_surfaces,
+            collect_recipe_repo_ids,
+        )
+
+        surfaces = collect_recipe_repo_ids()
+        ids = {p.meta_model for p in surfaces.values()} | {p.yaml_base for p in surfaces.values()}
+        api = _FakeApi({repo_id: _Info() for repo_id in ids})
+
+        report = check_surfaces(surfaces, api=api, not_found=_NotFoundError)
+
+        assert len(report) == len(surfaces)
+        assert all(r.meta.status is Status.EXISTS for r in report.values())
+
+    def test_a_divergent_yaml_base_is_actually_read(self, monkeypatch):
+        """Kills the mutant that mirrors `meta.model` into `yaml_base`.
+
+        Every shipped recipe currently has `meta.model == yaml base`, so that
+        mutation changes no output today — but it would mean the collector had
+        stopped reading the YAML at all, and divergence is the exact case the
+        two-surface design exists for (#661 found it on the meta surface).
+        """
+        from scripts.check_recipe_repo_ids import collect_recipe_repo_ids
+
+        class _Meta:
+            model = "org/from-meta"
+            yaml_str = "base: org/from-yaml\ntask: sft\n"
+
+        import soup_cli.recipes.catalog as catalog
+
+        monkeypatch.setattr(catalog, "RECIPES", {"synthetic": _Meta()})
+        pair = collect_recipe_repo_ids()["synthetic"]
+
+        assert pair.meta_model == "org/from-meta"
+        assert pair.yaml_base == "org/from-yaml", (
+            "the collector mirrored RecipeMeta.model instead of parsing the YAML"
         )

--- a/tests/test_issue677_recipe_repo_id_guard.py
+++ b/tests/test_issue677_recipe_repo_id_guard.py
@@ -1,0 +1,208 @@
+"""#677 — nothing checks that a shipped recipe's model id actually resolves.
+
+#661 found two that did not, both released. `validate-recipes` stayed green
+because a nonexistent repo id is a perfectly well-formed string.
+
+Three constraints from the issue, each of which makes the guard worse than
+nothing if got wrong, and each pinned below:
+
+1. **A bare 401 is not evidence.** An invented repo returns the same 401 as a
+   real private one — the mistake I made in #661 before it was worth filing.
+   The authoritative signal is `huggingface_hub`'s `RepositoryNotFoundError`
+   against an explicitly unauthenticated client.
+2. **Missing and gated are different, and only one is a bug.** A guard that
+   reports every gated Llama repo forever is one people mute.
+3. **A transient failure is not a missing repo.** Reported as one, the job
+   becomes noise and gets ignored — the #404 lesson.
+
+No test here touches the network: the Hub client is a fake, so the
+classification logic is pinned without depending on Hub availability.
+"""
+
+from __future__ import annotations
+
+
+class _NotFoundError(Exception):
+    """Stand-in for huggingface_hub.errors.RepositoryNotFoundError."""
+
+
+class _Info:
+    def __init__(self, gated=False, private=False):
+        self.gated = gated
+        self.private = private
+
+
+class _FakeApi:
+    """A Hub client with scripted answers. Records calls so a test can assert
+    the checker retried rather than classified on the first blip."""
+
+    def __init__(self, answers):
+        self._answers = answers
+        self.calls = []
+
+    def model_info(self, repo_id, **kwargs):
+        self.calls.append(repo_id)
+        answer = self._answers[repo_id]
+        if isinstance(answer, list):
+            answer = answer.pop(0)
+        if isinstance(answer, Exception):
+            raise answer
+        return answer
+
+
+class TestClassification:
+    def test_a_real_public_repo_is_exists(self):
+        from scripts.check_recipe_repo_ids import Status, classify_repo
+
+        api = _FakeApi({"org/model": _Info()})
+        assert classify_repo(api, "org/model", not_found=_NotFoundError).status is Status.EXISTS
+
+    def test_a_gated_repo_is_gated_not_missing(self):
+        """The direction that would make the guard permanently noisy."""
+        from scripts.check_recipe_repo_ids import Status, classify_repo
+
+        api = _FakeApi({"meta-llama/Llama-3.1-8B-Instruct": _Info(gated=True)})
+        result = classify_repo(api, "meta-llama/Llama-3.1-8B-Instruct", not_found=_NotFoundError)
+
+        assert result.status is Status.GATED
+        assert result.status is not Status.MISSING
+
+    def test_repository_not_found_is_missing(self):
+        from scripts.check_recipe_repo_ids import Status, classify_repo
+
+        api = _FakeApi({"org/gone": _NotFoundError("404")})
+        assert classify_repo(api, "org/gone", not_found=_NotFoundError).status is Status.MISSING
+
+    def test_a_transient_failure_is_unverified_not_missing(self):
+        """Constraint 3. A timeout reported as "missing" is how this becomes noise."""
+        from scripts.check_recipe_repo_ids import Status, classify_repo
+
+        api = _FakeApi({"org/flaky": TimeoutError("read timed out")})
+        result = classify_repo(api, "org/flaky", not_found=_NotFoundError, attempts=2, backoff=0)
+
+        assert result.status is Status.UNVERIFIED
+        assert result.status is not Status.MISSING
+
+    def test_a_transient_failure_is_retried_before_giving_up(self):
+        """One bad minute must not be one bad report."""
+        from scripts.check_recipe_repo_ids import Status, classify_repo
+
+        api = _FakeApi({"org/blip": [TimeoutError("blip"), _Info()]})
+        result = classify_repo(api, "org/blip", not_found=_NotFoundError, attempts=3, backoff=0)
+
+        assert result.status is Status.EXISTS
+        assert len(api.calls) == 2, "must retry a transient failure, not classify it"
+
+    def test_not_found_is_not_retried(self):
+        """A 404 is a definite answer; retrying it wastes the whole budget."""
+        from scripts.check_recipe_repo_ids import classify_repo
+
+        api = _FakeApi({"org/gone": _NotFoundError("404")})
+        classify_repo(api, "org/gone", not_found=_NotFoundError, attempts=3, backoff=0)
+
+        assert len(api.calls) == 1
+
+    def test_negative_control_an_invented_id_is_missing(self):
+        """The acceptance criterion: the checker must be provably able to fail."""
+        from scripts.check_recipe_repo_ids import Status, classify_repo
+
+        api = _FakeApi({"zz-invented/does-not-exist-xyz": _NotFoundError("404")})
+        result = classify_repo(api, "zz-invented/does-not-exist-xyz", not_found=_NotFoundError)
+
+        assert result.status is Status.MISSING
+
+
+class TestBothSurfacesAreCovered:
+    def test_every_recipe_contributes_meta_and_yaml_ids(self):
+        from scripts.check_recipe_repo_ids import collect_recipe_repo_ids
+
+        surfaces = collect_recipe_repo_ids()
+
+        assert len(surfaces) > 100, "the whole catalog, not a sample"
+        for name, pair in surfaces.items():
+            assert pair.meta_model, f"{name} has no RecipeMeta.model"
+            assert pair.yaml_base, f"{name} has no YAML base:"
+
+    def test_a_wrong_meta_model_is_caught_independently_of_the_yaml(self, monkeypatch):
+        """#666's mutation testing showed the snapshot guard sees only the YAML
+        half, so a wrong `RecipeMeta.model` slips past everything else."""
+        from scripts.check_recipe_repo_ids import Status, check_surfaces
+
+        api = _FakeApi({"good/real": _Info(), "bad/invented": _NotFoundError("404")})
+        report = check_surfaces(
+            {"r1": ("bad/invented", "good/real")}, api=api, not_found=_NotFoundError
+        )
+
+        assert report["r1"].meta.status is Status.MISSING
+        assert report["r1"].yaml.status is Status.EXISTS
+
+    def test_a_wrong_yaml_base_is_caught_independently_of_the_meta(self):
+        from scripts.check_recipe_repo_ids import Status, check_surfaces
+
+        api = _FakeApi({"good/real": _Info(), "bad/invented": _NotFoundError("404")})
+        report = check_surfaces(
+            {"r1": ("good/real", "bad/invented")}, api=api, not_found=_NotFoundError
+        )
+
+        assert report["r1"].meta.status is Status.EXISTS
+        assert report["r1"].yaml.status is Status.MISSING
+
+
+class TestReporting:
+    def test_only_missing_is_reported(self):
+        from scripts.check_recipe_repo_ids import check_surfaces, missing_only
+
+        api = _FakeApi({
+            "ok/public": _Info(),
+            "ok/gated": _Info(gated=True),
+            "bad/gone": _NotFoundError("404"),
+        })
+        report = check_surfaces(
+            {"a": ("ok/public", "ok/public"),
+             "b": ("ok/gated", "ok/gated"),
+             "c": ("bad/gone", "bad/gone")},
+            api=api, not_found=_NotFoundError,
+        )
+
+        assert sorted(missing_only(report)) == ["c"], (
+            "gated and existing recipes must not be reported"
+        )
+
+    def test_unverified_is_reported_separately_from_missing(self):
+        from scripts.check_recipe_repo_ids import check_surfaces, missing_only, unverified_only
+
+        api = _FakeApi({"ok/public": _Info(), "flaky/one": TimeoutError("t")})
+        report = check_surfaces(
+            {"a": ("ok/public", "ok/public"), "b": ("flaky/one", "flaky/one")},
+            api=api, not_found=_NotFoundError, attempts=1, backoff=0,
+        )
+
+        assert missing_only(report) == [], "a timeout is not a missing repo"
+        assert unverified_only(report) == ["b"]
+
+
+class TestTheWorkflow:
+    """Constraint 3: it must not run in the PR matrix."""
+
+    def _workflow(self):
+        from pathlib import Path
+
+        path = Path(__file__).parents[1] / ".github/workflows/recipe-repo-ids.yml"
+        assert path.is_file(), "the scheduled workflow is missing"
+        return path.read_text(encoding="utf-8")
+
+    def test_it_is_scheduled(self):
+        assert "schedule:" in self._workflow()
+        assert "cron:" in self._workflow()
+
+    def test_it_can_be_run_by_hand(self):
+        assert "workflow_dispatch:" in self._workflow()
+
+    def test_it_does_not_run_on_pull_requests(self):
+        """Asserted rather than trusted: 163 network calls per PR would make
+        every unrelated change depend on Hub availability."""
+        text = self._workflow()
+        assert "pull_request" not in text, (
+            "this job must never be a PR gate — a docs PR going red because the "
+            "Hub had a bad minute trains people to re-run rather than to read"
+        )


### PR DESCRIPTION
Closes the fourth acceptance item of #661 — the general guard. **And its first live run found nine more broken recipes.**

[Claimed here](https://github.com/MakazhanAlpamys/Soup/issues/677). `Refs #677`.

## What the guard found on its first run

Nine recipes name a repo that does not resolve anonymously, beyond the two #661 already caught:

```
checked 165 recipes / 330 surfaces
  exists=244  gated=68  missing=18  unverified=0

MISSING — 9 recipe(s):
  cogito-v2-sft            deepcogito/cogito-v2-preview
  devstral-sft             mistralai/Devstral-Small
  gemma3-9b-sft            google/gemma-3-9b-it
  glm-4.6-sft              THUDM/glm-4.6
  granite-4-sft            ibm-granite/granite-4.0-tiny-base
  internvl-3-5-sft         OpenGVLab/InternVL3-5
  kimi-k2-sft              moonshotai/Kimi-K2
  mistral-medium-3-5-sft   mistralai/Mistral-Medium-3.5
  voxtral-sft              mistralai/Voxtral-Mini-3B
```

**I am stating that precisely: "does not resolve anonymously", not "does not exist".** `RepositoryNotFoundError` covers missing *and* private, and anonymously those are indistinguishable. For a shipped recipe the distinction does not matter much — a user cannot reach either — but it is not the same claim and I am not going to make the stronger one.

Two of these repeat patterns already fixed once. `gemma3-9b-sft` names a **Gemma-3 9B**, and Gemma 3 has no 9B size — the identical error #661 found in `gemma3-9b-sft-mlx`. `glm-4.6-sft` names **THUDM**, the org that was wrong for `glm-5-sft` and had to be corrected to `zai-org` after release. The same two mistakes were made twice because nothing checked.

Verified independently, with both controls, before writing any of that down:

```
zz-invented/definitely-not-real-xyz  -> RepositoryNotFoundError   (negative control)
meta-llama/Llama-3.1-8B-Instruct     -> EXISTS gated=manual       (gated ≠ missing)
google/gemma-3-12b-it                -> EXISTS gated=manual
```

**Repairing them is not in this PR** — that is a catalog decision per recipe (rename? repoint? drop?), the same call `gemma3-9b-sft-mlx` needed in #666. This PR ships the detector. Happy to take the repairs as a follow-up, or leave them for whoever wants them.

## The three constraints from the issue

**1. A bare status code is not evidence.** The classifier takes `RepositoryNotFoundError` injected as a parameter, never a status code. That is the mistake I made in #661 before the report was worth filing, and the negative control above is in the test suite so the checker is provably able to fail.

**2. Gated ≠ missing.** Four outcomes, not two: `EXISTS`, `GATED`, `MISSING`, `UNVERIFIED`. 68 of the 330 surfaces resolved as gated on the live run and none is reported. A guard that fires on every `meta-llama/*` forever is one people mute.

**3. Not in the PR matrix.** Weekly `schedule:` plus `workflow_dispatch:`, and a test **asserts the absence** of a `pull_request` trigger rather than trusting the YAML to stay that way — the #596 lesson, where a job existed and collected nothing.

Plus one the issue did not ask for: **`UNVERIFIED` exists so a bad minute at the Hub is not a bug report.** Timeouts and 5xx retry with backoff and then classify as "could not check", which is reported separately and does **not** fail the job. `RepositoryNotFoundError` is a definite answer and is deliberately not retried, so it cannot burn the budget transient failures need.

And a guard on the guard: the script **refuses to run** if `HF_TOKEN` is set, because a token resolves gated repos as `EXISTS` and would silence the check exactly where a wrong id is most likely to hide.

```
$ HF_TOKEN=... python scripts/check_recipe_repo_ids.py
HF_TOKEN is set. This check must run anonymously: a token turns every gated
repo into EXISTS and hides the case the guard is for.
```

## Tests

15, none touching the network — the Hub client is a fake, so classification is pinned without depending on Hub availability. Both surfaces are covered independently, because #666's mutation testing showed the snapshot guard sees only the YAML half and a wrong `RecipeMeta.model` slips past everything else.

Covered: each of the four statuses; a transient failure retried rather than classified; a 404 **not** retried; a wrong `RecipeMeta.model` caught with a correct YAML and vice versa; only `MISSING` reported; `UNVERIFIED` reported separately; the negative control; and the three workflow-trigger assertions.

## Your two open questions from my claim

Both still yours, and neither blocks this:

**Reporting surface.** v1 **fails the job** rather than opening an issue — less machinery, no bot-authored issues in your tracker, and a red scheduled run is already visible. Swapping to "open or update one issue" is contained to `main()` if you prefer it.

**Offline PR check.** Not built. The weekly job could write a committed list of known-bad ids that `validate-recipes` reads offline, closing the window where a broken id is known but still merges. More moving parts, so I did not build it unopposed.

```
$ .venv/bin/python -m pytest tests/test_issue677_recipe_repo_id_guard.py -q -o addopts=
15 passed
$ .venv/bin/python -m ruff check scripts/ tests/
All checks passed!
$ git diff origin/main -- tests/ | grep -c "^-[^-]"
0
```

https://claude.ai/code/session_014vWWFgXhj9y46pYCyEjfcy
