### PR TITLE
fix(ppo): forward the configured KL coefficient and epoch budget (closes #721)

### DIFF
--- a/src/soup_cli/trainer/_trl_compat.py
+++ b/src/soup_cli/trainer/_trl_compat.py
@@ -120,6 +120,21 @@ def prompt_length_kwargs(config_cls: type, max_prompt_length: int) -> dict[str, 
     return {}
 
 
+def kl_penalty_kwargs(config_cls: type, kl_penalty: float) -> dict[str, float]:
+    """``{'kl_coef': x}`` or ``{'init_kl_coef': x}``, whichever this trl takes.
+
+    trl renamed ``init_kl_coef`` to ``kl_coef``. Asking for the new name first
+    matters more than the usual rename: an unrecognised keyword here was never
+    an error, it was silently dropped, so a PPO run kept going with trl's own
+    default KL strength rather than the configured one. Empty dict if neither
+    name exists, so a third rename fails the same visible way this one did not.
+    """
+    for name in ("kl_coef", "init_kl_coef"):
+        if config_accepts(config_cls, name):
+            return {name: kl_penalty}
+    return {}
+
+
 def _truncate_tokens(tokens: list[int], limit: int, mode: str) -> list[int]:
     """Truncate one token sequence using TRL's preference-side convention."""
     if limit <= 0:

--- a/src/soup_cli/trainer/ppo.py
+++ b/src/soup_cli/trainer/ppo.py
@@ -78,6 +78,8 @@ class PPOTrainerWrapper:
         from datasets import Dataset
 
         # Import PPOTrainer/PPOConfig — trl >=0.28 moved to trl.experimental
+        from soup_cli.trainer._trl_compat import kl_penalty_kwargs
+
         ppo_trainer_cls, ppo_config_cls, is_experimental = _import_ppo_classes()
 
         # Enable Rich progress bar for HuggingFace downloads
@@ -176,8 +178,17 @@ class PPOTrainerWrapper:
 
         if "cliprange" in ppo_params:
             ppo_kwargs["cliprange"] = tcfg.ppo_clip_ratio
-        if "init_kl_coef" in ppo_params:
-            ppo_kwargs["init_kl_coef"] = tcfg.ppo_kl_penalty
+
+        # trl renamed init_kl_coef -> kl_coef. Only init_kl_coef was checked, so
+        # on trl >= 0.29 the configured penalty was dropped and PPO silently ran
+        # at the library default.
+        ppo_kwargs.update(kl_penalty_kwargs(ppo_config_cls, tcfg.ppo_kl_penalty))
+
+        # training.epochs was only reaching the legacy manual loop (self._num_epochs),
+        # so the built-in trainer ran trl's default budget. ppo_epochs above is a
+        # different setting: optimization passes per batch, not dataset epochs.
+        if "num_train_epochs" in ppo_params:
+            ppo_kwargs["num_train_epochs"] = tcfg.epochs
 
         # Optional params that may not exist in all trl versions
         if "log_with" in ppo_params:

--- a/tests/test_issue721_ppo_kl_and_epochs.py
+++ b/tests/test_issue721_ppo_kl_and_epochs.py
@@ -1,0 +1,109 @@
+"""Issue #721 - PPO must forward the configured KL strength and epoch budget.
+
+Two values were resolved by name against the installed trl and lost when the
+name did not match:
+
+* ``training.ppo_kl_penalty`` was passed only as ``init_kl_coef``. trl 0.29
+  renamed that to ``kl_coef``, and an unrecognised keyword here was never an
+  error - it was dropped, so PPO ran at trl's own default KL strength with
+  nothing said.
+* ``training.epochs`` reached only the legacy manual loop, never
+  ``num_train_epochs`` on the built-in ``PPOConfig`` path. ``ppo_epochs`` is a
+  different setting (optimization passes per batch) and was always correct.
+
+trl is not a test dependency, so these ask the question without it: stand in
+synthetic config classes with each signature and read what comes back. The
+kwarg-selection half lives in ``_trl_compat.kl_penalty_kwargs`` so it can be
+called directly, next to ``prompt_length_kwargs``, which exists for the same
+kind of rename.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+from soup_cli.trainer._trl_compat import kl_penalty_kwargs
+
+_PPO_SOURCE = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "src"
+    / "soup_cli"
+    / "trainer"
+    / "ppo.py"
+).read_text(encoding="utf-8")
+
+
+class _ModernConfig:
+    """trl >= 0.29: the coefficient is ``kl_coef``."""
+
+    def __init__(self, kl_coef: float = 0.05, num_train_epochs: float = 3.0):
+        pass
+
+
+class _LegacyConfig:
+    """Older trl: the coefficient is ``init_kl_coef``."""
+
+    def __init__(self, init_kl_coef: float = 0.2):
+        pass
+
+
+class _NeitherConfig:
+    """A hypothetical trl that renamed it again."""
+
+    def __init__(self, cliprange: float = 0.2):
+        pass
+
+
+class TestKlPenaltyKwargs:
+    def test_modern_trl_gets_kl_coef(self):
+        assert kl_penalty_kwargs(_ModernConfig, 0.7) == {"kl_coef": 0.7}
+
+    def test_legacy_trl_still_gets_init_kl_coef(self):
+        assert kl_penalty_kwargs(_LegacyConfig, 0.7) == {"init_kl_coef": 0.7}
+
+    def test_a_config_with_neither_name_gets_nothing(self):
+        # Empty rather than a guess, so the next rename fails visibly at the
+        # call site instead of being silently dropped the way this one was.
+        assert kl_penalty_kwargs(_NeitherConfig, 0.7) == {}
+
+    def test_the_new_name_wins_when_a_config_carries_both(self):
+        class _Both:
+            def __init__(self, kl_coef: float = 0.05, init_kl_coef: float = 0.2):
+                pass
+
+        assert kl_penalty_kwargs(_Both, 0.7) == {"kl_coef": 0.7}
+
+
+class TestPpoForwardsTheEpochBudget:
+    def test_setup_passes_num_train_epochs(self):
+        """``training.epochs`` must reach the built-in PPOConfig path.
+
+        Read statically: reaching ``setup()`` needs a model and a dataset, and
+        trl is not installed in the test environment. What is checked is that
+        the assignment exists at all - it did not before, which is the bug.
+        """
+        tree = ast.parse(_PPO_SOURCE)
+        assigns = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Subscript)
+            and isinstance(node.targets[0].slice, ast.Constant)
+            and node.targets[0].slice.value == "num_train_epochs"
+        ]
+        assert assigns, "ppo.py never puts num_train_epochs into ppo_kwargs"
+        assert any(
+            ast.unparse(node.value) == "tcfg.epochs" for node in assigns
+        ), "num_train_epochs is set from something other than tcfg.epochs"
+
+    def test_ppo_epochs_is_still_a_separate_setting(self):
+        """The fix must not conflate the two. ppo_epochs is passes per batch."""
+        assert "num_ppo_epochs" in _PPO_SOURCE
+        assert "tcfg.ppo_epochs" in _PPO_SOURCE
+
+    def test_init_kl_coef_is_no_longer_resolved_by_hand(self):
+        """The old single-name lookup is gone, not merely supplemented."""
+        assert 'ppo_kwargs["init_kl_coef"]' not in _PPO_SOURCE
+        assert "kl_penalty_kwargs(ppo_config_cls" in _PPO_SOURCE


### PR DESCRIPTION
Closes #721.

## The two losses

**`ppo_kl_penalty`.** `setup()` resolved it as `init_kl_coef` only. trl renamed that to `kl_coef`, and a keyword `PPOConfig` does not recognise was never an error here -- it was dropped. So on trl 0.29 the run used trl's own `0.05` and nothing said otherwise, which is the part that makes this worse than an ordinary rename: the optimization objective changed silently.

**`training.epochs`.** Saved to `self._num_epochs` for the legacy manual loop and never passed to `PPOConfig`, so the built-in path ran trl's default budget. Every other trainer in `trainer/` passes `num_train_epochs=tcfg.epochs`; PPO was the exception.

`ppo_epochs` is a different setting -- optimization passes per batch -- and was already correct as `num_ppo_epochs`. Untouched, and there is a test that keeps it that way.

## Where the fix lives

`_trl_compat.kl_penalty_kwargs(config_cls, kl_penalty)`, next to `prompt_length_kwargs`, which exists for exactly this class of rename. It asks the class the caller is about to construct (so a namespace move is handled too), prefers `kl_coef`, falls back to `init_kl_coef`, and returns `{}` if neither exists.

The empty-dict case is deliberate. A third rename then produces a config that visibly ignores the setting at one call site, rather than repeating this bug one version later.

## Tests

`tests/test_issue721_ppo_kl_and_epochs.py`, 7 cases. trl is not a test dependency, so the kwarg-selection half is exercised against synthetic config classes carrying each signature -- modern (`kl_coef`), legacy (`init_kl_coef`), neither, and both at once -- and the epoch half is read statically out of `ppo.py`, in the style of `test_issue323_trl_kwarg_drift.py`.

Without the fix the module does not even import (`cannot import name 'kl_penalty_kwargs'`), which is the red state.

```
tests/test_issue721_ppo_kl_and_epochs.py                    7 passed

tests/test_ppo.py + test_trl_version_compat.py + test_issue323_trl_kwarg_drift.py
  with this change:   8 failed, 95 passed, 10 skipped
  on main:            8 failed, 88 passed, 10 skipped
```

The 8 are the same failures either way: `ModuleNotFoundError: No module named 'trl'` in `TestResolveTrlSymbol`, because trl is not installed in this environment. Nothing in this change touches them.

## Not verified here

I could not construct a real `PPOConfig` locally, so the "resolved built-in contract" table in the issue is not something I re-measured against trl 0.29.1 -- the synthetic signatures encode it instead. If CI has trl installed, `test_issue323_trl_kwarg_drift.py` should confirm the real class accepts both keywords this now passes.