### PR TITLE
fix(deepspeed): forward create_optimizer's arguments through the empty-group guard

### DIFF
--- a/src/soup_cli/utils/deepspeed.py
+++ b/src/soup_cli/utils/deepspeed.py
@@ -253,9 +253,7 @@ def resolve_deepspeed_config(
         zero["zero_hpz_partition_size"] = partition
 
     quant_keys = [
-        key
-        for key in ("zero_quantized_weights", "zero_quantized_gradients")
-        if zero.get(key)
+        key for key in ("zero_quantized_weights", "zero_quantized_gradients") if zero.get(key)
     ]
     if quant_keys:
         bf16_on = bool((resolved.get("bf16") or {}).get("enabled"))
@@ -289,9 +287,7 @@ def write_deepspeed_config(stage: str = "zero2", gpu_count: int | None = None) -
         console = Console()
         for note in notes:
             console.print(f"[yellow]DeepSpeed {stage}:[/] {escape(note)}")
-    tmp = tempfile.NamedTemporaryFile(
-        mode="w", suffix=".json", prefix="ds_config_", delete=False
-    )
+    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", prefix="ds_config_", delete=False)
     json.dump(config, tmp, indent=2)
     tmp.close()
     return tmp.name
@@ -339,9 +335,7 @@ def resolve_user_deepspeed_file(path: str, *, gpu_count: int | None = None) -> s
     for note in notes:
         console.print(f"[yellow]DeepSpeed {escape(label)}:[/] {escape(note)}")
 
-    tmp = tempfile.NamedTemporaryFile(
-        mode="w", suffix=".json", prefix="ds_user_", delete=False
-    )
+    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", prefix="ds_user_", delete=False)
     json.dump(resolved, tmp, indent=2)
     tmp.close()
     return tmp.name
@@ -410,8 +404,12 @@ def attach_empty_param_group_guard(trainer) -> bool:
     if not callable(original):
         return False
 
-    def create_optimizer():
-        optimizer = original()
+    # Forward exactly what the caller passed. transformers calls this both as
+    # ``create_optimizer()`` and, on the delayed-creation path, positionally as
+    # ``create_optimizer(model)`` (#784). Passing nothing through unchanged keeps
+    # the no-argument call identical, and no trainer's signature is assumed.
+    def create_optimizer(*args, **kwargs):
+        optimizer = original(*args, **kwargs)
         dropped = prune_empty_param_groups(optimizer)
         if dropped:
             from rich.console import Console
@@ -441,11 +439,13 @@ def detect_multi_gpu() -> dict:
         gpus = []
         for idx in range(gpu_count):
             props = torch.cuda.get_device_properties(idx)
-            gpus.append({
-                "index": idx,
-                "name": props.name,
-                "memory_gb": props.total_memory / (1024 ** 3),
-            })
+            gpus.append(
+                {
+                    "index": idx,
+                    "name": props.name,
+                    "memory_gb": props.total_memory / (1024**3),
+                }
+            )
 
         return {"gpu_count": gpu_count, "gpus": gpus}
     except ImportError:

--- a/tests/test_issue784_guard_forwards_model.py
+++ b/tests/test_issue784_guard_forwards_model.py
@@ -1,0 +1,105 @@
+"""Issue #784 — the empty-param-group guard must forward ``create_optimizer``'s argument.
+
+``transformers.Trainer.create_optimizer(self, model=None)`` is called both with no
+argument and, on the delayed-optimizer-creation path, positionally as
+``self.create_optimizer(model)``. The guard used to replace it with a function that
+took no arguments, so the positional call raised ``TypeError``.
+
+Not reachable today (the guard is attached only for DeepSpeed, and delayed creation
+is set for FSDP / SageMaker MP), but the reachability argument lives outside this
+function, so the guard has to accept every calling form on its own.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from soup_cli.utils.deepspeed import attach_empty_param_group_guard
+
+
+class _FakeOptimizer:
+    def __init__(self, param_groups):
+        self.param_groups = param_groups
+
+
+def _lora_like_groups():
+    """Decay group populated, no-decay group empty, as LoRA leaves them."""
+    return [
+        {"params": ["lora_A", "lora_B"], "weight_decay": 0.01},
+        {"params": [], "weight_decay": 0.0},
+    ]
+
+
+class _HFStyleTrainer:
+    """Mirrors ``transformers.Trainer.create_optimizer(self, model=None)``."""
+
+    def __init__(self):
+        self.received = []
+
+    def create_optimizer(self, model=None):
+        self.received.append(model)
+        return _FakeOptimizer(_lora_like_groups())
+
+
+class _NoArgTrainer:
+    """A trainer whose ``create_optimizer`` takes no argument at all."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def create_optimizer(self):
+        self.calls += 1
+        return _FakeOptimizer(_lora_like_groups())
+
+
+def test_positional_call_forwards_the_model_and_still_prunes():
+    trainer = _HFStyleTrainer()
+    model = object()
+    attach_empty_param_group_guard(trainer)
+
+    optimizer = trainer.create_optimizer(model)
+
+    # the model reaches the original, rather than being dropped on the delayed path
+    assert trainer.received == [model]
+    assert len(optimizer.param_groups) == 1
+
+
+def test_keyword_call_forwards_the_model_and_still_prunes():
+    trainer = _HFStyleTrainer()
+    model = object()
+    attach_empty_param_group_guard(trainer)
+
+    optimizer = trainer.create_optimizer(model=model)
+
+    assert trainer.received == [model]
+    assert len(optimizer.param_groups) == 1
+
+
+def test_no_argument_call_is_passed_through_unchanged():
+    """The guard adds no argument of its own, so a zero-arg original still works."""
+    trainer = _NoArgTrainer()
+    attach_empty_param_group_guard(trainer)
+
+    optimizer = trainer.create_optimizer()
+
+    assert trainer.calls == 1
+    assert len(optimizer.param_groups) == 1
+
+
+def test_hf_no_argument_call_keeps_its_default():
+    trainer = _HFStyleTrainer()
+    attach_empty_param_group_guard(trainer)
+
+    trainer.create_optimizer()
+
+    assert trainer.received == [None]
+
+
+def test_wrapper_signature_accepts_the_positional_form():
+    """Inspects the wrapper itself, so a rewrite back to ``def create_optimizer():``
+    goes red even before anything calls it."""
+    trainer = _HFStyleTrainer()
+    attach_empty_param_group_guard(trainer)
+
+    inspect.signature(trainer.create_optimizer).bind(object())
+    inspect.signature(trainer.create_optimizer).bind(model=object())


### PR DESCRIPTION
Closes #784.

The guard replaced `trainer.create_optimizer` with a function that took no arguments. transformers calls the original as `create_optimizer()` from `create_optimizer_and_scheduler` and on the eager path (`trainer.py:1226`, `:1675`), but positionally as `self.create_optimizer(model)` on the delayed-creation path (`:1694`). That call raised `TypeError`.

## Change

```python
def create_optimizer(*args, **kwargs):
    optimizer = original(*args, **kwargs)
```

The wrapper forwards exactly what it receives. I went with this rather than `model=None` → `original(model)` for one reason: the latter turns the zero-argument call into `original(None)`, which only works as long as every trainer the guard is attached to accepts a `model` parameter. None of TRL's trainers override `create_optimizer` today, so that is a hedge rather than a fix for a live problem. Forwarding keeps `create_optimizer()` literally unchanged either way.

`functools.wraps` is off on purpose. With it, `inspect.signature` would report the original's `(model=None)` and a signature test would pass even if the wrapper itself took no arguments.

## Tests

New `tests/test_issue784_guard_forwards_model.py`, following the fake-optimizer pattern in `test_issue336`:

- the positional and keyword calls both forward the same `model` object to the original, and still prune the empty group;
- the no-argument call reaches a zero-argument original unchanged, and an HF-style original still receives its `None` default;
- the wrapper's own signature binds a positional and a keyword `model`.

Without the fix, 3 of the 5 fail: positional, keyword and signature. The existing guard suites (`test_issue336`, `test_issue359`, `test_issue700`) pass unchanged: 143 passed. `ruff check` and `ruff format --check` are clean.

No changelog fragment, since the change isn't user-visible today. Happy to add a `fixed` one if you'd like it recorded.
