### PR TITLE
fix(ppo): forward configured schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,6 @@ reproducing 70+ versions of notes.
 
 ## [Unreleased]
 
-### Fixed
-
-- PPO now forwards `training.epochs` and `ppo_kl_penalty` to TRL 0.29's
-  `num_train_epochs` and `kl_coef` fields while retaining legacy field-name
-  compatibility (#721).
-
 ## [0.74.0] - 2026-09-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ reproducing 70+ versions of notes.
 
 ## [Unreleased]
 
+### Fixed
+
+- PPO now forwards `training.epochs` and `ppo_kl_penalty` to TRL 0.29's
+  `num_train_epochs` and `kl_coef` fields while retaining legacy field-name
+  compatibility (#721).
+
 ## [0.74.0] - 2026-09-04
 
 ### Added

--- a/changelog.d/0.74.0/737.fixed.md
+++ b/changelog.d/0.74.0/737.fixed.md
@@ -1,0 +1,3 @@
+- PPO now forwards `training.epochs` and `ppo_kl_penalty` to TRL 0.29's
+  `num_train_epochs` and `kl_coef` fields while retaining legacy field-name
+  compatibility (#721 by @be-student in #737).

--- a/docs/training.md
+++ b/docs/training.md
@@ -1198,6 +1198,7 @@ data:
   format: chatml
 training:
   reward_model: ./output_rm
+  epochs: 1
   ppo_epochs: 4
   ppo_clip_ratio: 0.2
   ppo_kl_penalty: 0.05
@@ -1207,6 +1208,11 @@ training:
   quantization: 4bit
 output: ./output_ppo
 ```
+
+`epochs` controls complete passes over the training dataset. `ppo_epochs`
+controls optimization passes within each PPO update. Soup forwards both values,
+plus `ppo_kl_penalty`, to the active TRL `PPOConfig` names and prints the
+effective schedule during setup.
 
 PPO supports two reward sources:
 - **Reward model** (`reward_model`): pre-trained reward model (from step 2)

--- a/src/soup_cli/trainer/ppo.py
+++ b/src/soup_cli/trainer/ppo.py
@@ -9,7 +9,7 @@ Full RLHF pipeline:  SFT → Reward Model → PPO
 
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 from rich.console import Console
 
@@ -24,6 +24,47 @@ from soup_cli.utils.mixed_precision import align_trainable_dtype_for_fp16
 from soup_cli.utils.seeding import apply_training_seed, training_seed_kwargs
 
 console = Console()
+
+
+def _set_ppo_training_kwargs(
+    ppo_kwargs: dict[str, object],
+    ppo_params: Mapping[str, object],
+    tcfg: Any,
+) -> dict[str, str]:
+    """Forward Soup's three PPO schedules across TRL parameter renames."""
+    applied: dict[str, str] = {}
+
+    if "num_train_epochs" in ppo_params:
+        ppo_kwargs["num_train_epochs"] = tcfg.epochs
+        applied["train_epochs"] = "num_train_epochs"
+
+    if "num_ppo_epochs" in ppo_params:
+        ppo_kwargs["num_ppo_epochs"] = tcfg.ppo_epochs
+        applied["ppo_epochs"] = "num_ppo_epochs"
+    elif "ppo_epochs" in ppo_params:
+        ppo_kwargs["ppo_epochs"] = tcfg.ppo_epochs
+        applied["ppo_epochs"] = "ppo_epochs"
+
+    if "kl_coef" in ppo_params:
+        ppo_kwargs["kl_coef"] = tcfg.ppo_kl_penalty
+        applied["kl_coef"] = "kl_coef"
+    elif "init_kl_coef" in ppo_params:
+        ppo_kwargs["init_kl_coef"] = tcfg.ppo_kl_penalty
+        applied["kl_coef"] = "init_kl_coef"
+
+    return applied
+
+
+def _effective_ppo_setting(
+    config: object,
+    kwargs: Mapping[str, object],
+    field: str | None,
+    fallback: object,
+) -> object:
+    """Read the constructed config value, with compatibility fallbacks."""
+    if field is None:
+        return fallback
+    return getattr(config, field, kwargs[field])
 
 
 class PPOTrainerWrapper:
@@ -168,16 +209,12 @@ class PPOTrainerWrapper:
 
         ppo_params = inspect.signature(ppo_config_cls).parameters
 
-        # trl renamed ppo_epochs -> num_ppo_epochs in newer versions
-        if "num_ppo_epochs" in ppo_params:
-            ppo_kwargs["num_ppo_epochs"] = tcfg.ppo_epochs
-        elif "ppo_epochs" in ppo_params:
-            ppo_kwargs["ppo_epochs"] = tcfg.ppo_epochs
+        applied_ppo_fields = _set_ppo_training_kwargs(
+            ppo_kwargs, ppo_params, tcfg
+        )
 
         if "cliprange" in ppo_params:
             ppo_kwargs["cliprange"] = tcfg.ppo_clip_ratio
-        if "init_kl_coef" in ppo_params:
-            ppo_kwargs["init_kl_coef"] = tcfg.ppo_kl_penalty
 
         # Optional params that may not exist in all trl versions
         if "log_with" in ppo_params:
@@ -195,6 +232,30 @@ class PPOTrainerWrapper:
             ppo_kwargs["use_cpu"] = True
 
         ppo_config = ppo_config_cls(**ppo_kwargs)
+        effective_train_epochs = _effective_ppo_setting(
+            ppo_config,
+            ppo_kwargs,
+            applied_ppo_fields.get("train_epochs"),
+            tcfg.epochs,
+        )
+        effective_ppo_epochs = _effective_ppo_setting(
+            ppo_config,
+            ppo_kwargs,
+            applied_ppo_fields.get("ppo_epochs"),
+            tcfg.ppo_epochs,
+        )
+        effective_kl_coef = _effective_ppo_setting(
+            ppo_config,
+            ppo_kwargs,
+            applied_ppo_fields.get("kl_coef"),
+            tcfg.ppo_kl_penalty,
+        )
+        console.print(
+            "[green]PPO schedule:[/] "
+            f"train epochs={effective_train_epochs}, "
+            f"PPO epochs={effective_ppo_epochs}, "
+            f"KL coefficient={effective_kl_coef}"
+        )
 
         # --- Build reward functions list for PPOTrainer ---
         reward_funcs = []

--- a/src/soup_cli/trainer/ppo.py
+++ b/src/soup_cli/trainer/ppo.py
@@ -63,7 +63,7 @@ def _effective_ppo_setting(
 ) -> object:
     """Read the constructed config value, with compatibility fallbacks."""
     if field is None:
-        return fallback
+        return f"{fallback} (not forwarded)"
     return getattr(config, field, kwargs[field])
 
 

--- a/tests/test_issue721_ppo_config_forwarding.py
+++ b/tests/test_issue721_ppo_config_forwarding.py
@@ -52,7 +52,7 @@ def test_legacy_trl_parameter_names_remain_supported(training_config) -> None:
 
 
 def test_installed_trl_exposes_and_receives_current_names(training_config) -> None:
-    pytest.importorskip("trl")
+    pytest.importorskip("trl.experimental.ppo")
     from trl.experimental.ppo import PPOConfig
 
     params = inspect.signature(PPOConfig).parameters

--- a/tests/test_issue721_ppo_config_forwarding.py
+++ b/tests/test_issue721_ppo_config_forwarding.py
@@ -1,0 +1,136 @@
+"""Regression coverage for PPOConfig schedule forwarding (#721)."""
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from soup_cli.trainer.ppo import _set_ppo_training_kwargs
+
+
+@pytest.fixture
+def training_config() -> SimpleNamespace:
+    return SimpleNamespace(epochs=7, ppo_epochs=2, ppo_kl_penalty=0.7)
+
+
+def test_current_trl_parameter_names_receive_non_defaults(training_config) -> None:
+    kwargs: dict[str, object] = {}
+    fields = _set_ppo_training_kwargs(
+        kwargs,
+        {"num_train_epochs": None, "num_ppo_epochs": None, "kl_coef": None},
+        training_config,
+    )
+
+    assert kwargs == {
+        "num_train_epochs": 7,
+        "num_ppo_epochs": 2,
+        "kl_coef": 0.7,
+    }
+    assert fields == {
+        "train_epochs": "num_train_epochs",
+        "ppo_epochs": "num_ppo_epochs",
+        "kl_coef": "kl_coef",
+    }
+
+
+def test_legacy_trl_parameter_names_remain_supported(training_config) -> None:
+    kwargs: dict[str, object] = {}
+    fields = _set_ppo_training_kwargs(
+        kwargs,
+        {"ppo_epochs": None, "init_kl_coef": None},
+        training_config,
+    )
+
+    assert kwargs == {"ppo_epochs": 2, "init_kl_coef": 0.7}
+    assert fields == {
+        "ppo_epochs": "ppo_epochs",
+        "kl_coef": "init_kl_coef",
+    }
+
+
+def test_installed_trl_exposes_and_receives_current_names(training_config) -> None:
+    pytest.importorskip("trl")
+    from trl.experimental.ppo import PPOConfig
+
+    params = inspect.signature(PPOConfig).parameters
+    kwargs: dict[str, object] = {}
+    _set_ppo_training_kwargs(kwargs, params, training_config)
+
+    assert kwargs["num_train_epochs"] == 7
+    assert kwargs["num_ppo_epochs"] == 2
+    assert kwargs["kl_coef"] == 0.7
+
+
+def test_setup_passes_current_schedule_to_trainer(tmp_path, capsys) -> None:
+    from soup_cli.config.schema import SoupConfig
+    from soup_cli.trainer.ppo import PPOTrainerWrapper
+
+    class CurrentPPOConfig:
+        def __init__(
+            self,
+            output_dir,
+            per_device_train_batch_size,
+            gradient_accumulation_steps,
+            learning_rate,
+            seed,
+            data_seed,
+            num_train_epochs=3.0,
+            num_ppo_epochs=4,
+            kl_coef=0.05,
+            cliprange=0.2,
+            use_cpu=False,
+        ):
+            self.num_train_epochs = num_train_epochs
+            self.num_ppo_epochs = num_ppo_epochs
+            self.kl_coef = kl_coef
+
+    class CurrentPPOTrainer:
+        def __init__(self, *, args, **kwargs):
+            self.args = args
+
+        def add_callback(self, callback) -> None:
+            pass
+
+    config = SoupConfig(
+        base="test-model",
+        task="ppo",
+        output=str(tmp_path),
+        data={"train": "./data.jsonl"},
+        training={
+            "epochs": 7,
+            "ppo_epochs": 2,
+            "ppo_kl_penalty": 0.7,
+            "reward_model": "test-reward-model",
+        },
+    )
+    wrapper = PPOTrainerWrapper(config, device="cpu")
+    wrapper.model = MagicMock()
+    wrapper.model.get_nb_trainable_parameters.return_value = (100, 1000)
+    wrapper.tokenizer = MagicMock()
+    wrapper.tokenizer.side_effect = lambda texts, **kwargs: {
+        "input_ids": [[1, 2]] * len(texts),
+        "attention_mask": [[1, 1]] * len(texts),
+    }
+
+    with (
+        patch.object(wrapper, "_setup_reward"),
+        patch.object(wrapper, "_setup_transformers"),
+        patch(
+            "soup_cli.trainer.ppo._import_ppo_classes",
+            return_value=(CurrentPPOTrainer, CurrentPPOConfig, True),
+        ),
+        patch.object(wrapper, "_get_or_create_reward_model", return_value=MagicMock()),
+        patch.object(wrapper, "_create_value_model", return_value=MagicMock()),
+    ):
+        wrapper.setup({"train": [{"prompt": "Q?", "answer": "A"}]})
+
+    assert wrapper.trainer.args.num_train_epochs == 7
+    assert wrapper.trainer.args.num_ppo_epochs == 2
+    assert wrapper.trainer.args.kl_coef == 0.7
+    schedule = capsys.readouterr().out
+    assert "train epochs=7" in schedule
+    assert "PPO epochs=2" in schedule
+    assert "KL coefficient=0.7" in schedule

--- a/tests/test_issue721_ppo_config_forwarding.py
+++ b/tests/test_issue721_ppo_config_forwarding.py
@@ -51,6 +51,34 @@ def test_legacy_trl_parameter_names_remain_supported(training_config) -> None:
     }
 
 
+def test_current_names_win_when_a_signature_carries_both(training_config) -> None:
+    # Gap spotted by @dchaudhari7177 in #741: the two tests above each present
+    # one spelling, so preferring the legacy name would pass both of them.
+    kwargs: dict[str, object] = {}
+    fields = _set_ppo_training_kwargs(
+        kwargs,
+        {
+            "num_train_epochs": None,
+            "num_ppo_epochs": None,
+            "ppo_epochs": None,
+            "kl_coef": None,
+            "init_kl_coef": None,
+        },
+        training_config,
+    )
+
+    assert kwargs == {
+        "num_train_epochs": 7,
+        "num_ppo_epochs": 2,
+        "kl_coef": 0.7,
+    }
+    assert fields == {
+        "train_epochs": "num_train_epochs",
+        "ppo_epochs": "num_ppo_epochs",
+        "kl_coef": "kl_coef",
+    }
+
+
 def test_installed_trl_exposes_and_receives_current_names(training_config) -> None:
     pytest.importorskip("trl.experimental.ppo")
     from trl.experimental.ppo import PPOConfig

--- a/tests/test_issue721_ppo_config_forwarding.py
+++ b/tests/test_issue721_ppo_config_forwarding.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from soup_cli.trainer.ppo import _set_ppo_training_kwargs
+from soup_cli.trainer.ppo import _effective_ppo_setting, _set_ppo_training_kwargs
 
 
 @pytest.fixture
@@ -77,6 +77,20 @@ def test_current_names_win_when_a_signature_carries_both(training_config) -> Non
         "ppo_epochs": "num_ppo_epochs",
         "kl_coef": "kl_coef",
     }
+
+
+def test_an_unforwarded_setting_is_marked_rather_than_echoed() -> None:
+    # When the installed trl exposes no field for a setting, the summary must
+    # not print the requested value as if it had reached the trainer.
+    shown = _effective_ppo_setting(SimpleNamespace(), {}, None, 7)
+
+    assert shown == "7 (not forwarded)"
+
+
+def test_a_forwarded_setting_reports_the_constructed_value() -> None:
+    config = SimpleNamespace(num_train_epochs=3)
+
+    assert _effective_ppo_setting(config, {"num_train_epochs": 7}, "num_train_epochs", 7) == 3
 
 
 def test_installed_trl_exposes_and_receives_current_names(training_config) -> None:


### PR DESCRIPTION
Fixes #721.

Forwards dataset epochs and the KL coefficient to TRL 0.29's `num_train_epochs` and `kl_coef`, while preserving legacy names and keeping PPO optimization epochs separate. Setup now reports the effective schedule.

Validation: 20,398 tests passed; Ruff passed; coverage 83.00%.
