### PR TITLE
test(doctor): pin the accelerate DEPS row to the declared pyproject floor

### DIFF
--- a/tests/test_issue352_fsdp_peft_checkpoint.py
+++ b/tests/test_issue352_fsdp_peft_checkpoint.py
@@ -29,6 +29,21 @@ def test_pyproject_accelerate_floor_supports_adapter_only_fsdp_checkpoints():
     )
 
 
+def test_doctor_deps_accelerate_floor_matches_declared_extra():
+    from soup_cli.commands.doctor import DEPS
+
+    pyproject = Path(__file__).parent.parent / "pyproject.toml"
+    match = re.search(r'"accelerate>=([0-9.]+)"', pyproject.read_text(encoding="utf-8"))
+    assert match, "accelerate floor pin not found in pyproject.toml"
+
+    doctor_floors = {package: floor for _, package, floor, _ in DEPS}
+    assert doctor_floors["accelerate"] == match.group(1), (
+        f"soup doctor reports accelerate>={doctor_floors['accelerate']} but pyproject.toml "
+        f"declares accelerate>={match.group(1)}; doctor would certify an environment that "
+        "reintroduces #352's full-base-model FSDP checkpoint"
+    )
+
+
 def test_installed_accelerate_save_fsdp_model_supports_adapter_only():
     from accelerate.utils import save_fsdp_model
 


### PR DESCRIPTION
Adds the guard gap you flagged in your comment on #352. Reverting `doctor.py`'s
accelerate row to 0.25.0 still passes the full suite, because
`test_doctor_training_bounds_match_declared_extra` only checks `_RUNTIME_FLOORS`
(transformers, trl, peft) against the `DEPS` table, and accelerate isn't in that
set. So `soup doctor` could certify an environment that reintroduces the 37 GB
checkpoint write with nothing catching it.

Went with your suggested shape: a separate assertion next to
`test_pyproject_accelerate_floor_supports_adapter_only_fsdp_checkpoints` in
`test_issue352_fsdp_peft_checkpoint.py`, not widening `_RUNTIME_FLOORS` (that
also drives `_REQUIRES_TRAINING_FLOOR`'s skip behavior for the transformers 5
tests, which this shouldn't touch).

No source change, only the missing coverage. Confirmed the new test fails when
`doctor.py`'s accelerate floor is reverted to 0.25.0 and the two existing
accelerate tests both still pass regardless, which is the exact blind spot.

Not closing #352, just this one guard gap; the resume-from-checkpoint criterion
stays open as you noted.
