### PR TITLE
fix(grpo): exclude masked tokens from the gspo batch-mean statistic

### DIFF
--- a/changelog.d/0.74.0/735.fixed.md
+++ b/changelog.d/0.74.0/735.fixed.md
@@ -1,0 +1,6 @@
+- `grpo_variant: gspo` centered the per-token log-ratio across the batch
+  before the completion mask was applied, so a masked (padding) token
+  shifted the loss and gradient of every unmasked row sharing its column,
+  and picked up a non-zero gradient of its own (#735 by @AmirF194, refs
+  #723). The batch-mean statistic is now taken over unmasked positions
+  only.

--- a/src/soup_cli/utils/grpo_variants.py
+++ b/src/soup_cli/utils/grpo_variants.py
@@ -275,8 +275,16 @@ def apply_variant_loss(
 
     if normalised == "gspo":
         # Group Stabilized: subtract per-group mean log-ratio (acts as
-        # control variate). Mean is taken over the batch dim.
-        log_ratio_centered = log_ratio - log_ratio.mean(dim=0, keepdim=True)
+        # control variate). Mean is taken over the batch dim, excluding
+        # masked (padding) positions so a masked token cannot shift the
+        # statistic other rows in its column are centered against.
+        if completion_mask is not None:
+            col_sum = (log_ratio * completion_mask).sum(dim=0, keepdim=True)
+            col_count = completion_mask.sum(dim=0, keepdim=True).clamp(min=1.0)
+            col_mean = col_sum / col_count
+        else:
+            col_mean = log_ratio.mean(dim=0, keepdim=True)
+        log_ratio_centered = log_ratio - col_mean
         ratio_stab = torch.exp(log_ratio_centered)
         token_loss = -(ratio_stab * advantages_2d)
         return _masked_mean(token_loss, completion_mask)

--- a/tests/test_v05311.py
+++ b/tests/test_v05311.py
@@ -85,6 +85,64 @@ class TestGRPOVariantKernels:
         )
         assert math.isfinite(float(out))
 
+    def test_gspo_masked_token_cannot_change_loss(self):
+        """A masked (padding) token must not shift the gspo batch-mean
+        statistic other rows are centered against (#723)."""
+        from soup_cli.utils.grpo_variants import apply_variant_loss
+
+        logp_old = torch.zeros(4, 2)
+        adv = torch.tensor([1.0, 0.6, -0.3, 0.2])
+        mask = torch.tensor([[1.0, 0.0], [1.0, 1.0], [1.0, 1.0], [1.0, 1.0]])
+
+        losses = []
+        for delta in (-2.0, -6.0):
+            logp_new = torch.zeros(4, 2)
+            logp_new[0, 1] = delta  # masked position
+            out = apply_variant_loss(
+                "gspo",
+                logp_new=logp_new,
+                logp_old=logp_old,
+                advantages=adv,
+                completion_mask=mask,
+            )
+            losses.append(float(out))
+        assert losses[0] == pytest.approx(losses[1])
+
+    def test_gspo_masked_token_zero_gradient(self):
+        """Every masked gspo token must receive exactly zero gradient (#723)."""
+        from soup_cli.utils.grpo_variants import apply_variant_loss
+
+        logp_old = torch.zeros(4, 2)
+        adv = torch.tensor([1.0, 0.6, -0.3, 0.2])
+        mask = torch.tensor([[1.0, 0.0], [1.0, 1.0], [1.0, 1.0], [1.0, 1.0]])
+        logp_new = torch.zeros(4, 2, requires_grad=True)
+        with torch.no_grad():
+            logp_new[0, 1] = -6.0
+        out = apply_variant_loss(
+            "gspo",
+            logp_new=logp_new,
+            logp_old=logp_old,
+            advantages=adv,
+            completion_mask=mask,
+        )
+        out.backward()
+        assert float(logp_new.grad[0, 1]) == pytest.approx(0.0)
+
+    def test_gspo_all_masked_column_no_nan(self):
+        """A column with zero unmasked entries must not divide by zero."""
+        from soup_cli.utils.grpo_variants import apply_variant_loss
+
+        logp_new, logp_old, adv = self._toy_inputs()
+        mask = torch.tensor([[1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]])
+        out = apply_variant_loss(
+            "gspo",
+            logp_new=logp_new,
+            logp_old=logp_old,
+            advantages=adv,
+            completion_mask=mask,
+        )
+        assert math.isfinite(float(out))
+
     def test_bool_beta_rejected(self):
         from soup_cli.utils.grpo_variants import apply_variant_loss
 


### PR DESCRIPTION
Fixed the masked-token leak: gspo's per-column centering mean now sums `log_ratio` only over unmasked positions (clamped so an all-masked column doesn't divide by zero), so a masked token can no longer shift another row's centering statistic or pick up a gradient of its own.

Added three tests: a masked token's value can't move the loss, a masked position gets exactly zero gradient, and an all-masked column stays finite. Ran the gspo/kernel/PRM/factory slice of `test_v05311.py` plus the runtime-contract test, 33 passed; the two new ones are red without this diff. `ruff check` is clean.

I didn't touch the sequence-level part. Making gspo match the published objective means adding per-sequence clipping, which needs a new epsilon and changes the loss shape for anyone already running `grpo_variant: gspo`, so that reads like its own PR once you've said what clip bounds you want. Happy to take that on too if you'd rather bundle it.

Refs #723
