### PR TITLE
test(peft): prove LoRA+ optimizer and scheduler state survive save/resume (#724)

### DIFF
--- a/changelog.d/0.74.0/747.added.md
+++ b/changelog.d/0.74.0/747.added.md
@@ -1,0 +1,10 @@
+- **Proved LoRA+ optimizer and scheduler state survive save/resume (#724 by @SID-6921 in
+  #747).**
+  #738 fixed `training.loraplus_lr_ratio` crashing on the SFT, pretrain and embedding
+  wrappers, but its last acceptance criterion — that resuming a LoRA+ run preserves the
+  optimizer's momentum and the scheduler's decayed learning rate — was never exercised.
+  A new test runs a real 4-step training loop twice against the same seeded base model and
+  dataset, once straight through and once interrupted at a real checkpoint and resumed,
+  both targeting the same `max_steps`; the optimizer momentum, scheduler LR, and final LoRA
+  weights all match exactly between the two. No production code changed: the existing
+  `attach_loraplus_optimizer` wiring already handled this correctly, it just wasn't proven.

--- a/tests/test_issue724_loraplus_optimizer.py
+++ b/tests/test_issue724_loraplus_optimizer.py
@@ -25,10 +25,14 @@ BASE_LR = 2e-5
 RATIO = 16.0
 
 
-def _tiny_peft_model():
+def _tiny_peft_model(seed: int = 0):
+    import torch
     from peft import LoraConfig, get_peft_model
     from transformers import AutoConfig, AutoModelForCausalLM
 
+    # Seeded so two separate calls can build bit-identical base + adapter
+    # weights - needed to compare a resumed run against an uninterrupted one.
+    torch.manual_seed(seed)
     cfg = AutoConfig.for_model(
         "llama", hidden_size=32, intermediate_size=64, num_hidden_layers=2,
         num_attention_heads=4, vocab_size=128,
@@ -37,6 +41,40 @@ def _tiny_peft_model():
     return get_peft_model(
         model, LoraConfig(r=8, lora_alpha=16, target_modules=["q_proj", "v_proj"])
     )
+
+
+def _tiny_dataset(n=16, seq_len=6, vocab_size=128, seed=123):
+    import torch
+
+    g = torch.Generator().manual_seed(seed)
+    return [
+        {
+            "input_ids": torch.randint(0, vocab_size, (seq_len,), generator=g),
+            "attention_mask": torch.ones(seq_len, dtype=torch.long),
+            "labels": torch.randint(0, vocab_size, (seq_len,), generator=g),
+        }
+        for _ in range(n)
+    ]
+
+
+def _trainer_with_data(model, tmp_path, dataset, *, max_steps, save_steps):
+    from transformers import Trainer, TrainingArguments
+
+    args = TrainingArguments(
+        output_dir=str(tmp_path), learning_rate=BASE_LR, optim="adamw_torch",
+        max_steps=max_steps, save_steps=save_steps, save_strategy="steps",
+        per_device_train_batch_size=4, report_to=[], logging_steps=1000,
+        disable_tqdm=True, seed=42, data_seed=42,
+    )
+    return Trainer(model=model, args=args, train_dataset=dataset)
+
+
+def _exp_avg_by_name(trainer):
+    return {
+        name: trainer.optimizer.state[p]["exp_avg"].clone()
+        for name, p in trainer.model.named_parameters()
+        if p in trainer.optimizer.state and "exp_avg" in trainer.optimizer.state[p]
+    }
 
 
 def _trainer(model, tmp_path, *, weight_decay=0.01, optim="adamw_torch"):
@@ -119,3 +157,73 @@ def test_training_arguments_still_rejects_the_kwarg():
 
     with pytest.raises(TypeError):
         TrainingArguments(output_dir="x", loraplus_lr_ratio=RATIO)
+
+
+class TestResumePreservesOptimizerAndSchedulerState:
+    """#724's last acceptance criterion, never previously exercised: does a
+    LoRA+ optimizer built by attach_loraplus_optimizer actually survive HF's
+    save/resume cycle, rather than just getting attached once and never
+    proven to reload correctly?
+
+    Runs a real 4-step training loop twice against the same seeded base
+    model and dataset, both targeting the same `max_steps` (matching how
+    `soup train --resume` is actually used - same config, continuing after
+    an interruption): once straight through, once stopped at the real
+    checkpoint saved at step 2 and resumed from it. `attach_loraplus_optimizer`
+    runs before `trainer.train()` in every wrapper (#724), which is what lets
+    `Trainer.create_optimizer` skip building a default optimizer and instead
+    build the scheduler around the LoRA+ one - but that ordering alone
+    doesn't prove `Trainer._load_optimizer_and_scheduler` correctly
+    restores ITS optimizer momentum and the scheduler's decayed LR onto a
+    freshly-built LoRA+ optimizer with matching param groups. If it silently
+    dropped or misaligned that state, the resumed run would diverge from the
+    uninterrupted one - exactly the kind of silent retuning #724 already
+    fixed for the initial construction, just at the resume boundary instead.
+
+    A run resumed with a DIFFERENT `max_steps` than it was checkpointed
+    under legitimately produces a different LR curve after resume (the
+    schedule's own decay depends on the target step count) - that is a
+    general `transformers.Trainer` characteristic, not something specific to
+    LoRA+, so it is deliberately not what this test compares.
+    """
+
+    def _train_to_step_4(self, out_dir, dataset, *, resume_from=None):
+        model = _tiny_peft_model(seed=7)
+        trainer = _trainer_with_data(model, out_dir, dataset, max_steps=4, save_steps=2)
+        attach_loraplus_optimizer(trainer, _TCfg(loraplus_lr_ratio=RATIO))
+        trainer.train(resume_from_checkpoint=resume_from)
+        return trainer
+
+    def test_resumed_run_matches_the_uninterrupted_run(self, tmp_path):
+        import torch
+
+        dataset = _tiny_dataset()
+        out_dir = tmp_path / "run"
+
+        reference = self._train_to_step_4(out_dir, dataset)
+        checkpoint = out_dir / "checkpoint-2"
+        assert checkpoint.is_dir()
+
+        resumed = self._train_to_step_4(out_dir, dataset, resume_from=str(checkpoint))
+
+        ref_state = _exp_avg_by_name(reference)
+        resumed_state = _exp_avg_by_name(resumed)
+        assert ref_state and set(ref_state) == set(resumed_state)
+        for name in ref_state:
+            assert torch.allclose(ref_state[name], resumed_state[name], atol=1e-6), (
+                f"optimizer momentum for {name} did not survive resume"
+            )
+
+        assert reference.lr_scheduler.get_last_lr() == resumed.lr_scheduler.get_last_lr()
+
+        compared_any = False
+        for (name, p_ref), (_, p_resumed) in zip(
+            reference.model.named_parameters(), resumed.model.named_parameters()
+        ):
+            if "lora_" not in name:
+                continue
+            compared_any = True
+            assert torch.allclose(p_ref, p_resumed, atol=1e-6), (
+                f"final weight for {name} diverged after resume"
+            )
+        assert compared_any

--- a/tests/test_issue724_loraplus_optimizer.py
+++ b/tests/test_issue724_loraplus_optimizer.py
@@ -21,8 +21,16 @@ pytest.importorskip("torch")
 pytest.importorskip("peft")
 pytest.importorskip("transformers")
 
+import torch  # noqa: E402 — after importorskip, for the version guard below
+
 BASE_LR = 2e-5
 RATIO = 16.0
+
+# transformers refuses torch.load for optimizer/scheduler checkpoints below
+# torch 2.6 (CVE-2025-32434) — the same floor gap as #651. This project
+# declares torch>=2.5.0, so an install at that floor must skip the resume
+# test below rather than fail red on a version restriction it can't control.
+_TORCH_VERSION = tuple(int(p) for p in torch.__version__.split("+")[0].split(".")[:2])
 
 
 def _tiny_peft_model(seed: int = 0):
@@ -159,6 +167,15 @@ def test_training_arguments_still_rejects_the_kwarg():
         TrainingArguments(output_dir="x", loraplus_lr_ratio=RATIO)
 
 
+@pytest.mark.skipif(
+    _TORCH_VERSION < (2, 6),
+    reason=(
+        f"torch {torch.__version__} predates 2.6; transformers refuses "
+        "torch.load for optimizer/scheduler checkpoints below that version "
+        "(CVE-2025-32434), so a real resume cycle cannot run here at all. "
+        "Resume is untested at this floor, not proven broken."
+    ),
+)
 class TestResumePreservesOptimizerAndSchedulerState:
     """#724's last acceptance criterion, never previously exercised: does a
     LoRA+ optimizer built by attach_loraplus_optimizer actually survive HF's


### PR DESCRIPTION
## Summary

Closes the last unchecked acceptance criterion on #724: "saving/resuming preserves optimizer and scheduler state" with LoRA+ active. PR #738 fixed the crash and wired the optimizer construction, but left this specific criterion unproven.

## What this is, and what it isn't

**It is not a bug fix.** `attach_loraplus_optimizer` already runs before `trainer.train()` in every wrapper (#738), which is what lets `Trainer.create_optimizer` skip building a default optimizer and build the scheduler around the LoRA+ one instead. I went in expecting to find a gap in that wiring and instead confirmed, empirically, that it already works correctly.

**It is the missing test.** Nothing previously proved that `Trainer._load_optimizer_and_scheduler` actually restores a LoRA+ optimizer's momentum and the scheduler's decayed LR correctly on resume, rather than just not crashing.

## How I verified it works before writing the test

Built a real tiny PEFT model + real `transformers.Trainer`, ran a 4-step training loop twice against the same seeded base model and dataset — once straight through, once interrupted at the real checkpoint saved at step 2 and resumed. With both runs targeting the same `max_steps` (matching how `--resume` is actually used — same config, continuing after an interruption), the resumed run's optimizer momentum, scheduler state, and final LoRA weights all matched the uninterrupted run's exactly (`torch.allclose` at 1e-6, and the momentum tensors matched bit-for-bit via `torch.equal` right at the checkpoint-load boundary, before any new steps ran).

One thing that looked like a bug at first and wasn't: if the resumed run targets a *different* `max_steps` than the original, the two runs diverge — but that's `transformers.Trainer`'s own general resume characteristic (the LR schedule's decay curve depends on the target step count), not anything specific to LoRA+. Worth knowing, not worth fixing here.

## The test

`TestResumePreservesOptimizerAndSchedulerState` in `tests/test_issue724_loraplus_optimizer.py`, following #738's own pattern of a real model + real `Trainer`, no mocks.

## Verification

- 8/8 tests pass in the file (7 existing + 1 new).
- **Mutation**: reordered the resumed run's `attach_loraplus_optimizer` call to *after* `trainer.train()` starts — simulating the exact ordering regression the existing docstring already warns is possible. The test fails with the real PyTorch error that ordering mistake actually produces: `ValueError: loaded state dict has a different number of parameter groups`. Reverted after confirming.
- `ruff check` and `mypy` both clean on the changed file.

A changelog fragment will follow in a quick commit once this PR has a number, per this repo's `changelog.d/<PR#>.<type>.md` convention.
