### PR TITLE
fix(data): exit 2 on zero valid rows, add --strict and --min-valid-fraction (#811)

### DIFF
--- a/changelog.d/0.74.0/861.fixed.md
+++ b/changelog.d/0.74.0/861.fixed.md
@@ -1,0 +1,4 @@
+- `soup data validate` now exits 2 when zero rows are valid for the format,
+  preventing datasets with no usable rows from silently passing CI gates
+  (#811 by @kok-o in #861). Added `--strict` to reject any dropped row
+  and `--min-valid-fraction` to enforce an opt-in valid-row threshold.

--- a/docs/data.md
+++ b/docs/data.md
@@ -736,6 +736,9 @@ soup data inspect ./data/train.jsonl
 # Validate format (auto-detects if --format not specified)
 soup data validate ./data/train.jsonl
 soup data validate ./data/train.jsonl --format alpaca
+soup data validate ./data/train.jsonl --strict                 # exit 2 on any dropped row
+soup data validate ./data/train.jsonl --min-valid-fraction 0.95 # exit 2 below 95% valid
+# Exit codes: 0 = valid, 1 = missing file / bad arguments, 2 = validation failed (0 valid or below threshold)
 
 # Convert between formats
 soup data convert ./data/train.jsonl --to sharegpt --output converted.jsonl

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -82,11 +82,32 @@ def validate(
         "auto", "--format", "-f",
         help="Expected format: auto, alpaca, sharegpt, chatml, dpo, kto, plaintext",
     ),
+    min_valid_fraction: Optional[float] = typer.Option(
+        None, "--min-valid-fraction",
+        help="Minimum fraction of valid rows required (0.0 to 1.0); exits 2 if below",
+    ),
+    strict: bool = typer.Option(
+        False, "--strict",
+        help="Require 100% of rows to be valid; exits 2 if any rows are dropped",
+    ),
 ):
-    """Validate dataset format and report issues."""
+    """Validate dataset format and report issues.
+
+    Exit codes:
+      0: Dataset passed validation.
+      1: File not found, undetectable format, or invalid arguments.
+      2: Validation failed (0 valid rows, below --min-valid-fraction, or
+         dropped rows with --strict).
+    """
     file_path = Path(path)
     if not file_path.exists():
         console.print(f"[red]File not found: {file_path}[/]")
+        raise typer.Exit(1)
+
+    if min_valid_fraction is not None and (min_valid_fraction < 0.0 or min_valid_fraction > 1.0):
+        console.print(
+            f"[red]--min-valid-fraction must be between 0.0 and 1.0, got {min_valid_fraction}[/]"
+        )
         raise typer.Exit(1)
 
     data = load_raw_data(file_path)
@@ -113,7 +134,32 @@ def validate(
 
     valid = result["valid_rows"]
     total = result["total"]
-    console.print(f"\n[green]{valid}/{total} rows valid for {fmt} format[/]")
+    if valid == 0 and total > 0:
+        console.print(f"\n[red]{valid}/{total} rows valid for {fmt} format[/]")
+    else:
+        console.print(f"\n[green]{valid}/{total} rows valid for {fmt} format[/]")
+
+    if total > 0 and valid == 0:
+        console.print(
+            f"[red]Validation failed: 0/{total} rows valid for '{fmt}' format (all rows dropped)[/]"
+        )
+        raise typer.Exit(2)
+
+    if strict and (valid < total or total == 0):
+        dropped = total - valid
+        console.print(
+            f"[red]Strict validation failed: {valid}/{total} rows valid ({dropped} dropped)[/]"
+        )
+        raise typer.Exit(2)
+
+    if min_valid_fraction is not None:
+        fraction = (valid / total) if total > 0 else 0.0
+        if fraction < min_valid_fraction:
+            console.print(
+                f"[red]Validation threshold failed: {valid}/{total} rows valid "
+                f"({fraction:.1%} < {min_valid_fraction:.1%})[/]"
+            )
+            raise typer.Exit(2)
 
 
 @app.command()

--- a/tests/test_issue811_data_validate_exit_code.py
+++ b/tests/test_issue811_data_validate_exit_code.py
@@ -1,0 +1,141 @@
+"""Regression tests for issue #811: soup data validate exit code contract.
+
+Validates that:
+1. When total > 0 and valid_rows == 0, soup data validate exits 2.
+2. Partial drops (e.g. 1/2 valid) default to exit 0.
+3. --strict exits 2 on any dropped row, and exits 0 when 100% of rows are valid.
+4. --min-valid-fraction exits 2 when valid fraction is below threshold, and 0 at or above.
+5. Out-of-range --min-valid-fraction values exit 1.
+6. Missing files and undetectable formats maintain exit 1.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from soup_cli.cli import app
+from tests.conftest import strip_ansi
+
+
+def test_zero_valid_rows_exits_2(tmp_path: Path) -> None:
+    path = tmp_path / "bad.jsonl"
+    rows = [{"instruction": None, "output": None} for _ in range(5)]
+    path.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["data", "validate", str(path), "--format", "alpaca"])
+    clean_out = strip_ansi(result.output)
+
+    assert result.exit_code == 2, result.output
+    assert "0/5 rows valid for alpaca format" in clean_out
+
+
+def test_partial_valid_rows_defaults_to_exit_0(tmp_path: Path) -> None:
+    path = tmp_path / "partial.jsonl"
+    rows = [
+        {"instruction": "say hi", "output": "hello"},
+        {"instruction": None, "output": None},
+    ]
+    path.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["data", "validate", str(path), "--format", "alpaca"])
+    clean_out = strip_ansi(result.output)
+
+    assert result.exit_code == 0, result.output
+    assert "1/2 rows valid for alpaca format" in clean_out
+
+
+def test_strict_mode_exits_2_on_dropped_rows(tmp_path: Path) -> None:
+    path = tmp_path / "partial.jsonl"
+    rows = [
+        {"instruction": "say hi", "output": "hello"},
+        {"instruction": None, "output": None},
+    ]
+    path.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+
+    result = CliRunner().invoke(
+        app, ["data", "validate", str(path), "--format", "alpaca", "--strict"]
+    )
+    clean_out = strip_ansi(result.output)
+
+    assert result.exit_code == 2, result.output
+    assert "Strict validation failed" in clean_out
+
+
+def test_strict_mode_exits_0_when_all_rows_valid(tmp_path: Path) -> None:
+    path = tmp_path / "all_good.jsonl"
+    rows = [
+        {"instruction": "say hi", "output": "hello"},
+        {"instruction": "say bye", "output": "goodbye"},
+    ]
+    path.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+
+    result = CliRunner().invoke(
+        app, ["data", "validate", str(path), "--format", "alpaca", "--strict"]
+    )
+    clean_out = strip_ansi(result.output)
+
+    assert result.exit_code == 0, result.output
+    assert "2/2 rows valid for alpaca format" in clean_out
+
+
+def test_min_valid_fraction_enforces_threshold(tmp_path: Path) -> None:
+    path = tmp_path / "partial.jsonl"
+    # 2 out of 5 valid = 40%
+    rows = [
+        {"instruction": "say hi", "output": "hello"},
+        {"instruction": "say bye", "output": "goodbye"},
+        {"instruction": None, "output": None},
+        {"instruction": None, "output": None},
+        {"instruction": None, "output": None},
+    ]
+    path.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+
+    # 40% < 50% -> exit 2
+    res_fail = CliRunner().invoke(
+        app,
+        ["data", "validate", str(path), "--format", "alpaca", "--min-valid-fraction", "0.5"],
+    )
+    assert res_fail.exit_code == 2, res_fail.output
+    assert "Validation threshold failed" in strip_ansi(res_fail.output)
+
+    # 40% >= 40% -> exit 0
+    res_pass = CliRunner().invoke(
+        app,
+        ["data", "validate", str(path), "--format", "alpaca", "--min-valid-fraction", "0.4"],
+    )
+    assert res_pass.exit_code == 0, res_pass.output
+    assert "2/5 rows valid for alpaca format" in strip_ansi(res_pass.output)
+
+
+def test_min_valid_fraction_out_of_range_exits_1(tmp_path: Path) -> None:
+    path = tmp_path / "data.jsonl"
+    rows = [{"instruction": "say hi", "output": "hello"}]
+    path.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+
+    res1 = CliRunner().invoke(
+        app,
+        ["data", "validate", str(path), "--format", "alpaca", "--min-valid-fraction", "1.5"],
+    )
+    assert res1.exit_code == 1, res1.output
+
+    res2 = CliRunner().invoke(
+        app,
+        ["data", "validate", str(path), "--format", "alpaca", "--min-valid-fraction", "-0.1"],
+    )
+    assert res2.exit_code == 1, res2.output
+
+
+def test_missing_file_and_undetectable_format_maintain_exit_1(tmp_path: Path) -> None:
+    # Missing file
+    res_missing = CliRunner().invoke(app, ["data", "validate", str(tmp_path / "nonexistent.jsonl")])
+    assert res_missing.exit_code == 1, res_missing.output
+    assert "File not found" in strip_ansi(res_missing.output)
+
+    # Undetectable format
+    empty_file = tmp_path / "empty.jsonl"
+    empty_file.write_text("", encoding="utf-8")
+    res_undetectable = CliRunner().invoke(app, ["data", "validate", str(empty_file)])
+    assert res_undetectable.exit_code == 1, res_undetectable.output


### PR DESCRIPTION
## What does this PR do?

Resolves #811 by updating `soup data validate` exit codes and adding strict validation options:
1. **Zero-valid-rows failure**: When `total > 0 and valid_rows == 0`, `soup data validate` now exits with code `2` (previously exited `0`), ensuring files with no usable rows fail CI gates.
2. **Default partial drop compatibility**: Partial drops (e.g. 1/2 rows valid) continue to default to exit `0` as before.
3. **Strict mode**: Added `--strict` to require 100% of rows to be valid, exiting `2` if any row is dropped.
4. **Valid fraction threshold**: Added `--min-valid-fraction` (float between 0.0 and 1.0) to exit `2` when the fraction of valid rows falls below the threshold. Out-of-range thresholds exit `1`.
5. **Docs and help**: Documented exit codes (0 = valid, 1 = file not found / bad argument / undetectable format, 2 = validation failed) in `--help` and `docs/data.md`.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [x] Tests

## Checklist

- [x] `ruff check src/soup_cli/ scripts/ tests/` passes
- [x] `pytest tests/ -v` passes
- [x] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed
- [x] Added a changelog fragment, or this change has no user-visible impact
