### PR TITLE
test: match NF4 resident reference compute path

### DIFF
--- a/src/soup_cli/utils/layer_stream_runtime.py
+++ b/src/soup_cli/utils/layer_stream_runtime.py
@@ -183,13 +183,12 @@ def install_dequant_forward(module: Any) -> int:
     tensor through the ordinary mechanism, which checkpointing DOES discard and
     recompute, and the transient lives only inside the recomputed block — O(window).
 
-    This is not a numerics change at training shapes. ``bitsandbytes::gemm_4bit``
-    dispatches on M with ``_gemm_4bit_custom_max_m = 1536``, and on real projection
-    shapes it takes ``_dequant_linear_fallback`` at every M measured from 8 to 2048 —
-    i.e. bitsandbytes already does exactly this. The dtype handling below therefore
-    mirrors ``Linear4bit.forward`` line for line, replacing only the final call: a
-    dequantisation into a different dtype than bnb's own would introduce a rounding
-    difference precisely where there is none today.
+    This changes the computation path used by the patched NF4 module. With
+    bitsandbytes 0.50.2, the native fused ``MatMul4Bit`` path and explicit
+    ``dequantize_4bit`` + ``F.linear`` can disagree at small M: measured at
+    K=N=4096, the paths diverge through M=64 and agree at M=2048. The
+    dequantise + linear path is retained for correctness under checkpointing
+    (#331), not because it is numerically free.
 
     Returns the number of modules patched, so a caller can assert it patched
     something. Zero would mean the model carries no 4-bit linears at all.

--- a/tests/test_issue385_stream_dtype.py
+++ b/tests/test_issue385_stream_dtype.py
@@ -449,10 +449,15 @@ def _copy_lora(src, dst):
 
 @CUDA
 class TestFloat16StreamingIsBitExact:
-    """Acceptance item 4 of #385. The reference is a resident model of MATCHING
-    numerics — for NF4 that means a genuinely NF4-quantised reference, because
-    comparing a streamed fp16 run against a bf16 resident one would measure the
-    dtype rather than the streaming."""
+    """Acceptance item 4 of #385.
+
+    The reference matches the streamed model's computation path. For NF4 that
+    means a genuinely NF4-quantised resident reference with
+    ``install_dequant_forward`` applied, because the native bitsandbytes
+    ``MatMul4Bit`` path can use a different fused kernel at small token counts.
+    Comparing those different kernels would measure kernel-path differences
+    rather than layer streaming.
+    """
 
     def _run(self, tmp_path, dtype: str, quant: str) -> float:
         import torch
@@ -462,6 +467,7 @@ class TestFloat16StreamingIsBitExact:
         from soup_cli.utils.layer_stream_runtime import (
             build_meta_skeleton,
             build_streamed_model,
+            install_dequant_forward,
             quantised_layer_suffixes,
         )
 
@@ -502,6 +508,7 @@ class TestFloat16StreamingIsBitExact:
                     weights, quantization_config=build_nf4_config(dtype),
                     dtype=getattr(torch, dtype), device_map={"": "cuda"},
                 )
+                assert install_dequant_forward(base) > 0
             base.config.use_cache = False
             for param in base.parameters():
                 param.requires_grad = False

--- a/tests/test_issue776_bnb_nf4_paths.py
+++ b/tests/test_issue776_bnb_nf4_paths.py
@@ -12,7 +12,6 @@ import importlib.metadata
 
 import pytest
 
-
 torch = pytest.importorskip("torch")
 
 CUDA = pytest.mark.skipif(

--- a/tests/test_issue776_bnb_nf4_paths.py
+++ b/tests/test_issue776_bnb_nf4_paths.py
@@ -1,0 +1,72 @@
+"""#776 — document the two bitsandbytes NF4 forward paths.
+
+The streaming repair in #857 deliberately uses ``dequantize_4bit`` +
+``torch.nn.functional.linear``. A resident NF4 ``Linear4bit`` normally uses
+bitsandbytes' ``matmul_4bit`` path instead. With bitsandbytes 0.50.2 those
+kernels are observably different at small M, so the bit-exact streaming test
+must compare matching computation paths rather than treating this backend
+property as a streaming regression.
+"""
+
+import importlib.metadata
+
+import pytest
+
+
+torch = pytest.importorskip("torch")
+
+CUDA = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="requires CUDA to exercise bitsandbytes NF4 kernels",
+)
+
+
+@CUDA
+@pytest.mark.parametrize("rows", [64, 2048])
+def test_nf4_fused_and_dequant_paths_are_close(rows):
+    """The divergence is a bitsandbytes 0.50.2 property, not a Soup invariant."""
+    import bitsandbytes as bnb
+    import torch.nn.functional as functional
+
+    bnb_version = importlib.metadata.version("bitsandbytes")
+    if bnb_version != "0.50.2":
+        pytest.skip(
+            "measured kernel-path behaviour is pinned to bitsandbytes 0.50.2"
+        )
+
+    torch.manual_seed(0)
+
+    inputs = torch.randn(
+        rows, 4096, device="cuda", dtype=torch.float16
+    )
+    weights = torch.randn(
+        4096, 4096, device="cuda", dtype=torch.float32
+    )
+
+    packed, quant_state = bnb.functional.quantize_nf4(
+        weights,
+        blocksize=64,
+    )
+
+    fused = bnb.functional.matmul_4bit(
+        inputs,
+        packed,
+        bias=None,
+        quant_state=quant_state,
+    )
+
+    dequant = functional.linear(
+        inputs,
+        bnb.functional.dequantize_4bit(
+            packed,
+            quant_state,
+        ),
+    )
+
+    max_error = (fused.float() - dequant.float()).abs().max().item()
+
+    if rows == 64:
+        assert max_error > 0.0
+        assert max_error <= 1e-2
+    else:
+        assert max_error <= 1e-6


### PR DESCRIPTION
## Summary

Fix the NF4 bit-exactness reference in `TestFloat16StreamingIsBitExact`.

The streamed NF4 path deliberately uses `install_dequant_forward` (`dequantize_4bit + F.linear`), while a resident NF4 `Linear4bit` can use bitsandbytes' native `MatMul4Bit` path. With current bitsandbytes versions, those paths are not necessarily numerically identical at small token counts.

The test was therefore comparing:

* streamed NF4: explicit dequantisation + `F.linear`
* resident NF4: native bitsandbytes dispatch

That means a failure can measure a kernel-path difference rather than a streaming difference.

This change applies `install_dequant_forward` to the resident NF4 reference as well, so the exact `== 0.0` assertion compares matching computation paths.

## Validation

Local CPU/non-CUDA validation passes:

```text
23 passed, 6 skipped
```

Static checks also pass:

* `python -m py_compile tests/test_issue385_stream_dtype.py`
* `git diff --check`

The CUDA-specific test cannot be executed on my current machine because it has no NVIDIA GPU. In particular, I have not claimed Blackwell (`sm_120`) validation.

## Related issue

Refs #776.

The exact-equality assertion is intentionally retained; this PR does not replace it with a tolerance.
