### PR TITLE
fix(train): widen the failure boundary so setup errors reach fail_run, and record the run's pid (#764)

### DIFF
--- a/changelog.d/0.74.0/767.fixed.md
+++ b/changelog.d/0.74.0/767.fixed.md
@@ -1,0 +1,13 @@
+- **`soup train` left a run at `status='running'` forever when setup failed (#764 by
+  @SID-6921 in #767).**
+  The tracker registered a run before loading the model, but the only `except` that marked
+  a run failed wrapped the training call alone — a tokenizer/model load, quantization, LoRA
+  attach, or dataset mapping failure in the ~250 lines before it left the row stuck at
+  `running` with no way to tell it apart from a live run. On a real database this was 220 of
+  432 rows, the oldest since 2026-03-04. The failure boundary now wraps everything from right
+  after the run is registered through the end of the command, and `fail_run` records the
+  exception type and message on the row (`runs.error_message`, added via the existing lazy
+  migration). Separately, `soup train` now records its own pid via `mark_running` the way the
+  MCP execution path already does, so `_reconcile_orphaned_run` (#401) can rescue a
+  SIGKILL'd or Ctrl+C'd run on the next `soup runs` instead of leaving it invisible to a
+  mechanism this project already built for exactly that purpose.

--- a/changelog.d/0.75.0/767.fixed.md
+++ b/changelog.d/0.75.0/767.fixed.md
@@ -10,4 +10,7 @@
   migration). Separately, `soup train` now records its own pid via `mark_running` the way the
   MCP execution path already does, so `_reconcile_orphaned_run` (#401) can rescue a
   SIGKILL'd or Ctrl+C'd run on the next `soup runs` instead of leaving it invisible to a
-  mechanism this project already built for exactly that purpose.
+  mechanism this project already built for exactly that purpose. `error_message` is
+  redacted and length-capped before storage, and `soup runs show` now surfaces it and
+  reports `terminated`/`launching` correctly instead of falling back to `running` for
+  every non-completed, non-failed status.

--- a/src/soup_cli/commands/runs.py
+++ b/src/soup_cli/commands/runs.py
@@ -156,12 +156,19 @@ def show(
         console.print("[dim]Use [bold]soup runs[/] to see all runs.[/]")
         raise typer.Exit(1)
 
-    # Format status
+    # Format status. Enumerated rather than a catch-all "else: running" —
+    # that fallback used to print "running" for a "terminated" row too,
+    # since _reconcile_orphaned_run (#401) and a "launching" MCP row both
+    # fell through it silently (#764/#767 review).
     status = run["status"]
     if status == "completed":
         status_str = "[green]completed[/]"
     elif status == "failed":
         status_str = "[red]failed[/]"
+    elif status == "terminated":
+        status_str = "[red]terminated[/]"
+    elif status == "launching":
+        status_str = "[dim]launching[/]"
     else:
         status_str = "[yellow]running[/]"
 
@@ -180,6 +187,13 @@ def show(
         f"Name:       {_esc(str(run.get('experiment_name') or '-'))}",
         f"Status:     {status_str}",
         f"Date:       {run['created_at'][:19].replace('T', ' ')}",
+    ]
+    # error_message (#764/#767): written by fail_run since #764, but read by
+    # nothing until now — a failed run's "why" was sitting in the database
+    # with no surface to show it.
+    if run.get("error_message"):
+        info_lines.append(f"Error:      {_esc(str(run['error_message']))}")
+    info_lines.extend([
         "",
         f"Model:      [bold]{_esc(str(run.get('base_model') or '-'))}[/]",
         f"Task:       {_esc(str(run.get('task') or '-'))}",
@@ -192,7 +206,7 @@ def show(
         f"Duration:   {duration_str}",
         f"Cost:       {_fmt_cost(run)}",
         f"Output:     {_esc(str(run.get('output_dir') or '-'))}",
-    ]
+    ])
     console.print(Panel("\n".join(info_lines), title="Run Details"))
 
     # Config section

--- a/src/soup_cli/commands/train.py
+++ b/src/soup_cli/commands/train.py
@@ -193,14 +193,28 @@ def _describe_exception_for_tracker(exc: BaseException) -> str:
     """Format ``exc`` for ``ExperimentTracker.fail_run``'s ``error=`` column.
 
     A handled setup failure (a bad ``--tracker`` value, a hub download
-    error) exits via ``raise typer.Exit(...) from exc``. ``typer.Exit``
-    carries no message of its own, so formatting the caught exception
-    directly writes ``"Exit: "`` to the row and loses the reason a human
-    needs — the one already printed to the console just before the raise.
-    Unwrapping to ``__cause__`` when present recovers it (#764 review).
+    error, a hub-cache path-containment refusal) exits via
+    ``raise typer.Exit(...)``, sometimes chained with ``from exc`` and
+    sometimes not. ``typer.Exit`` carries no message of its own, so
+    formatting it directly writes ``"Exit: "`` to the row and loses the
+    reason a human needs. Unwrapping to ``__cause__`` recovers it for the
+    chained sites; recording ``exit_code`` covers the one site that
+    raises bare, so all three read as something more useful than
+    ``"Exit: "`` (#764/#767 review).
+
+    The unwrap is gated to ``typer.Exit`` specifically — this helper also
+    runs on ordinary training failures (``raise X from Y`` deep inside a
+    library), where the outer exception X is the operator-facing reason
+    and the inner cause Y is just the mechanism. Unwrapping unconditionally
+    would discard X and keep only Y, which is less informative than before
+    this fix existed — the exact regression the same review caught.
     """
-    cause = exc.__cause__ or exc
-    return f"{type(cause).__name__}: {cause}"
+    if isinstance(exc, typer.Exit):
+        if exc.__cause__ is not None:
+            cause = exc.__cause__
+            return f"{type(cause).__name__}: {cause} (exit code {exc.exit_code})"
+        return f"Exit(code={exc.exit_code})"
+    return f"{type(exc).__name__}: {exc}"
 
 
 def train(

--- a/src/soup_cli/commands/train.py
+++ b/src/soup_cli/commands/train.py
@@ -1289,266 +1289,275 @@ def train(
         experiment_name=experiment_name,
         run_id=os.environ.get("SOUP_MCP_RUN_ID") or None,
     )
+    # #764: without a pid, a SIGKILL'd or Ctrl+C'd run has no way for
+    # _reconcile_orphaned_run to ever notice the process is gone — the
+    # rescue path #401 built for MCP-spawned runs was otherwise inert here.
+    tracker.mark_running(run_id, pid=os.getpid())
     console.print(f"[dim]Run ID: {run_id}[/]")
 
-    # Build trainer based on task type
-    from soup_cli.utils.trackers import resolve_report_to
-
     try:
-        report_to = resolve_report_to(
-            wandb=wandb, tensorboard=tensorboard, tracker=tracker_backend
-        )
-    except ValueError as exc:
-        from rich.markup import escape as _esc
+        # Build trainer based on task type
+        from soup_cli.utils.trackers import resolve_report_to
 
-        console.print(f"[red]{_esc(str(exc))}[/]")
-        raise typer.Exit(code=2) from exc
-    console.print("[dim]Setting up model + trainer...[/]")
-    # v0.53.8 #130 — pre-fetch model from non-HF hub into a local cache and
-    # rewrite cfg.base to point at the local snapshot. The trainer wrappers
-    # still use transformers.from_pretrained, which reads HF Hub by default;
-    # by snapshotting first we keep every wrapper unchanged.
-    hub_name = getattr(cfg.training, "hub", "hf") or "hf"
-    if hub_name != "hf":
-        import re as _re
-
-        from rich.markup import escape as _markup_escape
-
-        from soup_cli.utils.hubs import download_repo
-        from soup_cli.utils.paths import is_under_cwd
-
-        # Sanitise cache subdir name — strip every path-separator and
-        # `..` segment so a crafted ``base: ../../etc`` cannot escape the
-        # cache root (Windows ``\\`` and POSIX ``/`` both blocked).
-        safe_slug = _re.sub(r"[^A-Za-z0-9._-]+", "__", cfg.base).strip("._-") or "model"
-        cache_dir = (Path.cwd() / ".soup_hub_cache" / safe_slug).resolve()
-        if not is_under_cwd(str(cache_dir)):
-            console.print(
-                "[red]Resolved hub cache dir escaped the current working "
-                "directory; refusing to download.[/]"
-            )
-            raise typer.Exit(code=1)
         try:
-            # Idempotency: if the cache dir already has a config.json, skip
-            # the re-download (modelscope/openmind-hub also short-circuit on
-            # match but having an explicit probe lets us print a clear hint).
-            existing_cfg = cache_dir / "config.json"
-            if existing_cfg.is_file():
-                local_path = str(cache_dir)
-                console.print(
-                    f"[dim]Using cached snapshot at {local_path}[/]"
-                )
-            else:
-                local_path = download_repo(
-                    hub_name,
-                    cfg.base,
-                    local_dir=str(cache_dir),
-                )
-                console.print(
-                    f"[dim]Fetched {cfg.base} from hub={hub_name} → "
-                    f"{local_path}[/]"
-                )
-            # Use ``model_copy(update=...)`` so the Pydantic field
-            # validators on ``base`` rerun (matches v0.33.0 #47 / v0.40.0
-            # Part B immutability policy).
-            cfg = cfg.model_copy(update={"base": local_path})
-        except ImportError as exc:
-            console.print(f"[red]{_markup_escape(str(exc))}[/]")
-            raise typer.Exit(code=1) from exc
-
-    # v0.53.8 #89 — friendly missing-dep advisory for `--tracker <name>`.
-    if report_to and report_to not in ("none", "wandb", "tensorboard"):
-        from soup_cli.utils.trackers import tracker_missing_dep_message
-
-        msg = tracker_missing_dep_message(report_to)
-        if msg:
-            console.print(f"[yellow]{msg}[/]")
-    trainer_kwargs = {
-        "device": device,
-        "report_to": report_to,
-        "deepspeed_config": ds_config_path,
-        "fsdp_config": fsdp_kwargs,
-    }
-    # v0.40.4 #63 — every transformer-backend trainer now threads
-    # --trust-remote-code through the wrapper (closes the v0.36.0 Part B gap).
-    trainer_kwargs = dict(trainer_kwargs, trust_remote_code=trust_remote_code)
-    from soup_cli.trainer.mlx_routing import resolve_trainer
-
-    mlx_cls, trainer_kwargs = resolve_trainer(cfg, trainer_kwargs)
-    if mlx_cls is not None:
-        trainer_wrapper = mlx_cls(cfg, **trainer_kwargs)
-    elif cfg.task == "dpo":
-        from soup_cli.trainer.dpo import DPOTrainerWrapper
-
-        trainer_wrapper = DPOTrainerWrapper(cfg, **trainer_kwargs)
-    elif cfg.task == "online_dpo":
-        from soup_cli.trainer.online_dpo import OnlineDPOTrainerWrapper
-
-        trainer_wrapper = OnlineDPOTrainerWrapper(cfg, **trainer_kwargs)
-    elif cfg.task == "grpo":
-        from soup_cli.trainer.grpo import GRPOTrainerWrapper
-
-        trainer_wrapper = GRPOTrainerWrapper(cfg, **trainer_kwargs)
-    elif cfg.task == "ppo":
-        from soup_cli.trainer.ppo import PPOTrainerWrapper
-
-        trainer_wrapper = PPOTrainerWrapper(cfg, **trainer_kwargs)
-    elif cfg.task == "kto":
-        from soup_cli.trainer.kto import KTOTrainerWrapper
-
-        trainer_wrapper = KTOTrainerWrapper(cfg, **trainer_kwargs)
-    elif cfg.task == "orpo":
-        from soup_cli.trainer.orpo import ORPOTrainerWrapper
-
-        trainer_wrapper = ORPOTrainerWrapper(cfg, **trainer_kwargs)
-    elif cfg.task == "simpo":
-        from soup_cli.trainer.simpo import SimPOTrainerWrapper
-
-        trainer_wrapper = SimPOTrainerWrapper(cfg, **trainer_kwargs)
-    elif cfg.task == "ipo":
-        from soup_cli.trainer.ipo import IPOTrainerWrapper
-
-        trainer_wrapper = IPOTrainerWrapper(cfg, **trainer_kwargs)
-    elif cfg.task == "bco":
-        from soup_cli.trainer.bco import BCOTrainerWrapper
-
-        trainer_wrapper = BCOTrainerWrapper(cfg, **trainer_kwargs)
-    elif cfg.task == "preference":
-        from soup_cli.trainer.preference import PreferenceTrainerWrapper
-
-        trainer_wrapper = PreferenceTrainerWrapper(cfg, **trainer_kwargs)
-    elif cfg.task == "reward_model":
-        from soup_cli.trainer.reward_model import RewardModelTrainerWrapper
-
-        trainer_wrapper = RewardModelTrainerWrapper(cfg, **trainer_kwargs)
-    elif cfg.task == "pretrain":
-        from soup_cli.trainer.pretrain import PretrainTrainerWrapper
-
-        trainer_wrapper = PretrainTrainerWrapper(cfg, **trainer_kwargs)
-    elif cfg.task == "embedding":
-        from soup_cli.trainer.embedding import EmbeddingTrainerWrapper
-
-        trainer_wrapper = EmbeddingTrainerWrapper(cfg, **trainer_kwargs)
-    elif cfg.task == "distill":
-        # v0.53.2 #133 — knowledge distillation (student + frozen teacher).
-        from soup_cli.trainer.distill import DistillTrainerWrapper
-
-        trainer_wrapper = DistillTrainerWrapper(cfg, **trainer_kwargs)
-    elif cfg.task == "prm":
-        # v0.53.11 #126 — Process Reward Model trainer.
-        from soup_cli.trainer.prm import PRMTrainerWrapper
-
-        trainer_wrapper = PRMTrainerWrapper(cfg, **trainer_kwargs)
-    elif cfg.task in ("classifier", "reranker", "cross_encoder"):
-        # v0.53.2 #132 — sequence-classification head.
-        from soup_cli.trainer.classifier import ClassifierTrainerWrapper
-
-        trainer_wrapper = ClassifierTrainerWrapper(cfg, **trainer_kwargs)
-    elif cfg.task == "unlearn":
-        # v0.71.9 #193 — NPO / SimNPO / RMU unlearning.
-        from soup_cli.trainer.unlearn import UnlearnTrainerWrapper
-
-        trainer_wrapper = UnlearnTrainerWrapper(cfg, **trainer_kwargs)
-    elif cfg.task == "moe_lora_routing":
-        # v0.71.12 #222 — MoLE per-token routing over N frozen task LoRAs.
-        from soup_cli.trainer.mole_routing import MoleRoutingTrainerWrapper
-
-        trainer_wrapper = MoleRoutingTrainerWrapper(cfg, **trainer_kwargs)
-    elif cfg.task == "tts":
-        # v0.71.20 #131 — TTS fine-tuning (SFT-style next-token CE over
-        # text + audio-codec-token sequences; per-family templating).
-        from soup_cli.trainer.tts import TTSTrainerWrapper
-
-        trainer_wrapper = TTSTrainerWrapper(cfg, **trainer_kwargs)
-    elif cfg.task == "asr":
-        # v0.71.32 — ASR (Whisper) fine-tuning via Seq2SeqTrainer.
-        from soup_cli.trainer.asr import AsrTrainerWrapper
-
-        trainer_wrapper = AsrTrainerWrapper(cfg, **trainer_kwargs)
-    else:
-        # Keep the transformers/TRL SFT surface outside the backend-first MLX
-        # route. The wrapper is import-light today, but importing it eagerly
-        # makes an MLX-only install depend on that remaining true forever.
-        from soup_cli.trainer.sft import SFTTrainerWrapper
-
-        trainer_wrapper = SFTTrainerWrapper(cfg, **trainer_kwargs)
-    trainer_wrapper.setup(dataset)
-
-    # #350 — PEFT promotes newly-created adapters to fp32. FSDP cannot flatten
-    # those beside bf16/float16 BNB storage, so align every trainable floating
-    # tensor after setup creates PEFT modules and before train() wraps the model.
-    aligned_fsdp_params = 0
-    if fsdp and cfg.training.quantization == "4bit":
-        from soup_cli.utils.gpu import get_compute_dtype
-        from soup_cli.utils.mixed_precision import align_trainable_dtype_for_fsdp_qlora
-
-        aligned_fsdp_params = align_trainable_dtype_for_fsdp_qlora(
-            getattr(trainer_wrapper, "model", None),
-            fsdp=True,
-            quantization=cfg.training.quantization,
-            compute_dtype=get_compute_dtype(),
-        )
-    if aligned_fsdp_params:
-        console.print(
-            f"[green]FSDP QLoRA:[/] aligned {aligned_fsdp_params} trainable "
-            "parameter tensor(s) to the compute dtype"
-        )
-
-    # --- HF auto-push callback (Part B of v0.29.0) ---
-    if push_as:
-        from soup_cli.monitoring.hf_push import build_push_callback
-
-        push_cb = build_push_callback(
-            repo_id=push_as,
-            output_dir=cfg.output,
-            private=False,
-        )
-        if push_cb is None:
-            console.print(
-                "[yellow]--push-as: no HF token available; skipping auto-push[/]"
+            report_to = resolve_report_to(
+                wandb=wandb, tensorboard=tensorboard, tracker=tracker_backend
             )
-        else:
-            hf_trainer = getattr(trainer_wrapper, "trainer", None)
-            if hf_trainer is not None and hasattr(hf_trainer, "add_callback"):
-                hf_trainer.add_callback(push_cb)
-                console.print(
-                    f"[green]HF auto-push enabled[/] -> {push_as} "
-                    "(one branch per save_steps)"
-                )
-            else:
-                console.print(
-                    "[yellow]--push-as: trainer does not expose add_callback; "
-                    "auto-push disabled for this run[/]"
-                )
-
-    # Train with live display and experiment tracking
-    display = TrainingDisplay(cfg, device_name=device_name)
-    console.print("[bold green]Training started![/]\n")
-
-    profiler_ctx = contextlib.nullcontext()
-    if profile_run:
-        from soup_cli.utils.profiling import profile_training
-
-        profiler_ctx = profile_training(output_dir=Path(cfg.output), run_id=run_id)
-        console.print(
-            "[cyan]--profile:[/] writing torch.profiler trace to "
-            f"{cfg.output}/profiles/{run_id}.trace.json (early-steps window)"
-        )
-
-    # v0.71.3 #180 — optional codecarbon energy/CO2 measurement around the
-    # training window. Lazy-built; a graceful no-op when codecarbon is absent.
-    energy_ctx = contextlib.nullcontext()
-    energy_tracker = None
-    if track_energy:
-        try:
-            from soup_cli.utils.energy import EnergyTracker
-
-            energy_tracker = EnergyTracker(country_iso_code=energy_country)
-            energy_ctx = energy_tracker
         except ValueError as exc:
-            console.print(f"[yellow]--track-energy disabled:[/] {exc}")
-            energy_tracker = None
-            energy_ctx = contextlib.nullcontext()
+            from rich.markup import escape as _esc
+
+            console.print(f"[red]{_esc(str(exc))}[/]")
+            raise typer.Exit(code=2) from exc
+        console.print("[dim]Setting up model + trainer...[/]")
+        # v0.53.8 #130 — pre-fetch model from non-HF hub into a local cache and
+        # rewrite cfg.base to point at the local snapshot. The trainer wrappers
+        # still use transformers.from_pretrained, which reads HF Hub by default;
+        # by snapshotting first we keep every wrapper unchanged.
+        hub_name = getattr(cfg.training, "hub", "hf") or "hf"
+        if hub_name != "hf":
+            import re as _re
+
+            from rich.markup import escape as _markup_escape
+
+            from soup_cli.utils.hubs import download_repo
+            from soup_cli.utils.paths import is_under_cwd
+
+            # Sanitise cache subdir name — strip every path-separator and
+            # `..` segment so a crafted ``base: ../../etc`` cannot escape the
+            # cache root (Windows ``\\`` and POSIX ``/`` both blocked).
+            safe_slug = _re.sub(r"[^A-Za-z0-9._-]+", "__", cfg.base).strip("._-") or "model"
+            cache_dir = (Path.cwd() / ".soup_hub_cache" / safe_slug).resolve()
+            if not is_under_cwd(str(cache_dir)):
+                console.print(
+                    "[red]Resolved hub cache dir escaped the current working "
+                    "directory; refusing to download.[/]"
+                )
+                raise typer.Exit(code=1)
+            try:
+                # Idempotency: if the cache dir already has a config.json, skip
+                # the re-download (modelscope/openmind-hub also short-circuit on
+                # match but having an explicit probe lets us print a clear hint).
+                existing_cfg = cache_dir / "config.json"
+                if existing_cfg.is_file():
+                    local_path = str(cache_dir)
+                    console.print(
+                        f"[dim]Using cached snapshot at {local_path}[/]"
+                    )
+                else:
+                    local_path = download_repo(
+                        hub_name,
+                        cfg.base,
+                        local_dir=str(cache_dir),
+                    )
+                    console.print(
+                        f"[dim]Fetched {cfg.base} from hub={hub_name} → "
+                        f"{local_path}[/]"
+                    )
+                # Use ``model_copy(update=...)`` so the Pydantic field
+                # validators on ``base`` rerun (matches v0.33.0 #47 / v0.40.0
+                # Part B immutability policy).
+                cfg = cfg.model_copy(update={"base": local_path})
+            except ImportError as exc:
+                console.print(f"[red]{_markup_escape(str(exc))}[/]")
+                raise typer.Exit(code=1) from exc
+
+        # v0.53.8 #89 — friendly missing-dep advisory for `--tracker <name>`.
+        if report_to and report_to not in ("none", "wandb", "tensorboard"):
+            from soup_cli.utils.trackers import tracker_missing_dep_message
+
+            msg = tracker_missing_dep_message(report_to)
+            if msg:
+                console.print(f"[yellow]{msg}[/]")
+        trainer_kwargs = {
+            "device": device,
+            "report_to": report_to,
+            "deepspeed_config": ds_config_path,
+            "fsdp_config": fsdp_kwargs,
+        }
+        # v0.40.4 #63 — every transformer-backend trainer now threads
+        # --trust-remote-code through the wrapper (closes the v0.36.0 Part B gap).
+        trainer_kwargs = dict(trainer_kwargs, trust_remote_code=trust_remote_code)
+        from soup_cli.trainer.mlx_routing import resolve_trainer
+
+        mlx_cls, trainer_kwargs = resolve_trainer(cfg, trainer_kwargs)
+        if mlx_cls is not None:
+            trainer_wrapper = mlx_cls(cfg, **trainer_kwargs)
+        elif cfg.task == "dpo":
+            from soup_cli.trainer.dpo import DPOTrainerWrapper
+
+            trainer_wrapper = DPOTrainerWrapper(cfg, **trainer_kwargs)
+        elif cfg.task == "online_dpo":
+            from soup_cli.trainer.online_dpo import OnlineDPOTrainerWrapper
+
+            trainer_wrapper = OnlineDPOTrainerWrapper(cfg, **trainer_kwargs)
+        elif cfg.task == "grpo":
+            from soup_cli.trainer.grpo import GRPOTrainerWrapper
+
+            trainer_wrapper = GRPOTrainerWrapper(cfg, **trainer_kwargs)
+        elif cfg.task == "ppo":
+            from soup_cli.trainer.ppo import PPOTrainerWrapper
+
+            trainer_wrapper = PPOTrainerWrapper(cfg, **trainer_kwargs)
+        elif cfg.task == "kto":
+            from soup_cli.trainer.kto import KTOTrainerWrapper
+
+            trainer_wrapper = KTOTrainerWrapper(cfg, **trainer_kwargs)
+        elif cfg.task == "orpo":
+            from soup_cli.trainer.orpo import ORPOTrainerWrapper
+
+            trainer_wrapper = ORPOTrainerWrapper(cfg, **trainer_kwargs)
+        elif cfg.task == "simpo":
+            from soup_cli.trainer.simpo import SimPOTrainerWrapper
+
+            trainer_wrapper = SimPOTrainerWrapper(cfg, **trainer_kwargs)
+        elif cfg.task == "ipo":
+            from soup_cli.trainer.ipo import IPOTrainerWrapper
+
+            trainer_wrapper = IPOTrainerWrapper(cfg, **trainer_kwargs)
+        elif cfg.task == "bco":
+            from soup_cli.trainer.bco import BCOTrainerWrapper
+
+            trainer_wrapper = BCOTrainerWrapper(cfg, **trainer_kwargs)
+        elif cfg.task == "preference":
+            from soup_cli.trainer.preference import PreferenceTrainerWrapper
+
+            trainer_wrapper = PreferenceTrainerWrapper(cfg, **trainer_kwargs)
+        elif cfg.task == "reward_model":
+            from soup_cli.trainer.reward_model import RewardModelTrainerWrapper
+
+            trainer_wrapper = RewardModelTrainerWrapper(cfg, **trainer_kwargs)
+        elif cfg.task == "pretrain":
+            from soup_cli.trainer.pretrain import PretrainTrainerWrapper
+
+            trainer_wrapper = PretrainTrainerWrapper(cfg, **trainer_kwargs)
+        elif cfg.task == "embedding":
+            from soup_cli.trainer.embedding import EmbeddingTrainerWrapper
+
+            trainer_wrapper = EmbeddingTrainerWrapper(cfg, **trainer_kwargs)
+        elif cfg.task == "distill":
+            # v0.53.2 #133 — knowledge distillation (student + frozen teacher).
+            from soup_cli.trainer.distill import DistillTrainerWrapper
+
+            trainer_wrapper = DistillTrainerWrapper(cfg, **trainer_kwargs)
+        elif cfg.task == "prm":
+            # v0.53.11 #126 — Process Reward Model trainer.
+            from soup_cli.trainer.prm import PRMTrainerWrapper
+
+            trainer_wrapper = PRMTrainerWrapper(cfg, **trainer_kwargs)
+        elif cfg.task in ("classifier", "reranker", "cross_encoder"):
+            # v0.53.2 #132 — sequence-classification head.
+            from soup_cli.trainer.classifier import ClassifierTrainerWrapper
+
+            trainer_wrapper = ClassifierTrainerWrapper(cfg, **trainer_kwargs)
+        elif cfg.task == "unlearn":
+            # v0.71.9 #193 — NPO / SimNPO / RMU unlearning.
+            from soup_cli.trainer.unlearn import UnlearnTrainerWrapper
+
+            trainer_wrapper = UnlearnTrainerWrapper(cfg, **trainer_kwargs)
+        elif cfg.task == "moe_lora_routing":
+            # v0.71.12 #222 — MoLE per-token routing over N frozen task LoRAs.
+            from soup_cli.trainer.mole_routing import MoleRoutingTrainerWrapper
+
+            trainer_wrapper = MoleRoutingTrainerWrapper(cfg, **trainer_kwargs)
+        elif cfg.task == "tts":
+            # v0.71.20 #131 — TTS fine-tuning (SFT-style next-token CE over
+            # text + audio-codec-token sequences; per-family templating).
+            from soup_cli.trainer.tts import TTSTrainerWrapper
+
+            trainer_wrapper = TTSTrainerWrapper(cfg, **trainer_kwargs)
+        elif cfg.task == "asr":
+            # v0.71.32 — ASR (Whisper) fine-tuning via Seq2SeqTrainer.
+            from soup_cli.trainer.asr import AsrTrainerWrapper
+
+            trainer_wrapper = AsrTrainerWrapper(cfg, **trainer_kwargs)
+        else:
+            # Keep the transformers/TRL SFT surface outside the backend-first MLX
+            # route. The wrapper is import-light today, but importing it eagerly
+            # makes an MLX-only install depend on that remaining true forever.
+            from soup_cli.trainer.sft import SFTTrainerWrapper
+
+            trainer_wrapper = SFTTrainerWrapper(cfg, **trainer_kwargs)
+        trainer_wrapper.setup(dataset)
+
+        # #350 — PEFT promotes newly-created adapters to fp32. FSDP cannot flatten
+        # those beside bf16/float16 BNB storage, so align every trainable floating
+        # tensor after setup creates PEFT modules and before train() wraps the model.
+        aligned_fsdp_params = 0
+        if fsdp and cfg.training.quantization == "4bit":
+            from soup_cli.utils.gpu import get_compute_dtype
+            from soup_cli.utils.mixed_precision import align_trainable_dtype_for_fsdp_qlora
+
+            aligned_fsdp_params = align_trainable_dtype_for_fsdp_qlora(
+                getattr(trainer_wrapper, "model", None),
+                fsdp=True,
+                quantization=cfg.training.quantization,
+                compute_dtype=get_compute_dtype(),
+            )
+        if aligned_fsdp_params:
+            console.print(
+                f"[green]FSDP QLoRA:[/] aligned {aligned_fsdp_params} trainable "
+                "parameter tensor(s) to the compute dtype"
+            )
+
+        # --- HF auto-push callback (Part B of v0.29.0) ---
+        if push_as:
+            from soup_cli.monitoring.hf_push import build_push_callback
+
+            push_cb = build_push_callback(
+                repo_id=push_as,
+                output_dir=cfg.output,
+                private=False,
+            )
+            if push_cb is None:
+                console.print(
+                    "[yellow]--push-as: no HF token available; skipping auto-push[/]"
+                )
+            else:
+                hf_trainer = getattr(trainer_wrapper, "trainer", None)
+                if hf_trainer is not None and hasattr(hf_trainer, "add_callback"):
+                    hf_trainer.add_callback(push_cb)
+                    console.print(
+                        f"[green]HF auto-push enabled[/] -> {push_as} "
+                        "(one branch per save_steps)"
+                    )
+                else:
+                    console.print(
+                        "[yellow]--push-as: trainer does not expose add_callback; "
+                        "auto-push disabled for this run[/]"
+                    )
+
+        # Train with live display and experiment tracking
+        display = TrainingDisplay(cfg, device_name=device_name)
+        console.print("[bold green]Training started![/]\n")
+
+        profiler_ctx = contextlib.nullcontext()
+        if profile_run:
+            from soup_cli.utils.profiling import profile_training
+
+            profiler_ctx = profile_training(output_dir=Path(cfg.output), run_id=run_id)
+            console.print(
+                "[cyan]--profile:[/] writing torch.profiler trace to "
+                f"{cfg.output}/profiles/{run_id}.trace.json (early-steps window)"
+            )
+
+        # v0.71.3 #180 — optional codecarbon energy/CO2 measurement around the
+        # training window. Lazy-built; a graceful no-op when codecarbon is absent.
+        energy_ctx = contextlib.nullcontext()
+        energy_tracker = None
+        if track_energy:
+            try:
+                from soup_cli.utils.energy import EnergyTracker
+
+                energy_tracker = EnergyTracker(country_iso_code=energy_country)
+                energy_ctx = energy_tracker
+            except ValueError as exc:
+                console.print(f"[yellow]--track-energy disabled:[/] {exc}")
+                energy_tracker = None
+                energy_ctx = contextlib.nullcontext()
+
+    except Exception as exc:
+        tracker.fail_run(run_id, error=f"{type(exc).__name__}: {exc}")
+        raise
 
     try:
         with profiler_ctx, energy_ctx:
@@ -1567,7 +1576,7 @@ def train(
             output_dir=result["output_dir"],
         )
     except Exception as exc:
-        tracker.fail_run(run_id)
+        tracker.fail_run(run_id, error=f"{type(exc).__name__}: {exc}")
         # v0.34.0 Part D — write a .crash bundle next to the run for triage.
         try:
             from soup_cli.utils.crash import build_crash_bundle, write_crash_bundle

--- a/src/soup_cli/commands/train.py
+++ b/src/soup_cli/commands/train.py
@@ -189,6 +189,20 @@ def _apply_replay_overrides(cfg, *, replay, replay_ratio, replay_seed=None):
     return type(cfg)(**payload)
 
 
+def _describe_exception_for_tracker(exc: BaseException) -> str:
+    """Format ``exc`` for ``ExperimentTracker.fail_run``'s ``error=`` column.
+
+    A handled setup failure (a bad ``--tracker`` value, a hub download
+    error) exits via ``raise typer.Exit(...) from exc``. ``typer.Exit``
+    carries no message of its own, so formatting the caught exception
+    directly writes ``"Exit: "`` to the row and loses the reason a human
+    needs — the one already printed to the console just before the raise.
+    Unwrapping to ``__cause__`` when present recovers it (#764 review).
+    """
+    cause = exc.__cause__ or exc
+    return f"{type(cause).__name__}: {cause}"
+
+
 def train(
     config: str = typer.Option(
         "soup.yaml",
@@ -1556,7 +1570,7 @@ def train(
                 energy_ctx = contextlib.nullcontext()
 
     except Exception as exc:
-        tracker.fail_run(run_id, error=f"{type(exc).__name__}: {exc}")
+        tracker.fail_run(run_id, error=_describe_exception_for_tracker(exc))
         raise
 
     try:
@@ -1576,7 +1590,7 @@ def train(
             output_dir=result["output_dir"],
         )
     except Exception as exc:
-        tracker.fail_run(run_id, error=f"{type(exc).__name__}: {exc}")
+        tracker.fail_run(run_id, error=_describe_exception_for_tracker(exc))
         # v0.34.0 Part D — write a .crash bundle next to the run for triage.
         try:
             from soup_cli.utils.crash import build_crash_bundle, write_crash_bundle

--- a/src/soup_cli/experiment/tracker.py
+++ b/src/soup_cli/experiment/tracker.py
@@ -62,7 +62,8 @@ CREATE TABLE IF NOT EXISTS runs (
     pid             INTEGER,
     command_digest  TEXT,
     log_path        TEXT,
-    exit_code       INTEGER
+    exit_code       INTEGER,
+    error_message   TEXT
 );
 
 CREATE TABLE IF NOT EXISTS metrics (
@@ -178,6 +179,7 @@ class ExperimentTracker:
             ("runs", "command_digest", "ALTER TABLE runs ADD COLUMN command_digest TEXT"),
             ("runs", "log_path", "ALTER TABLE runs ADD COLUMN log_path TEXT"),
             ("runs", "exit_code", "ALTER TABLE runs ADD COLUMN exit_code INTEGER"),
+            ("runs", "error_message", "ALTER TABLE runs ADD COLUMN error_message TEXT"),
             # Deliberately nullable with no default: a row written before this
             # column existed has no evaluation loss, and NULL says so. A 0.0
             # would read as a measurement nobody took.
@@ -409,10 +411,18 @@ class ExperimentTracker:
         )
         conn.commit()
 
-    def fail_run(self, run_id: str) -> None:
-        """Mark run as failed."""
+    def fail_run(self, run_id: str, *, error: Optional[str] = None) -> None:
+        """Mark run as failed, optionally recording why (#764).
+
+        ``error`` distinguishes a run that never got past setup from one that
+        diverged mid-training — both used to read as an identical 'failed'
+        row with nothing else to go on.
+        """
         conn = self._get_conn()
-        conn.execute("UPDATE runs SET status = 'failed' WHERE run_id = ?", (run_id,))
+        conn.execute(
+            "UPDATE runs SET status = 'failed', error_message = ? WHERE run_id = ?",
+            (error, run_id),
+        )
         conn.commit()
 
     def _reconcile_orphaned_run(self, run: dict) -> dict:

--- a/src/soup_cli/experiment/tracker.py
+++ b/src/soup_cli/experiment/tracker.py
@@ -18,7 +18,13 @@ from pathlib import Path
 from typing import Optional
 
 from soup_cli.utils.constants import EXPERIMENTS_DB, SOUP_DIR
+from soup_cli.utils.crash import redact_secrets
 from soup_cli.utils.process_liveness import process_is_alive as _process_is_alive
+
+# error_message is operator-facing text read in `soup runs show`, not a
+# diagnostic dump — capped well short of a full traceback so one runaway
+# stack trace can't bloat the runs table (#764/#767 review).
+_MAX_ERROR_MESSAGE_CHARS = 2000
 
 # Run status values this module reconciles. A watcher that never unwound (its
 # daemon thread was killed when the MCP server exited) leaves the run at
@@ -416,9 +422,16 @@ class ExperimentTracker:
 
         ``error`` distinguishes a run that never got past setup from one that
         diverged mid-training — both used to read as an identical 'failed'
-        row with nothing else to go on.
+        row with nothing else to go on. Redacted and length-capped before
+        storage: an exception message can embed a token from a failed HF/hub
+        auth call, and this column must not become the place secrets leak
+        into a locally-readable database (#764/#767 review).
         """
         conn = self._get_conn()
+        if error is not None:
+            error = redact_secrets(error)
+            if len(error) > _MAX_ERROR_MESSAGE_CHARS:
+                error = error[:_MAX_ERROR_MESSAGE_CHARS] + "...(truncated)"
         conn.execute(
             "UPDATE runs SET status = 'failed', error_message = ? WHERE run_id = ?",
             (error, run_id),

--- a/tests/test_issue764_run_status_reconciliation.py
+++ b/tests/test_issue764_run_status_reconciliation.py
@@ -87,7 +87,14 @@ class TestSetupFailureReachesFailRun:
     ):
         """The gap covered every setup step, not only trainer_wrapper.setup —
         pin one earlier in the sequence (--tracker resolution) too, so the
-        fix is proven at more than the one call site it was written against."""
+        fix is proven at more than the one call site it was written against.
+
+        This site is reached via ``raise typer.Exit(...) from exc``, not a
+        bare raise — asserting the real message, not just non-None, is what
+        catches recording "Exit: " instead of the actual reason (review
+        finding on #767: typer.Exit carries no message of its own, and the
+        except here originally formatted the caught exception directly
+        rather than unwrapping to __cause__)."""
         from soup_cli.utils import trackers as trackers_mod
 
         def _raise_resolve(**kwargs):
@@ -102,6 +109,9 @@ class TestSetupFailureReachesFailRun:
         run = _the_run(db_path)
         assert run["status"] == "failed", run
         assert run["error_message"] is not None
+        message = run["error_message"]
+        assert "ValueError" in message, message
+        assert "simulated --tracker resolution failure" in message, message
 
 
 class TestRunRecordsItsOwnPid:

--- a/tests/test_issue764_run_status_reconciliation.py
+++ b/tests/test_issue764_run_status_reconciliation.py
@@ -1,0 +1,123 @@
+"""#764 — a failure during setup left the tracker row at status='running' forever.
+
+`soup train` registers a run in the experiment tracker before it loads the
+model, and the only `except` that marked a run failed covered the training
+call alone. Everything in between -- tokenizer load, model load,
+quantization, LoRA attach, dataset mapping, trainer construction -- left the
+row unreconcilable: on a real database, 220 of 432 runs were stuck at
+'running', the oldest since 2026-03-04.
+
+Two independent parts, both covered here:
+1. The failure boundary now wraps from right after the run is registered
+   through the end of the command, so any setup exception reaches
+   ``fail_run`` with the exception type and message recorded.
+2. ``soup train`` now records its own pid via ``mark_running`` the way the
+   MCP execution path already does, so ``_reconcile_orphaned_run`` (#401)
+   can rescue a SIGKILL'd or Ctrl+C'd run on the next `soup runs` the same
+   way it already does for MCP-spawned runs.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("transformers")
+
+
+def _write_config(tmp_path):
+    (tmp_path / "data.jsonl").write_text(
+        '{"instruction": "hi", "output": "hello"}\n', encoding="utf-8",
+    )
+    (tmp_path / "soup.yaml").write_text(
+        "base: sshleifer/tiny-gpt2\n"
+        "task: sft\n"
+        "data: {train: data.jsonl, format: alpaca}\n"
+        "training: {epochs: 1, lr: 1e-4, batch_size: 1}\n",
+        encoding="utf-8",
+    )
+
+
+def _invoke_train(tmp_path, monkeypatch, db_path):
+    from typer.testing import CliRunner
+
+    from soup_cli.cli import app
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("SOUP_DB_PATH", str(db_path))
+    _write_config(tmp_path)
+
+    return CliRunner().invoke(app, ["train", "--config", "soup.yaml", "--yes"])
+
+
+def _the_run(db_path):
+    from soup_cli.experiment.tracker import ExperimentTracker
+
+    tracker = ExperimentTracker(db_path=db_path)
+    runs = tracker.list_runs(limit=5)
+    assert runs, "no run was registered in the tracker at all"
+    return runs[0]
+
+
+class TestSetupFailureReachesFailRun:
+    """A setup-phase exception must land the run at 'failed', not 'running'."""
+
+    def test_a_setup_failure_marks_the_run_failed_with_a_reason(self, tmp_path, monkeypatch):
+        from soup_cli.trainer.sft import SFTTrainerWrapper
+
+        def _raise_setup(self, dataset):
+            raise RuntimeError("simulated tokenizer/model load failure")
+
+        monkeypatch.setattr(SFTTrainerWrapper, "setup", _raise_setup)
+
+        db_path = tmp_path / "experiments.db"
+        result = _invoke_train(tmp_path, monkeypatch, db_path)
+
+        assert result.exit_code != 0, result.output
+        run = _the_run(db_path)
+        assert run["status"] == "failed", run
+        assert run["error_message"] is not None
+        assert "RuntimeError" in run["error_message"]
+        assert "simulated tokenizer/model load failure" in run["error_message"]
+
+    def test_a_config_only_failure_before_trainer_setup_also_marks_failed(
+        self, tmp_path, monkeypatch
+    ):
+        """The gap covered every setup step, not only trainer_wrapper.setup —
+        pin one earlier in the sequence (--tracker resolution) too, so the
+        fix is proven at more than the one call site it was written against."""
+        from soup_cli.utils import trackers as trackers_mod
+
+        def _raise_resolve(**kwargs):
+            raise ValueError("simulated --tracker resolution failure")
+
+        monkeypatch.setattr(trackers_mod, "resolve_report_to", _raise_resolve)
+
+        db_path = tmp_path / "experiments.db"
+        result = _invoke_train(tmp_path, monkeypatch, db_path)
+
+        assert result.exit_code != 0, result.output
+        run = _the_run(db_path)
+        assert run["status"] == "failed", run
+        assert run["error_message"] is not None
+
+
+class TestRunRecordsItsOwnPid:
+    """Without a pid, _reconcile_orphaned_run (#401) has nothing to check
+    liveness against, so a SIGKILL'd `soup train` process is never rescued."""
+
+    def test_the_run_is_registered_with_the_current_process_pid(self, tmp_path, monkeypatch):
+        from soup_cli.trainer.sft import SFTTrainerWrapper
+
+        def _raise_setup(self, dataset):
+            raise RuntimeError("stop before real training - pid is what's under test")
+
+        monkeypatch.setattr(SFTTrainerWrapper, "setup", _raise_setup)
+
+        db_path = tmp_path / "experiments.db"
+        _invoke_train(tmp_path, monkeypatch, db_path)
+
+        run = _the_run(db_path)
+        assert run["pid"] == os.getpid(), run

--- a/tests/test_issue764_run_status_reconciliation.py
+++ b/tests/test_issue764_run_status_reconciliation.py
@@ -131,3 +131,124 @@ class TestRunRecordsItsOwnPid:
 
         run = _the_run(db_path)
         assert run["pid"] == os.getpid(), run
+
+
+class TestDescribeExceptionForTracker:
+    """Second review round on #767: the first fix over-corrected.
+
+    Unwrapping to ``__cause__`` fixes the three ``typer.Exit`` sites, but
+    doing it unconditionally also rewrites ordinary training-phase
+    failures — a plain ``raise X from Y`` deep inside a library then
+    stores Y (the mechanism) and discards X (the operator-facing reason),
+    which is *less* informative than before this whole fix existed. The
+    unwrap must be gated to ``typer.Exit`` specifically.
+    """
+
+    def test_a_chained_typer_exit_unwraps_to_the_real_cause(self):
+        import typer
+
+        from soup_cli.commands.train import _describe_exception_for_tracker
+
+        try:
+            try:
+                raise ValueError("simulated --tracker resolution failure")
+            except ValueError as exc:
+                raise typer.Exit(code=2) from exc
+        except typer.Exit as e:
+            message = _describe_exception_for_tracker(e)
+
+        assert "ValueError" in message
+        assert "simulated --tracker resolution failure" in message
+        assert "Exit:" not in message
+
+    def test_a_bare_typer_exit_records_the_exit_code_not_a_blank_reason(self):
+        """The hub-cache containment refusal raises `typer.Exit(code=1)`
+        with no `from exc` at all — there is no cause to unwrap, so the
+        fix has to record *something* other than the old "Exit: "."""
+        import typer
+
+        from soup_cli.commands.train import _describe_exception_for_tracker
+
+        try:
+            raise typer.Exit(code=1)
+        except typer.Exit as e:
+            message = _describe_exception_for_tracker(e)
+
+        assert message != "Exit: "
+        assert "1" in message
+
+    def test_an_ordinary_chained_exception_keeps_the_outer_message(self):
+        """Regression pin: a plain `raise X from Y` (not a typer.Exit) must
+        keep reporting X, the operator-facing reason, not Y, the inner
+        mechanism — unwrapping unconditionally inverts #764's own point,
+        that a run dying at 'Loading tokenizer' should read differently
+        from one that diverged at step 900."""
+        from soup_cli.commands.train import _describe_exception_for_tracker
+
+        try:
+            try:
+                raise OSError("permission denied: /home/u/.ssh/id_rsa")
+            except OSError as exc:
+                raise RuntimeError(
+                    "failed to load tokenizer for meta-llama/Llama-3.1-8B"
+                ) from exc
+        except RuntimeError as e:
+            message = _describe_exception_for_tracker(e)
+
+        assert "RuntimeError" in message
+        assert "failed to load tokenizer" in message
+        assert "permission denied" not in message
+
+
+class TestFailRunRedactsAndCapsTheErrorMessage:
+    """error_message is stored verbatim otherwise: a token embedded in an
+    exception (a failed hub download's URL, an auth header) would sit in
+    plaintext in a locally-readable database, and an unbounded string from
+    a runaway stack trace could bloat the runs table."""
+
+    def test_a_token_shaped_string_is_redacted(self, tmp_path):
+        from soup_cli.experiment.tracker import ExperimentTracker
+
+        db_path = tmp_path / "experiments.db"
+        tracker = ExperimentTracker(db_path=db_path)
+        run_id = tracker.start_run(
+            config_dict={"base": "x"}, device="cpu", device_name="cpu", gpu_info={},
+        )
+        tracker.fail_run(
+            run_id,
+            error="RuntimeError: failed to download: "
+            "token=hf_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345",
+        )
+
+        stored = tracker.get_run(run_id)["error_message"]
+        assert "hf_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345" not in stored
+        assert "<redacted>" in stored
+
+    def test_an_oversized_message_is_capped(self, tmp_path):
+        from soup_cli.experiment.tracker import (
+            _MAX_ERROR_MESSAGE_CHARS,
+            ExperimentTracker,
+        )
+
+        db_path = tmp_path / "experiments.db"
+        tracker = ExperimentTracker(db_path=db_path)
+        run_id = tracker.start_run(
+            config_dict={"base": "x"}, device="cpu", device_name="cpu", gpu_info={},
+        )
+        tracker.fail_run(run_id, error="x" * (_MAX_ERROR_MESSAGE_CHARS * 3))
+
+        stored = tracker.get_run(run_id)["error_message"]
+        assert len(stored) <= _MAX_ERROR_MESSAGE_CHARS + len("...(truncated)")
+
+    def test_a_short_message_is_left_alone(self, tmp_path):
+        """Control: redaction/capping must not corrupt an ordinary message."""
+        from soup_cli.experiment.tracker import ExperimentTracker
+
+        db_path = tmp_path / "experiments.db"
+        tracker = ExperimentTracker(db_path=db_path)
+        run_id = tracker.start_run(
+            config_dict={"base": "x"}, device="cpu", device_name="cpu", gpu_info={},
+        )
+        tracker.fail_run(run_id, error="ValueError: bad config")
+
+        assert tracker.get_run(run_id)["error_message"] == "ValueError: bad config"

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -79,6 +79,66 @@ def test_runs_show_with_data(tracker):
     assert "test-model" in result.output
 
 
+def test_runs_show_a_terminated_run_reads_terminated_not_running(tracker):
+    """#764/#767 review: the status branch had a silent 'else: running'
+    catch-all, so a row _reconcile_orphaned_run (#401) had already
+    rewritten to 'terminated' still displayed as 'running' in `soup runs
+    show` — the database and the CLI disagreed about the same run."""
+    import subprocess
+    import sys
+
+    run_id = tracker.start_run(
+        config_dict={"base": "test-model", "task": "sft"},
+        device="cpu",
+        device_name="CPU",
+        gpu_info={"memory_total": "16 GB"},
+    )
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait()
+    tracker.mark_running(run_id, pid=proc.pid)
+
+    assert tracker.get_run(run_id)["status"] == "terminated"
+
+    result = runner.invoke(app, ["runs", "show", run_id, "--no-plot"])
+    assert result.exit_code == 0
+    assert "terminated" in result.output.lower()
+    assert "running" not in result.output.lower()
+
+
+def test_runs_show_surfaces_the_stored_error_message(tracker):
+    """error_message was written by fail_run since #764, but nothing read
+    it — a failed run's recorded reason was sitting in the database with
+    no way to see it from the CLI."""
+    run_id = tracker.start_run(
+        config_dict={"base": "test-model", "task": "sft"},
+        device="cpu",
+        device_name="CPU",
+        gpu_info={"memory_total": "16 GB"},
+    )
+    tracker.fail_run(run_id, error="RuntimeError: simulated tokenizer load failure")
+
+    result = runner.invoke(app, ["runs", "show", run_id, "--no-plot"])
+    assert result.exit_code == 0
+    assert "RuntimeError" in result.output
+    assert "simulated tokenizer load failure" in result.output
+
+
+def test_runs_show_omits_the_error_line_when_there_is_none(tracker):
+    """Control: a run with no error_message must not print a stray 'Error:'
+    line — the field is genuinely absent for completed/running runs, not
+    an empty string worth displaying."""
+    run_id = tracker.start_run(
+        config_dict={"base": "test-model", "task": "sft"},
+        device="cpu",
+        device_name="CPU",
+        gpu_info={"memory_total": "16 GB"},
+    )
+
+    result = runner.invoke(app, ["runs", "show", run_id, "--no-plot"])
+    assert result.exit_code == 0
+    assert "Error:" not in result.output
+
+
 def test_runs_compare_not_found():
     """soup runs compare with bad IDs should fail."""
     result = runner.invoke(app, ["runs", "compare", "run_1", "run_2"])


### PR DESCRIPTION
## Summary

Closes #764. `soup train` registers a run in the tracker before it loads the model, but the only `except` that marked a run failed wrapped the training call alone — everything in between (tokenizer load, model load, quantization, LoRA attach, dataset mapping, trainer construction) left the row at `status='running'` forever on any exception. On the real database in the issue, 220 of 432 runs were stuck this way.

## What's here

Two independent parts, both from the issue's acceptance criteria:

1. **Widened the failure boundary.** Everything from right after the run is registered through the end of the command now runs inside `try/except`, so a setup-phase exception reaches `fail_run` with the exception type and message recorded on the row. `fail_run` gained an optional `error=` kwarg, and `runs` gained an `error_message` column via the existing lazy-migration pattern (same style as the `pid`/`exit_code` columns already there). The pre-existing training-phase `except` (which writes a crash bundle) is untouched — this only closes the gap in front of it.

2. **`soup train` now records its own pid.** `tracker.mark_running(run_id, pid=os.getpid())` right after `start_run`, the same call the MCP execution path already makes. `_reconcile_orphaned_run` (#401) only rescues a row that has a pid; `soup train` runs never wrote one, so a SIGKILL'd or Ctrl+C'd run was invisible to a mechanism this project already built for exactly that purpose. I didn't duplicate #401's own dead-pid reconciliation test — that mechanism is already proven correct in `test_issue401_orphaned_run_reconcile.py`; this PR only proves the new call site actually feeds it a real pid.

## About the diff size

Most of `train.py`'s diff is a mechanical reindent — the setup block moving one level under the new `try:` — not a logic change. The actual new lines are the `mark_running` call, the `try:`/`except:` pair around setup, and one `error=` kwarg added to the pre-existing training-phase `fail_run` call.

## Verification

- 3 new tests in `tests/test_issue764_run_status_reconciliation.py`, invoking `soup train` end to end via `CliRunner` against a real (tiny, local) config, with `SFTTrainerWrapper.setup` or `resolve_report_to` monkeypatched to raise at different points in the setup sequence.
- **Mutation**: reverted both changes and confirmed all three new tests fail against the original code with exactly the reported symptom — status stays `running`, pid stays `None` — then restored and confirmed green.
- Full tracker/train-adjacent regression suite: 1433 tests across 33 files pass, no regressions.
- `ruff check` clean.
- `mypy`: 2 new error lines, both instances of the pre-existing `tracker: str` vs `ExperimentTracker` type-shadowing limitation already responsible for 4 of the file's 12 baseline errors (the code's own comment names this: *"Capture the --tracker CLI value BEFORE the local ExperimentTracker shadows it"*). Not a new class of problem — left alone rather than scope-creeping a fix for it into this PR.

## Not done here, on purpose

A migration or `soup runs --reconcile` for the ~220 rows already stuck on someone's real disk, per the issue's own note that silently rewriting them is a separate decision from fixing the code path that created them.
