### PR TITLE
fix(deepspeed): forward model parameter in empty param group guard (#784)

### DIFF
--- a/src/soup_cli/utils/deepspeed.py
+++ b/src/soup_cli/utils/deepspeed.py
@@ -410,8 +410,11 @@ def attach_empty_param_group_guard(trainer) -> bool:
     if not callable(original):
         return False
 
-    def create_optimizer():
-        optimizer = original()
+    def create_optimizer(model=None):
+        if model is not None:
+            optimizer = original(model)
+        else:
+            optimizer = original()
         dropped = prune_empty_param_groups(optimizer)
         if dropped:
             from rich.console import Console

--- a/tests/test_issue359_deepspeed_guard_coverage.py
+++ b/tests/test_issue359_deepspeed_guard_coverage.py
@@ -223,6 +223,107 @@ class TestGuardToleratesTrainersWithoutCreateOptimizer:
         assert len(optimizer.param_groups) == 1  # the empty group is gone
 
 
+class TestGuardForwardsModelParameter:
+    """Issue #784 — the wrapper must accept and forward the ``model`` kwarg.
+
+    ``transformers.Trainer.create_optimizer(self, model=None)`` is called
+    positionally on the ``delay_optimizer_creation`` path:
+    ``self.create_optimizer(model)``.  The guard wrapper must accept that
+    call form and forward ``model`` to the original, not swallow it.
+    """
+
+    def test_positional_model_is_forwarded(self):
+        from soup_cli.utils.deepspeed import attach_empty_param_group_guard
+
+        sentinel = object()
+
+        class _Trainer:
+            def __init__(self):
+                self.received_model = None
+
+            def create_optimizer(self, model=None):
+                self.received_model = model
+                return types.SimpleNamespace(param_groups=[{"params": [1]}])
+
+        trainer = _Trainer()
+        attach_empty_param_group_guard(trainer)
+        trainer.create_optimizer(sentinel)
+        assert trainer.received_model is sentinel
+
+    def test_keyword_model_is_forwarded(self):
+        from soup_cli.utils.deepspeed import attach_empty_param_group_guard
+
+        sentinel = object()
+
+        class _Trainer:
+            def __init__(self):
+                self.received_model = None
+
+            def create_optimizer(self, model=None):
+                self.received_model = model
+                return types.SimpleNamespace(param_groups=[{"params": [1]}])
+
+        trainer = _Trainer()
+        attach_empty_param_group_guard(trainer)
+        trainer.create_optimizer(model=sentinel)
+        assert trainer.received_model is sentinel
+
+    def test_no_model_still_works(self):
+        from soup_cli.utils.deepspeed import attach_empty_param_group_guard
+
+        class _Trainer:
+            def __init__(self):
+                self.received_model = "UNSET"
+
+            def create_optimizer(self, model=None):
+                self.received_model = model
+                return types.SimpleNamespace(param_groups=[{"params": [1]}])
+
+        trainer = _Trainer()
+        attach_empty_param_group_guard(trainer)
+        trainer.create_optimizer()
+        assert trainer.received_model is None
+
+    def test_positional_model_with_pruning(self):
+        """The guard must still prune empty groups when model is supplied."""
+        from soup_cli.utils.deepspeed import attach_empty_param_group_guard
+
+        sentinel = object()
+
+        class _Trainer:
+            def __init__(self):
+                self.received_model = None
+
+            def create_optimizer(self, model=None):
+                self.received_model = model
+                return types.SimpleNamespace(
+                    param_groups=[{"params": [1, 2]}, {"params": []}]
+                )
+
+        trainer = _Trainer()
+        attach_empty_param_group_guard(trainer)
+        optimizer = trainer.create_optimizer(sentinel)
+        assert trainer.received_model is sentinel
+        assert len(optimizer.param_groups) == 1  # empty group pruned
+
+    def test_wrapper_signature_accepts_positional_arg(self):
+        """The wrapper must not regress to a zero-arg signature."""
+        import inspect
+
+        from soup_cli.utils.deepspeed import attach_empty_param_group_guard
+
+        class _Trainer:
+            def create_optimizer(self, model=None):
+                return types.SimpleNamespace(param_groups=[])
+
+        trainer = _Trainer()
+        attach_empty_param_group_guard(trainer)
+        sig = inspect.signature(trainer.create_optimizer)
+        params = list(sig.parameters.values())
+        assert len(params) >= 1, "wrapper must accept at least one parameter (model)"
+        assert params[0].default is None
+
+
 class TestUserSuppliedDeepspeedFileIsResolved:
     """#359 criterion 4 — decided: resolve, but only what is provably invalid.
 


### PR DESCRIPTION
## Summary

Fixes #784 — `attach_empty_param_group_guard` shadows `transformers.Trainer.create_optimizer(self, model=None)`. Previously the wrapper took zero arguments, which would raise `TypeError: ... takes 0 positional arguments but 1 was given` if called on the `delay_optimizer_creation` path (`self.create_optimizer(model)`).

## Changes

- In `src/soup_cli/utils/deepspeed.py`:
  - Update `create_optimizer` inside `attach_empty_param_group_guard` to accept `model=None`.
  - Forward `model` to `original(model)` when provided (`model is not None`), and call `original()` without arguments when `model is None` to preserve compatibility with zero-arg stubs.
  - Retain empty parameter group pruning behavior.

- In `tests/test_issue359_deepspeed_guard_coverage.py`:
  - Add `TestGuardForwardsModelParameter` covering:
    - Positional `model` forwarding (`trainer.create_optimizer(sentinel)`)
    - Keyword `model` forwarding (`trainer.create_optimizer(model=sentinel)`)
    - Zero-arg calls (`trainer.create_optimizer()`)
    - Positional calls with empty param group pruning
    - Signature inspection verifying `create_optimizer` accepts positional-or-keyword `model`

## Verification

- `pytest tests/test_issue359_deepspeed_guard_coverage.py` passes completely (88 passed).
- `ruff check src/soup_cli/utils/deepspeed.py tests/test_issue359_deepspeed_guard_coverage.py` passes with zero errors.
