### PR TITLE
test(paths): repo-wide AST ratchet for relative_to containment (#775)

### DIFF
--- a/tests/test_code_review_recurring.py
+++ b/tests/test_code_review_recurring.py
@@ -13,6 +13,9 @@ from pathlib import Path
 import pytest
 
 import soup_cli
+from tests.test_issue775_path_containment_ratchet import (
+    find_containment_relative_to,
+)
 
 
 def _src(rel: str) -> str:
@@ -34,8 +37,14 @@ def test_containment_holdouts_migrated_to_commonpath_helper():
     }.items():
         src = _src(rel)
         assert needle in src, f"{rel} not migrated to {needle}"
-        # The buggy cwd-containment idiom must be gone from these sites.
-        assert ".relative_to(cwd)" not in src, f"{rel} still uses relative_to(cwd)"
+        # The buggy containment idiom must be gone from these sites. Checked by
+        # AST rather than by the literal `".relative_to(cwd)"` this line used to
+        # search for: that text match missed `.relative_to(base)`, `(root)`, and
+        # any call the formatter split across lines (#775). The repo-wide
+        # version of this scan lives in
+        # tests/test_issue775_path_containment_ratchet.py.
+        found = find_containment_relative_to(src)
+        assert found == [], f"{rel} still decides containment with relative_to: {found}"
 
     # data.py migrated all three sample/download output-path checks.
     assert _src("commands/data.py").count("is_under_cwd(") >= 3

--- a/tests/test_issue775_path_containment_ratchet.py
+++ b/tests/test_issue775_path_containment_ratchet.py
@@ -1,0 +1,399 @@
+"""#775 — repo-wide ratchet: containment must not ride on ``relative_to``.
+
+``Path.resolve() + relative_to()`` is the containment idiom AGENTS.md bans:
+one of the two paths can carry a Windows 8.3 short name (``C:\\Users\\RUNNER~1``)
+while the other carries the long form, so ``relative_to`` raises ``ValueError``
+for a path that *is* inside the base and the guard denies a legitimate write.
+The migration to ``utils.paths.is_under`` (realpath + commonpath) is done; this
+file is the lock that keeps it done.
+
+**Why the previous guard was not a lock.** ``test_code_review_recurring.py``
+asserted ``".relative_to(cwd)" not in src`` over **seven named files**. Two
+holes, both fatal to its purpose:
+
+1. *Scope.* A new module — or an eighth existing one — could reintroduce the
+   idiom and the guard would never look at it.
+2. *Spelling.* It matched one literal. ``.relative_to(base)``,
+   ``.relative_to(root)``, ``.relative_to(\n    directory\n)`` and
+   ``.is_relative_to(...)`` all sailed past. The variable happened to be named
+   ``cwd`` at the sites that were migrated; nothing makes the next one agree.
+
+So the scan is an AST walk over ``src/soup_cli/**/*.py`` and keys on the CALL,
+not on the text around it. Every spelling of the receiver and the argument is
+the same tree.
+
+**What counts as containment** (a plain ``relative_to`` is not automatically a
+bug — it is also the normal way to shorten a path for display):
+
+* ``is_relative_to`` — always. It returns a bool and exists for no other
+  purpose than answering "is this inside that".
+* ``relative_to`` inside a ``try`` whose ``except`` can catch ``ValueError`` —
+  that handler is the containment decision. Where the answer is used (deny,
+  skip, fall back) is deliberately NOT inspected: telling "reject" from
+  "cosmetic fallback" apart needs a taint analysis, and the cheap version got
+  ``adapters.py:38`` wrong in both directions while being written. A benign
+  site is one allowlist line with a reason instead.
+* ``relative_to`` in a boolean position — ``if``/``while``/``assert`` test,
+  ``not``, ``and``/``or``, a ternary condition, a comprehension filter. Nobody
+  writes that for display.
+
+Everything else — ``rel = p.relative_to(root)`` with no ``ValueError`` guard —
+is left alone.
+
+At the time of writing the scan finds **two** sites, both in
+``commands/adapters.py``, both benign and both allowlisted below with their
+reason. There is no cleanup left, which makes ``TestTheScannerCanActuallyFail``
+load-bearing: a scanner whose only findings are allowlisted must be shown
+capable of finding something, or it is indistinguishable from one that matches
+nothing at all.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import textwrap
+
+SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "soup_cli"
+
+_CONTAINMENT_METHODS = frozenset({"relative_to", "is_relative_to"})
+
+#: Exception names whose handler catches ``ValueError``. A bare ``except:``
+#: (``handler.type is None``) counts too — it catches everything.
+_CATCHES_VALUE_ERROR = frozenset({"ValueError", "Exception", "BaseException"})
+
+#: Benign call sites, each with the reason it does not decide containment.
+#: Keyed by ``(path relative to src/soup_cli, line)``. Both entries are
+#: verified live by ``test_the_allowlist_has_no_dead_entries`` — a moved or
+#: deleted site fails there rather than rotting into a silent hole.
+ALLOWLIST: dict[tuple[str, int], str] = {
+    ("commands/adapters.py", 38): (
+        "depth counter, not a gate. The paths come from "
+        "`directory.rglob('adapter_config.json')`, so they are already under "
+        "`directory` by construction; the result is only measured for its "
+        "`.parts` length against max_depth, and the `except ValueError: "
+        "continue` is unreachable for rglob output rather than a denial."
+    ),
+    ("commands/adapters.py", 107): (
+        "display-only shortening. On ValueError it falls back to the full "
+        "`adapter_path` and still renders the row — the value reaches "
+        "`table.add_row` and nothing else, so a short-name mismatch costs a "
+        "longer string in a table, never a refused path."
+    ),
+}
+
+
+def _parent_map(tree: ast.AST) -> dict[ast.AST, ast.AST]:
+    parents: dict[ast.AST, ast.AST] = {}
+    for node in ast.walk(tree):
+        for child in ast.iter_child_nodes(node):
+            parents[child] = node
+    return parents
+
+
+def _handler_catches_value_error(handler: ast.ExceptHandler) -> bool:
+    exc = handler.type
+    if exc is None:  # bare `except:`
+        return True
+    candidates = exc.elts if isinstance(exc, ast.Tuple) else [exc]
+    for candidate in candidates:
+        name = (
+            candidate.id
+            if isinstance(candidate, ast.Name)
+            else candidate.attr
+            if isinstance(candidate, ast.Attribute)
+            else ""
+        )
+        if name in _CATCHES_VALUE_ERROR:
+            return True
+    return False
+
+
+def _in_field(parent: ast.AST, child: ast.AST, field: str) -> bool:
+    """Is ``child`` reachable from ``parent.<field>``?
+
+    ``child`` is the node one step below ``parent`` on the walk up, so a direct
+    identity check on the field (or membership in a field that is a list) says
+    which branch of the parent the call came from — ``If.test`` versus
+    ``If.body`` is the whole difference between a containment check and a
+    display line that happens to sit in a branch.
+    """
+    value = getattr(parent, field, None)
+    if isinstance(value, list):
+        return any(item is child for item in value)
+    return value is child
+
+
+def _containment_reason(call: ast.Call, parents: dict[ast.AST, ast.AST]) -> str | None:
+    """Why ``call`` decides containment, or ``None`` when it does not."""
+    if call.func.attr == "is_relative_to":  # type: ignore[union-attr]
+        return "is_relative_to is a containment predicate"
+
+    child: ast.AST = call
+    parent = parents.get(child)
+    while parent is not None:
+        if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            # A `try` further out belongs to the caller, not to this call.
+            return None
+        if isinstance(parent, (ast.Try, getattr(ast, "TryStar", ast.Try))):
+            if _in_field(parent, child, "body") and any(
+                _handler_catches_value_error(h) for h in parent.handlers
+            ):
+                return "relative_to guarded by an except that catches ValueError"
+        if isinstance(parent, (ast.If, ast.While, ast.Assert, ast.IfExp)):
+            if _in_field(parent, child, "test"):
+                return "relative_to used as a condition"
+        if isinstance(parent, ast.BoolOp):
+            return "relative_to used in a boolean expression"
+        if isinstance(parent, ast.UnaryOp) and isinstance(parent.op, ast.Not):
+            return "relative_to negated as a boolean"
+        if isinstance(parent, ast.comprehension) and _in_field(parent, child, "ifs"):
+            return "relative_to used as a comprehension filter"
+        child, parent = parent, parents.get(parent)
+    return None
+
+
+def find_containment_relative_to(source: str) -> list[tuple[int, str, str]]:
+    """Return ``(lineno, call text, reason)`` per containment-deciding call.
+
+    Returns ``[]`` for source that cannot be parsed, so one malformed file never
+    fails the whole guard — a broken file fails its own tests.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:  # pragma: no cover — a broken file fails its own tests
+        return []
+    parents = _parent_map(tree)
+    lines = source.splitlines()
+    offenders: list[tuple[int, str, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr not in _CONTAINMENT_METHODS:
+            continue
+        reason = _containment_reason(node, parents)
+        if reason is None:
+            continue
+        # The call's own source, wrapping collapsed: `lines[lineno - 1]` is
+        # `rel = (` for a formatter-split call and would report nothing useful.
+        segment = ast.get_source_segment(source, node) or lines[node.lineno - 1]
+        text = " ".join(segment.split())
+        offenders.append((node.lineno, text[:120], reason))
+    return offenders
+
+
+def _scan_src() -> list[tuple[str, int, str, str]]:
+    """Every containment-deciding call under ``src/soup_cli``, allowlist aside."""
+    hits: list[tuple[str, int, str, str]] = []
+    for path in sorted(SRC.rglob("*.py")):
+        rel = path.relative_to(SRC).as_posix()
+        source = path.read_text(encoding="utf-8", errors="replace")
+        for lineno, text, reason in find_containment_relative_to(source):
+            hits.append((rel, lineno, text, reason))
+    return hits
+
+
+class TestNoUnjustifiedContainmentRelativeToInSrc:
+    def test_src_routes_containment_through_the_commonpath_helper(self):
+        offenders = [
+            f"{rel}:{lineno}: {text}  [{reason}]"
+            for rel, lineno, text, reason in _scan_src()
+            if (rel, lineno) not in ALLOWLIST
+        ]
+        assert not offenders, (
+            "Containment decided by `relative_to` / `is_relative_to`. One of "
+            "the two paths can carry a Windows 8.3 short name while the other "
+            "carries the long form, so this denies paths that ARE inside the "
+            "base (AGENTS.md: realpath + commonpath). Use "
+            "`soup_cli.utils.paths.is_under(path, base)` / `is_under_cwd(path)`. "
+            "If the call is genuinely not a gate, add it to ALLOWLIST in this "
+            "file with the reason.\n  " + "\n  ".join(offenders)
+        )
+
+    def test_the_scan_actually_covers_src(self):
+        """CONTROL for the control: a scan that stopped discovering modules
+        would pass the guard above by looking at nothing."""
+        scanned = list(SRC.rglob("*.py"))
+        assert len(scanned) >= 400, f"only {len(scanned)} modules scanned"
+        # And the walk must still reach the two known call sites.
+        assert {(rel, lineno) for rel, lineno, _text, _reason in _scan_src()} == set(
+            ALLOWLIST
+        )
+
+    def test_the_allowlist_has_no_dead_entries(self):
+        """An allowlist entry that no longer matches a live call site is a hole:
+        the code moved, the reason was never re-checked, and the next reader
+        assumes it was. Fail loudly instead."""
+        live = {(rel, lineno) for rel, lineno, _text, _reason in _scan_src()}
+        dead = sorted(set(ALLOWLIST) - live)
+        assert not dead, (
+            "ALLOWLIST entries no longer point at a containment call — the code "
+            "moved or was fixed. Re-verify the site and update the line number, "
+            "or drop the entry: " + ", ".join(f"{rel}:{line}" for rel, line in dead)
+        )
+
+    def test_every_allowlist_entry_carries_a_reason(self):
+        for key, reason in ALLOWLIST.items():
+            assert len(reason.split()) >= 10, f"{key} has a placeholder reason"
+
+
+class TestTheScannerCanActuallyFail:
+    """The scan's only findings are allowlisted. That is meaningful only if the
+    scanner is shown able to find something it has not been told about."""
+
+    #: The exact idiom the seven migrated files used to carry.
+    CWD_IDIOM = '''
+def _validate(output_path):
+    cwd = Path.cwd()
+    try:
+        output_path.resolve().relative_to(cwd)
+    except ValueError:
+        raise ValueError("output must stay under cwd")
+    return output_path
+'''
+
+    #: Same bug, different variable name — invisible to a `".relative_to(cwd)"`
+    #: text match, which is the reason this file exists.
+    OTHER_NAME = '''
+def _validate(target, base):
+    try:
+        target.resolve().relative_to(base)
+    except ValueError:
+        return False
+    return True
+'''
+
+    #: Same bug, split across lines by the formatter — also invisible to a
+    #: single-line text match.
+    WRAPPED = '''
+def _validate(target, root):
+    try:
+        relative = target.resolve().relative_to(
+            root.resolve(),
+        )
+    except ValueError:
+        return None
+    return relative
+'''
+
+    def test_it_catches_the_cwd_idiom(self):
+        found = find_containment_relative_to(textwrap.dedent(self.CWD_IDIOM))
+        assert len(found) == 1, found
+        assert "relative_to(cwd)" in found[0][1]
+
+    def test_it_catches_a_differently_named_base(self):
+        found = find_containment_relative_to(textwrap.dedent(self.OTHER_NAME))
+        assert len(found) == 1, found
+        assert "relative_to(base)" in found[0][1]
+
+    def test_it_catches_a_call_split_across_lines(self):
+        found = find_containment_relative_to(textwrap.dedent(self.WRAPPED))
+        assert len(found) == 1, found
+        # The reported text is the whole call, not `relative = (`.
+        assert "relative_to( root.resolve(), )" in found[0][1]
+
+    def test_it_catches_is_relative_to_in_a_condition(self):
+        source = '''
+def _validate(target, base):
+    if not target.resolve().is_relative_to(base.resolve()):
+        raise ValueError("escape")
+'''
+        found = find_containment_relative_to(source)
+        assert len(found) == 1, found
+        assert "is_relative_to" in found[0][1]
+
+    def test_it_catches_a_bare_is_relative_to_return(self):
+        """`is_relative_to` is flagged wherever it appears — it answers exactly
+        the containment question and nothing else."""
+        found = find_containment_relative_to(
+            "def under(p, b):\n    return p.is_relative_to(b)\n"
+        )
+        assert len(found) == 1, found
+
+    def test_it_catches_a_comprehension_filter(self):
+        source = '''
+def _keep(paths, base):
+    return [p for p in paths if p.resolve().is_relative_to(base)]
+'''
+        assert len(find_containment_relative_to(source)) == 1
+
+    def test_a_bare_except_still_counts(self):
+        """`except:` and `except Exception:` catch ValueError as well, so the
+        containment decision is the same one — only the blast radius differs."""
+        source = '''
+def _validate(target, base):
+    try:
+        target.relative_to(base)
+    except Exception:
+        return False
+    return True
+'''
+        assert len(find_containment_relative_to(source)) == 1
+
+    # ── controls: the shapes that must NOT be flagged ──
+
+    def test_the_migrated_helper_is_accepted(self):
+        """CONTROL. The repaired form must be clean, or the guard would demand
+        rewriting the fix it exists to protect."""
+        source = '''
+def _validate(output_path):
+    from soup_cli.utils.paths import is_under_cwd
+
+    if not is_under_cwd(output_path):
+        raise ValueError("output must stay under cwd")
+    return output_path
+'''
+        assert find_containment_relative_to(source) == []
+
+    def test_display_only_relative_to_is_not_flagged(self):
+        """CONTROL. Shortening a path for a table is the method's normal use and
+        decides nothing. A guard that flagged it would be noise, and a noisy
+        guard gets deleted."""
+        source = '''
+def _label(path, root):
+    rel = path.relative_to(root)
+    return str(rel)
+'''
+        assert find_containment_relative_to(source) == []
+
+    def test_relative_to_inside_a_branch_body_is_not_flagged(self):
+        """CONTROL. `If.body` is not `If.test`: sitting inside a branch does not
+        make a call a condition."""
+        source = '''
+def _label(path, root, shorten):
+    if shorten:
+        return str(path.relative_to(root))
+    return str(path)
+'''
+        assert find_containment_relative_to(source) == []
+
+    def test_a_try_catching_only_os_error_is_not_flagged(self):
+        """CONTROL. `except OSError` cannot catch the ValueError that
+        `relative_to` raises, so that handler is not the containment decision."""
+        source = '''
+def _label(path, root):
+    try:
+        return str(path.relative_to(root))
+    except OSError:
+        return str(path)
+'''
+        assert find_containment_relative_to(source) == []
+
+    def test_an_enclosing_function_boundary_stops_the_walk(self):
+        """CONTROL. A `try` around a *definition* does not guard calls in the
+        body — those run later, at the caller's mercy."""
+        source = '''
+try:
+    def _label(path, root):
+        return str(path.relative_to(root))
+except ValueError:
+    _label = None
+'''
+        assert find_containment_relative_to(source) == []
+
+    def test_an_unrelated_method_named_similarly_is_not_flagged(self):
+        source = "def f(a, b):\n    return a.relative_path(b)\n"
+        assert find_containment_relative_to(source) == []
+
+    def test_unparseable_source_does_not_explode(self):
+        assert find_containment_relative_to("def broken(:\n") == []


### PR DESCRIPTION
## What does this PR do?

Turns the `relative_to` containment guard into a repo-wide AST ratchet, as requested in #775.

**Why the old guard was not a lock.** `tests/test_code_review_recurring.py` asserted `".relative_to(cwd)" not in src` over seven named files. Both halves leaked:

1. *Scope* — a new module (or an eighth existing one) could reintroduce the banned idiom and the guard would never look at it.
2. *Spelling* — it matched one literal. `.relative_to(base)`, `.relative_to(root)`, a call the formatter split across lines, and `.is_relative_to(...)` all sailed past, even inside the seven files it did cover. The variable happened to be named `cwd` at the migrated sites; nothing makes the next one agree.

**What replaces it.** `tests/test_issue775_path_containment_ratchet.py` walks the AST of every module under `src/soup_cli/` (501 today) and keys on the *call*, not on the text around it. A call decides containment when:

* it is `is_relative_to` — bool-only API, it answers exactly the containment question;
* it is `relative_to` inside a `try` whose `except` can catch `ValueError` (including a bare `except:` / `except Exception:`) — that handler *is* the containment decision;
* it is `relative_to` in a boolean position — an `if`/`while`/`assert` test, `not`, `and`/`or`, a ternary condition, or a comprehension filter.

A plain `rel = p.relative_to(root)` with no `ValueError` guard is display formatting and is left alone, so the guard stays on the shapes that actually break.

**On `adapters.py:38` and `:107`.** Whether the `ValueError` handler rejects or falls back is deliberately *not* inspected: separating "deny" from "cosmetic fallback" needs a taint analysis, and the cheap heuristic misclassified `:38` in both directions while being written. Both sites are therefore in an explicit `ALLOWLIST` with the reason they decide nothing — a depth counter over `rglob` output whose `except` is unreachable for that input, and display-only shortening that falls back to the full path and reaches `table.add_row` and nothing else. A benign site costs one allowlist line with a reason; `test_the_allowlist_has_no_dead_entries` fails when an entry stops matching a live call, so a moved or fixed site cannot rot into a silent hole instead of being re-verified.

**The scan finds nothing outside that allowlist today**, which makes `TestTheScannerCanActuallyFail` load-bearing — modelled on `TestTheScannerCanActuallyFail` in `test_cli_help_assertions_are_ansi_safe.py`, as suggested in the issue. It asserts the scanner **red** against the `cwd` idiom, a differently named base, a call wrapped across lines, `is_relative_to` in a condition, a bare `is_relative_to` return, a comprehension filter and an `except Exception` handler; and **green** against `is_under`, a display-only call, a call in a branch *body* (`If.body` is not `If.test`), an `except OSError` that cannot catch the `ValueError`, a `try` around a function *definition*, a similarly named method, and unparseable source. Reported text comes from `ast.get_source_segment` with wrapping collapsed, so a split call reports the whole call rather than `relative = (`.

Verified red end to end, not just against synthetic strings: an offending module dropped into `src/soup_cli/` makes the repo-wide test fail and name the file — the exact shape the seven-file guard could not see. (Probe removed; not part of the diff.)

The seven-file check keeps its own `is_under` / `is_under_cwd` assertions and now routes its containment half through the same scanner, so it is no longer spelling-dependent.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Tests

## Checklist

- [x] `ruff check src/soup_cli/ scripts/ tests/` passes (ran `src/soup_cli/ scripts/ tests/ benchmarks/`, clean)
- [ ] `pytest tests/ -v` passes — **partially run locally**, see below
- [ ] Updated relevant docs — not needed, no behaviour change
- [x] Added a changelog fragment, or this change has no user-visible impact — test-only ratchet, no user-visible impact (happy to add a fragment if you would rather have one)

### Test results

Run on Python 3.10 (project floor) and 3.12; ML extras are not installed in this environment, so the torch/MLX-dependent suites were **not** run locally and CI is relied on for those.

```
tests/test_issue775_path_containment_ratchet.py  18 passed
tests/test_code_review_recurring.py               7 passed
tests/test_cli_help_assertions_are_ansi_safe.py
tests/test_issue633_ansi_in_highlighted_output.py
tests/test_issue487_changelog_fragments.py
tests/test_issue382_windows_ci_guard_is_shared.py 50 passed, 1 skipped
```

`ruff check src/soup_cli/ scripts/ tests/ benchmarks/` — all checks passed.

Closes #777 (claimed there before starting). Refs #775 — the Rust-port SWOT half of that audit is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
