### PR TITLE
Raise PyTorch floor to 2.6.0 for TRL FSDP2 (#651)

### DIFF
--- a/.github/constraints/transformers-floor.txt
+++ b/.github/constraints/transformers-floor.txt
@@ -2,10 +2,10 @@
 # Qwen3.8-Flash-Next text loading establishes Transformers 5.16.1 as Soup's
 # declared training floor. trl 0.29 is the first release that does not import the
 # Transformers private availability helper whose v5 return type broke trl 0.28.
-# Torch 2.5.1 deliberately exercises Qwen4-Exp's legacy int64-only scatter path.
+# Torch 2.6.0 deliberately exercises Qwen4-Exp's legacy int64-only scatter path.
 # Plotext 6.0.0 is pinned here so one CI cell exercises the real Figure API rather
 # than relying only on the fake 5.x/6.x contract doubles in the unit suite.
-torch==2.5.1
+torch==2.6.0
 transformers==5.16.1
 trl==0.29.0
 peft==0.20.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,10 +119,10 @@ jobs:
       - name: Install training dependencies
         # torch>=2.6 is load-bearing, not belt-and-braces: sshleifer/tiny-gpt2
         # ships only pytorch_model.bin, and transformers refuses torch.load
-        # below 2.6 under CVE-2025-32434. Removing this pin because "[dev]
+        # below 2.6.0 under CVE-2025-32434. Removing this pin because "[dev]
         # already pulls torch" breaks the job with a message naming the CVE
         # rather than the cause.
-        run: pip install -e ".[dev]" "torch>=2.6"
+        run: pip install -e ".[dev]" "torch>=2.6.0"
 
       - name: Warm tiny GPT-2 cache
         shell: python
@@ -143,7 +143,7 @@ jobs:
           path: ${{ runner.temp }}/hf-cache
           key: hf-pytorch-smoke-${{ runner.os }}-${{ hashFiles('tests/test_smoke_train.py', 'pyproject.toml') }}
 
-  # #502/#503/#522/#571: install the exact Torch 2.5.1 / Transformers 5.16.1 /
+  # #502/#503/#522/#571/#651: install the exact Torch 2.6.0 / Transformers 5.16.1 /
   # trl 0.29 / PEFT 0.20 support stack and Plotext 6.0.0 so pip cannot silently
   # upgrade the cell, then assert every pinned compatibility boundary.
   transformers-floor:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,26 @@ jobs:
               )
               print(f"{name}={got} (matches constraints)")
           PY
+      - name: Prove the pinned torch actually supports trl's FSDP2 path
+        run: |
+          python - <<'PY'
+          import torch
+          import torch.distributed.fsdp as fsdp
+
+          assert hasattr(fsdp, "FSDPModule"), (
+              "torch.distributed.fsdp.FSDPModule is absent — this is the #651 "
+              "root cause; the declared torch floor does not support trl 0.29"
+          )
+          import trl
+          from trl import DPOTrainer, KTOTrainer
+
+          print(
+              "trl",
+              trl.__version__,
+              "imports on torch",
+              torch.__version__,
+          )
+          PY
       - name: Run Transformers floor compatibility guard
         run: >
           pytest -o addopts= --no-cov -q

--- a/changelog.d/0.74.0/651.fixed.md
+++ b/changelog.d/0.74.0/651.fixed.md
@@ -1,0 +1,1 @@
+- #651: Raise the minimum supported PyTorch version to 2.6.0 because TRL 0.29 preference trainers require the public FSDP2 API.

--- a/changelog.d/0.74.0/651.fixed.md
+++ b/changelog.d/0.74.0/651.fixed.md
@@ -1,1 +1,0 @@
-- #651: Raise the minimum supported PyTorch version to 2.6.0 because TRL 0.29 preference trainers require the public FSDP2 API.

--- a/changelog.d/0.74.0/717.fixed.md
+++ b/changelog.d/0.74.0/717.fixed.md
@@ -1,0 +1,1 @@
+- #651: Raise the minimum supported PyTorch version to 2.6.0 because TRL 0.29 preference trainers require the public FSDP2 API. (#651 by @Samearth17 in #717)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,15 +51,14 @@ dependencies = [
 # v0.71.0 — heavy training stack. `pip install 'soup-cli[train]'` to fine-tune.
 # These were core dependencies through v0.70.0.
 train = [
-    # The binding floor is transformers', not Soup's: the torch extra of
-    # 5.16.1 (the floor declared just below) requires torch>=2.5, so no
-    # installable [train] env can carry torch below 2.5 regardless of what
-    # is declared here (#636). oQ/Qwen4's uint32 need (2.3) is subsumed.
+    # Soup's training floor is 2.6.0 because TRL preference trainers
+    # require the public FSDP2 API introduced in PyTorch 2.6.0. This also
+    # subsumes Transformers 5.16.1's torch>=2.5 requirement (#651).
     # tests/test_issue636_torch_floor.py pins this floor against the declared
     # transformers floor's own requirement (real metadata, on the
     # transformers-floor CI job that installs exactly 5.16.1) and pins
     # doctor's literal copy against this file, so neither can drift silently.
-    "torch>=2.5.0",
+    "torch>=2.6.0",
     # 5.16.1 is the validated Qwen4-Exp floor: an outer `qwen4_exp` config
     # selects the text-only Qwen4ExpForCausalLM, and the patch release restores
     # tensor-parallel compatibility needed by large-model training. The v5

--- a/src/soup_cli/commands/doctor.py
+++ b/src/soup_cli/commands/doctor.py
@@ -22,7 +22,7 @@ DEPS = [
     # This literal is a copy, pinned to the declaration by
     # tests/test_issue636_torch_floor.py — reading installed metadata instead
     # would report the install's history, not the declaration (#636).
-    ("torch", "torch", "2.5.0", True),
+    ("torch", "torch", "2.6.0", True),
     ("transformers", "transformers", "5.16.1", True),
     ("peft", "peft", "0.20.0", True),
     ("trl", "trl", "0.29.0", True),

--- a/tests/test_issue602_qwen4_ple_streaming.py
+++ b/tests/test_issue602_qwen4_ple_streaming.py
@@ -1138,13 +1138,14 @@ def test_qwen4_oq_torch_floor_matches_project_and_doctor():
     entries = re.findall(r'"([^"]+)"', block.group(1))
     torch_entries = [e for e in entries if e.split(">")[0].strip() == "torch"]
 
-    assert torch_entries == ["torch>=2.5.0"], (
+    assert torch_entries == ["torch>=2.6.0"], (
         "the `train` extra must declare exactly one torch floor, and it must be "
-        "2.5.0 -- transformers 5.16.1's own torch extra forces torch>=2.5, "
-        "which subsumes Qwen4/oQ's uint32 need at 2.3 (#636); found "
+        "2.6.0 -- transformers 5.16.1's own torch extra requires torch>=2.5, "
+        "while TRL 0.29 preference trainers require the public PyTorch 2.6 "
+        "FSDP2 API (#651); found "
         f"{torch_entries}"
     )
-    assert next(item for item in DEPS if item[0] == "torch")[2] == "2.5.0", (
+    assert next(item for item in DEPS if item[0] == "torch")[2] == "2.6.0", (
         "`soup doctor` keeps a literal copy of the torch floor; it must equal "
         "the one pyproject.toml declares, pinned by "
         "tests/test_issue636_torch_floor.py (#636)"

--- a/tests/test_issue636_torch_floor.py
+++ b/tests/test_issue636_torch_floor.py
@@ -1,9 +1,10 @@
 """The declared torch floor must be the binding one, and doctor's copy pinned (#636).
 
-``pyproject.toml [train]`` declared ``torch>=2.3.0`` while requiring
-``transformers>=5.16.1``, whose own torch extra forces ``torch>=2.5`` — so the
-declared floor could never bind, and ``soup doctor`` carried an unpinned second
-copy of it. These tests pin both halves:
+``pyproject.toml [train]`` declared ``torch>=2.6.0`` while requiring
+``transformers>=5.16.1``. The torch floor is kept explicit because TRL's
+FSDP2-based preference trainers require the public PyTorch 2.6 API, and
+``soup doctor`` carries a second literal copy that must not drift.
+These tests pin both halves:
 
 * the pyproject floor is at least what the *declared* transformers floor's own
   torch extra requires. That requirement is read from real metadata only where


### PR DESCRIPTION
## Summary
- raise the declared training PyTorch minimum from 2.5.x to 2.6.0
- pin the dependency-floor CI stack and `soup doctor` to Torch 2.6.0
- update the floor guard tests and changelog for TRL 0.29 FSDP2 requirements

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -o addopts= -q tests/test_issue636_torch_floor.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -o addopts= -q tests/test_v07203.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -o addopts= -q`
- `git diff --check`

Full suite passes locally: 20,279 passed, 108 skipped.