### PR TITLE
fix(data): stop the text SFT path from training on a doubled BOS (#785)

### DIFF
--- a/changelog.d/0.74.0/788.fixed.md
+++ b/changelog.d/0.74.0/788.fixed.md
@@ -12,14 +12,20 @@
   pre-tokenises with `add_special_tokens=False` (via `build_full_sequence_labels`), so the
   chat template is the single source of special tokens, matching inference and HF's own
   `apply_chat_template(tokenize=True)`: one BOS for a `{{ bos_token }}` template, zero for
-  Soup's `data.chat_template` presets. The stop token is preserved rather than lost: when
-  the tokenizer's post-processor would have appended an EOS and the template rendered none,
-  that EOS is re-appended, so the trained EOS count per row is unchanged (a template that
-  already ends on EOS gets no redundant one added). Both the live-training path and the
-  `soup data preprocess` cache path do this through one shared helper
-  (`loss_mask.reappend_eos_if_dropped`), so the AOT cache read straight into the trainer
-  cannot silently train on a missing stop token. The rule applies only to text a chat
-  template rendered; pretrain-style raw text with no template keeps the tokenizer's own
-  BOS. Adapters trained with `train_on_responses_only: false` before this change carry one
-  extra leading BOS in training compared with inference. The `soup data preprocess` cache
-  key changes so datasets cached under the old encoding are re-tokenised rather than reused.
+  Soup's `data.chat_template` presets. The stop token is preserved rather than lost.
+  TRL's language-modeling path also appended `eos_token` as a string to every text row
+  that did not already end with it (`add_eos`), independent of the tokenizer's
+  post-processor, so the pre-tokenised row reproduces that rule: the EOS id is appended
+  when the sequence does not already end on it. A `{{ bos_token }}` template on a BOS-only
+  or EOS-less (Qwen-shaped) tokenizer therefore keeps the single trailing stop token it
+  trained on before, while tokenizers that previously produced a duplicated EOS now end on
+  exactly one. The rule applies only to text a chat template rendered; pretrain-style raw
+  text with no template keeps the tokenizer's own special tokens unchanged. `soup data
+  doctor --show-mask` now renders through the same builder, so the X-ray matches training.
+  Adapters trained with `train_on_responses_only: false` before this change carry one extra
+  leading BOS in training compared with inference. `soup data preprocess` also stopped
+  doubling the BOS; its EOS behaviour is left exactly as before (it never went through TRL's
+  `add_eos`), so a Qwen-shaped tokenizer's cache and live path can still differ on the EOS —
+  that pre-existing mismatch is tracked separately in #791 rather than changed here. The
+  `soup data preprocess` cache key changes so datasets cached under the old encoding are
+  re-tokenised rather than reused.

--- a/changelog.d/0.74.0/788.fixed.md
+++ b/changelog.d/0.74.0/788.fixed.md
@@ -1,0 +1,22 @@
+- **`train_on_responses_only: false` trained on a doubled BOS, one token off from
+  inference after #782 (#788 by @abdulwaarith0).**
+  The default SFT path (`train_on_responses_only: true`) builds its ids with
+  `add_special_tokens=False` in `data/loss_mask.py`, so it never doubled the BOS. The
+  opt-out text path did: `data/sft_format.py` handed TRL a `{"text"}` column, and TRL's
+  language-modeling `tokenize_fn` re-tokenised it with the tokenizer's default
+  `add_special_tokens=True`. A chat template that renders `{{ bos_token }}` (Llama-3,
+  Gemma, Mistral) on a tokenizer whose post-processor also prepends BOS therefore trained
+  on `[bos, bos, ...]`. Before #782 that matched inference by accident; after #782 inference
+  sends one BOS, so adapters trained on the text path were off by one token from how they
+  are prompted. `soup data preprocess` tokenised the same way. The text path now
+  pre-tokenises with `add_special_tokens=False` (via `build_full_sequence_labels`), so the
+  chat template is the single source of special tokens, matching inference and HF's own
+  `apply_chat_template(tokenize=True)`: one BOS for a `{{ bos_token }}` template, zero for
+  Soup's `data.chat_template` presets. The stop token is preserved rather than lost: when
+  the tokenizer's post-processor would have appended an EOS and the template rendered none,
+  that EOS is re-appended, so the trained EOS count per row is unchanged (a template that
+  already ends on EOS gets no redundant one added). The rule applies only to text a chat
+  template rendered; pretrain-style raw text with no template keeps the tokenizer's own
+  BOS. Adapters trained with `train_on_responses_only: false` before this change carry one
+  extra leading BOS in training compared with inference. The `soup data preprocess` cache
+  key changes so datasets cached under the old encoding are re-tokenised rather than reused.

--- a/changelog.d/0.74.0/788.fixed.md
+++ b/changelog.d/0.74.0/788.fixed.md
@@ -11,21 +11,29 @@
   are prompted. `soup data preprocess` tokenised the same way. The text path now
   pre-tokenises with `add_special_tokens=False` (via `build_full_sequence_labels`), so the
   chat template is the single source of special tokens, matching inference and HF's own
-  `apply_chat_template(tokenize=True)`: one BOS for a `{{ bos_token }}` template, zero for
-  Soup's `data.chat_template` presets. The stop token is preserved rather than lost.
-  TRL's language-modeling path also appended `eos_token` as a string to every text row
-  that did not already end with it (`add_eos`), independent of the tokenizer's
+  `apply_chat_template(tokenize=True)`: one BOS for a `{{ bos_token }}` template, and zero
+  for a template that renders no BOS at all — both Soup's `data.chat_template` presets and
+  native templates of that shape (TinyLlama, Zephyr). The stop token is preserved rather
+  than lost. TRL's language-modeling path also appended `eos_token` as a string to every
+  text row that did not already end with it (`add_eos`), independent of the tokenizer's
   post-processor, so the pre-tokenised row reproduces that rule: the EOS id is appended
   when the sequence does not already end on it. A `{{ bos_token }}` template on a BOS-only
   or EOS-less (Qwen-shaped) tokenizer therefore keeps the single trailing stop token it
-  trained on before, while tokenizers that previously produced a duplicated EOS now end on
-  exactly one. The rule applies only to text a chat template rendered; pretrain-style raw
-  text with no template keeps the tokenizer's own special tokens unchanged. `soup data
-  doctor --show-mask` now renders through the same builder, so the X-ray matches training.
-  Adapters trained with `train_on_responses_only: false` before this change carry one extra
-  leading BOS in training compared with inference. `soup data preprocess` also stopped
-  doubling the BOS; its EOS behaviour is left exactly as before (it never went through TRL's
-  `add_eos`), so a Qwen-shaped tokenizer's cache and live path can still differ on the EOS —
-  that pre-existing mismatch is tracked separately in #791 rather than changed here. The
-  `soup data preprocess` cache key changes so datasets cached under the old encoding are
-  re-tokenised rather than reused.
+  trained on before. This changes training results in two ways on configs that hit the
+  affected shapes: a template that renders no BOS (TinyLlama / Zephyr, not only Soup's
+  presets) now trains with zero leading BOS rather than the tokenizer's default one, and a
+  row that used to end on two trailing EOS tokens — a template or post-processor that
+  appended one on top of `add_eos`'s — now trains on exactly one. The rule applies only to
+  text a chat template rendered; pretrain-style raw text with no template keeps the
+  tokenizer's own special tokens unchanged. `soup data doctor --show-mask` now renders
+  through the same builder, so the X-ray matches training. Adapters trained with
+  `train_on_responses_only: false` before this change carry one extra leading BOS in
+  training compared with inference. `soup data preprocess` de-duplicates the same leading
+  BOS but stays pinned to the old cache contents otherwise: it tokenises as before
+  (`add_special_tokens=True`) and drops only the one duplicated leading BOS, so every other
+  token is unchanged — including the post-processor's EOS and the room HF truncation
+  reserves for it, so a truncated row still ends on its stop token. Its EOS therefore
+  remains whatever the post-processor added (never TRL's `add_eos`), so a Qwen-shaped
+  tokenizer's cache and live path can still differ on the EOS — that pre-existing mismatch
+  is tracked separately in #791 rather than changed here. The `soup data preprocess` cache
+  key changes so datasets cached under the old encoding are re-tokenised rather than reused.

--- a/changelog.d/0.74.0/788.fixed.md
+++ b/changelog.d/0.74.0/788.fixed.md
@@ -15,7 +15,10 @@
   Soup's `data.chat_template` presets. The stop token is preserved rather than lost: when
   the tokenizer's post-processor would have appended an EOS and the template rendered none,
   that EOS is re-appended, so the trained EOS count per row is unchanged (a template that
-  already ends on EOS gets no redundant one added). The rule applies only to text a chat
+  already ends on EOS gets no redundant one added). Both the live-training path and the
+  `soup data preprocess` cache path do this through one shared helper
+  (`loss_mask.reappend_eos_if_dropped`), so the AOT cache read straight into the trainer
+  cannot silently train on a missing stop token. The rule applies only to text a chat
   template rendered; pretrain-style raw text with no template keeps the tokenizer's own
   BOS. Adapters trained with `train_on_responses_only: false` before this change carry one
   extra leading BOS in training compared with inference. The `soup data preprocess` cache

--- a/changelog.d/0.75.0/788.fixed.md
+++ b/changelog.d/0.75.0/788.fixed.md
@@ -35,5 +35,7 @@
   reserves for it, so a truncated row still ends on its stop token. Its EOS therefore
   remains whatever the post-processor added (never TRL's `add_eos`), so a Qwen-shaped
   tokenizer's cache and live path can still differ on the EOS — that pre-existing mismatch
-  is tracked separately in #791 rather than changed here. The `soup data preprocess` cache
+  is tracked separately in #791 rather than changed here. The cache also keeps `main`'s
+  single leading BOS where the live path now yields none for a `data.chat_template` preset;
+  that BOS divergence is tracked in #876. The `soup data preprocess` cache
   key changes so datasets cached under the old encoding are re-tokenised rather than reused.

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -2498,30 +2498,32 @@ def preprocess_dataset(
                 truncation=True,
                 padding=False,
                 return_attention_mask=True,
-                # #785: the chat path renders the template's special tokens
-                # already (including any {{ bos_token }}), so re-adding the
-                # tokenizer's defaults here doubled the BOS — one token off from
-                # post-#782 inference. Pretrain feeds raw document text with no
-                # template, so it still gets the tokenizer's leading BOS.
-                add_special_tokens=is_pretrain,
+                # Tokenise exactly as ``main`` (add_special_tokens defaults to
+                # True). This keeps ``main``'s truncation reservation — a
+                # truncated row still ends on the post-processor's EOS — and the
+                # post-processor BOS/EOS, so the cache's EOS stays pinned to
+                # ``main``. #785's only defect on this path is the doubled BOS,
+                # removed below for the chat path.
             )
         except Exception:  # noqa: BLE001 — tokenizer errors vary
             continue
         input_ids = tokens["input_ids"]
+        attention_mask = tokens.get("attention_mask", [1] * len(input_ids))
         if not is_pretrain:
-            # #788: add_special_tokens=False (the #785 BOS fix) also strips the
-            # tokenizer post-processor's EOS. Put it back exactly as the live
-            # training path (loss_mask.build_full_sequence_labels) does, then
-            # re-truncate — otherwise a template that renders BOS but not EOS
-            # trains on a missing stop token from this cache. Pretrain feeds raw
-            # document text and keeps the tokenizer's own specials untouched.
-            from soup_cli.data.loss_mask import reappend_eos_if_dropped
+            # #785/#788: the chat template already renders the BOS; ``main``'s
+            # add_special_tokens=True prepends a second one. Drop only that one
+            # duplicated leading BOS so the row is byte-identical to ``main``
+            # apart from the extra BOS (EOS and truncation untouched). Pretrain
+            # feeds raw document text with no template BOS, so nothing to drop.
+            from soup_cli.data.loss_mask import strip_doubled_leading_bos
 
-            input_ids = reappend_eos_if_dropped(tokenizer, input_ids)[:max_length]
+            input_ids, attention_mask = strip_doubled_leading_bos(
+                tokenizer, input_ids, attention_mask
+            )
         rendered_rows.append(
             {
                 "input_ids": input_ids,
-                "attention_mask": [1] * len(input_ids),
+                "attention_mask": attention_mask,
             }
         )
 

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -2507,12 +2507,21 @@ def preprocess_dataset(
             )
         except Exception:  # noqa: BLE001 — tokenizer errors vary
             continue
+        input_ids = tokens["input_ids"]
+        if not is_pretrain:
+            # #788: add_special_tokens=False (the #785 BOS fix) also strips the
+            # tokenizer post-processor's EOS. Put it back exactly as the live
+            # training path (loss_mask.build_full_sequence_labels) does, then
+            # re-truncate — otherwise a template that renders BOS but not EOS
+            # trains on a missing stop token from this cache. Pretrain feeds raw
+            # document text and keeps the tokenizer's own specials untouched.
+            from soup_cli.data.loss_mask import reappend_eos_if_dropped
+
+            input_ids = reappend_eos_if_dropped(tokenizer, input_ids)[:max_length]
         rendered_rows.append(
             {
-                "input_ids": tokens["input_ids"],
-                "attention_mask": tokens.get(
-                    "attention_mask", [1] * len(tokens["input_ids"])
-                ),
+                "input_ids": input_ids,
+                "attention_mask": [1] * len(input_ids),
             }
         )
 

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -2498,6 +2498,12 @@ def preprocess_dataset(
                 truncation=True,
                 padding=False,
                 return_attention_mask=True,
+                # #785: the chat path renders the template's special tokens
+                # already (including any {{ bos_token }}), so re-adding the
+                # tokenizer's defaults here doubled the BOS — one token off from
+                # post-#782 inference. Pretrain feeds raw document text with no
+                # template, so it still gets the tokenizer's leading BOS.
+                add_special_tokens=is_pretrain,
             )
         except Exception:  # noqa: BLE001 — tokenizer errors vary
             continue

--- a/src/soup_cli/data/loss_mask.py
+++ b/src/soup_cli/data/loss_mask.py
@@ -324,6 +324,69 @@ def build_assistant_only_labels(
     return _truncate(full_ids, labels, max_length)
 
 
+def build_full_sequence_labels(
+    messages: Sequence[dict],
+    tokenizer: Any,
+    max_length: int = 2048,
+) -> dict[str, list[int]]:
+    """Build labels where EVERY token contributes to loss (no masking).
+
+    The ``train_on_responses_only=False`` / ``train_on_messages_with_train_field
+    =False`` path. Pre-tokenises with ``add_special_tokens=False`` (via
+    ``_tokenize_only``) so the chat template is the single source of special
+    tokens, matching inference and ``apply_chat_template(tokenize=True)`` (#785).
+
+    Previously this path handed TRL a ``{"text"}`` column, and TRL's
+    language-modeling ``tokenize_fn`` re-tokenised it with the tokenizer's
+    default ``add_special_tokens=True``. A template that renders
+    ``{{ bos_token }}`` then trained on a doubled BOS, one token off from
+    post-#782 inference.
+    """
+    _check_messages(messages)
+    _validate_max_length(max_length)
+    if not getattr(tokenizer, "chat_template", None):
+        raise ValueError(
+            "tokenizer has no chat_template — cannot render messages for the "
+            "text (train_on_responses_only=false) path"
+        )
+    full_ids = _tokenize_only(tokenizer, messages)
+    # #785: the BOS fix must not cost the training EOS. The pre-#785 path let TRL
+    # tokenize the rendered text with the tokenizer's defaults, so a tokenizer
+    # whose post-processor appends EOS gave every row a trailing stop token even
+    # when the template rendered none. add_special_tokens=False (above) removes
+    # the doubled BOS but also that EOS, which teaches run-on generation
+    # (the failure `soup data doctor`'s eos_in_labels check exists to catch). Put
+    # the stop token back when the tokenizer would have appended one and the
+    # template did not already end the sequence with it.
+    appended_eos = _tokenizer_appends_eos(tokenizer)
+    if appended_eos is not None and (not full_ids or full_ids[-1] != appended_eos):
+        full_ids = full_ids + [appended_eos]
+    labels = list(full_ids)
+    return _truncate(full_ids, labels, max_length)
+
+
+def _tokenizer_appends_eos(tokenizer: Any) -> Optional[int]:
+    """Return the EOS id the tokenizer appends under ``add_special_tokens=True``.
+
+    ``None`` when the tokenizer appends no trailing EOS (e.g. a BOS-only
+    post-processor, or none at all). Detected by probing a trivial string both
+    ways so the answer reflects the real ``tokenizers`` post-processor rather
+    than an assumption. Mirrors ``trainer/sft.py``'s ``_processor_adds_leading_bos``
+    for the trailing end.
+    """
+    eos_id = _resolve_eos_token_id(tokenizer)
+    if eos_id is None or not callable(tokenizer):
+        return None
+    try:
+        with_special = coerce_token_ids(tokenizer("a", add_special_tokens=True))
+        without = coerce_token_ids(tokenizer("a", add_special_tokens=False))
+    except (TypeError, ValueError):
+        return None
+    appends = bool(with_special) and with_special[-1] == eos_id
+    already = bool(without) and without[-1] == eos_id
+    return eos_id if appends and not already else None
+
+
 def _resolve_eos_token_id(tokenizer: Any) -> Optional[int]:
     """Return an int EOS/EOT token id, or None if undetermined.
 

--- a/src/soup_cli/data/loss_mask.py
+++ b/src/soup_cli/data/loss_mask.py
@@ -376,10 +376,12 @@ def append_training_eos(tokenizer: Any, input_ids: list[int]) -> list[int]:
     space so the pre-tokenised row trains on the same EOS ``main`` did.
 
     Used by the live-training path (:func:`build_full_sequence_labels`). The
-    ``soup data preprocess`` cache path deliberately does NOT use this -- its EOS
-    behaviour is pinned to ``main`` (post-processor only) via
-    :func:`reappend_eos_if_dropped`, and the resulting cache-vs-live mismatch is
-    tracked separately in #791.
+    ``soup data preprocess`` cache path deliberately does NOT use this -- it
+    tokenises exactly as ``main`` (``add_special_tokens=True``, so the
+    post-processor supplies the EOS) and only drops #785's duplicated leading
+    BOS via :func:`strip_doubled_leading_bos`. Its EOS is therefore whatever the
+    post-processor added, not TRL's ``add_eos`` rule, and the resulting
+    cache-vs-live mismatch is tracked separately in #791.
     """
     eos_id = _resolve_eos_token_id(tokenizer)
     if eos_id is not None and (not input_ids or input_ids[-1] != eos_id):
@@ -387,48 +389,48 @@ def append_training_eos(tokenizer: Any, input_ids: list[int]) -> list[int]:
     return input_ids
 
 
-def reappend_eos_if_dropped(tokenizer: Any, input_ids: list[int]) -> list[int]:
-    """Put back the EOS that ``add_special_tokens=False`` stripped, if any.
+def strip_doubled_leading_bos(
+    tokenizer: Any, input_ids: list[int], attention_mask: list[int]
+) -> tuple[list[int], list[int]]:
+    """Drop only the one duplicated leading BOS #785 introduced on the cache path.
 
-    The #785 BOS fix tokenises the rendered chat template with
-    ``add_special_tokens=False`` so the template is the single source of special
-    tokens. That also drops the trailing EOS a tokenizer's post-processor would
-    otherwise append. Re-append exactly that (and only that) so the
-    ``soup data preprocess`` cache keeps the EOS count it had on ``main``, where
-    the path tokenised with ``add_special_tokens=True``.
+    ``soup data preprocess`` tokenises the rendered chat template exactly as
+    ``main`` did (``add_special_tokens=True``), which keeps ``main``'s truncation
+    reservation and post-processor EOS. The only #785 defect on this path is the
+    doubled BOS: a template rendering ``{{ bos_token }}`` on a tokenizer whose
+    post-processor also prepends BOS yields ``[bos, bos, ...]``. Drop exactly that
+    duplicate (the post-processor's leading copy) and nothing else, so the row is
+    byte-identical to ``main`` apart from the extra BOS and matches post-#782
+    inference's one BOS.
 
-    NOTE: this is the post-processor rule, NOT TRL's ``add_eos`` string rule that
-    the live path uses (:func:`append_training_eos`). The two differ for
-    tokenizers whose post-processor appends no EOS (Qwen-shaped): the live path
-    trains on one, the preprocess cache on none. That mismatch is pre-existing on
-    ``main`` and is tracked in #791 -- it is deliberately not resolved here.
+    A single post-processor BOS (no template BOS, e.g. Zephyr/TinyLlama) or none
+    at all (Qwen) is not a duplicate and is left as ``main`` had it -- the cache
+    is deliberately pinned to ``main`` here, not to the live path's
+    template-only rule, and that difference is the #791 family.
     """
-    appended_eos = _tokenizer_appends_eos(tokenizer)
-    if appended_eos is not None and (not input_ids or input_ids[-1] != appended_eos):
-        return input_ids + [appended_eos]
-    return input_ids
+    bos_id = _resolve_bos_token_id(tokenizer)
+    if (
+        bos_id is not None
+        and len(input_ids) >= 2
+        and input_ids[0] == bos_id
+        and input_ids[1] == bos_id
+    ):
+        return input_ids[1:], attention_mask[1:]
+    return input_ids, attention_mask
 
 
-def _tokenizer_appends_eos(tokenizer: Any) -> Optional[int]:
-    """Return the EOS id the tokenizer appends under ``add_special_tokens=True``.
-
-    ``None`` when the tokenizer appends no trailing EOS (e.g. a BOS-only
-    post-processor, or none at all). Detected by probing a trivial string both
-    ways so the answer reflects the real ``tokenizers`` post-processor rather
-    than an assumption. Mirrors ``trainer/sft.py``'s ``_processor_adds_leading_bos``
-    for the trailing end.
-    """
-    eos_id = _resolve_eos_token_id(tokenizer)
-    if eos_id is None or not callable(tokenizer):
+def _resolve_bos_token_id(tokenizer: Any) -> Optional[int]:
+    """Return an int BOS token id, or None. Mirrors :func:`_resolve_eos_token_id`."""
+    candidate = getattr(tokenizer, "bos_token_id", None)
+    if isinstance(candidate, bool):
         return None
-    try:
-        with_special = coerce_token_ids(tokenizer("a", add_special_tokens=True))
-        without = coerce_token_ids(tokenizer("a", add_special_tokens=False))
-    except (TypeError, ValueError):
-        return None
-    appends = bool(with_special) and with_special[-1] == eos_id
-    already = bool(without) and without[-1] == eos_id
-    return eos_id if appends and not already else None
+    if isinstance(candidate, int):
+        return candidate
+    if isinstance(candidate, list):
+        for entry in candidate:
+            if isinstance(entry, int) and not isinstance(entry, bool):
+                return entry
+    return None
 
 
 def _resolve_eos_token_id(tokenizer: Any) -> Optional[int]:

--- a/src/soup_cli/data/loss_mask.py
+++ b/src/soup_cli/data/loss_mask.py
@@ -358,11 +358,28 @@ def build_full_sequence_labels(
     # (the failure `soup data doctor`'s eos_in_labels check exists to catch). Put
     # the stop token back when the tokenizer would have appended one and the
     # template did not already end the sequence with it.
-    appended_eos = _tokenizer_appends_eos(tokenizer)
-    if appended_eos is not None and (not full_ids or full_ids[-1] != appended_eos):
-        full_ids = full_ids + [appended_eos]
+    full_ids = reappend_eos_if_dropped(tokenizer, full_ids)
     labels = list(full_ids)
     return _truncate(full_ids, labels, max_length)
+
+
+def reappend_eos_if_dropped(tokenizer: Any, input_ids: list[int]) -> list[int]:
+    """Put back the EOS that ``add_special_tokens=False`` stripped, if any.
+
+    The #785 BOS fix tokenises the rendered chat template with
+    ``add_special_tokens=False`` so the template is the single source of special
+    tokens. That also drops the trailing EOS a tokenizer's post-processor would
+    otherwise append, teaching run-on generation. Re-append it when the tokenizer
+    would have added one and the sequence does not already end on it.
+
+    Shared by the live-training path (:func:`build_full_sequence_labels`) and the
+    ``soup data preprocess`` cache path (``commands/data.py``) so the two cannot
+    silently diverge on EOS handling (#785/#788).
+    """
+    appended_eos = _tokenizer_appends_eos(tokenizer)
+    if appended_eos is not None and (not input_ids or input_ids[-1] != appended_eos):
+        return input_ids + [appended_eos]
+    return input_ids
 
 
 def _tokenizer_appends_eos(tokenizer: Any) -> Optional[int]:

--- a/src/soup_cli/data/loss_mask.py
+++ b/src/soup_cli/data/loss_mask.py
@@ -406,7 +406,9 @@ def strip_doubled_leading_bos(
     A single post-processor BOS (no template BOS, e.g. Zephyr/TinyLlama) or none
     at all (Qwen) is not a duplicate and is left as ``main`` had it -- the cache
     is deliberately pinned to ``main`` here, not to the live path's
-    template-only rule, and that difference is the #791 family.
+    template-only rule, and that difference (the live path now yields zero
+    leading BOS for a ``data.chat_template`` preset while the cache keeps
+    ``main``'s one) is tracked in #876.
     """
     bos_id = _resolve_bos_token_id(tokenizer)
     if (

--- a/src/soup_cli/data/loss_mask.py
+++ b/src/soup_cli/data/loss_mask.py
@@ -350,17 +350,41 @@ def build_full_sequence_labels(
             "text (train_on_responses_only=false) path"
         )
     full_ids = _tokenize_only(tokenizer, messages)
-    # #785: the BOS fix must not cost the training EOS. The pre-#785 path let TRL
-    # tokenize the rendered text with the tokenizer's defaults, so a tokenizer
-    # whose post-processor appends EOS gave every row a trailing stop token even
-    # when the template rendered none. add_special_tokens=False (above) removes
-    # the doubled BOS but also that EOS, which teaches run-on generation
-    # (the failure `soup data doctor`'s eos_in_labels check exists to catch). Put
-    # the stop token back when the tokenizer would have appended one and the
-    # template did not already end the sequence with it.
-    full_ids = reappend_eos_if_dropped(tokenizer, full_ids)
+    # #785/#788: the BOS fix must not cost the training EOS. On ``main`` the
+    # legacy text rows reached TRL as ``{"text": ...}``, and TRL 0.29.1's
+    # language-modeling path appends ``eos_token`` as a STRING to every row that
+    # does not already end with it (``sft_trainer.py`` ``add_eos``), before
+    # tokenizing -- independent of the tokenizer's post-processor. Pre-tokenising
+    # here skips that TRL step, so reproduce its rule in token space: append the
+    # EOS id when the sequence does not already end on it. Probing the
+    # post-processor instead (an earlier #788 attempt) under-appended for
+    # BOS-only and Qwen-shaped tokenizers, dropping the stop token ``main``
+    # trained on and teaching run-on generation (the failure `soup data doctor`'s
+    # eos_in_labels check exists to catch).
+    full_ids = append_training_eos(tokenizer, full_ids)
     labels = list(full_ids)
     return _truncate(full_ids, labels, max_length)
+
+
+def append_training_eos(tokenizer: Any, input_ids: list[int]) -> list[int]:
+    """Append the EOS the SFT language-modeling path trains on (TRL's rule).
+
+    Reproduces TRL 0.29.1's ``add_eos`` (``sft_trainer.py``): the trained text row
+    ends in ``eos_token`` unless it already does, regardless of whether the
+    tokenizer's post-processor would append one. #785 pre-tokenises the rendered
+    template so TRL never runs ``add_eos``; this puts the stop token back in token
+    space so the pre-tokenised row trains on the same EOS ``main`` did.
+
+    Used by the live-training path (:func:`build_full_sequence_labels`). The
+    ``soup data preprocess`` cache path deliberately does NOT use this -- its EOS
+    behaviour is pinned to ``main`` (post-processor only) via
+    :func:`reappend_eos_if_dropped`, and the resulting cache-vs-live mismatch is
+    tracked separately in #791.
+    """
+    eos_id = _resolve_eos_token_id(tokenizer)
+    if eos_id is not None and (not input_ids or input_ids[-1] != eos_id):
+        return input_ids + [eos_id]
+    return input_ids
 
 
 def reappend_eos_if_dropped(tokenizer: Any, input_ids: list[int]) -> list[int]:
@@ -369,12 +393,15 @@ def reappend_eos_if_dropped(tokenizer: Any, input_ids: list[int]) -> list[int]:
     The #785 BOS fix tokenises the rendered chat template with
     ``add_special_tokens=False`` so the template is the single source of special
     tokens. That also drops the trailing EOS a tokenizer's post-processor would
-    otherwise append, teaching run-on generation. Re-append it when the tokenizer
-    would have added one and the sequence does not already end on it.
+    otherwise append. Re-append exactly that (and only that) so the
+    ``soup data preprocess`` cache keeps the EOS count it had on ``main``, where
+    the path tokenised with ``add_special_tokens=True``.
 
-    Shared by the live-training path (:func:`build_full_sequence_labels`) and the
-    ``soup data preprocess`` cache path (``commands/data.py``) so the two cannot
-    silently diverge on EOS handling (#785/#788).
+    NOTE: this is the post-processor rule, NOT TRL's ``add_eos`` string rule that
+    the live path uses (:func:`append_training_eos`). The two differ for
+    tokenizers whose post-processor appends no EOS (Qwen-shaped): the live path
+    trains on one, the preprocess cache on none. That mismatch is pre-existing on
+    ``main`` and is tracked in #791 -- it is deliberately not resolved here.
     """
     appended_eos = _tokenizer_appends_eos(tokenizer)
     if appended_eos is not None and (not input_ids or input_ids[-1] != appended_eos):

--- a/src/soup_cli/data/sft_format.py
+++ b/src/soup_cli/data/sft_format.py
@@ -196,21 +196,23 @@ def _build_full_sequence_format_row(
 
 
 def _legacy_text_format_row(tokenizer: Any) -> Callable[[dict], dict]:
+    """No-template fallback for a masking config: reached from
+    :func:`build_format_row` only when a masking flag is set but the tokenizer has
+    no ``chat_template``, so it always raises.
+
+    #788: the ``{"text": rendered}`` return this used to produce is dead now that
+    the full-sequence path pre-tokenises (returning ``input_ids``), so it is gone;
+    what remains is the hard error that (v0.36.0 Part C) replaced the silent
+    ``f"{role}: {content}"`` fallback which produced garbage training data.
+    """
+
     def format_row(example: dict) -> dict:
-        if not getattr(tokenizer, "chat_template", None):
-            # v0.36.0 Part C: hard error replaces the silent
-            # ``f"{role}: {content}"`` fallback that produced garbage
-            # training data on tokenizers without a chat template.
-            raise ValueError(
-                "Tokenizer has no chat_template. Pass "
-                "data.chat_template: chatml (or llama3/qwen2.5/mistral/"
-                "gemma3/phi4/deepseek-r1) in soup.yaml, or supply a raw "
-                "Jinja string. The previous silent f-string fallback "
-                "produced wrong loss labels and was removed in v0.36.0."
-            )
-        text = tokenizer.apply_chat_template(
-            example["messages"], tokenize=False, add_generation_prompt=False
+        raise ValueError(
+            "Tokenizer has no chat_template. Pass "
+            "data.chat_template: chatml (or llama3/qwen2.5/mistral/"
+            "gemma3/phi4/deepseek-r1) in soup.yaml, or supply a raw "
+            "Jinja string. The previous silent f-string fallback "
+            "produced wrong loss labels and was removed in v0.36.0."
         )
-        return {"text": text}
 
     return format_row

--- a/src/soup_cli/data/sft_format.py
+++ b/src/soup_cli/data/sft_format.py
@@ -26,6 +26,7 @@ from soup_cli.config.schema import DataConfig
 from soup_cli.data.chat_templates import apply_chat_template_override
 from soup_cli.data.loss_mask import (
     build_assistant_only_labels,
+    build_full_sequence_labels,
     build_per_message_train_labels,
 )
 
@@ -89,7 +90,7 @@ def build_format_row(
             tokenizer, max_length, include_eot=include_eot
         )
     else:
-        inner = _legacy_text_format_row(tokenizer)
+        inner = _build_full_sequence_format_row(tokenizer, max_length)
     return _wrap_with_prompt_strategy(
         _wrap_with_reasoning_effort(inner, reasoning_effort),
         prompt_strategy_spec,
@@ -168,6 +169,26 @@ def _build_per_message_format_row(
 ) -> Callable[[dict], dict]:
     def format_row(example: dict) -> dict:
         return build_per_message_train_labels(
+            example["messages"], tokenizer, max_length=max_length
+        )
+
+    return format_row
+
+
+def _build_full_sequence_format_row(
+    tokenizer: Any, max_length: int
+) -> Callable[[dict], dict]:
+    """Legacy (both flags False) path: train on every token, no masking.
+
+    #785: pre-tokenise with ``add_special_tokens=False`` so TRL skips its own
+    language-modeling ``tokenize_fn`` (which re-adds the tokenizer's default
+    special tokens and doubled the BOS on ``{{ bos_token }}`` templates). The
+    rendered chat template is the single source of special tokens, matching
+    inference after #782.
+    """
+
+    def format_row(example: dict) -> dict:
+        return build_full_sequence_labels(
             example["messages"], tokenizer, max_length=max_length
         )
 

--- a/src/soup_cli/utils/data_doctor.py
+++ b/src/soup_cli/utils/data_doctor.py
@@ -260,8 +260,8 @@ def _build_row_labels(
     """
     from soup_cli.data.loss_mask import (
         build_assistant_only_labels,
+        build_full_sequence_labels,
         build_per_message_train_labels,
-        coerce_token_ids,
     )
 
     if train_on_messages_with_train_field:
@@ -270,18 +270,12 @@ def _build_row_labels(
         return build_assistant_only_labels(
             messages, tokenizer, max_length=max_length, include_eot=include_eot
         )
-    ids = coerce_token_ids(
-        tokenizer.apply_chat_template(
-            messages, tokenize=True, add_generation_prompt=False
-        )
-    )
-    # Truncate to max_length like the other two strategies (both delegate
-    # to data.loss_mask._truncate) — otherwise legacy_text is the only path
-    # where --show-mask can render more tokens than the trainer actually
-    # would, and the max_length-truncation check above would never trigger
-    # for this strategy either.
-    ids = list(ids)[:max_length]
-    return {"input_ids": ids, "labels": ids}
+    # #788: legacy full-sequence path — call the SAME builder the trainer uses
+    # (build_full_sequence_labels) so --show-mask reflects the one-BOS,
+    # add_eos-EOS tokenization. Re-rendering here with the tokenizer's default
+    # add_special_tokens=True instead doubled the BOS and skipped TRL's EOS rule,
+    # so the X-ray stopped matching what training actually consumes.
+    return build_full_sequence_labels(messages, tokenizer, max_length=max_length)
 
 
 def _mask_strategy_name(

--- a/src/soup_cli/utils/data_pipeline.py
+++ b/src/soup_cli/utils/data_pipeline.py
@@ -191,9 +191,10 @@ def validate_shards(value: Optional[int]) -> Optional[int]:
 # tokenizer + max_length + format + dataset path → SHA-256 → cache filename.
 # Bump whenever the on-disk tokenization of a preprocessed row changes, so a
 # dataset cached under an older encoding is never silently reused. v2 (#785):
-# the chat path now tokenizes with add_special_tokens=False (the chat template
-# already renders its special tokens), removing the doubled BOS that older
-# caches baked in.
+# the chat path still tokenizes with the tokenizer's default add_special_tokens=True
+# (so the cache stays byte-identical to older behaviour on EOS and truncation) but
+# now strips the one doubled leading BOS the chat template already rendered, so a
+# row that used to bake in [bos, bos, ...] no longer does.
 _PREPROCESS_TOKENIZE_SCHEMA = "v2"
 
 

--- a/src/soup_cli/utils/data_pipeline.py
+++ b/src/soup_cli/utils/data_pipeline.py
@@ -189,6 +189,14 @@ def validate_shards(value: Optional[int]) -> Optional[int]:
 
 # Mirrors v0.36.0 batch_cache.json content-hash policy. Cache key includes
 # tokenizer + max_length + format + dataset path → SHA-256 → cache filename.
+# Bump whenever the on-disk tokenization of a preprocessed row changes, so a
+# dataset cached under an older encoding is never silently reused. v2 (#785):
+# the chat path now tokenizes with add_special_tokens=False (the chat template
+# already renders its special tokens), removing the doubled BOS that older
+# caches baked in.
+_PREPROCESS_TOKENIZE_SCHEMA = "v2"
+
+
 def make_preprocess_cache_key(
     *,
     dataset_path: str,
@@ -215,7 +223,10 @@ def make_preprocess_cache_key(
         raise ValueError("max_length must be a positive int")
     if not isinstance(format_name, str) or not format_name:
         raise ValueError("format_name must be a non-empty string")
-    blob = f"{dataset_path}\x1f{tokenizer_name}\x1f{max_length}\x1f{format_name}"
+    blob = (
+        f"{_PREPROCESS_TOKENIZE_SCHEMA}\x1f{dataset_path}\x1f{tokenizer_name}"
+        f"\x1f{max_length}\x1f{format_name}"
+    )
     return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
 
 

--- a/tests/test_assistant_mask.py
+++ b/tests/test_assistant_mask.py
@@ -622,8 +622,12 @@ class TestBuildFormatRow:
         )
         fn = build_format_row(tok, cfg)
         out = fn(self._row())
-        assert "text" in out
-        assert "input_ids" not in out
+        # #785: the legacy (both-False) path now PRE-tokenizes with
+        # add_special_tokens=False so TRL never re-adds the template's special
+        # tokens (which doubled the BOS). Full-sequence: every token is a target.
+        assert "text" not in out
+        assert "input_ids" in out
+        assert out["labels"] == out["input_ids"]
 
     def test_no_chat_template_calling_format_row_raises(self):
         """v0.36.0 Part C: previous silent fallback now raises ValueError."""

--- a/tests/test_chat_template.py
+++ b/tests/test_chat_template.py
@@ -261,7 +261,9 @@ class TestHardError:
                 self, messages, tokenize=False, add_generation_prompt=False, **kwargs
             ):
                 self.applied.append(messages)
-                return "RENDERED"
+                # #785: the legacy path now pre-tokenizes (tokenize=True); it
+                # renders to text only for display/other callers.
+                return [1, 2, 3] if tokenize else "RENDERED"
 
         tok = _T()
         cfg = DataConfig(
@@ -272,5 +274,6 @@ class TestHardError:
         )
         fn = build_format_row(tok, cfg, console=None)
         out = fn({"messages": [{"role": "user", "content": "hi"}]})
-        assert out["text"] == "RENDERED"
+        assert out["input_ids"] == [1, 2, 3]  # override made the legacy path usable
+        assert tok.applied  # apply_chat_template was invoked
         assert tok.chat_template is not None  # override was applied

--- a/tests/test_issue781_inference_bos.py
+++ b/tests/test_issue781_inference_bos.py
@@ -581,9 +581,12 @@ _ALLOWLIST = {
         "passes add_special_tokens through **processor_kwargs, decided per processor "
         "by _processor_adds_leading_bos (#302)"
     ),
-    # preprocess_dataset was fixed in #785: its chat branch now tokenizes with
-    # add_special_tokens=is_pretrain (False for templated rows), so it no longer
-    # renders-then-adds and has left the allowlist.
+    "commands/data.py::preprocess_dataset": (
+        "renders a template, then tokenizes with the tokenizer's default "
+        "add_special_tokens=True on purpose so the cache stays byte-identical to "
+        "main (truncation reservation and post-processor EOS preserved), and strips "
+        "only the one doubled leading BOS afterwards (#785/#788)"
+    ),
     "utils/live_eval.py::extract_layer_activations": (
         "activation capture; changing the ids changes saved steering vectors and "
         "probe calibration (#781, out of scope)"

--- a/tests/test_issue781_inference_bos.py
+++ b/tests/test_issue781_inference_bos.py
@@ -581,10 +581,9 @@ _ALLOWLIST = {
         "passes add_special_tokens through **processor_kwargs, decided per processor "
         "by _processor_adds_leading_bos (#302)"
     ),
-    "commands/data.py::preprocess_dataset": (
-        "training-side: writes the pre_tokenized rows training consumes; changing it "
-        "changes training data and the pipeline cache key (#781, out of scope)"
-    ),
+    # preprocess_dataset was fixed in #785: its chat branch now tokenizes with
+    # add_special_tokens=is_pretrain (False for templated rows), so it no longer
+    # renders-then-adds and has left the allowlist.
     "utils/live_eval.py::extract_layer_activations": (
         "activation capture; changing the ids changes saved steering vectors and "
         "probe calibration (#781, out of scope)"

--- a/tests/test_issue785_training_bos.py
+++ b/tests/test_issue785_training_bos.py
@@ -36,6 +36,7 @@ _WORDS = [
     "?", "Paris", "system", "user", "assistant",
 ]
 _BOS_ID = _SPECIALS.index("<s>")
+_EOS_ID = _SPECIALS.index("</s>")
 
 _BOS_TEMPLATE = (
     "{{ bos_token }}"
@@ -90,10 +91,33 @@ def _legacy_format_row(tok):
     return build_format_row(tokenizer=tok, data_cfg=dcfg)
 
 
+def _trl_main_lm_ids(tok, messages):
+    """The ids the SFT language-modeling text path trained on for ``messages`` on
+    ``main`` (the baseline #788 must be measured against).
+
+    Reproduces TRL 0.29.1's two real operations on a legacy ``{"text"}`` row using
+    the real tokenizer: ``add_eos`` appends ``eos_token`` as a string when the
+    rendered text does not already end with it (``sft_trainer.py`` ``add_eos``,
+    lines 1026-1031), then TRL tokenizes with the tokenizer's default
+    ``add_special_tokens=True`` (line 1131). ``tok(text=text)`` alone omits
+    ``add_eos`` and under-counts the trained EOS — the mistake the first #788
+    attempt made and the reason these tests are baselined against this instead.
+    """
+    text = tok.apply_chat_template(
+        messages, tokenize=False, add_generation_prompt=False
+    )
+    if not text.endswith(tok.eos_token):
+        text = text + tok.eos_token
+    return tok(text)["input_ids"]
+
+
 class TestLegacyTextPathBOS:
-    def test_bos_template_trains_on_exactly_one_bos(self):
-        """A template that renders {{ bos_token }} must train on one BOS, and the
-        ids must equal HF's own one-step encode (what inference sends post-#782).
+    def test_bos_template_trains_on_one_bos_and_keeps_the_eos(self):
+        """A template that renders {{ bos_token }} must train on one BOS (not the
+        two ``main`` produced) while keeping the trailing EOS ``main`` trained on.
+
+        The body equals inference's one-step encode (add_special_tokens=False,
+        what #782 sends) plus the training stop token inference does not send.
 
         Fails on pre-fix main: that path returned a ``{"text"}`` row, so there is
         no ``input_ids`` to read, and TRL then tokenized the text to two BOS.
@@ -107,10 +131,17 @@ class TestLegacyTextPathBOS:
         ids = row["input_ids"]
         assert ids.count(_BOS_ID) == 1, f"expected one BOS, got ids={ids}"
 
-        reference = tok.apply_chat_template(
-            _MESSAGES, tokenize=True, add_generation_prompt=False, return_dict=True
+        main_ids = _trl_main_lm_ids(tok, _MESSAGES)
+        assert main_ids.count(_BOS_ID) == 2, "sanity: main doubled the BOS here"
+        # The stop token main trained on (TRL add_eos) is preserved, not dropped.
+        assert ids[-1] == _EOS_ID and main_ids[-1] == _EOS_ID
+        assert ids.count(_EOS_ID) == main_ids.count(_EOS_ID) == 1
+
+        inference = tok.apply_chat_template(
+            _MESSAGES, tokenize=True, add_generation_prompt=False,
+            add_special_tokens=False, return_dict=True,
         )["input_ids"]
-        assert ids == list(reference)
+        assert ids == list(inference) + [_EOS_ID]
         # Full-sequence training: every token is a target, none masked.
         assert row["labels"] == ids
         assert set(row["attention_mask"]) == {1}
@@ -143,89 +174,112 @@ class TestLegacyTextPathBOS:
 class TestTrainingEOSPreserved:
     """The BOS fix must not cost the stop token (maintainer req 1 on #785).
 
-    On the training side, dropping a tokenizer-appended trailing EOS is the
-    opposite of #782's inference goal: it teaches run-on generation. Behaviour
-    stated per case below.
+    ``main``'s live text path trained on the EOS TRL's ``add_eos`` appends as a
+    string, independent of the tokenizer's post-processor. Dropping it teaches
+    run-on generation. Every case is baselined against ``_trl_main_lm_ids`` (what
+    ``main`` trained on), not ``tok(text=...)`` which omits ``add_eos``. The fix
+    reproduces TRL's rule: end on exactly one EOS, removing ``main``'s duplicates
+    but never dropping the stop token.
     """
 
-    _EOS_ID = _SPECIALS.index("</s>")
+    @pytest.mark.parametrize(
+        "post_processor",
+        ["bos", None],
+        ids=["bos-only (Gemma/Llama-2)", "no-post-processor (Qwen)"],
+    )
+    def test_eos_kept_when_post_processor_appends_none(self, post_processor):
+        """The regression the #788 review caught. Template renders no EOS on a
+        tokenizer whose post-processor appends none. ``main`` still trained on one
+        EOS because TRL's ``add_eos`` appends it as a string; probing the
+        post-processor (the first #788 attempt) added none and dropped the stop
+        token 1 -> 0. The fix keeps it."""
+        tok = _tokenizer(_BOS_TEMPLATE, post_processor=post_processor)
+        main_ids = _trl_main_lm_ids(tok, _MESSAGES)
+        assert main_ids.count(_EOS_ID) == 1, "main trained on one EOS via add_eos"
 
-    def test_eos_preserved_when_template_renders_none_and_tokenizer_appends(self):
-        """Template renders no EOS, tokenizer's post-processor appends one.
+        ids = _legacy_format_row(tok)({"messages": _MESSAGES})["input_ids"]
+        assert ids[-1] == _EOS_ID and ids.count(_EOS_ID) == 1, (
+            f"fix must keep the EOS main trained on, not drop it; got {ids}"
+        )
 
-        Pre-fix (render then tokenize with defaults) kept that appended EOS.
-        add_special_tokens=False alone would drop it; the fix re-appends it, so
-        the trained EOS count is unchanged and the row still ends on the stop
-        token."""
+    def test_eos_not_duplicated_when_post_processor_also_appends(self):
+        """Template renders no EOS; the post-processor appends one AND TRL's
+        add_eos appended another, so ``main`` trained on a duplicated EOS. The fix
+        ends on exactly one stop token — main's duplicate removed, like the BOS."""
         tok = _tokenizer(_BOS_TEMPLATE, post_processor="bos_eos")
-        text = tok.apply_chat_template(_MESSAGES, tokenize=False, add_generation_prompt=False)
-        pre_fix_eos = tok(text=text)["input_ids"].count(self._EOS_ID)
+        main_ids = _trl_main_lm_ids(tok, _MESSAGES)
+        assert main_ids.count(_EOS_ID) == 2, "sanity: main duplicated the EOS here"
 
         ids = _legacy_format_row(tok)({"messages": _MESSAGES})["input_ids"]
-        assert ids.count(self._EOS_ID) == pre_fix_eos == 1
-        assert ids[-1] == self._EOS_ID, "row must end on the stop token"
-        assert ids.count(_BOS_ID) == 1, "and still carry exactly one BOS"
-
-    def test_eos_unchanged_when_template_renders_it(self):
-        """Template renders the EOS itself; the tokenizer appends none.
-
-        The template's EOS carries through untouched and none is re-added, so the
-        trained EOS count is unchanged from the pre-fix path and only the leading
-        duplicate BOS is removed."""
-        tok = _tokenizer(_BOS_EOS_TEMPLATE, post_processor="bos")
-        text = tok.apply_chat_template(_MESSAGES, tokenize=False, add_generation_prompt=False)
-        pre_fix = tok(text=text)["input_ids"]
-
-        ids = _legacy_format_row(tok)({"messages": _MESSAGES})["input_ids"]
-        assert ids.count(self._EOS_ID) == pre_fix.count(self._EOS_ID)
-        assert ids[-1] == self._EOS_ID, "row still ends on the stop token"
-        assert ids == pre_fix[1:], "only diff is the removed leading BOS"
+        assert ids[-1] == _EOS_ID, "row ends on the stop token"
+        assert ids.count(_EOS_ID) == 1, "exactly one, the duplicate removed"
         assert ids.count(_BOS_ID) == 1
 
-    def test_no_eos_invented_when_neither_side_provides_one(self):
-        """Template renders no EOS and the tokenizer appends none: pre-fix had no
-        stop token, and the fix invents none (unchanged)."""
-        tok = _tokenizer(_BOS_TEMPLATE, post_processor="bos")
+    def test_template_rendered_eos_is_kept_and_not_re_appended(self):
+        """Template renders the EOS itself; the fix adds none because the sequence
+        already ends on it (TRL's rule: append only if not already ending on EOS).
+        The body equals inference's encode; main's add_eos duplicate is gone."""
+        tok = _tokenizer(_BOS_EOS_TEMPLATE, post_processor="bos")
         ids = _legacy_format_row(tok)({"messages": _MESSAGES})["input_ids"]
-        assert ids.count(self._EOS_ID) == 0
+
+        assert ids[-1] == _EOS_ID, "row ends on the template's stop token"
+        inference = tok.apply_chat_template(
+            _MESSAGES, tokenize=True, add_generation_prompt=False,
+            add_special_tokens=False, return_dict=True,
+        )["input_ids"]
+        assert ids == list(inference), "nothing re-appended; already ends on EOS"
+        assert ids.count(_BOS_ID) == 1
+
+        main_ids = _trl_main_lm_ids(tok, _MESSAGES)
+        assert main_ids.count(_EOS_ID) == ids.count(_EOS_ID) + 1, (
+            "main's add_eos duplicated the trailing EOS; the fix does not"
+        )
 
 
 class TestTemplatedOnly:
     """The rule applies only to text a chat template rendered (maintainer req 2)."""
 
-    def test_no_template_is_rejected_not_silently_stripped(self):
-        """A tokenizer with no chat_template never reaches add_special_tokens=False:
-        the text path raises rather than silently dropping the tokenizer's own
-        (only) special tokens. Same behaviour as main (it raised before too)."""
-        from soup_cli.data.loss_mask import build_full_sequence_labels
+    def test_no_template_row_raises_rather_than_being_silently_pretokenized(self):
+        """A tokenizer with no chat_template must raise, not be silently stripped
+        into wrong training data. Routed through ``build_format_row`` — the real
+        dispatch, present on ``main`` too — so it discriminates the raise
+        behaviour rather than the mere absence of a #788 import."""
+        from soup_cli.config.schema import DataConfig
+        from soup_cli.data.sft_format import build_format_row
 
         tok = _tokenizer(None, post_processor="bos")  # no chat_template
         tok.chat_template = None
+        dcfg = DataConfig(
+            train="t.jsonl",
+            train_on_responses_only=False,
+            train_on_messages_with_train_field=False,
+            max_length=2048,
+        )
+        format_row = build_format_row(tokenizer=tok, data_cfg=dcfg)
         with pytest.raises(ValueError, match="chat_template"):
-            build_full_sequence_labels(_MESSAGES, tok, max_length=2048)
+            format_row({"messages": _MESSAGES})
 
 
 class TestPreprocessCachePathEOS:
-    """`soup data preprocess` must handle EOS exactly like live training.
+    """`soup data preprocess` EOS behaviour is pinned to ``main`` (post-processor
+    only), deliberately NOT to the live path.
 
-    The BOS fix (#785) lives on two paths: ``loss_mask.build_full_sequence_labels``
-    (live tokenize) and ``preprocess_dataset`` (the AOT cache read straight into
-    the trainer by ``sft._maybe_load_pretokenized``). Both now tokenize the
-    rendered template with ``add_special_tokens=False``, which also drops the
-    tokenizer post-processor's EOS. #788 review (AmirF194): the cache path did not
-    re-append it, so a BOS-but-not-EOS template silently trained on a missing stop
-    token from the cache. These pin the two paths to identical ids.
+    #788 de-duplicates the BOS on the preprocess cache path just as on the live
+    path, but it must NOT change what EOS the cache trains on: ``main``'s
+    preprocess never went through TRL's ``add_eos``, so its EOS is whatever the
+    post-processor added. The live path now reproduces ``add_eos`` and so trains
+    on an EOS the cache does not (Qwen shape). That cache-vs-live mismatch is
+    pre-existing on ``main`` and tracked in #791 — not resolved here.
     """
 
-    _EOS_ID = _SPECIALS.index("</s>")
-
-    def _run_preprocess(self, tmp_path, monkeypatch, tok, task="sft"):
+    def _run_preprocess(self, tmp_path, monkeypatch, tok, *, task="sft", rows=None):
         transformers = pytest.importorskip("transformers")
         datasets = pytest.importorskip("datasets")
         from typer.testing import CliRunner
 
         from soup_cli.cli import app
 
+        rows = rows if rows is not None else [{"messages": _MESSAGES}]
         monkeypatch.chdir(tmp_path)
         (tmp_path / "soup.yaml").write_text(
             f"base: x/y\ntask: {task}\n"
@@ -239,8 +293,7 @@ class TestPreprocessCachePathEOS:
         # Control the rows directly so the assertion is about tokenization, not
         # format conversion. preprocess_dataset local-imports this name.
         monkeypatch.setattr(
-            "soup_cli.data.loader.load_dataset",
-            lambda *a, **k: {"train": [{"messages": _MESSAGES}]},
+            "soup_cli.data.loader.load_dataset", lambda *a, **k: {"train": rows}
         )
         result = CliRunner().invoke(app, ["data", "preprocess", "soup.yaml", "--yes"])
         assert result.exit_code == 0, result.output
@@ -249,35 +302,50 @@ class TestPreprocessCachePathEOS:
         ds = datasets.load_from_disk(str(cache_dirs[0]))
         return list(ds[0]["input_ids"])
 
-    def test_cache_preserves_eos_the_tokenizer_appends(self, tmp_path, monkeypatch):
-        """Template renders BOS but not EOS; the tokenizer appends EOS. The cached
-        row must still end on the stop token and match the live path exactly.
+    def _main_preprocess_ids(self, tok):
+        """What ``main``'s preprocess chat path produced: ``tokenizer(text)`` with
+        the default ``add_special_tokens=True`` (no TRL ``add_eos`` on this path)."""
+        text = tok.apply_chat_template(
+            _MESSAGES, tokenize=False, add_generation_prompt=False
+        )
+        return tok(text, add_special_tokens=True)["input_ids"]
 
-        Fails without the #788 re-append: the cache row would end one token short
-        (EOS dropped), which reaches the trainer verbatim."""
-        from soup_cli.data.loss_mask import build_full_sequence_labels
-
+    def test_cache_eos_matches_main_when_post_processor_appends(self, tmp_path, monkeypatch):
+        """bos_eos post-processor: ``main``'s preprocess kept one EOS (from the
+        post-processor). The cache keeps exactly that and drops the doubled BOS."""
         tok = _tokenizer(_BOS_TEMPLATE, post_processor="bos_eos")
         ids = self._run_preprocess(tmp_path, monkeypatch, tok)
-        live = build_full_sequence_labels(_MESSAGES, tok, max_length=2048)["input_ids"]
+        main_pp = self._main_preprocess_ids(tok)
 
-        assert ids == live, "cache path must equal the live-training path"
-        assert ids[-1] == self._EOS_ID, "cached row must end on the stop token"
-        assert ids.count(self._EOS_ID) == 1
-        assert ids.count(_BOS_ID) == 1
+        assert ids.count(_EOS_ID) == main_pp.count(_EOS_ID) == 1, "EOS unchanged vs main"
+        assert main_pp.count(_BOS_ID) == 2 and ids.count(_BOS_ID) == 1, "BOS de-duplicated"
 
-    def test_cache_invents_no_eos_when_tokenizer_appends_none(self, tmp_path, monkeypatch):
-        """Tokenizer appends no EOS: the cache path must not invent one, matching
-        the live path (control against over-eager re-appending)."""
+    def test_cache_keeps_mains_zero_eos_for_no_eos_post_processor(self, tmp_path, monkeypatch):
+        """Qwen/BOS-only shape: ``main``'s preprocess added no EOS, so the cache
+        keeps zero rather than adopting the live path's one. Documents that the
+        cache and live path diverge here — the #791 mismatch."""
         from soup_cli.data.loss_mask import build_full_sequence_labels
 
         tok = _tokenizer(_BOS_TEMPLATE, post_processor="bos")
         ids = self._run_preprocess(tmp_path, monkeypatch, tok)
-        live = build_full_sequence_labels(_MESSAGES, tok, max_length=2048)["input_ids"]
+        main_pp = self._main_preprocess_ids(tok)
 
-        assert ids == live
-        assert ids.count(self._EOS_ID) == 0
-        assert ids.count(_BOS_ID) == 1
+        assert ids.count(_EOS_ID) == main_pp.count(_EOS_ID) == 0, "EOS unchanged vs main"
+        assert ids.count(_BOS_ID) == 1, "BOS de-duplicated"
+        live = build_full_sequence_labels(_MESSAGES, tok, max_length=2048)["input_ids"]
+        assert live.count(_EOS_ID) == 1, "live trains on an EOS the cache does not (#791)"
+
+    def test_pretrain_cache_is_byte_identical_to_main(self, tmp_path, monkeypatch):
+        """Pretrain rows never went through a template, so #788 must leave them
+        exactly as ``main``: ``add_special_tokens=True`` and no EOS re-append.
+        Kills the two surviving mutations (add_special_tokens=False on pretrain,
+        and the EOS re-append applied to pretrain)."""
+        tok = _tokenizer(_BOS_TEMPLATE, post_processor="bos_eos")
+        raw = "You are terse ."
+        ids = self._run_preprocess(
+            tmp_path, monkeypatch, tok, task="pretrain", rows=[{"text": raw}]
+        )
+        assert ids == tok(raw, add_special_tokens=True)["input_ids"]
 
 
 class TestPreprocessCacheKey:

--- a/tests/test_issue785_training_bos.py
+++ b/tests/test_issue785_training_bos.py
@@ -272,7 +272,9 @@ class TestPreprocessCachePathEOS:
     pre-existing on ``main`` and tracked in #791 — not resolved here.
     """
 
-    def _run_preprocess(self, tmp_path, monkeypatch, tok, *, task="sft", rows=None):
+    def _run_preprocess(
+        self, tmp_path, monkeypatch, tok, *, task="sft", rows=None, max_length=2048
+    ):
         transformers = pytest.importorskip("transformers")
         datasets = pytest.importorskip("datasets")
         from typer.testing import CliRunner
@@ -283,7 +285,8 @@ class TestPreprocessCachePathEOS:
         monkeypatch.chdir(tmp_path)
         (tmp_path / "soup.yaml").write_text(
             f"base: x/y\ntask: {task}\n"
-            "data:\n  train: ./d.jsonl\n  format: chatml\n  max_length: 2048\n",
+            "data:\n  train: ./d.jsonl\n  format: chatml\n"
+            f"  max_length: {max_length}\n",
             encoding="utf-8",
         )
         (tmp_path / "d.jsonl").write_text("{}\n", encoding="utf-8")
@@ -302,13 +305,18 @@ class TestPreprocessCachePathEOS:
         ds = datasets.load_from_disk(str(cache_dirs[0]))
         return list(ds[0]["input_ids"])
 
-    def _main_preprocess_ids(self, tok):
+    def _main_preprocess_ids(self, tok, *, messages=None, max_length=2048):
         """What ``main``'s preprocess chat path produced: ``tokenizer(text)`` with
-        the default ``add_special_tokens=True`` (no TRL ``add_eos`` on this path)."""
+        the default ``add_special_tokens=True`` and the same truncation budget (no
+        TRL ``add_eos`` on this path). HF truncation reserves room for the
+        post-processor's specials, so a truncated ``main`` row still ends on EOS."""
+        messages = messages if messages is not None else _MESSAGES
         text = tok.apply_chat_template(
-            _MESSAGES, tokenize=False, add_generation_prompt=False
+            messages, tokenize=False, add_generation_prompt=False
         )
-        return tok(text, add_special_tokens=True)["input_ids"]
+        return tok(
+            text, max_length=max_length, truncation=True, add_special_tokens=True
+        )["input_ids"]
 
     def test_cache_eos_matches_main_when_post_processor_appends(self, tmp_path, monkeypatch):
         """bos_eos post-processor: ``main``'s preprocess kept one EOS (from the
@@ -347,6 +355,44 @@ class TestPreprocessCachePathEOS:
         )
         assert ids == tok(raw, add_special_tokens=True)["input_ids"]
 
+    def test_cache_keeps_eos_on_truncated_row(self, tmp_path, monkeypatch):
+        """The #788 round-2 blocker. A row long enough to truncate must still end
+        on the post-processor's EOS, exactly as ``main``. The first round-2 attempt
+        (``add_special_tokens=False``, re-append the EOS, slice ``[:max_length]``)
+        filled the whole budget with content and sliced the re-appended EOS back
+        off (1 -> 0). Tokenising as ``main`` reserves truncation room for the EOS,
+        so it survives; we only drop the one duplicated leading BOS."""
+        tok = _tokenizer(_BOS_TEMPLATE, post_processor="bos_eos")
+        long_msgs = [
+            {"role": "user", "content": "What is the capital of France ? " * 40},
+            {"role": "assistant", "content": "Paris . " * 40},
+        ]
+        ids = self._run_preprocess(
+            tmp_path, monkeypatch, tok, rows=[{"messages": long_msgs}], max_length=64
+        )
+        main_pp = self._main_preprocess_ids(tok, messages=long_msgs, max_length=64)
+        assert len(main_pp) == 64, "sanity: main filled the truncation budget"
+        assert main_pp[0] == main_pp[1] == _BOS_ID, "sanity: main doubled the BOS"
+        assert ids == main_pp[1:], "cache == main minus the one duplicated leading BOS"
+        assert ids[-1] == _EOS_ID and ids.count(_EOS_ID) == 1, (
+            f"truncated row must still end on the stop token; got {ids}"
+        )
+        assert ids.count(_BOS_ID) == 1, "doubled BOS removed even under truncation"
+
+    def test_cache_keeps_mains_eos_when_template_renders_it(self, tmp_path, monkeypatch):
+        """Template renders the EOS itself AND the post-processor appends one, so
+        ``main`` trained on several trailing EOS. The cache reproduces ``main``'s
+        EOS count (it does NOT collapse to one like the live path — that divergence
+        is #791), minus only the duplicated leading BOS."""
+        tok = _tokenizer(_BOS_EOS_TEMPLATE, post_processor="bos_eos")
+        ids = self._run_preprocess(tmp_path, monkeypatch, tok)
+        main_pp = self._main_preprocess_ids(tok)
+
+        assert main_pp[0] == main_pp[1] == _BOS_ID, "sanity: main doubled the BOS"
+        assert ids == main_pp[1:], "cache == main minus the duplicated BOS"
+        assert ids.count(_EOS_ID) == main_pp.count(_EOS_ID) > 1, "EOS count pinned to main"
+        assert ids[-1] == _EOS_ID and ids.count(_BOS_ID) == 1
+
 
 class TestPreprocessCacheKey:
     def test_cache_key_changed_from_pre_fix_blob(self):
@@ -368,3 +414,42 @@ class TestPreprocessCacheKey:
         )
         old_key = hashlib.sha256(old_blob.encode("utf-8")).hexdigest()[:16]
         assert make_preprocess_cache_key(**args) != old_key
+
+
+class TestDataDoctorLegacyMatchesTraining:
+    """``soup data doctor --show-mask`` must X-ray what training actually
+    consumes. Its legacy (``train_on_responses_only=false``) branch therefore
+    calls the SAME builder as the trainer, :func:`build_full_sequence_labels`.
+
+    #788 regression guard: ``main`` re-rendered here with
+    ``apply_chat_template(tokenize=True)`` and the tokenizer's default specials,
+    which doubled the BOS and skipped TRL's ``add_eos`` — so the X-ray diverged
+    from training. Reverting ``_build_row_labels`` to that now fails here rather
+    than silently. (Without this test the revert passes the whole suite.)
+    """
+
+    @pytest.mark.parametrize(
+        "post_processor",
+        ["bos_eos", "bos", None],
+        ids=["bos+eos", "bos-only", "no-post-processor (Qwen)"],
+    )
+    def test_legacy_branch_matches_the_training_builder(self, post_processor):
+        from soup_cli.data.loss_mask import build_full_sequence_labels
+        from soup_cli.utils.data_doctor import _build_row_labels
+
+        tok = _tokenizer(_BOS_TEMPLATE, post_processor=post_processor)
+        doctor = _build_row_labels(
+            tok,
+            _MESSAGES,
+            max_length=2048,
+            train_on_responses_only=False,
+            train_on_messages_with_train_field=False,
+            include_eot=True,
+        )
+        training = build_full_sequence_labels(_MESSAGES, tok, max_length=2048)
+        assert doctor["input_ids"] == training["input_ids"], (
+            "the mask X-ray must tokenize identically to training"
+        )
+        assert doctor["labels"] == training["labels"]
+        # and it is genuinely the post-#785 shape, not main's doubled BOS
+        assert doctor["input_ids"].count(_BOS_ID) == 1

--- a/tests/test_issue785_training_bos.py
+++ b/tests/test_issue785_training_bos.py
@@ -1,0 +1,227 @@
+"""#785 — train_on_responses_only=false trained on a doubled BOS.
+
+The default SFT path (``train_on_responses_only``) builds ids with
+``add_special_tokens=False`` in ``data/loss_mask.py``, so it never doubled the
+BOS. The opt-out text path did not: ``data/sft_format.py`` handed TRL a
+``{"text"}`` column, and TRL 0.29.1's language-modeling ``tokenize_fn``
+(``sft_trainer.py`` ``processing_class(text=...)``) re-tokenised it with the
+tokenizer's default ``add_special_tokens=True``. A template that renders
+``{{ bos_token }}`` (Llama-3 / Gemma / Mistral) on a tokenizer whose
+post-processor also prepends BOS therefore trained on ``[bos, bos, ...]``.
+After #782 fixed inference to send exactly one BOS, those adapters are one
+token off from how they are prompted.
+
+The invariant pinned here mirrors #781/#782 on the training side: when a
+template renders the sequence, the tokenizer adds nothing on top. That is what
+``apply_chat_template(tokenize=True)`` does and what inference now does. It is
+deliberately NOT "drop a duplicate BOS": Soup's ``data.chat_template`` presets
+render no BOS at all, so their adapters must train on none.
+
+Every tokenizer below is a real ``transformers`` fast tokenizer built offline
+from an in-memory vocab, so ``apply_chat_template`` is the genuine Jinja
+renderer and the BOS/EOS come from a genuine ``tokenizers`` post-processor.
+"""
+
+import hashlib
+
+import pytest
+
+_SPECIALS = [
+    "<unk>", "<s>", "</s>",
+    "<|system|>", "<|user|>", "<|assistant|>", "<|end|>",
+    "<|im_start|>", "<|im_end|>",
+]
+_WORDS = [
+    "You", "are", "terse", ".", "What", "is", "the", "capital", "of", "France",
+    "?", "Paris", "system", "user", "assistant",
+]
+_BOS_ID = _SPECIALS.index("<s>")
+
+_BOS_TEMPLATE = (
+    "{{ bos_token }}"
+    "{% for m in messages %}<|{{ m['role'] }}|> {{ m['content'] }} <|end|> {% endfor %}"
+    "{% if add_generation_prompt %}<|assistant|>{% endif %}"
+)
+# Renders the tokenizer's EOS itself, so the template is the source of the stop token.
+_BOS_EOS_TEMPLATE = (
+    "{{ bos_token }}"
+    "{% for m in messages %}<|{{ m['role'] }}|> {{ m['content'] }} {{ eos_token }} {% endfor %}"
+)
+
+_USER = {"role": "user", "content": "What is the capital of France?"}
+_ANSWER = {"role": "assistant", "content": "Paris ."}
+_MESSAGES = [_USER, _ANSWER]
+
+
+def _tokenizer(chat_template, *, post_processor="bos"):
+    """A real fast tokenizer whose post-processor adds ``post_processor``."""
+    transformers = pytest.importorskip("transformers")
+    tokenizers = pytest.importorskip("tokenizers")
+    from tokenizers import models, pre_tokenizers, processors
+
+    vocab = {token: index for index, token in enumerate(_SPECIALS + _WORDS)}
+    backend = tokenizers.Tokenizer(models.WordLevel(vocab=vocab, unk_token="<unk>"))
+    backend.pre_tokenizer = pre_tokenizers.Whitespace()
+    backend.add_special_tokens(_SPECIALS)
+    single = {"bos": "<s> $A", "bos_eos": "<s> $A </s>", None: None}[post_processor]
+    if single is not None:
+        backend.post_processor = processors.TemplateProcessing(
+            single=single,
+            special_tokens=[("<s>", _BOS_ID), ("</s>", _SPECIALS.index("</s>"))],
+        )
+    tok = transformers.PreTrainedTokenizerFast(
+        tokenizer_object=backend, unk_token="<unk>", bos_token="<s>", eos_token="</s>"
+    )
+    tok.chat_template = chat_template
+    return tok
+
+
+def _legacy_format_row(tok):
+    """The ``train_on_responses_only=false`` row builder."""
+    from soup_cli.config.schema import DataConfig
+    from soup_cli.data.sft_format import build_format_row
+
+    dcfg = DataConfig(
+        train="train.jsonl",
+        train_on_responses_only=False,
+        train_on_messages_with_train_field=False,
+        max_length=2048,
+    )
+    return build_format_row(tokenizer=tok, data_cfg=dcfg)
+
+
+class TestLegacyTextPathBOS:
+    def test_bos_template_trains_on_exactly_one_bos(self):
+        """A template that renders {{ bos_token }} must train on one BOS, and the
+        ids must equal HF's own one-step encode (what inference sends post-#782).
+
+        Fails on pre-fix main: that path returned a ``{"text"}`` row, so there is
+        no ``input_ids`` to read, and TRL then tokenized the text to two BOS.
+        """
+        tok = _tokenizer(_BOS_TEMPLATE, post_processor="bos")
+        row = _legacy_format_row(tok)({"messages": _MESSAGES})
+
+        assert "input_ids" in row, (
+            "legacy path must pre-tokenize so TRL never re-adds special tokens"
+        )
+        ids = row["input_ids"]
+        assert ids.count(_BOS_ID) == 1, f"expected one BOS, got ids={ids}"
+
+        reference = tok.apply_chat_template(
+            _MESSAGES, tokenize=True, add_generation_prompt=False, return_dict=True
+        )["input_ids"]
+        assert ids == list(reference)
+        # Full-sequence training: every token is a target, none masked.
+        assert row["labels"] == ids
+        assert set(row["attention_mask"]) == {1}
+
+    def test_the_prefix_encoding_would_have_doubled_the_bos(self):
+        """Document the defect: the pre-fix mechanism (render to text, then let
+        the tokenizer add its defaults) yields two BOS on the same tokenizer."""
+        tok = _tokenizer(_BOS_TEMPLATE, post_processor="bos")
+        text = tok.apply_chat_template(
+            _MESSAGES, tokenize=False, add_generation_prompt=False
+        )
+        pre_fix_ids = tok(text=text)["input_ids"]  # TRL's default add_special_tokens=True
+        assert pre_fix_ids.count(_BOS_ID) == 2
+
+        fixed_ids = _legacy_format_row(tok)({"messages": _MESSAGES})["input_ids"]
+        assert fixed_ids.count(_BOS_ID) == 1
+        assert fixed_ids != pre_fix_ids
+
+    def test_preset_template_trains_on_zero_bos(self):
+        """Soup's data.chat_template presets render no BOS; the path must add
+        none, even on a tokenizer whose post-processor prepends one."""
+        from soup_cli.data.chat_templates import apply_chat_template_override
+
+        tok = _tokenizer(None, post_processor="bos")
+        apply_chat_template_override(tok, "chatml")
+        ids = _legacy_format_row(tok)({"messages": _MESSAGES})["input_ids"]
+        assert ids.count(_BOS_ID) == 0, f"chatml preset must add no BOS, got {ids}"
+
+
+class TestTrainingEOSPreserved:
+    """The BOS fix must not cost the stop token (maintainer req 1 on #785).
+
+    On the training side, dropping a tokenizer-appended trailing EOS is the
+    opposite of #782's inference goal: it teaches run-on generation. Behaviour
+    stated per case below.
+    """
+
+    _EOS_ID = _SPECIALS.index("</s>")
+
+    def test_eos_preserved_when_template_renders_none_and_tokenizer_appends(self):
+        """Template renders no EOS, tokenizer's post-processor appends one.
+
+        Pre-fix (render then tokenize with defaults) kept that appended EOS.
+        add_special_tokens=False alone would drop it; the fix re-appends it, so
+        the trained EOS count is unchanged and the row still ends on the stop
+        token."""
+        tok = _tokenizer(_BOS_TEMPLATE, post_processor="bos_eos")
+        text = tok.apply_chat_template(_MESSAGES, tokenize=False, add_generation_prompt=False)
+        pre_fix_eos = tok(text=text)["input_ids"].count(self._EOS_ID)
+
+        ids = _legacy_format_row(tok)({"messages": _MESSAGES})["input_ids"]
+        assert ids.count(self._EOS_ID) == pre_fix_eos == 1
+        assert ids[-1] == self._EOS_ID, "row must end on the stop token"
+        assert ids.count(_BOS_ID) == 1, "and still carry exactly one BOS"
+
+    def test_eos_unchanged_when_template_renders_it(self):
+        """Template renders the EOS itself; the tokenizer appends none.
+
+        The template's EOS carries through untouched and none is re-added, so the
+        trained EOS count is unchanged from the pre-fix path and only the leading
+        duplicate BOS is removed."""
+        tok = _tokenizer(_BOS_EOS_TEMPLATE, post_processor="bos")
+        text = tok.apply_chat_template(_MESSAGES, tokenize=False, add_generation_prompt=False)
+        pre_fix = tok(text=text)["input_ids"]
+
+        ids = _legacy_format_row(tok)({"messages": _MESSAGES})["input_ids"]
+        assert ids.count(self._EOS_ID) == pre_fix.count(self._EOS_ID)
+        assert ids[-1] == self._EOS_ID, "row still ends on the stop token"
+        assert ids == pre_fix[1:], "only diff is the removed leading BOS"
+        assert ids.count(_BOS_ID) == 1
+
+    def test_no_eos_invented_when_neither_side_provides_one(self):
+        """Template renders no EOS and the tokenizer appends none: pre-fix had no
+        stop token, and the fix invents none (unchanged)."""
+        tok = _tokenizer(_BOS_TEMPLATE, post_processor="bos")
+        ids = _legacy_format_row(tok)({"messages": _MESSAGES})["input_ids"]
+        assert ids.count(self._EOS_ID) == 0
+
+
+class TestTemplatedOnly:
+    """The rule applies only to text a chat template rendered (maintainer req 2)."""
+
+    def test_no_template_is_rejected_not_silently_stripped(self):
+        """A tokenizer with no chat_template never reaches add_special_tokens=False:
+        the text path raises rather than silently dropping the tokenizer's own
+        (only) special tokens. Same behaviour as main (it raised before too)."""
+        from soup_cli.data.loss_mask import build_full_sequence_labels
+
+        tok = _tokenizer(None, post_processor="bos")  # no chat_template
+        tok.chat_template = None
+        with pytest.raises(ValueError, match="chat_template"):
+            build_full_sequence_labels(_MESSAGES, tok, max_length=2048)
+
+
+class TestPreprocessCacheKey:
+    def test_cache_key_changed_from_pre_fix_blob(self):
+        """The #785 tokenization change must invalidate old preprocess caches:
+        the key includes a schema token, so it differs from the old blob's hash.
+        Fails if someone drops the schema token and reverts to the old format.
+        """
+        from soup_cli.utils.data_pipeline import make_preprocess_cache_key
+
+        args = dict(
+            dataset_path="data/train.jsonl",
+            tokenizer_name="meta-llama/Llama-3.1-8B",
+            max_length=2048,
+            format_name="chatml",
+        )
+        old_blob = (
+            f"{args['dataset_path']}\x1f{args['tokenizer_name']}"
+            f"\x1f{args['max_length']}\x1f{args['format_name']}"
+        )
+        old_key = hashlib.sha256(old_blob.encode("utf-8")).hexdigest()[:16]
+        assert make_preprocess_cache_key(**args) != old_key

--- a/tests/test_issue785_training_bos.py
+++ b/tests/test_issue785_training_bos.py
@@ -205,6 +205,81 @@ class TestTemplatedOnly:
             build_full_sequence_labels(_MESSAGES, tok, max_length=2048)
 
 
+class TestPreprocessCachePathEOS:
+    """`soup data preprocess` must handle EOS exactly like live training.
+
+    The BOS fix (#785) lives on two paths: ``loss_mask.build_full_sequence_labels``
+    (live tokenize) and ``preprocess_dataset`` (the AOT cache read straight into
+    the trainer by ``sft._maybe_load_pretokenized``). Both now tokenize the
+    rendered template with ``add_special_tokens=False``, which also drops the
+    tokenizer post-processor's EOS. #788 review (AmirF194): the cache path did not
+    re-append it, so a BOS-but-not-EOS template silently trained on a missing stop
+    token from the cache. These pin the two paths to identical ids.
+    """
+
+    _EOS_ID = _SPECIALS.index("</s>")
+
+    def _run_preprocess(self, tmp_path, monkeypatch, tok, task="sft"):
+        transformers = pytest.importorskip("transformers")
+        datasets = pytest.importorskip("datasets")
+        from typer.testing import CliRunner
+
+        from soup_cli.cli import app
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "soup.yaml").write_text(
+            f"base: x/y\ntask: {task}\n"
+            "data:\n  train: ./d.jsonl\n  format: chatml\n  max_length: 2048\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "d.jsonl").write_text("{}\n", encoding="utf-8")
+        monkeypatch.setattr(
+            transformers.AutoTokenizer, "from_pretrained", lambda *a, **k: tok
+        )
+        # Control the rows directly so the assertion is about tokenization, not
+        # format conversion. preprocess_dataset local-imports this name.
+        monkeypatch.setattr(
+            "soup_cli.data.loader.load_dataset",
+            lambda *a, **k: {"train": [{"messages": _MESSAGES}]},
+        )
+        result = CliRunner().invoke(app, ["data", "preprocess", "soup.yaml", "--yes"])
+        assert result.exit_code == 0, result.output
+        cache_dirs = [p for p in (tmp_path / ".soup-tokenized").iterdir() if p.is_dir()]
+        assert len(cache_dirs) == 1, cache_dirs
+        ds = datasets.load_from_disk(str(cache_dirs[0]))
+        return list(ds[0]["input_ids"])
+
+    def test_cache_preserves_eos_the_tokenizer_appends(self, tmp_path, monkeypatch):
+        """Template renders BOS but not EOS; the tokenizer appends EOS. The cached
+        row must still end on the stop token and match the live path exactly.
+
+        Fails without the #788 re-append: the cache row would end one token short
+        (EOS dropped), which reaches the trainer verbatim."""
+        from soup_cli.data.loss_mask import build_full_sequence_labels
+
+        tok = _tokenizer(_BOS_TEMPLATE, post_processor="bos_eos")
+        ids = self._run_preprocess(tmp_path, monkeypatch, tok)
+        live = build_full_sequence_labels(_MESSAGES, tok, max_length=2048)["input_ids"]
+
+        assert ids == live, "cache path must equal the live-training path"
+        assert ids[-1] == self._EOS_ID, "cached row must end on the stop token"
+        assert ids.count(self._EOS_ID) == 1
+        assert ids.count(_BOS_ID) == 1
+
+    def test_cache_invents_no_eos_when_tokenizer_appends_none(self, tmp_path, monkeypatch):
+        """Tokenizer appends no EOS: the cache path must not invent one, matching
+        the live path (control against over-eager re-appending)."""
+        from soup_cli.data.loss_mask import build_full_sequence_labels
+
+        tok = _tokenizer(_BOS_TEMPLATE, post_processor="bos")
+        ids = self._run_preprocess(tmp_path, monkeypatch, tok)
+        live = build_full_sequence_labels(_MESSAGES, tok, max_length=2048)["input_ids"]
+
+        assert ids == live
+        assert ids.count(self._EOS_ID) == 0
+        assert ids.count(_BOS_ID) == 1
+
+
 class TestPreprocessCacheKey:
     def test_cache_key_changed_from_pre_fix_blob(self):
         """The #785 tokenization change must invalidate old preprocess caches:

--- a/tests/test_v0537.py
+++ b/tests/test_v0537.py
@@ -372,8 +372,10 @@ class TestPromptStrategyRuntime:
         )
         tokenizer = MagicMock()
         tokenizer.chat_template = "{% for msg in messages %}{{msg['content']}}{% endfor %}"
-        # #785: the legacy path now pre-tokenizes (apply_chat_template tokenize=True
-        # returns ids). Not callable as tokenizer(...) here, so no EOS probe fires.
+        # #785/#788: the legacy path now pre-tokenizes (apply_chat_template
+        # tokenize=True returns ids). No EOS is appended here not because the mock
+        # is uncallable (a MagicMock IS callable) but because its eos_token_id does
+        # not resolve to an int, so append_training_eos is a no-op.
         tokenizer.apply_chat_template = MagicMock(return_value=[7, 8, 9])
         fn = build_format_row(tokenizer, data_cfg)
         # When invoked, the inner row should pass through the attach transform

--- a/tests/test_v0537.py
+++ b/tests/test_v0537.py
@@ -372,13 +372,15 @@ class TestPromptStrategyRuntime:
         )
         tokenizer = MagicMock()
         tokenizer.chat_template = "{% for msg in messages %}{{msg['content']}}{% endfor %}"
-        tokenizer.apply_chat_template = MagicMock(return_value="rendered")
+        # #785: the legacy path now pre-tokenizes (apply_chat_template tokenize=True
+        # returns ids). Not callable as tokenizer(...) here, so no EOS probe fires.
+        tokenizer.apply_chat_template = MagicMock(return_value=[7, 8, 9])
         fn = build_format_row(tokenizer, data_cfg)
         # When invoked, the inner row should pass through the attach transform
         result = fn({"messages": [{"role": "user", "content": "hi"}]})
-        # Verify the legacy text formatter ran with attached row.
+        # Verify the legacy formatter ran (pre-tokenized) through the wrapper.
         assert tokenizer.apply_chat_template.called
-        assert "rendered" in result.get("text", "")
+        assert result.get("input_ids") == [7, 8, 9]
 
 
 # ----- #86 soup data preprocess live tokenize ----------------------------


### PR DESCRIPTION
Part 1 of #785. Part 2 (the vLLM / SGLang / MII `prompt_token_ids[:2]` measurement) will follow as a separate PR, so I'm leaving #785 open.

## The bug

The default SFT path (`train_on_responses_only: true`) builds ids with `add_special_tokens=False` in `data/loss_mask.py`, so it never doubled the BOS. The opt-out text path did: `data/sft_format.py` handed TRL a `{"text"}` column, and TRL 0.29.1's language-modeling `tokenize_fn` (`processing_class(text=...)`) re-tokenised it with the tokenizer's default `add_special_tokens=True`. A template that renders `{{ bos_token }}` (Llama-3, Gemma, Mistral) on a tokenizer whose post-processor also prepends BOS therefore trained on `[bos, bos, ...]`. Before #782 that matched inference by accident; after #782 inference sends one BOS, so these adapters are one token off from how they are prompted. `soup data preprocess` tokenised the same way.

I reproduced it on a real fast tokenizer first: the text path tokenised to `[1, 1, ...]` (two BOS) against `[1, ...]` (one) for `apply_chat_template(tokenize=True)`.

## The fix

The text path now pre-tokenises with `add_special_tokens=False` (`build_full_sequence_labels`), so the chat template is the single source of special tokens, matching inference and `apply_chat_template(tokenize=True)`: one BOS for a `{{ bos_token }}` template, zero for the `data.chat_template` presets. `soup data preprocess` de-duplicates the same leading BOS but otherwise tokenises exactly as `main` (`add_special_tokens=True`, so HF still reserves truncation room for the post-processor's specials and a truncated row still ends on its stop token), dropping only the one duplicated leading BOS; its cache key is bumped so datasets tokenised under the old encoding are re-tokenised rather than reused.

### EOS matches TRL's rule, not the post-processor

On `main` the legacy text rows reached TRL as `{"text": ...}`, and TRL 0.29.1's `add_eos` (`sft_trainer.py:1026-1031`) appends `eos_token` as a string to any row not already ending with it, **before** tokenizing and **independent of the post-processor**. Pre-tokenising skips that step, so `build_full_sequence_labels` reproduces the rule in token space via `append_training_eos`: append the EOS id unless the sequence already ends on it. (An earlier revision of this PR probed the post-processor instead, which under-appended for BOS-only and Qwen-shaped tokenizers and dropped the stop token `main` trained on, 1 -> 0 — thanks @AmirF194 / maintainer review for catching that.) Per case, measured against TRL's real `add_eos` baseline:

- template renders no EOS, post-processor appends none (Qwen / Gemma / Llama-2): `main` trained on one EOS via `add_eos`; the fix keeps it. **1 -> 1.**
- template renders no EOS, post-processor also appends one: `main` had a duplicated EOS; the fix ends on exactly one. 2 -> 1.
- template renders the EOS itself: carried through, nothing re-appended since it already ends on EOS; `main`'s `add_eos` duplicate is gone.

### `soup data preprocess` EOS is left as on `main`

The preprocess cache never went through TRL's `add_eos`, so its EOS is whatever the post-processor added. This PR de-duplicates its BOS but leaves that EOS behaviour exactly as on `main` (post-processor only), rather than adopting the live rule. For a Qwen-shaped tokenizer the cache therefore trains on zero EOS while the live path trains on one — a pre-existing `main` mismatch, now tracked in #791 and deliberately not resolved here.

### Templated-only

The rule applies only to text a chat template rendered. A tokenizer with no chat_template raises (through `build_format_row`) rather than being silently stripped, and pretrain-style raw text keeps the tokenizer's own special tokens. `soup data doctor --show-mask` now renders through `build_full_sequence_labels`, so the X-ray matches training.

## Before / after on real rows (baseline = TRL's real `add_eos` + default tokenize)

```
BOS-only tokenizer (<s> $A)
  main : BOS=2 EOS=1  [1, 1, 4, 11, 12, 13, 14, 15, 16, 17, 6, 5, 18, 10, 6, 2]
  after: BOS=1 EOS=1  [1, 4, 11, 12, 13, 14, 15, 16, 17, 6, 5, 18, 10, 6, 2]
Qwen-shape tokenizer (no post-processor)
  main : BOS=1 EOS=1  [1, 4, 11, 12, 13, 14, 15, 16, 17, 6, 5, 18, 10, 6, 2]
  after: BOS=1 EOS=1  [1, 4, 11, 12, 13, 14, 15, 16, 17, 6, 5, 18, 10, 6, 2]
BOS+EOS tokenizer (<s> $A </s>)
  main : BOS=2 EOS=2  [1, 1, 4, 11, 12, 13, 14, 15, 16, 17, 6, 5, 18, 10, 6, 2, 2]
  after: BOS=1 EOS=1  [1, 4, 11, 12, 13, 14, 15, 16, 17, 6, 5, 18, 10, 6, 2]
```

The stop token is never dropped (every `after` ends on EOS); duplicated BOS/EOS are collapsed to one. The Qwen row is unchanged from `main` — the point of the review fix: its EOS is kept, not lost.

## Tests

`tests/test_issue785_training_bos.py` (real fast tokenizers, no network), baselined against `_trl_main_lm_ids` (TRL's real `add_eos` + default tokenize), not `tok(text=...)`: one BOS for `{{ bos_token }}` templates, zero for presets; the EOS kept for BOS-only and Qwen shapes (parametrized), duplicates collapsed, template-rendered EOS not re-appended; the no-template path raises through the real `build_format_row` dispatch; and a pretrain preprocess row byte-identical to `main`. Mutations: dropping the live EOS append fails 5 tests, `add_special_tokens=False` on pretrain fails 1. The preprocess re-append on pretrain is inert by construction (with `add_special_tokens=True` the post-processor EOS is already present, so `reappend_eos_if_dropped` never fires) — noted rather than force-killed.
