### PR TITLE
fix(data): fail validation when no rows are usable

### DIFF
--- a/changelog.d/0.74.0/858.fixed.md
+++ b/changelog.d/0.74.0/858.fixed.md
@@ -1,0 +1,2 @@
+- Make `soup data validate` fail when no rows are usable, and add an optional
+  minimum-valid-fraction threshold for stricter CI gates (#811 by @akkupratap323 in #858).

--- a/docs/data.md
+++ b/docs/data.md
@@ -737,6 +737,9 @@ soup data inspect ./data/train.jsonl
 soup data validate ./data/train.jsonl
 soup data validate ./data/train.jsonl --format alpaca
 
+# Require at least 90% of rows to be usable
+soup data validate ./data/train.jsonl --min-valid-fraction 0.9
+
 # Convert between formats
 soup data convert ./data/train.jsonl --to sharegpt --output converted.jsonl
 
@@ -754,6 +757,12 @@ soup data filter ./data/train.jsonl --coherence 0.3
 soup data filter ./data/train.jsonl --perplexity 500 --coherence 0.3
 soup data filter ./data/train.jsonl --score-only  # add scores without filtering
 ```
+
+`soup data validate` exits with code `0` when at least one row is usable and the
+optional minimum valid fraction is met. It exits with code `1` for input errors,
+such as a missing file or an undetectable format, and code `2` when a non-empty
+dataset has no usable rows or falls below `--min-valid-fraction`. A partially valid
+dataset still exits with code `0` when no minimum is specified.
 
 
 ## Demo Datasets (`soup data demo`)

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -82,8 +82,15 @@ def validate(
         "auto", "--format", "-f",
         help="Expected format: auto, alpaca, sharegpt, chatml, dpo, kto, plaintext",
     ),
+    min_valid_fraction: float = typer.Option(
+        0.0,
+        "--min-valid-fraction",
+        min=0.0,
+        max=1.0,
+        help="Exit 2 when the fraction of valid rows is below this value",
+    ),
 ):
-    """Validate dataset format and report issues."""
+    """Validate a dataset, returning exit 1 for input errors and 2 for unusable data."""
     file_path = Path(path)
     if not file_path.exists():
         console.print(f"[red]File not found: {file_path}[/]")
@@ -114,6 +121,17 @@ def validate(
     valid = result["valid_rows"]
     total = result["total"]
     console.print(f"\n[green]{valid}/{total} rows valid for {fmt} format[/]")
+
+    if total > 0 and valid == 0:
+        console.print("[red]Validation failed: no usable rows remain.[/]")
+        raise typer.Exit(2)
+
+    if total > 0 and valid / total < min_valid_fraction:
+        console.print(
+            f"[red]Validation failed: valid fraction {valid / total:.3f} is below "
+            f"--min-valid-fraction {min_valid_fraction:.3f}.[/]"
+        )
+        raise typer.Exit(2)
 
 
 @app.command()

--- a/tests/test_issue811_data_validate_exit_codes.py
+++ b/tests/test_issue811_data_validate_exit_codes.py
@@ -1,0 +1,97 @@
+"""Regression tests for ``soup data validate`` exit codes (#811)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import Result
+from typer.testing import CliRunner
+
+from soup_cli.cli import app
+
+from .conftest import strip_ansi
+
+
+def _write_alpaca(path: Path, rows: list[dict]) -> None:
+    path.write_text(
+        "".join(json.dumps(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def _invoke_validate(path: Path, *extra_args: str) -> Result:
+    return CliRunner().invoke(
+        app,
+        ["data", "validate", str(path), "--format", "alpaca", *extra_args],
+    )
+
+
+def test_validate_exits_two_when_all_rows_are_unusable(tmp_path: Path) -> None:
+    path = tmp_path / "invalid.jsonl"
+    _write_alpaca(path, [{"instruction": None, "output": None}] * 5)
+
+    result = _invoke_validate(path)
+    output = strip_ansi(result.output)
+
+    assert result.exit_code == 2
+    assert "0/5 rows valid" in output
+    assert "no usable rows remain" in output
+
+
+def test_validate_allows_partially_valid_data_by_default(tmp_path: Path) -> None:
+    path = tmp_path / "partial.jsonl"
+    _write_alpaca(
+        path,
+        [
+            {"instruction": "Summarize this", "output": "A summary"},
+            {"instruction": None, "output": None},
+        ],
+    )
+
+    result = _invoke_validate(path)
+
+    assert result.exit_code == 0, result.output
+    assert "1/2 rows valid" in strip_ansi(result.output)
+
+
+@pytest.mark.parametrize(
+    ("minimum", "expected_exit_code"),
+    [("0.75", 2), ("0.5", 0)],
+)
+def test_validate_applies_minimum_fraction(
+    tmp_path: Path,
+    minimum: str,
+    expected_exit_code: int,
+) -> None:
+    path = tmp_path / "partial.jsonl"
+    _write_alpaca(
+        path,
+        [
+            {"instruction": "Summarize this", "output": "A summary"},
+            {"instruction": None, "output": None},
+        ],
+    )
+
+    result = _invoke_validate(path, "--min-valid-fraction", minimum)
+
+    assert result.exit_code == expected_exit_code, result.output
+    if expected_exit_code == 2:
+        assert "valid fraction 0.500 is below --min-valid-fraction 0.750" in strip_ansi(
+            result.output
+        )
+
+
+def test_validate_keeps_input_errors_at_exit_one(tmp_path: Path) -> None:
+    missing = _invoke_validate(tmp_path / "missing.jsonl")
+
+    assert missing.exit_code == 1
+    assert "File not found" in strip_ansi(missing.output)
+
+    unknown = tmp_path / "unknown.jsonl"
+    unknown.write_text('{"unrecognized": "shape"}\n', encoding="utf-8")
+    undetectable = CliRunner().invoke(app, ["data", "validate", str(unknown)])
+
+    assert undetectable.exit_code == 1
+    assert "Cannot detect format" in strip_ansi(undetectable.output)


### PR DESCRIPTION
﻿## What does this PR do?

`soup data validate` reported `0/N rows valid` but returned success, allowing generated CI gates to accept datasets that the loader would reduce to zero rows. This change returns exit code 2 when a non-empty dataset has no usable rows and adds `--min-valid-fraction` for CI policies that need a stricter threshold. Partial drops still succeed by default, and input/format errors keep exit code 1.

The CLI help and data guide document the exit codes and threshold behavior. Regression tests cover zero usable rows, partial drops, below/equal threshold behavior, and both exit-1 cases.

Closes #811

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [x] Tests

## Checklist

- [x] `ruff check src/soup_cli/ scripts/ tests/` passes
- [ ] `pytest tests/ -v` passes
- [x] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed
- [x] Added a changelog fragment, or this change has no user-visible impact

## Validation

- `pytest -o addopts='' tests/test_issue811_data_validate_exit_codes.py tests/test_issue676_non_dict_messages.py tests/test_data_tools.py tests/test_bugfixes.py::TestValidateAutoDetect -q` (53 passed)
- `ruff check src/soup_cli/ scripts/ tests/ benchmarks/`

The full local suite requires the optional training dependency stack; the focused CLI/data suites pass with the core development dependencies installed.
