### PR TITLE
fix(data): uncolorize plotext output under NO_COLOR and redirect (#824)

### DIFF
--- a/changelog.d/0.74.0/862.fixed.md
+++ b/changelog.d/0.74.0/862.fixed.md
@@ -1,0 +1,8 @@
+- **Uncolorize plotext charts under NO_COLOR and redirected output (#824 by @kok-o in #862).**
+  `soup data stats` and `soup runs replay` rendered histograms and loss curves using
+  `plotext.show()`, which wrote directly to the process stdout file descriptor, bypassing
+  Rich console routing and emitting raw ANSI escape sequences (`\x1b[...]`) even when `NO_COLOR=1`
+  was set or output was piped to a file. Rendered charts are now built via `.build()`,
+  uncolorized when `NO_COLOR` is active, redirected, or running in an uncolored console,
+  and printed through Rich, allowing test runners and piped outputs to cleanly capture
+  text without ANSI escape contamination or terminal background paint.

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -629,7 +629,7 @@ def stats(
                     title="Text Length Distribution (chars)",
                     xlabel="Length",
                     ylabel="Count",
-                    theme="dark",
+                    console=console,
                 )
             finally:
                 sys.stdout = original_stdout

--- a/src/soup_cli/commands/runs.py
+++ b/src/soup_cli/commands/runs.py
@@ -565,7 +565,7 @@ def _plot_loss_curve(metrics: list[dict]) -> None:
         title="Training Loss",
         xlabel="Step",
         ylabel="Loss",
-        theme="dark",
+        console=console,
     )
 
 

--- a/src/soup_cli/utils/plotext_compat.py
+++ b/src/soup_cli/utils/plotext_compat.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import re
 from typing import Any
 
 
@@ -9,6 +11,23 @@ def _v6_figure(plotext: Any) -> Any | None:
     """Return plotext 6's figure object, or ``None`` for the 5.x API."""
     figure = getattr(plotext, "figure", None)
     return figure if figure is not None and not callable(figure) else None
+
+
+def _print_chart(plotext: Any, raw: str, console: Any = None) -> None:
+    """Output a rendered chart via the Rich console, stripping escapes when uncolored."""
+    from rich.console import Console
+    from rich.text import Text
+
+    cons = console if console is not None else Console()
+    if "NO_COLOR" in os.environ or cons.no_color or not cons.is_terminal:
+        clean = getattr(plotext, "uncolorize", None)
+        if callable(clean):
+            text_str = clean(raw)
+        else:
+            text_str = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", raw)
+        cons.print(Text(text_str))
+    else:
+        cons.print(Text.from_ansi(raw))
 
 
 def render_histogram(
@@ -19,7 +38,8 @@ def render_histogram(
     title: str,
     xlabel: str,
     ylabel: str,
-    theme: str,
+    theme: str | None = None,
+    console: Any = None,
 ) -> None:
     """Render a histogram with either plotext 5.x or 6.x."""
     figure = _v6_figure(plotext)
@@ -29,17 +49,20 @@ def render_histogram(
         figure.title(title)
         figure.label(xlabel, axis=0)
         figure.label(ylabel, axis=1)
-        figure.theme(theme)
-        figure.show()
-        return
+        if theme is not None:
+            figure.theme(theme)
+        raw = figure.build()
+    else:
+        plotext.clf()
+        plotext.hist(values, bins=bins)
+        plotext.title(title)
+        plotext.xlabel(xlabel)
+        plotext.ylabel(ylabel)
+        if theme is not None:
+            plotext.theme(theme)
+        raw = plotext.build()
 
-    plotext.clf()
-    plotext.hist(values, bins=bins)
-    plotext.title(title)
-    plotext.xlabel(xlabel)
-    plotext.ylabel(ylabel)
-    plotext.theme(theme)
-    plotext.show()
+    _print_chart(plotext, raw, console=console)
 
 
 def render_line(
@@ -51,7 +74,8 @@ def render_line(
     title: str,
     xlabel: str,
     ylabel: str,
-    theme: str,
+    theme: str | None = None,
+    console: Any = None,
 ) -> None:
     """Render a labelled line with either plotext 5.x or 6.x."""
     figure = _v6_figure(plotext)
@@ -62,14 +86,17 @@ def render_line(
         figure.title(title)
         figure.label(xlabel, axis=0)
         figure.label(ylabel, axis=1)
-        figure.theme(theme)
-        figure.show()
-        return
+        if theme is not None:
+            figure.theme(theme)
+        raw = figure.build()
+    else:
+        plotext.clf()
+        plotext.plot(x_values, y_values, label=label)
+        plotext.title(title)
+        plotext.xlabel(xlabel)
+        plotext.ylabel(ylabel)
+        if theme is not None:
+            plotext.theme(theme)
+        raw = plotext.build()
 
-    plotext.clf()
-    plotext.plot(x_values, y_values, label=label)
-    plotext.title(title)
-    plotext.xlabel(xlabel)
-    plotext.ylabel(ylabel)
-    plotext.theme(theme)
-    plotext.show()
+    _print_chart(plotext, raw, console=console)

--- a/tests/test_issue824_plotext_no_color_ansi.py
+++ b/tests/test_issue824_plotext_no_color_ansi.py
@@ -1,0 +1,139 @@
+"""Tests for issue #824: plotext histogram bypasses Rich and emits ANSI escape codes."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from rich.console import Console
+from typer.testing import CliRunner
+
+from soup_cli.cli import app
+from soup_cli.utils.plotext_compat import render_histogram, render_line
+
+runner = CliRunner()
+
+
+def test_cli_runner_captures_histogram_without_ansi(tmp_path: Path) -> None:
+    data_file = tmp_path / "data.jsonl"
+    data_file.write_text(
+        json.dumps({"instruction": "hi", "output": "hello world"}) + "\n"
+        + json.dumps({"instruction": "describe soup", "output": "a fine tool"}) + "\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["data", "stats", str(data_file)])
+    assert result.exit_code == 0
+    # The histogram should now be captured by CliRunner
+    assert "Text Length Distribution" in result.output
+    # Must not contain raw escape bytes
+    assert "\x1b" not in result.output
+
+
+def test_subprocess_data_stats_no_color_has_zero_ansi_escapes(tmp_path: Path) -> None:
+    data_file = tmp_path / "data.jsonl"
+    data_file.write_text(
+        "\n".join(
+            json.dumps({"instruction": f"prompt {i}", "output": f"answer {'x' * (i * 10)}"})
+            for i in range(1, 15)
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    env = {
+        **os.environ,
+        "NO_COLOR": "1",
+        "PYTHONIOENCODING": "utf-8",
+        "PYTHONLEGACYWINDOWSSTDIO": "0",
+    }
+    cmd = [sys.executable, "-m", "soup_cli", "data", "stats", str(data_file)]
+    proc = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        timeout=30,
+    )
+    assert proc.returncode == 0
+    assert b"\x1b" not in proc.stdout
+    decoded = proc.stdout.decode("utf-8", errors="replace")
+    assert "Text Length Distribution" in decoded
+
+
+def test_subprocess_data_stats_redirected_stdout_has_zero_ansi_escapes(tmp_path: Path) -> None:
+    data_file = tmp_path / "data.jsonl"
+    data_file.write_text(
+        json.dumps({"instruction": "q", "output": "a"}) + "\n",
+        encoding="utf-8",
+    )
+
+    env = {
+        **os.environ,
+        "PYTHONIOENCODING": "utf-8",
+        "PYTHONLEGACYWINDOWSSTDIO": "0",
+    }
+    env.pop("NO_COLOR", None)
+
+    cmd = [sys.executable, "-m", "soup_cli", "data", "stats", str(data_file)]
+    proc = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        timeout=30,
+    )
+    assert proc.returncode == 0
+    # Standard output redirected to pipe is not a tty/terminal, so no ANSI codes
+    assert b"\x1b" not in proc.stdout
+    decoded = proc.stdout.decode("utf-8", errors="replace")
+    assert "Text Length Distribution" in decoded
+
+
+def test_plotext_compat_uncolorize_on_non_terminal_console() -> None:
+    import plotext
+
+    buf = io.StringIO()
+    cons = Console(file=buf, force_terminal=False, color_system=None)
+
+    render_histogram(
+        plotext,
+        [10, 20, 30, 40, 50],
+        bins=5,
+        title="Test Distribution",
+        xlabel="Length",
+        ylabel="Count",
+        console=cons,
+    )
+
+    output = buf.getvalue()
+    assert "Test Distribution" in output
+    assert "\x1b" not in output
+
+
+def test_plotext_compat_render_line_uncolorize(monkeypatch: pytest.MonkeyPatch) -> None:
+    import plotext
+
+    buf = io.StringIO()
+    cons = Console(file=buf, force_terminal=True, color_system="standard")
+    monkeypatch.setenv("NO_COLOR", "1")
+
+    render_line(
+        plotext,
+        [1, 2, 3],
+        [1.0, 0.5, 0.2],
+        label="train_loss",
+        title="Loss Curve",
+        xlabel="Step",
+        ylabel="Loss",
+        console=cons,
+    )
+
+    output = buf.getvalue()
+    assert "Loss Curve" in output
+    assert "\x1b" not in output

--- a/tests/test_plotext_compat.py
+++ b/tests/test_plotext_compat.py
@@ -38,6 +38,10 @@ class _Plotext5(_Recorder):
     def theme(self, *args, **kwargs):
         return self._record("theme", *args, **kwargs)
 
+    def build(self):
+        self._record("build")
+        return "mock_chart"
+
     def show(self):
         return self._record("show")
 
@@ -73,6 +77,10 @@ class _Figure6(_Recorder):
 
     def theme(self, *args, **kwargs):
         return self._record("theme", *args, **kwargs)
+
+    def build(self):
+        self._record("build")
+        return "mock_chart"
 
     def show(self):
         return self._record("show")
@@ -113,14 +121,14 @@ def test_plotext5_module_api_remains_supported() -> None:
         "xlabel",
         "ylabel",
         "theme",
-        "show",
+        "build",
         "clf",
         "plot",
         "title",
         "xlabel",
         "ylabel",
         "theme",
-        "show",
+        "build",
     ]
 
 
@@ -155,7 +163,7 @@ def test_plotext6_figure_api_is_used() -> None:
         "label",
         "label",
         "theme",
-        "show",
+        "build",
         "clear",
         "signal",
         "draw",
@@ -163,7 +171,7 @@ def test_plotext6_figure_api_is_used() -> None:
         "label",
         "label",
         "theme",
-        "show",
+        "build",
     ]
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes #824 by ensuring plotext charts rendered in `soup data stats` and `soup runs replay` route through the Rich console and uncolorize when output is redirected or `NO_COLOR` is set:

1. **Rich Console Routing**: Refactored `render_histogram` and `render_line` in `soup_cli.utils.plotext_compat` to call `build()` instead of directly printing via `show()`. Output is passed through the command's Rich `Console`, allowing `CliRunner` and test harnesses to capture output properly.
2. **ANSI Escape Stripping**: Detects `NO_COLOR` in environment, `console.no_color`, or non-terminal redirected output (`not console.is_terminal`), and strips raw ANSI escape codes using `plotext.uncolorize(raw)` with regex fallback.
3. **Avoid Hardcoded Dark Theme Backgrounds**: Dropped hardcoded `theme="dark"` from `data stats` and `runs replay`, avoiding unwanted background paint escape codes (`\x1b[48;5;0m`) when redirecting to files or uncolored terminals.
4. **Regression Tests**:
   - Subprocess test with `NO_COLOR=1` confirming 0 raw ANSI escape bytes in stdout while preserving chart text.
   - Subprocess test with redirected pipe stdout confirming 0 raw ANSI escape bytes.
   - `CliRunner` test confirming chart output is captured without ANSI escapes.
   - Unit tests covering 5.x and 6.x mock doubles and `render_line` / `render_histogram`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Tests

## Checklist

- [x] `ruff check src/soup_cli/ scripts/ tests/` passes
- [x] `pytest tests/ -v` passes
- [x] Added a changelog fragment, or this change has no user-visible impact
