### PR TITLE
fix(migrate): detect JSONL by structure

### DIFF
--- a/changelog.d/0.74.0/730.fixed.md
+++ b/changelog.d/0.74.0/730.fixed.md
@@ -1,0 +1,6 @@
+- `soup migrate` now recognizes multi-record JSONL by structure even when the
+  filename does not end in `.jsonl`, so a data file such as `data.json` gets the
+  existing friendly wrong-file error instead of a raw YAML `ParserError`.
+  Single JSON objects and Unsloth notebooks still reach their selected migrator,
+  and the structural sniff remains bounded to 64 KiB (#730 by @be-student,
+  closes #699).

--- a/src/soup_cli/commands/migrate.py
+++ b/src/soup_cli/commands/migrate.py
@@ -1,5 +1,6 @@
 """soup migrate — import configs from LLaMA-Factory, Axolotl, and Unsloth."""
 
+import json
 from pathlib import Path
 
 import typer
@@ -63,11 +64,17 @@ def migrate(
         console.print(f"[red]{exc}[/]")
         raise typer.Exit(1)
 
-    # v0.40.1 Part D / N2 — friendly error when the user passes a JSONL
-    # data file (`.jsonl`) instead of a YAML config. The sniff helper is
-    # only invoked when the suffix says ``.jsonl`` (notebook .ipynb files
-    # legitimately start with ``{`` — we must not falsely flag them).
-    if input_path.suffix.lower() == ".jsonl" and _looks_like_jsonl(input_path):
+    # Keep the permissive content check for explicit .jsonl files. For every
+    # other suffix, require two complete JSON objects on separate lines so a
+    # single JSON config or notebook is not mistaken for training data.
+    suffix = input_path.suffix.lower()
+    is_jsonl = (
+        suffix == ".jsonl" and _looks_like_jsonl(input_path)
+    ) or (
+        suffix != ".jsonl"
+        and _looks_like_jsonl(input_path, require_multiple_objects=True)
+    )
+    if is_jsonl:
         console.print(
             f"[red]Expected a {source} YAML config; got JSONL "
             f"({input_path.name}) — did you pass the wrong file?[/]"
@@ -141,8 +148,8 @@ def migrate(
     console.print(f"[dim]Next: soup train --config {output}[/]")
 
 
-def _looks_like_jsonl(path: Path) -> bool:
-    """v0.40.1 Part D / N2 — sniff first non-blank line for `{` (JSONL).
+def _looks_like_jsonl(path: Path, *, require_multiple_objects: bool = False) -> bool:
+    """Inspect a bounded prefix for explicit or structurally identifiable JSONL.
 
     ``utf-8-sig``, not ``utf-8``: a UTF-8 BOM decodes to U+FEFF, which
     ``str.strip()`` does not remove because it is not whitespace, so a BOM'd
@@ -150,18 +157,32 @@ def _looks_like_jsonl(path: Path) -> bool:
     error. Windows tooling writes that BOM by default, PowerShell's
     ``Out-File`` included (#675 review).
 
-    The read is bounded because a file with no newline is one single line, so
-    ``for line in fh`` would pull all of it into memory: a 120 MB one-liner
-    measured 240.9 MB peak. Only the first non-blank chunk is ever inspected,
-    so a truncated long line costs nothing here.
+    The read is bounded because a file with no newline is one single line. An
+    unbounded line iteration pulled a measured 240.9 MB peak for a 120 MB
+    one-liner. Unknown suffixes use the stricter mode: two non-blank lines must
+    each be complete JSON objects, which separates JSONL from one JSON document.
     """
     try:
         with open(path, "r", encoding="utf-8-sig", errors="replace") as fh:
-            while line := fh.readline(65536):
-                stripped = line.strip()
-                if not stripped:
-                    continue
-                return stripped.startswith("{")
+            prefix = fh.read(65536)
     except OSError:
         return False
+
+    lines = [line.strip() for line in prefix.splitlines() if line.strip()]
+    if not lines:
+        return False
+    if not require_multiple_objects:
+        return lines[0].startswith("{")
+
+    object_count = 0
+    for line in lines:
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError:
+            return False
+        if not isinstance(value, dict):
+            return False
+        object_count += 1
+        if object_count == 2:
+            return True
     return False

--- a/src/soup_cli/commands/migrate.py
+++ b/src/soup_cli/commands/migrate.py
@@ -157,32 +157,34 @@ def _looks_like_jsonl(path: Path, *, require_multiple_objects: bool = False) -> 
     error. Windows tooling writes that BOM by default, PowerShell's
     ``Out-File`` included (#675 review).
 
-    The read is bounded because a file with no newline is one single line. An
+    Each of at most 64 line reads is bounded because a file with no newline is one single line. An
     unbounded line iteration pulled a measured 240.9 MB peak for a 120 MB
     one-liner. Unknown suffixes use the stricter mode: two non-blank lines must
     each be complete JSON objects, which separates JSONL from one JSON document.
     """
     try:
         with open(path, "r", encoding="utf-8-sig", errors="replace") as fh:
-            prefix = fh.read(65536)
+            object_count = 0
+            for _ in range(64):
+                line = fh.readline(65536)
+                if not line:
+                    break
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                if not require_multiple_objects:
+                    return stripped.startswith("{")
+                if not line.endswith("\n") and len(line) >= 65536:
+                    return False
+                try:
+                    value = json.loads(stripped)
+                except json.JSONDecodeError:
+                    return False
+                if not isinstance(value, dict):
+                    return False
+                object_count += 1
+                if object_count == 2:
+                    return True
     except OSError:
         return False
-
-    lines = [line.strip() for line in prefix.splitlines() if line.strip()]
-    if not lines:
-        return False
-    if not require_multiple_objects:
-        return lines[0].startswith("{")
-
-    object_count = 0
-    for line in lines:
-        try:
-            value = json.loads(line)
-        except json.JSONDecodeError:
-            return False
-        if not isinstance(value, dict):
-            return False
-        object_count += 1
-        if object_count == 2:
-            return True
     return False

--- a/tests/test_v0401_part_d.py
+++ b/tests/test_v0401_part_d.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 # --- H4: Template help is dynamically generated --------------------------
@@ -80,15 +81,18 @@ def test_migrate_jsonl_input_yields_friendly_error(tmp_path: Path, monkeypatch):
     assert "got JSONL" in result.output
 
 
+@pytest.mark.parametrize("record_size", [2, 40000])
+@pytest.mark.parametrize("trailing_newline", [True, False])
 def test_migrate_jsonl_with_json_suffix_yields_friendly_error(
-    tmp_path: Path, monkeypatch
+    tmp_path: Path, monkeypatch, record_size: int, trailing_newline: bool
 ):
     """Multiple JSON objects are data even when the suffix does not say JSONL."""
     from soup_cli.cli import app
 
     monkeypatch.chdir(tmp_path)
     data = tmp_path / "data.json"
-    data.write_text('{"prompt": "hi"}\n{"prompt": "world"}\n', encoding="utf-8")
+    record = json.dumps({"prompt": "x" * record_size})
+    data.write_text(f"{record}\n{record}" + ("\n" if trailing_newline else ""), encoding="utf-8")
 
     result = CliRunner().invoke(
         app, ["migrate", "--from", "llamafactory", "data.json", "--dry-run"]

--- a/tests/test_v0401_part_d.py
+++ b/tests/test_v0401_part_d.py
@@ -10,6 +10,7 @@ Closes:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -77,6 +78,86 @@ def test_migrate_jsonl_input_yields_friendly_error(tmp_path: Path, monkeypatch):
     )
     assert result.exit_code == 2, (result.output, repr(result.exception))
     assert "got JSONL" in result.output
+
+
+def test_migrate_jsonl_with_json_suffix_yields_friendly_error(
+    tmp_path: Path, monkeypatch
+):
+    """Multiple JSON objects are data even when the suffix does not say JSONL."""
+    from soup_cli.cli import app
+
+    monkeypatch.chdir(tmp_path)
+    data = tmp_path / "data.json"
+    data.write_text('{"prompt": "hi"}\n{"prompt": "world"}\n', encoding="utf-8")
+
+    result = CliRunner().invoke(
+        app, ["migrate", "--from", "llamafactory", "data.json", "--dry-run"]
+    )
+
+    assert result.exit_code == 2, (result.output, repr(result.exception))
+    assert "got JSONL" in result.output
+
+
+def test_migrate_single_json_object_is_not_reported_as_jsonl(tmp_path: Path, monkeypatch):
+    """A valid single-object config must continue to the selected migrator."""
+    from soup_cli.cli import app
+
+    monkeypatch.chdir(tmp_path)
+    config = tmp_path / "config.json"
+    config.write_text(
+        json.dumps(
+            {
+                "model_name_or_path": "meta-llama/Llama-3-8B",
+                "stage": "sft",
+                "finetuning_type": "lora",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(
+        app, ["migrate", "--from", "llamafactory", "config.json", "--dry-run"]
+    )
+
+    assert result.exit_code == 0, (result.output, repr(result.exception))
+    assert "got JSONL" not in result.output
+
+
+def test_migrate_unsloth_notebook_is_not_reported_as_jsonl(tmp_path: Path, monkeypatch):
+    """A multi-line notebook remains a single JSON document and still migrates."""
+    from soup_cli.cli import app
+
+    monkeypatch.chdir(tmp_path)
+    notebook = tmp_path / "train.ipynb"
+    notebook.write_text(
+        json.dumps(
+            {
+                "cells": [
+                    {
+                        "cell_type": "code",
+                        "source": [
+                            "model, tokenizer = FastLanguageModel.from_pretrained(\n",
+                            "    model_name='unsloth/llama-3',\n",
+                            ")\n",
+                            "trainer = SFTTrainer()\n",
+                        ],
+                    }
+                ],
+                "metadata": {},
+                "nbformat": 4,
+                "nbformat_minor": 5,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(
+        app, ["migrate", "--from", "unsloth", "train.ipynb", "--dry-run"]
+    )
+
+    assert result.exit_code == 0, (result.output, repr(result.exception))
+    assert "got JSONL" not in result.output
 
 
 def test_migrate_yaml_config_named_jsonl_still_migrates(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
Closes #699.

`soup migrate` now identifies disguised JSONL only when a bounded 64 KiB prefix contains at least two complete JSON objects on separate lines. Explicit `.jsonl` behavior remains unchanged, while single JSON configs and Unsloth notebooks continue to their selected migrator.

Validation: 20,351 tests passed, 106 skipped, 5 deselected; full Ruff scope passed; changelog fragments validated.
