### PR TITLE
perf(multipack): place FFD items through a segment tree, not a linear scan

### DIFF
--- a/src/soup_cli/utils/multipack_sampler.py
+++ b/src/soup_cli/utils/multipack_sampler.py
@@ -67,9 +67,11 @@ MULTIPACK_ARCHITECTURES: frozenset[str] = frozenset({
 })
 
 
-# Worst-case FFD complexity is O(N^2). Cap N to prevent a crafted dataset
-# from pinning a CPU. 1M samples is ~3 orders of magnitude beyond typical
-# fine-tuning workloads.
+# Cap N to prevent a crafted dataset from pinning a CPU or exhausting memory.
+# 1M samples is ~3 orders of magnitude beyond typical fine-tuning workloads.
+# The cap predates the indexed placement below and is kept: packing is now
+# O(N log N) rather than O(N^2), but a caller that hands over ten million
+# lengths still wants a loud error rather than a multi-gigabyte list.
 _MAX_FFD_ITEMS: int = 1_000_000
 
 
@@ -80,6 +82,78 @@ def _check_int(name: str, value: object) -> int:
     if not isinstance(value, int):
         raise TypeError(f"{name} must be int, got {type(value).__name__}")
     return value
+
+
+class _CapacityTree:
+    """Remaining bin capacities, indexed so first-fit is O(log N).
+
+    A max segment tree over a growing array. Each internal node stores the
+    maximum remaining capacity in its subtree, so a descent can skip any
+    subtree that cannot hold the item, and by always trying the left child
+    first it lands on the *leftmost* bin that fits. That is the bin the
+    original linear scan returned, which is what keeps this first-fit rather
+    than turning it into best-fit.
+
+    Deliberately a flat list of ints and pure Python: the packing has to be
+    identical on every supported interpreter and OS, and no compiled
+    dependency is worth that risk for a setup-time cost.
+    """
+
+    __slots__ = ("_tree", "_capacity", "_size")
+
+    def __init__(self) -> None:
+        self._capacity = 1  # number of leaf slots; a power of two
+        self._tree = [0, 0]  # 1-indexed heap layout; index 0 unused
+        self._size = 0  # number of bins actually in use
+
+    def append(self, remaining: int) -> None:
+        """Add a new bin with ``remaining`` free space."""
+        if self._size == self._capacity:
+            self._grow()
+        self._set(self._size, remaining)
+        self._size += 1
+
+    def take(self, bin_idx: int, length: int) -> None:
+        """Consume ``length`` from bin ``bin_idx``."""
+        self._set(bin_idx, self._tree[self._capacity + bin_idx] - length)
+
+    def leftmost_with_room(self, length: int) -> int | None:
+        """The lowest bin index whose remaining capacity is >= ``length``.
+
+        ``None`` when no open bin fits, which is the caller's signal to start
+        a new one -- the same condition as the old scan falling off the end.
+        """
+        if self._size == 0 or self._tree[1] < length:
+            return None
+        node = 1
+        while node < self._capacity:
+            left = node * 2
+            # Left first: this is what makes the result the *leftmost* fit.
+            node = left if self._tree[left] >= length else left + 1
+        return node - self._capacity
+
+    def _set(self, leaf: int, value: int) -> None:
+        node = self._capacity + leaf
+        self._tree[node] = value
+        node //= 2
+        while node >= 1:
+            self._tree[node] = max(self._tree[node * 2], self._tree[node * 2 + 1])
+            node //= 2
+
+    def _grow(self) -> None:
+        """Double the leaf capacity, rebuilding the tree around the old leaves.
+
+        Amortised O(1) per append: the rebuild costs O(N) and happens after N
+        appends. Unused leaves hold 0, which is below every valid item length
+        (they are validated positive above), so they can never be selected.
+        """
+        old_leaves = self._tree[self._capacity : self._capacity + self._size]
+        self._capacity *= 2
+        self._tree = [0] * (2 * self._capacity)
+        for offset, value in enumerate(old_leaves):
+            self._tree[self._capacity + offset] = value
+        for node in range(self._capacity - 1, 0, -1):
+            self._tree[node] = max(self._tree[node * 2], self._tree[node * 2 + 1])
 
 
 def ffd_bin_pack(lengths: Sequence[int], max_len: int) -> list[list[int]]:
@@ -110,7 +184,7 @@ def ffd_bin_pack(lengths: Sequence[int], max_len: int) -> list[list[int]]:
     if len(lengths) > _MAX_FFD_ITEMS:
         raise ValueError(
             f"too many items for FFD bin-packing: {len(lengths)} > "
-            f"{_MAX_FFD_ITEMS} (algorithm is O(N^2) worst-case)"
+            f"{_MAX_FFD_ITEMS}"
         )
 
     # Validate each length up-front so we fail loudly before packing.
@@ -131,18 +205,22 @@ def ffd_bin_pack(lengths: Sequence[int], max_len: int) -> list[list[int]]:
     )
 
     bins: list[list[int]] = []
-    bin_remaining: list[int] = []  # parallel to bins: free space in each
+    # A max segment tree over the bins' remaining capacity, replacing the
+    # linear scan this loop used to do. `_leftmost_bin_with_room` returns the
+    # same bin the scan would have found, so this is first-fit exactly as
+    # before -- not best-fit, and not any other order. The only thing that
+    # changes is how long it takes to find it: O(log N) per item rather than
+    # O(N), which removes the N(N-1)/2 worst case that appears when every item
+    # is larger than half the budget and no earlier bin can ever fit.
+    tree = _CapacityTree()
     for orig_idx, length in indexed:
-        placed = False
-        for bin_idx, remaining in enumerate(bin_remaining):
-            if length <= remaining:
-                bins[bin_idx].append(orig_idx)
-                bin_remaining[bin_idx] = remaining - length
-                placed = True
-                break
-        if not placed:
+        bin_idx = tree.leftmost_with_room(length)
+        if bin_idx is None:
             bins.append([orig_idx])
-            bin_remaining.append(max_len - length)
+            tree.append(max_len - length)
+        else:
+            bins[bin_idx].append(orig_idx)
+            tree.take(bin_idx, length)
 
     return bins
 

--- a/tests/test_multipack_ffd_placement.py
+++ b/tests/test_multipack_ffd_placement.py
@@ -1,0 +1,162 @@
+"""`ffd_bin_pack` places items through an indexed structure, not a scan (#694).
+
+The packing is unchanged: same bins, same order, same exceptions. Only the cost
+of finding each bin changed, from O(N) per item to O(log N). These tests exist
+to keep that "unchanged" honest, because a first-fit implementation that
+quietly becomes best-fit still produces plausible-looking bins.
+
+The reference implementation below is the exact pre-#694 loop. Comparing
+against it rather than against hand-written expectations is what makes the
+equivalence claim checkable: a hand-written case pins what someone believed
+the old code did, and the whole risk here is that the belief is wrong.
+"""
+
+from __future__ import annotations
+
+import random
+import statistics
+import time
+from typing import Sequence
+
+import pytest
+
+from soup_cli.utils.multipack_sampler import ffd_bin_pack
+
+
+def linear_scan_ffd(lengths: Sequence[int], max_len: int) -> list[list[int]]:
+    """The placement loop `ffd_bin_pack` used before #694, verbatim."""
+    indexed = sorted(enumerate(list(lengths)), key=lambda pair: pair[1], reverse=True)
+    bins: list[list[int]] = []
+    bin_remaining: list[int] = []
+    for orig_idx, length in indexed:
+        placed = False
+        for bin_idx, remaining in enumerate(bin_remaining):
+            if length <= remaining:
+                bins[bin_idx].append(orig_idx)
+                bin_remaining[bin_idx] = remaining - length
+                placed = True
+                break
+        if not placed:
+            bins.append([orig_idx])
+            bin_remaining.append(max_len - length)
+    return bins
+
+
+@pytest.mark.parametrize("seed", range(25))
+def test_placement_is_identical_to_the_linear_scan(seed: int) -> None:
+    rng = random.Random(seed)
+    for _ in range(40):
+        max_len = rng.choice([8, 16, 64, 128, 1024])
+        count = rng.randint(0, 120)
+        lengths = [rng.randint(1, max_len) for _ in range(count)]
+        assert ffd_bin_pack(lengths, max_len) == linear_scan_ffd(lengths, max_len)
+
+
+@pytest.mark.parametrize("seed", range(10))
+def test_ties_break_the_same_way(seed: int) -> None:
+    """The case a best-fit regression would survive.
+
+    With distinct lengths, several placement rules agree often enough to look
+    right. With heavy ties they diverge, so this draws from a tiny alphabet and
+    from all-identical inputs on purpose.
+    """
+    rng = random.Random(1000 + seed)
+    for _ in range(40):
+        max_len = rng.choice([16, 64, 1024])
+        count = rng.randint(0, 100)
+        alphabet = [1, max(1, max_len // 2), max_len]
+        lengths = [rng.choice(alphabet) for _ in range(count)]
+        assert ffd_bin_pack(lengths, max_len) == linear_scan_ffd(lengths, max_len)
+
+        uniform = [rng.randint(1, max_len)] * count
+        assert ffd_bin_pack(uniform, max_len) == linear_scan_ffd(uniform, max_len)
+
+
+def test_the_worst_case_shape_is_identical() -> None:
+    """Every item over half the budget: no earlier bin can ever fit."""
+    lengths = [600] * 1500
+    assert ffd_bin_pack(lengths, 1024) == linear_scan_ffd(lengths, 1024)
+
+
+def test_first_fit_not_best_fit() -> None:
+    """A case where the two rules disagree, stated directly.
+
+    Sorted descending: 10, 6, 5, 4. Bins after the first three items are
+    [10] (0 left), [6, 5] (5 left)... the 4 must land in the *first* bin with
+    room, which best-fit would not choose if a tighter one existed later.
+    """
+    lengths = [10, 6, 5, 4, 4]
+    assert ffd_bin_pack(lengths, 11) == linear_scan_ffd(lengths, 11)
+
+
+@pytest.mark.parametrize("count", [0, 1, 2, 3, 17, 64, 65, 128, 129])
+def test_bin_capacity_growth_boundaries(count: int) -> None:
+    """The tree's leaf array doubles, so exercise around the powers of two.
+
+    An off-by-one in the rebuild would show up only at these sizes.
+    """
+    lengths = [7] * count
+    assert ffd_bin_pack(lengths, 7) == linear_scan_ffd(lengths, 7)
+
+
+def test_every_index_appears_exactly_once() -> None:
+    rng = random.Random(99)
+    lengths = [rng.randint(1, 512) for _ in range(400)]
+    bins = ffd_bin_pack(lengths, 512)
+    flat = sorted(idx for group in bins for idx in group)
+    assert flat == list(range(len(lengths)))
+
+
+def test_no_bin_exceeds_the_budget() -> None:
+    rng = random.Random(1234)
+    lengths = [rng.randint(1, 300) for _ in range(500)]
+    bins = ffd_bin_pack(lengths, 300)
+    for group in bins:
+        assert sum(lengths[idx] for idx in group) <= 300
+
+
+@pytest.mark.parametrize(
+    ("lengths", "max_len", "exc", "message"),
+    [
+        ([1, 2], 0, ValueError, "max_len must be positive"),
+        ([1, 2], -5, ValueError, "max_len must be positive"),
+        ([1, 2], True, TypeError, "max_len must not be bool"),
+        ([0, 1], 8, ValueError, "must be positive"),
+        ([-3], 8, ValueError, "must be positive"),
+        ([9], 8, ValueError, "exceeds max_len"),
+        ([1.5], 8, TypeError, "must be int"),
+    ],
+)
+def test_validation_is_unchanged(lengths, max_len, exc, message) -> None:
+    with pytest.raises(exc, match=message):
+        ffd_bin_pack(lengths, max_len)
+
+
+def test_empty_input_returns_no_bins() -> None:
+    assert ffd_bin_pack([], 8) == []
+
+
+def _median_seconds(fn, *args, reps: int = 3) -> float:
+    samples = []
+    for _ in range(reps):
+        start = time.perf_counter()
+        fn(*args)
+        samples.append(time.perf_counter() - start)
+    return statistics.median(samples)
+
+
+def test_the_worst_case_is_no_longer_quadratic() -> None:
+    """A regression threshold, deliberately generous.
+
+    Measured locally at 18x to 30x on the cases in #694. The bar here is 3x,
+    which a reintroduced linear scan cannot clear at this size while leaving
+    ample room for a loaded CI runner. This asserts the shape of the change,
+    not a performance number.
+    """
+    lengths = [600] * 3000
+    scan = _median_seconds(linear_scan_ffd, lengths, 1024)
+    indexed = _median_seconds(ffd_bin_pack, lengths, 1024)
+    assert indexed * 3 < scan, (
+        f"indexed placement took {indexed * 1000:.1f}ms against the linear "
+        f"scan's {scan * 1000:.1f}ms; expected at least a 3x margin"
+    )


### PR DESCRIPTION
Closes #694. Implements the recommended approach: a pure-Python max segment tree over the bins' remaining capacity.

**Left-first descent is the whole correctness argument.** The tree stores each subtree's maximum remaining capacity, so a descent skips any subtree that cannot hold the item; by always trying the left child first it lands on the **leftmost** bin that fits, which is precisely the bin the linear scan returned. That keeps this first-fit. A best-fit variant would still produce valid, plausible-looking bins, which is why the tests below compare against the old code rather than against hand-written expectations.

### Acceptance criteria

**Output identical on property-generated valid inputs, including tied lengths.** The pre-#694 loop is kept verbatim in the test file as `linear_scan_ffd` and everything is compared against it. 3,000 randomised cases across budgets 8–1024 and sizes 0–120: **zero mismatches.** Ties are exercised deliberately — a 3-value alphabet and all-identical inputs — because that is where placement rules diverge and where a best-fit regression would otherwise hide. Growth boundaries (0, 1, 2, 3, 17, 64, 65, 128, 129 bins) are parametrised separately, since an off-by-one in the tree's doubling rebuild would only appear at powers of two.

**Validation and exception types/messages unchanged.** All seven paths checked:

```
max_len=0    -> ValueError: max_len must be positive, got 0
max_len=True -> TypeError:  max_len must not be bool, got True
[0,1]        -> ValueError: lengths[0] must be positive, got 0
[9], ml=8    -> ValueError: lengths[0]=9 exceeds max_len=8
[1.5]        -> TypeError:  lengths[0] must be int, got float
[True]       -> TypeError:  lengths[0] must not be bool, got True
[1,"x"]      -> TypeError:  lengths[1] must be int, got str
```

**Worst-case benchmark, with a CI-generous threshold.** Local medians, function only:

| case | current | segment tree | speedup |
|---|---:|---:|---:|
| 3,000 × 600, budget 1,024 | 389.28 ms | 21.01 ms | 18.5× |
| 6,000 × 600, budget 1,024 | 1616.61 ms | 53.50 ms | 30.2× |
| 6,000 uniform 1..1,024 | 738.27 ms | 55.18 ms | 13.4× |

Close to the figures in the issue. The committed regression test asserts only a **3×** margin on the 3,000-item case — a reintroduced linear scan cannot clear that at this size, and it leaves plenty of room for a loaded runner. It asserts the shape of the change, not a performance number.

**Deterministic across versions and platforms.** Flat `list[int]`, no floats, no dict ordering, no compiled dependency.

**Documentation scoped to preparation latency.** The docstring and commit say multipack preparation only. No claim about tokens/second, GPU memory or RSS, none of which was measured.

### One deviation, flagged rather than slipped in

The criterion says messages remain unchanged, and I changed one: the `_MAX_FFD_ITEMS` error said `(algorithm is O(N^2) worst-case)`, which is now false. I kept the cap and the `ValueError` — a caller passing ten million lengths still wants a loud error rather than a multi-gigabyte list — and dropped only the false parenthetical, updating the comment above it to say why the cap survives the complexity change. `test_ffd_rejects_too_many_items` matches on `"too many items"` only, so its behaviour is unmodified. Happy to restore the wording if you would rather keep it byte-identical.

### Verification

- `tests/test_multipack_ffd_placement.py`: 57 pass.
- Existing `test_multipack_sampler.py`, `test_multipack_invariants.py`, `test_multipack_config.py` plus the new file: **144 pass, 0 fail.**
- `ruff check`: clean.
- Mutation-checked: flipping the descent to try the right child first (turning first-fit into something best-fit-like) fails **25** of the new tests, so the equivalence assertions genuinely bite.
