### PR TITLE
fix(cli): route terminal plots through Rich

### DIFF
--- a/changelog.d/0.74.0/860.fixed.md
+++ b/changelog.d/0.74.0/860.fixed.md
@@ -1,0 +1,2 @@
+- Route terminal charts through Rich so `NO_COLOR` and redirected output contain no raw
+  ANSI escapes while interactive charts retain colour (#824 by @akkupratap323 in #860).

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -625,11 +625,11 @@ def stats(
                 render_histogram(
                     plt,
                     lengths,
+                    console=console,
                     bins=30,
                     title="Text Length Distribution (chars)",
                     xlabel="Length",
                     ylabel="Count",
-                    theme="dark",
                 )
             finally:
                 sys.stdout = original_stdout

--- a/src/soup_cli/commands/runs.py
+++ b/src/soup_cli/commands/runs.py
@@ -561,11 +561,11 @@ def _plot_loss_curve(metrics: list[dict]) -> None:
         plt,
         steps,
         losses,
+        console=console,
         label="loss",
         title="Training Loss",
         xlabel="Step",
         ylabel="Loss",
-        theme="dark",
     )
 
 

--- a/src/soup_cli/utils/plotext_compat.py
+++ b/src/soup_cli/utils/plotext_compat.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from rich.text import Text
+
 
 def _v6_figure(plotext: Any) -> Any | None:
     """Return plotext 6's figure object, or ``None`` for the 5.x API."""
@@ -15,13 +17,14 @@ def render_histogram(
     plotext: Any,
     values: list[int],
     *,
+    console: Any,
     bins: int,
     title: str,
     xlabel: str,
     ylabel: str,
-    theme: str,
+    theme: str | None = None,
 ) -> None:
-    """Render a histogram with either plotext 5.x or 6.x."""
+    """Render a histogram through Rich with either plotext 5.x or 6.x."""
     figure = _v6_figure(plotext)
     if figure is not None:
         figure.clear()
@@ -29,8 +32,9 @@ def render_histogram(
         figure.title(title)
         figure.label(xlabel, axis=0)
         figure.label(ylabel, axis=1)
-        figure.theme(theme)
-        figure.show()
+        if theme is not None:
+            figure.theme(theme)
+        console.print(Text.from_ansi(str(figure.build())))
         return
 
     plotext.clf()
@@ -38,8 +42,9 @@ def render_histogram(
     plotext.title(title)
     plotext.xlabel(xlabel)
     plotext.ylabel(ylabel)
-    plotext.theme(theme)
-    plotext.show()
+    if theme is not None:
+        plotext.theme(theme)
+    console.print(Text.from_ansi(str(plotext.build())))
 
 
 def render_line(
@@ -47,13 +52,14 @@ def render_line(
     x_values: list[int],
     y_values: list[float],
     *,
+    console: Any,
     label: str,
     title: str,
     xlabel: str,
     ylabel: str,
-    theme: str,
+    theme: str | None = None,
 ) -> None:
-    """Render a labelled line with either plotext 5.x or 6.x."""
+    """Render a labelled line through Rich with either plotext 5.x or 6.x."""
     figure = _v6_figure(plotext)
     if figure is not None:
         figure.clear()
@@ -62,8 +68,9 @@ def render_line(
         figure.title(title)
         figure.label(xlabel, axis=0)
         figure.label(ylabel, axis=1)
-        figure.theme(theme)
-        figure.show()
+        if theme is not None:
+            figure.theme(theme)
+        console.print(Text.from_ansi(str(figure.build())))
         return
 
     plotext.clf()
@@ -71,5 +78,6 @@ def render_line(
     plotext.title(title)
     plotext.xlabel(xlabel)
     plotext.ylabel(ylabel)
-    plotext.theme(theme)
-    plotext.show()
+    if theme is not None:
+        plotext.theme(theme)
+    console.print(Text.from_ansi(str(plotext.build())))

--- a/src/soup_cli/utils/plotext_compat.py
+++ b/src/soup_cli/utils/plotext_compat.py
@@ -34,7 +34,7 @@ def render_histogram(
         figure.label(ylabel, axis=1)
         if theme is not None:
             figure.theme(theme)
-        console.print(Text.from_ansi(str(figure.build())))
+        console.print(Text.from_ansi(str(figure.build())), soft_wrap=True)
         return
 
     plotext.clf()
@@ -44,7 +44,7 @@ def render_histogram(
     plotext.ylabel(ylabel)
     if theme is not None:
         plotext.theme(theme)
-    console.print(Text.from_ansi(str(plotext.build())))
+    console.print(Text.from_ansi(str(plotext.build())), soft_wrap=True)
 
 
 def render_line(
@@ -70,7 +70,7 @@ def render_line(
         figure.label(ylabel, axis=1)
         if theme is not None:
             figure.theme(theme)
-        console.print(Text.from_ansi(str(figure.build())))
+        console.print(Text.from_ansi(str(figure.build())), soft_wrap=True)
         return
 
     plotext.clf()
@@ -80,4 +80,4 @@ def render_line(
     plotext.ylabel(ylabel)
     if theme is not None:
         plotext.theme(theme)
-    console.print(Text.from_ansi(str(plotext.build())))
+    console.print(Text.from_ansi(str(plotext.build())), soft_wrap=True)

--- a/tests/test_bugfixes.py
+++ b/tests/test_bugfixes.py
@@ -1251,11 +1251,14 @@ class TestStatsHistogramWindows:
         )
 
         try:
+            from rich.console import Console
+
             from soup_cli.utils.plotext_compat import render_histogram
 
             render_histogram(
                 plt,
                 [10, 20, 30, 40, 50],
+                console=Console(file=sys.stdout),
                 bins=3,
                 title="Test",
                 xlabel="Value",

--- a/tests/test_cli_subprocess.py
+++ b/tests/test_cli_subprocess.py
@@ -309,10 +309,55 @@ class TestDataCommands:
         data_file.write_text(
             "\n".join(json.dumps(r) for r in rows), encoding="utf-8"
         )
-        result = run_soup("data", "stats", str(data_file))
+        result = run_soup(
+            "data",
+            "stats",
+            str(data_file),
+            env={"NO_COLOR": "1"},
+        )
         assert result.returncode == 0, (
             f"data stats failed (rc={result.returncode}):\n{result.stderr}"
         )
+        assert "Text Length Distribution" in result.stdout
+        assert "\x1b" not in result.stdout
+
+
+class TestRunCommands:
+    def test_runs_replay_no_color_has_no_escape_bytes(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "runs.db"
+        monkeypatch.setenv("SOUP_DB_PATH", str(db_path))
+
+        from soup_cli.experiment.tracker import ExperimentTracker
+
+        tracker = ExperimentTracker()
+        run_id = tracker.start_run(
+            config_dict={"base": "x", "task": "sft"},
+            device="cpu",
+            device_name="cpu",
+            gpu_info={},
+        )
+        for step in range(3):
+            tracker.log_metrics(run_id, step=step, loss=2.0 - step * 0.25)
+        tracker.finish_run(
+            run_id=run_id,
+            initial_loss=2.0,
+            final_loss=1.5,
+            total_steps=3,
+            duration_secs=1.0,
+            output_dir=str(tmp_path),
+        )
+        tracker.close()
+
+        result = run_soup(
+            "runs",
+            "replay",
+            run_id,
+            env={"NO_COLOR": "1", "SOUP_DB_PATH": str(db_path)},
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "Training Loss" in result.stdout
+        assert "\x1b" not in result.stdout
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_data_tools.py
+++ b/tests/test_data_tools.py
@@ -221,6 +221,7 @@ def test_stats_command(sample_alpaca_file):
     assert result.exit_code == 0
     assert "p50" in result.output
     assert "Tokens" in result.output
+    assert "Text Length Distribution" in result.output
 
 
 def test_stats_missing_file():

--- a/tests/test_plotext_compat.py
+++ b/tests/test_plotext_compat.py
@@ -21,9 +21,11 @@ class _Recorder:
 class _Console:
     def __init__(self) -> None:
         self.output: list[str] = []
+        self.options: list[dict] = []
 
-    def print(self, value) -> None:
+    def print(self, value, **kwargs) -> None:
         self.output.append(str(value))
+        self.options.append(kwargs)
 
 
 class _Plotext5(_Recorder):
@@ -138,6 +140,7 @@ def test_plotext5_module_api_remains_supported() -> None:
         "build",
     ]
     assert console.output == ["plot", "plot"]
+    assert console.options == [{"soft_wrap": True}, {"soft_wrap": True}]
 
 
 def test_plotext6_figure_api_is_used() -> None:
@@ -185,6 +188,7 @@ def test_plotext6_figure_api_is_used() -> None:
         "build",
     ]
     assert console.output == ["plot", "plot"]
+    assert console.options == [{"soft_wrap": True}, {"soft_wrap": True}]
 
 
 def test_installed_plotext_runtime_renders_histogram_and_line() -> None:
@@ -240,3 +244,22 @@ def test_rich_console_controls_plot_color(monkeypatch) -> None:
     )
 
     assert "\x1b[" in terminal_output.getvalue()
+
+
+def test_rich_console_does_not_wrap_plot_rows() -> None:
+    plotext = _Plotext5()
+    plotext.build = lambda: "123456\nabcdef"
+    redirected_output = StringIO()
+    redirected = Console(file=redirected_output, width=4, color_system=None)
+
+    render_histogram(
+        plotext,
+        [1, 2],
+        console=redirected,
+        bins=2,
+        title="Histogram",
+        xlabel="X",
+        ylabel="Y",
+    )
+
+    assert redirected_output.getvalue().splitlines() == ["123456", "abcdef"]

--- a/tests/test_plotext_compat.py
+++ b/tests/test_plotext_compat.py
@@ -1,8 +1,10 @@
 """Plotext 5.x / 6.x compatibility coverage."""
 
 from importlib.metadata import version as distribution_version
+from io import StringIO
 
 from packaging.version import Version
+from rich.console import Console
 
 from soup_cli.utils.plotext_compat import render_histogram, render_line
 
@@ -14,6 +16,14 @@ class _Recorder:
     def _record(self, name: str, *args, **kwargs):
         self.calls.append((name, args, kwargs))
         return self
+
+
+class _Console:
+    def __init__(self) -> None:
+        self.output: list[str] = []
+
+    def print(self, value) -> None:
+        self.output.append(str(value))
 
 
 class _Plotext5(_Recorder):
@@ -38,8 +48,9 @@ class _Plotext5(_Recorder):
     def theme(self, *args, **kwargs):
         return self._record("theme", *args, **kwargs)
 
-    def show(self):
-        return self._record("show")
+    def build(self):
+        self._record("build")
+        return "\x1b[31mplot\x1b[0m"
 
 
 class _Signal(_Recorder):
@@ -74,8 +85,9 @@ class _Figure6(_Recorder):
     def theme(self, *args, **kwargs):
         return self._record("theme", *args, **kwargs)
 
-    def show(self):
-        return self._record("show")
+    def build(self):
+        self._record("build")
+        return "\x1b[31mplot\x1b[0m"
 
 
 class _Plotext6:
@@ -85,9 +97,11 @@ class _Plotext6:
 
 def test_plotext5_module_api_remains_supported() -> None:
     plotext = _Plotext5()
+    console = _Console()
     render_histogram(
         plotext,
         [1, 2],
+        console=console,
         bins=2,
         title="Histogram",
         xlabel="X",
@@ -98,6 +112,7 @@ def test_plotext5_module_api_remains_supported() -> None:
         plotext,
         [1, 2],
         [0.5, 0.25],
+        console=console,
         label="loss",
         title="Loss",
         xlabel="Step",
@@ -113,22 +128,25 @@ def test_plotext5_module_api_remains_supported() -> None:
         "xlabel",
         "ylabel",
         "theme",
-        "show",
+        "build",
         "clf",
         "plot",
         "title",
         "xlabel",
         "ylabel",
         "theme",
-        "show",
+        "build",
     ]
+    assert console.output == ["plot", "plot"]
 
 
 def test_plotext6_figure_api_is_used() -> None:
     plotext = _Plotext6()
+    console = _Console()
     render_histogram(
         plotext,
         [1, 2],
+        console=console,
         bins=2,
         title="Histogram",
         xlabel="X",
@@ -139,6 +157,7 @@ def test_plotext6_figure_api_is_used() -> None:
         plotext,
         [1, 2],
         [0.5, 0.25],
+        console=console,
         label="loss",
         title="Loss",
         xlabel="Step",
@@ -155,7 +174,7 @@ def test_plotext6_figure_api_is_used() -> None:
         "label",
         "label",
         "theme",
-        "show",
+        "build",
         "clear",
         "signal",
         "draw",
@@ -163,22 +182,24 @@ def test_plotext6_figure_api_is_used() -> None:
         "label",
         "label",
         "theme",
-        "show",
+        "build",
     ]
+    assert console.output == ["plot", "plot"]
 
 
-def test_installed_plotext_runtime_renders_histogram_and_line(monkeypatch) -> None:
+def test_installed_plotext_runtime_renders_histogram_and_line() -> None:
     """Exercise the installed package, not only the two contract doubles."""
     import plotext
 
     major = Version(distribution_version("plotext")).major
     assert major in {5, 6}
     runtime = plotext.figure if major == 6 else plotext
-    assert callable(runtime.show)
-    monkeypatch.setattr(runtime, "show", lambda: None)
+    assert callable(runtime.build)
+    console = _Console()
     render_histogram(
         plotext,
         [1, 2, 3],
+        console=console,
         bins=2,
         title="Histogram",
         xlabel="X",
@@ -189,6 +210,7 @@ def test_installed_plotext_runtime_renders_histogram_and_line(monkeypatch) -> No
         plotext,
         [1, 2, 3],
         [0.5, 0.25, 0.125],
+        console=console,
         label="loss",
         title="Loss",
         xlabel="Step",
@@ -197,3 +219,24 @@ def test_installed_plotext_runtime_renders_histogram_and_line(monkeypatch) -> No
     )
     built = runtime.build()
     assert "Loss" in str(built)
+    assert "Histogram" in console.output[0]
+    assert "Loss" in console.output[1]
+
+
+def test_rich_console_controls_plot_color(monkeypatch) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    plotext = _Plotext5()
+    terminal_output = StringIO()
+    terminal = Console(file=terminal_output, force_terminal=True, color_system="standard")
+
+    render_histogram(
+        plotext,
+        [1, 2],
+        console=terminal,
+        bins=2,
+        title="Histogram",
+        xlabel="X",
+        ylabel="Y",
+    )
+
+    assert "\x1b[" in terminal_output.getvalue()

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -168,8 +168,14 @@ class TestCli:
         )
         tracker.close()
         runner = CliRunner()
-        result = runner.invoke(app, ["runs", "replay", run_id, "--no-plot"])
+        result = runner.invoke(
+            app,
+            ["runs", "replay", run_id],
+            env={"NO_COLOR": "1"},
+        )
         assert result.exit_code == 0, (result.output, repr(result.exception))
         assert run_id in result.output
         # Summary should reference initial / final loss
         assert "2.0" in result.output or "2.00" in result.output
+        assert "Training Loss" in result.output
+        assert "\x1b" not in result.output

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -153,7 +153,12 @@ class TestCli:
 
     def test_replay_renders(self, tmp_path, monkeypatch):
         monkeypatch.setenv("SOUP_DB_PATH", str(tmp_path / "y.db"))
+        from rich.console import Console
+
+        from soup_cli.commands import runs as runs_command
         from soup_cli.experiment.tracker import ExperimentTracker
+
+        monkeypatch.setattr(runs_command, "console", Console(no_color=True))
 
         tracker = ExperimentTracker()
         run_id = tracker.start_run(
@@ -171,7 +176,6 @@ class TestCli:
         result = runner.invoke(
             app,
             ["runs", "replay", run_id],
-            env={"NO_COLOR": "1"},
         )
         assert result.exit_code == 0, (result.output, repr(result.exception))
         assert run_id in result.output
@@ -179,3 +183,7 @@ class TestCli:
         assert "2.0" in result.output or "2.00" in result.output
         assert "Training Loss" in result.output
         assert "\x1b" not in result.output
+
+        no_plot = runner.invoke(app, ["runs", "replay", run_id, "--no-plot"])
+        assert no_plot.exit_code == 0, (no_plot.output, repr(no_plot.exception))
+        assert "Training Loss" not in no_plot.output


### PR DESCRIPTION
﻿## What does this PR do?

Plotext wrote charts directly to `sys.stdout`, bypassing Rich's terminal and `NO_COLOR` handling. As a result, `soup data stats > stats.txt` and `soup runs replay` could emit hundreds of raw ANSI escape bytes, while `CliRunner` did not capture the chart.

This change builds Plotext 5/6 charts as strings, parses their ANSI styling into Rich `Text`, and prints them through the command's Rich console. Redirected and `NO_COLOR=1` output is clean, interactive terminals retain color, and both charts are visible to `CliRunner`. The hard-coded dark theme is also removed so Rich and the active terminal control presentation.

Closes #824

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Tests

## Checklist

- [x] `ruff check src/soup_cli/ scripts/ tests/` passes
- [ ] `pytest tests/ -v` passes
- [x] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed
- [x] Added a changelog fragment, or this change has no user-visible impact

## Validation

- 73 focused Plotext, data stats, replay, Windows encoding, and subprocess tests passed
- Real subprocess checks verify `NO_COLOR=1` output for both `data stats` and `runs replay` contains the chart and no `\x1b` bytes
- A forced interactive Rich console test verifies chart color remains enabled
- `ruff check src/soup_cli/ scripts/ tests/ benchmarks/`

The full local suite requires the optional training dependency stack; the focused command and compatibility suites pass with the core development dependencies installed.
