### PR TITLE
docs: cover 23 missing commands in commands.md (#822)

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -11,6 +11,8 @@ soup init [--template chat|code|...|audio]       Create config
 soup init --template hipaa|soc2|eu-ai-act|sr-11-7  Compliance-shaped starting config + the commands for that regime (v0.71.35)
 soup autopilot --model <id> --data d.jsonl --goal <g>  Zero-config: pick task/quant/LR/epochs from data + model + goal
 soup advise <data> --goal "..."               Pre-flight decision: PROMPT_ENG / RAG / SFT / DPO / GRPO — run BEFORE spending GPU hours
+soup advise compare                           Show prior verdicts from advise history
+soup advise explain                           Rubric + evidence trail of the last verdict
 soup fetch <name>                             Fetch a ready-to-edit example config from the bundled catalog
 soup train --config soup.yaml                 Start training
 soup train --config soup.yaml --tensorboard   Train with TensorBoard logging
@@ -61,6 +63,16 @@ soup eval leaderboard                         Local model leaderboard
 soup eval human --input p.jsonl               Human A/B evaluation
 soup eval gate --suite gate.yaml              Run eval-gate suite standalone
 soup eval quant-check --before X --after Y --tasks t.jsonl  Before/after quantization eval (OK/MINOR/MAJOR verdict)
+soup eval design DATA                         Draft an eval suite from training data + goal
+soup eval discover DATA                       Discover a held-out canary set
+soup eval lock DESIGN                         Freeze a design as a checksummed suite
+soup eval coverage DESIGN                     Coverage / gap analysis for an eval suite
+soup eval against BASELINE_RUN_ID             Run-vs-run regression check (paired bootstrap)
+soup eval gate-install                        Install a pre-push regression gate
+soup eval behavior RUN_ID                     Behaviour battery pre/post diff
+soup eval capability RUN_ID                   Capability profile (MMLU-Pro / GPQA / AIME ...)
+soup eval checklist SPEC                      CheckList MFT / INV / DIR tests
+soup eval irt-subset RESPONSES                Minimum-cost eval subset via IRT
 soup diagnose <run-id>                        Post-training report card: forgetting / refusal / format / mode collapse / memorization / contamination
 soup serve --model ./output --port 8000       OpenAI-compatible API server
 soup serve --model ./output --backend vllm    vLLM backend (2-4x throughput)
@@ -124,6 +136,10 @@ soup data push --input d.jsonl --hf-dataset u/n --hub modelscope|modelers  Uploa
 soup data registry                           List all registered datasets
 soup data demo                                List bundled demo JSONL fixtures
 soup data demo alpaca_demo --output ./d.jsonl Copy a bundled demo JSONL fixture
+soup data ingest FILE                         PDF/DOCX/MD/TXT -> JSONL (one row per page/heading)
+soup data preprocess CONFIG                   AOT-tokenize and cache for reuse across runs
+soup data recipe PATH                         Validate / execute a Data Recipe DAG
+soup data mix                                 BETA mixture-weight optimiser (proxy runs)
 soup data forge --docs ./docs --task sft --target-rows 1000  Synthetic data pipeline + provenance
 soup data forge --docs ./docs --hub modelscope --teacher owner/name  Pre-fetch the teacher from an alternative hub
 soup data score --input rows.jsonl            Composite quality scorecard (PII + toxicity + lang + edu)
@@ -141,6 +157,9 @@ soup cost --config soup.yaml --gpu H100      Estimate training cost for specific
 soup adapters list ./output/                 Scan for LoRA adapters
 soup adapters info ./output/checkpoint-500/  Show adapter metadata
 soup adapters compare adapter1/ adapter2/    Compare two adapters
+soup adapters branches                        List snapshotted branches
+soup adapters checkout NAME                   Restore a snapshotted branch's config
+soup adapters diff A B                        Per-layer ΔW Frobenius diff + effective-rank drift
 soup loop init <model> --eval <s> --baseline <b> [--pre-wired]  Create .soup/loop.yaml (data flywheel; --pre-wired = real stages)
 soup loop status                              Counters + status + pre_wired flag
 soup loop watch [--detach] [--max-iter N] [--pre-wired] [--pack-cans]  Harvest → train → gate → deploy daemon (pre-wired stages + Soup Can packing)
@@ -170,6 +189,9 @@ soup runs                                     List training runs
 soup runs show <run_id>                       Run details + loss graph + cost
 soup runs compare <run_1> <run_2>             Compare two runs
 soup runs replay <run_id>                     Replay summary + loss curve from history (also plots a benchmark-score curve when the metric lives in eval_results)
+soup runs clean RUN_ID                        Clean redundant checkpoint files
+soup runs curriculum-curve RUN_ID             BETA curriculum bucket-weight plot
+soup runs delete RUN_ID                       Delete a run and its metrics
 soup why [run_id]                             Explain training anomalies (heuristic)
 soup ship --base <m> --adapter <lora> --task-eval t.jsonl  SHIP / DON'T-SHIP verdict: task win AND no regression on the bundled suite (exit 0=SHIP / 2=DON'T / 3=usage / 1=runtime) (v0.71.25; leg-2 real + usage-off-2 v0.71.38)
 soup ship --evidence ev.json [--output v.json]  Decide offline from pre-computed scores (no model load)
@@ -220,7 +242,7 @@ soup doctor [--nccl] [--disk] [--config F]    Check environment (optionally chec
 soup monitor                                  NVIDIA / Apple Silicon GPU monitor: util / temp / VRAM / power
 soup quickstart [--dry-run]                   Full demo
 soup plugins list|install|enable|disable      Manage Soup plugins
-soup llama cli|mtmd-cli|gguf-split|server ... Proxy to the llama.cpp binaries
+soup llama cli|mtmd-cli|gguf-split|server|quantize ... Proxy to the llama.cpp binaries
 soup quantize <model> --to <fmt>              Quantize a model — ergonomic alias for `soup export --format <fmt>`
 soup bom emit --name <n> --base-sha <hex> --config-sha <hex> --format cyclonedx|spdx|both  CycloneDX ML-BOM / SPDX AI bill of materials
 soup adapters scan <adapter>                  Spectral backdoor scan (rank-1 dominance + outlier detection)

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -9,6 +9,7 @@
 - [Post-train X-rays (`soup probe`, `soup adapters blame --live`)](#post-train-x-rays-soup-probe-soup-adapters-blame---live)
 - [Pre-flight Decision (`soup advise`)](#pre-flight-decision-soup-advise)
 - [Eval Design Pipeline (`soup eval design / discover / lock / coverage`)](#eval-design-pipeline-soup-eval-design--discover--lock--coverage)
+- [Run-vs-run Regression (`soup eval against`)](#run-vs-run-regression-soup-eval-against)
 - [Pre-Push Regression Gate (`soup eval gate-install`)](#pre-push-regression-gate-soup-eval-gate-install)
 - [Eval-Gated Training](#eval-gated-training)
 - [Sequential A/B Harness (`soup ab`)](#sequential-ab-harness-soup-ab)
@@ -146,6 +147,25 @@ iff their semantic content matches.
 from both `regex` and `rlvr`, etc. Missing scorers surface as named
 recommendations so operators can spot gaps before shipping the gate.
 
+
+
+
+## Run-vs-run Regression (`soup eval against`)
+
+Compare a candidate run to a baseline with a paired-bootstrap confidence interval
+on a chosen metric. Exit `0` when no regression is detected, `1` otherwise — the
+same check the pre-push hook from `soup eval gate-install` invokes.
+
+```bash
+soup eval against run-baseline-123 --candidate run-candidate-456
+soup eval against run-baseline-123 --candidate run-candidate-456 \
+  --metric task_accuracy --suite evals/locked.json --json-only
+```
+
+Reads per-row metric series from the experiment tracker for both runs, runs the
+paired-bootstrap decision on the delta, and optionally validates a locked suite
+from `soup eval lock` as a hard precondition (`--suite`). Supported metrics:
+`task_accuracy`, `refusal_rate`, `format_validity`, `p95_latency_ms`.
 
 ## Pre-Push Regression Gate (`soup eval gate-install`)
 

--- a/docs/serving-and-export.md
+++ b/docs/serving-and-export.md
@@ -595,7 +595,15 @@ soup llama --help                  # list supported subcommands
 soup llama cli -m model.gguf -p "Hello"
 soup llama gguf-split --merge a.gguf b.gguf out.gguf
 soup llama server -m model.gguf
+soup llama quantize model.gguf model-q4_k_m.gguf q4_K_M
 ```
+
+### `soup llama quantize`
+
+Forwards every trailing argument to the `llama-quantize` binary on `PATH` (same
+closed allowlist / filtered-env rules as the other `soup llama` subcommands). Use
+it when you already have a GGUF and want llama.cpp's quantizer directly, rather
+than going through `soup export --format gguf` / `soup quantize`.
 
 Closed allowlist: `cli` / `mtmd-cli` / `gguf-split` / `server` / `quantize`. Forwards to `llama-*` binary on PATH (`shutil.which`) with **filtered child env** — `HF_TOKEN` / `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` and other secrets are dropped before exec; only `PATH` / `HOME` / `USER` / locale + llama.cpp-recognised `LLAMA_CPP_HOME` / `GGML_*` / `OMP_NUM_THREADS` are forwarded.
 

--- a/tests/test_commands_md_covers_registered_commands.py
+++ b/tests/test_commands_md_covers_registered_commands.py
@@ -1,0 +1,155 @@
+"""Ratchet: every registered Typer leaf command must appear in docs/commands.md.
+
+`docs/commands.md` opens with "> The full `soup` command list." When new leaf
+commands land, Markdown docs auto-merge quietly across concurrent PRs and the
+reference drifts (see #822 — 23 leaves were missing). This test walks the live
+Typer app the same way the issue reproduced the gap and asserts coverage,
+accepting the page's existing `a|b|c` / `a / b` shorthand and the
+`soup advise <data>` → `soup advise run` argv rewrite.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+from typing import Iterable
+
+import pytest
+from typer.core import TyperGroup
+from typer.main import get_command
+
+from soup_cli.cli import app
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+COMMANDS_MD = ROOT / "docs" / "commands.md"
+
+_ARGISH = re.compile(r"^[A-Z][A-Z0-9_-]*$")
+_CMDISH = re.compile(r"^[a-z0-9|._-]+$")
+
+
+def iter_leaf_paths(cmd=None, prefix: tuple[str, ...] = ()) -> list[tuple[str, ...]]:
+    """Recursively collect leaf command paths from the Typer/Click app."""
+    if cmd is None:
+        cmd = get_command(app)
+    leaves: list[tuple[str, ...]] = []
+    if isinstance(cmd, TyperGroup):
+        names = list(cmd.list_commands(None) or [])
+        if names:
+            for name in names:
+                sub = cmd.get_command(None, name)
+                if sub is not None:
+                    leaves.extend(iter_leaf_paths(sub, prefix + (name,)))
+            return leaves
+    if prefix:
+        leaves.append(prefix)
+    return leaves
+
+
+def _shorthand_alts(line: str, prefix: tuple[str, ...]) -> list[str]:
+    """Return alternate leaf names from a shorthand region after ``prefix``."""
+    alts: list[str] = []
+    idx = 0
+    while True:
+        j = line.find("soup ", idx)
+        if j < 0:
+            break
+        toks = line[j + len("soup ") :].split()
+        if list(toks[: len(prefix)]) != list(prefix):
+            idx = j + 1
+            continue
+        region: list[str] = []
+        for t in toks[len(prefix) :]:
+            if t.startswith(("-", "<", "[", "./", '"', "'")):
+                break
+            if _ARGISH.fullmatch(t):
+                break
+            if any(
+                t.endswith(suf)
+                for suf in (".jsonl", ".yaml", ".can", ".gguf", ".json", ".md", ".py")
+            ):
+                break
+            if t in ("|", "/") or _CMDISH.fullmatch(t):
+                region.append(t.rstrip("."))
+                continue
+            break
+        blob = " ".join(region).replace("...", "")
+        for piece in re.split(r"\s*[|/]\s*", blob):
+            piece = piece.strip()
+            if not piece or piece == "soup":
+                continue
+            alts.append(piece.split()[0])
+        idx = j + 1
+    return alts
+
+
+def is_documented(path: tuple[str, ...], doc: str) -> bool:
+    """True when ``docs/commands.md`` mentions ``soup <path>`` (or shorthand)."""
+    if path == ("advise", "run"):
+        # cli._rewrite_advise_argv turns documented `soup advise <data>` into
+        # `soup advise run <data>`.
+        return "soup advise " in doc
+    needle = "soup " + " ".join(path)
+    if needle in doc:
+        return True
+    leaf = path[-1]
+    prefix = path[:-1]
+    for line in doc.splitlines():
+        if "soup " not in line:
+            continue
+        if leaf in _shorthand_alts(line, prefix):
+            return True
+    return False
+
+
+def undocumented_commands(
+    doc: str, leaves: Iterable[tuple[str, ...]] | None = None
+) -> list[str]:
+    """Return `soup …` paths missing from ``doc``."""
+    if leaves is None:
+        leaves = iter_leaf_paths()
+    return ["soup " + " ".join(p) for p in leaves if not is_documented(p, doc)]
+
+
+@pytest.mark.unit
+class TestCommandsMdCoversRegisteredCommands:
+    """Live Typer leaf paths must stay represented in the command reference."""
+
+    def test_every_registered_leaf_is_mentioned_in_commands_md(self) -> None:
+        doc = COMMANDS_MD.read_text(encoding="utf-8")
+        missing = undocumented_commands(doc)
+        assert not missing, (
+            "docs/commands.md claims to be the full command list but omits:\n  - "
+            + "\n  - ".join(missing)
+        )
+
+    def test_leaf_walk_is_non_trivial(self) -> None:
+        leaves = iter_leaf_paths()
+        assert len(leaves) >= 200
+        assert ("eval", "against") in leaves
+        assert ("llama", "quantize") in leaves
+
+
+@pytest.mark.unit
+class TestCommandsMdCoverageGuardHasTeeth:
+    """CONTROL: the auditor must fail when a known leaf is stripped from the doc."""
+
+    def test_stripped_eval_against_is_reported(self) -> None:
+        doc = COMMANDS_MD.read_text(encoding="utf-8")
+        scrubbed = doc.replace("soup eval against", "soup eval __against__")
+        # Keep other commands intact; only hide the against needle + shorthand.
+        missing = undocumented_commands(scrubbed, leaves=[("eval", "against")])
+        assert missing == ["soup eval against"]
+
+    def test_llama_quantize_shorthand_counts(self) -> None:
+        stub = (
+            "soup llama cli|mtmd-cli|gguf-split|server|quantize ... "
+            "Proxy to the llama.cpp binaries\n"
+        )
+        assert undocumented_commands(stub, leaves=[("llama", "quantize")]) == []
+        stub_old = (
+            "soup llama cli|mtmd-cli|gguf-split|server ... "
+            "Proxy to the llama.cpp binaries\n"
+        )
+        assert undocumented_commands(stub_old, leaves=[("llama", "quantize")]) == [
+            "soup llama quantize"
+        ]


### PR DESCRIPTION
## Summary
- Add the 23 registered leaf commands that were missing from `docs/commands.md` (including `soup eval against` / `soup llama quantize` via the existing `llama …|…` shorthand).
- Document `soup eval against` in `docs/evaluation.md` and `soup llama quantize` in `docs/serving-and-export.md`.
- Add a Typer-walk ratchet (`tests/test_commands_md_covers_registered_commands.py`) so the “full command list” claim cannot silently drift again.

Closes #822

## Test plan
- [x] Walked the live Typer app: 0 undocumented leaves after the docs change (23 before).
- [x] `pytest tests/test_commands_md_covers_registered_commands.py -o addopts=` — 4 passed
- [ ] Spot-check the new command lines in `docs/commands.md` for placement/format
- [ ] Confirm topic sections render for `eval against` and `llama quantize`