### PR TITLE
Add Graft MCP config and repo instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,34 +1,3 @@
-# AGENTS.md
-
-Tool-agnostic entry point for AI coding agents (Codex, Cursor, Aider, Claude Code, etc.).
-
-**Soup** is a CLI-first LLM fine-tuning tool. Python 3.10+, Apache-2.0.
-
-## Build & test
-
-```bash
-pip install -e ".[dev]"          # Editable install + test deps
-pytest tests/ -v --tb=short      # Run the suite (smoke tests are excluded by default)
-ruff check src/soup_cli/ tests/  # Lint — must be clean before any commit
-```
-
-- `pytest -m smoke` runs the slow tests that download models and train (skipped by default).
-- CI matrix: Python 3.10 / 3.11 / 3.12 × Ubuntu / Windows / macOS.
-
-## Conventions (must follow)
-
-- **Config** is Pydantic v2 in `src/soup_cli/config/schema.py` — single source of truth.
-- **Heavy deps** (`torch`, `transformers`, `peft`, `trl`, `mlx`) are lazy-imported inside functions, never at module top.
-- **Output** via `rich.console.Console`, never bare `print()`.
-- **Path containment**: use `os.path.realpath` + `os.path.commonpath`, not `Path.resolve() + relative_to()` (breaks on Windows short names).
-- **Line length** 100, ruff rules `E, F, I, N, W`.
-
-## Full instructions
-
-- **Feature reference** lives in [`docs/`](docs/README.md) — per-topic guides plus the full `soup` command list ([`docs/commands.md`](docs/commands.md)). Read the relevant page before changing a feature.
-- **Contribution workflow, project structure, and architecture notes** are in [`CONTRIBUTING.md`](CONTRIBUTING.md). Read it before making non-trivial changes.
-- The Pydantic config schema in [`src/soup_cli/config/schema.py`](src/soup_cli/config/schema.py) is the single source of truth for every config field.
-
 <!-- graft:start -->
 ## Graft — repo context graph
 

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ docs/superpowers/
 
 # Layer-streaming disk-throughput probe scratch file (soup doctor --disk / training pre-flight)
 .soup-diskprobe-*
+
+# graft's local graph cache — regenerable, not committed (run `graft build`).
+/graft/

--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,5 @@
+# graft's cards are gitignored but should stay greppable: ripgrep reads
+# .ignore before .gitignore, so this re-admits the tree to search only.
+!graft/
+graft/.cache/
+graft/.graph/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "graft": {
+      "command": "node",
+      "args": [
+        "C:/Users/buzbe/AppData/Roaming/npm/node_modules/@nanonets/graft/dist/cli.js",
+        "mcp"
+      ]
+    }
+  }
+}

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,13 @@
+{
+  "mcp": {
+    "graft": {
+      "type": "local",
+      "command": [
+        "node",
+        "C:/Users/buzbe/AppData/Roaming/npm/node_modules/@nanonets/graft/dist/cli.js",
+        "mcp"
+      ],
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
Introduces Graft setup across the repo: adds shared Graft usage guidance to AGENTS.md and a new .github/copilot-instructions.md, adds MCP server config files (.mcp.json and opencode.json), and updates ignore rules so the generated graft/ graph stays untracked while remaining searchable.

## What does this PR do?

<!-- Brief description of the change -->

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / cleanup
- [x] Documentation
- [x] Tests

## Checklist

- [x] `ruff check src/soup_cli/ scripts/ tests/` passes
- [x] `pytest tests/ -v` passes
- [x] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed
- [x] Added a changelog fragment, or this change has no user-visible impact
