### PR TITLE
feat(recipes): add qwen3.5-0.8b-grpo and qwen3.5-2b-grpo (#848, #275)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ src/soup_cli/
   experiment/         - SQLite experiment tracking
   eval/               - Eval platform (custom tasks, LLM judge, human eval, leaderboard)
   migrate/            - Config migration (LLaMA-Factory, Axolotl, Unsloth)
-  recipes/            - Ready-made configs for popular models (165 recipes)
+  recipes/            - Ready-made configs for popular models (167 recipes)
   autopilot/          - Zero-config decision engine (v0.25.0)
   registry/           - Model Registry (hashing, store, diff, attach) (v0.26.0 + v0.33.0)
   cans/               - Shareable .can artifact format + run/publish orchestrator (v0.26.0 + v0.33.0)

--- a/changelog.d/0.74.0/864.added.md
+++ b/changelog.d/0.74.0/864.added.md
@@ -1,0 +1,7 @@
+- **Added the `qwen3.5-0.8b-grpo` and `qwen3.5-2b-grpo` recipes (#848 by @SID-6921 in
+  #864).**
+  `Qwen/Qwen3.5-0.8B` and `Qwen/Qwen3.5-2B` previously shipped SFT only; both models are
+  small enough that a contributor might actually run a few steps of GRPO reasoning training
+  on their own hardware. Learning rate (`1e-5`), LoRA rank (`r=16`/`alpha=32`), and
+  `max_length: 4096` follow the existing GRPO templates rather than the SFT siblings'
+  values, stated explicitly rather than inherited silently. Catalog count: 165 -> 167.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -152,7 +152,7 @@ soup migrate --from llamafactory config.yaml  Import config from LLaMA-Factory
 soup migrate --from axolotl config.yml        Import config from Axolotl
 soup migrate --from unsloth notebook.ipynb    Import config from Unsloth notebook
 soup migrate --from llamafactory c.yaml --dry-run  Preview without writing
-soup recipes list                             List all 165 ready-made recipes
+soup recipes list                             List all 167 ready-made recipes
 soup recipes show llama3.1-8b-sft            Print recipe YAML
 soup recipes use llama3.1-8b-sft             Copy recipe to soup.yaml
 soup recipes search "reasoning"              Search by keyword/task/size

--- a/docs/serving-and-export.md
+++ b/docs/serving-and-export.md
@@ -546,7 +546,7 @@ soup ui
 
 **Pages:**
 - **Dashboard** — view all experiment runs, loss charts, system info, multi-run comparison
-- **New Training** — create configs from templates or 165 ready-made recipes, validate, start training with live SSE log streaming and progress bar
+- **New Training** — create configs from templates or 167 ready-made recipes, validate, start training with live SSE log streaming and progress bar
 - **Data Explorer** — browse and inspect datasets (JSONL, JSON, CSV, Parquet)
 - **Model Chat** — chat with streaming responses, configurable temperature/top_p/max_tokens, system prompt, adapter selection, markdown rendering, chat export
 
@@ -555,7 +555,7 @@ soup ui
 - **Enhanced Metrics** — 2x2 chart grid (loss, LR, grad_norm, throughput) + GPU memory chart, eval results table
 - **Multi-Run Compare** — overlay loss curves from up to 5 runs side-by-side
 - **Chat Upgrade** — SSE streaming via proxy, typing indicator, cancel button, markdown renderer (bold, italic, code blocks), chat export as JSON
-- **Config Builder** — recipe dropdown (165 recipes), config schema API for dynamic form generation
+- **Config Builder** — recipe dropdown (167 recipes), config schema API for dynamic form generation
 
 **Security:** The Web UI generates a random auth token at startup (printed to console). Every private endpoint — mutating (start/stop training, delete runs, inspect data, validate config) and reading (runs, metrics, system, recipes, SSE streams) — requires an `Authorization: Bearer <token>` header. `/` and `/api/health` stay open so the dashboard can load. CORS is restricted to the served origin. Data inspection is sandboxed to the working directory.
 

--- a/src/soup_cli/recipes/catalog.py
+++ b/src/soup_cli/recipes/catalog.py
@@ -48,7 +48,7 @@ def search_recipes(
 
 
 # ---------------------------------------------------------------------------
-# Recipe catalog (165 recipes)
+# Recipe catalog (167 recipes)
 # ---------------------------------------------------------------------------
 
 RECIPES: Dict[str, RecipeMeta] = {
@@ -3798,6 +3798,39 @@ training:
 output: ./output
 """,
     ),
+    "qwen3.5-0.8b-grpo": RecipeMeta(
+        model="Qwen/Qwen3.5-0.8B",
+        task="grpo",
+        size="0.8B",
+        tags=("qwen", "qwen3.5", "grpo", "reasoning", "thinking", "tiny", "edge", "mobile"),
+        description="Qwen 3.5 0.8B GRPO reasoning training (Apache-2.0, tiny / mobile)",
+        yaml_str="""\
+base: Qwen/Qwen3.5-0.8B
+task: grpo
+modality: text
+
+data:
+  train: ./data/reasoning_train.jsonl
+  format: auto
+  max_length: 4096
+
+training:
+  epochs: 3
+  lr: 1e-5
+  batch_size: auto
+  gradient_accumulation_steps: 8
+  lora:
+    r: 16
+    alpha: 32
+    target_modules: auto
+  quantization: 4bit
+  grpo_beta: 0.1
+  num_generations: 4
+  reward_fn: accuracy
+
+output: ./output
+""",
+    ),
     "qwen3.5-2b-sft": RecipeMeta(
         model="Qwen/Qwen3.5-2B",
         task="sft",
@@ -3823,6 +3856,39 @@ training:
     alpha: 16
     target_modules: auto
   quantization: 4bit
+
+output: ./output
+""",
+    ),
+    "qwen3.5-2b-grpo": RecipeMeta(
+        model="Qwen/Qwen3.5-2B",
+        task="grpo",
+        size="2B",
+        tags=("qwen", "qwen3.5", "grpo", "reasoning", "thinking", "small", "edge"),
+        description="Qwen 3.5 2B GRPO reasoning training (Apache-2.0, small / edge)",
+        yaml_str="""\
+base: Qwen/Qwen3.5-2B
+task: grpo
+modality: text
+
+data:
+  train: ./data/reasoning_train.jsonl
+  format: auto
+  max_length: 4096
+
+training:
+  epochs: 3
+  lr: 1e-5
+  batch_size: auto
+  gradient_accumulation_steps: 8
+  lora:
+    r: 16
+    alpha: 32
+    target_modules: auto
+  quantization: 4bit
+  grpo_beta: 0.1
+  num_generations: 4
+  reward_fn: accuracy
 
 output: ./output
 """,

--- a/tests/fixtures/recipe_config_snapshots.json
+++ b/tests/fixtures/recipe_config_snapshots.json
@@ -1670,6 +1670,17 @@
       "training.lr": 1e-05,
       "training.moe_lora": true
     },
+    "qwen3.5-0.8b-grpo": {
+      "base": "Qwen/Qwen3.5-0.8B",
+      "data.format": "auto",
+      "data.max_length": 4096,
+      "data.train": "./data/reasoning_train.jsonl",
+      "task": "grpo",
+      "training.gradient_accumulation_steps": 8,
+      "training.lora.alpha": 32,
+      "training.lora.r": 16,
+      "training.lr": 1e-05
+    },
     "qwen3.5-0.8b-sft": {
       "base": "Qwen/Qwen3.5-0.8B",
       "data.format": "auto",
@@ -1696,6 +1707,17 @@
       "data.format": "auto",
       "data.max_length": 4096,
       "data.train": "./data/train.jsonl",
+      "training.gradient_accumulation_steps": 8,
+      "training.lora.alpha": 32,
+      "training.lora.r": 16,
+      "training.lr": 1e-05
+    },
+    "qwen3.5-2b-grpo": {
+      "base": "Qwen/Qwen3.5-2B",
+      "data.format": "auto",
+      "data.max_length": 4096,
+      "data.train": "./data/reasoning_train.jsonl",
+      "task": "grpo",
       "training.gradient_accumulation_steps": 8,
       "training.lora.alpha": 32,
       "training.lora.r": 16,

--- a/tests/test_issue427_qwen35_text_modality.py
+++ b/tests/test_issue427_qwen35_text_modality.py
@@ -10,7 +10,9 @@ from soup_cli.recipes.catalog import RECIPES
 
 EXPECTED_QWEN35_TEXT_RECIPES = {
     "qwen3.5-0.8b-sft",
+    "qwen3.5-0.8b-grpo",
     "qwen3.5-2b-sft",
+    "qwen3.5-2b-grpo",
     "qwen3.5-4b-sft",
     "qwen3.5-4b-pretrain",
     "qwen3.5-9b-sft",

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -338,6 +338,87 @@ class TestIssue277Qwen35GrpoRecipe:
         )
 
 
+class TestQwen35SmallGrpoRecipes:
+    """Regression coverage for qwen3.5-0.8b-grpo / qwen3.5-2b-grpo (#848, #275).
+
+    The 0.8B and 2B siblings shipped SFT only; small enough that a contributor
+    might actually run them, unlike most #275 rows. Same two-surface
+    discipline as ``TestDeepSeekV4FlashDpoRecipe``: the model id is pinned on
+    ``RecipeMeta.model`` and on the YAML ``base:`` in two separate tests, so a
+    mutation to either alone names the surface it broke. LR follows the GRPO
+    precedent (1e-5, the majority across existing GRPO recipes) rather than
+    the SFT siblings' 2e-4/3e-4; LoRA r=16/alpha=32 and max_length: 4096
+    follow the GRPO template (``qwen3.5-9b-grpo``), not the SFT siblings'
+    r=8/alpha=16/2048 — reasoning completions run long.
+    """
+
+    RECIPES = {
+        "qwen3.5-0.8b-grpo": "Qwen/Qwen3.5-0.8B",
+        "qwen3.5-2b-grpo": "Qwen/Qwen3.5-2B",
+    }
+
+    @pytest.mark.parametrize("name,model", list(RECIPES.items()))
+    def test_recipe_meta_pins_the_model_id(self, name: str, model: str) -> None:
+        """Surface 1: the catalog metadata, read without touching the YAML."""
+        from soup_cli.recipes.catalog import get_recipe
+
+        recipe = get_recipe(name)
+        assert recipe is not None, f"{name} is missing from the catalog"
+        assert recipe.model == model
+        assert recipe.task == "grpo"
+
+    @pytest.mark.parametrize("name,model", list(RECIPES.items()))
+    def test_yaml_base_pins_the_model_id(self, name: str, model: str) -> None:
+        """Surface 2: the YAML body, parsed directly rather than via ``.model``."""
+        import yaml
+
+        from soup_cli.recipes.catalog import get_recipe
+
+        recipe = get_recipe(name)
+        assert recipe is not None
+        parsed = yaml.safe_load(recipe.yaml_str)
+        assert parsed["base"] == model
+        assert parsed["task"] == "grpo"
+
+    @pytest.mark.parametrize("name,model", list(RECIPES.items()))
+    def test_recipe_loads_with_expected_grpo_shape(self, name: str, model: str) -> None:
+        from soup_cli.config.loader import load_config_from_string
+        from soup_cli.recipes.catalog import get_recipe
+
+        recipe = get_recipe(name)
+        assert recipe is not None
+
+        config = load_config_from_string(recipe.yaml_str)
+        assert config.base == model
+        assert config.task == "grpo"
+        assert config.training.grpo_beta == 0.1
+        assert config.training.num_generations == 4
+        assert config.training.reward_fn == "accuracy"
+        assert config.training.quantization == "4bit"
+        assert config.training.lora.r == 16
+        assert config.training.lora.alpha == 32
+        assert config.training.gradient_accumulation_steps == 8
+        assert config.data.train == "./data/reasoning_train.jsonl"
+        assert config.data.max_length == 4096
+
+    @pytest.mark.parametrize("name,model", list(RECIPES.items()))
+    def test_show_and_use_recipe(
+        self,
+        name: str,
+        model: str,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        show_result = runner.invoke(app, ["recipes", "show", name])
+        assert show_result.exit_code == 0
+        assert model in show_result.output
+
+        monkeypatch.chdir(tmp_path)
+        use_result = runner.invoke(app, ["recipes", "use", name, "--yes"])
+        assert use_result.exit_code == 0
+        assert model in (tmp_path / "soup.yaml").read_text(encoding="utf-8")
+
+
 class TestIssue280Glm51DpoRecipe:
     """Regression coverage for the glm-5.1-dpo recipe."""
 
@@ -933,7 +1014,7 @@ class TestV025NewRecipes:
             assert cfg.base == recipe.model
             assert cfg.task == recipe.task
 
-    def test_catalog_size_is_165(self):
+    def test_catalog_size_is_167(self):
         """Total catalog size — grew with each release.
 
         v0.25.0 shipped 43 recipes (29 + 9 Part A + 2 Part B tools + 3 Part E MLX).
@@ -962,10 +1043,11 @@ class TestV025NewRecipes:
         Task-variant for #275 added 1 (glm-5.1-grpo) -> 163.
         Task-variant for #275 added 1 (deepseek-v4-flash-dpo) -> 164.
         Task-variant for #275 added 1 (kimi-k2.6-dpo) -> 165.
+        Task-variant for #275 added 2 (qwen3.5-0.8b-grpo, qwen3.5-2b-grpo) -> 167.
         """
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 165
+        assert len(RECIPES) == 167
 
     def test_new_recipes_searchable(self):
         """Search returns the new recipes via keyword/task filter."""

--- a/tests/test_v07124.py
+++ b/tests/test_v07124.py
@@ -274,11 +274,11 @@ class TestCatalogCount:
 
         It had drifted through 116 -> 134 -> 137 -> 158 -> 162 without the name
         following, so the one thing a reader saw first was the one thing that
-        was false. The count itself is pinned by `test_catalog_size_is_165` in
+        was false. The count itself is pinned by `test_catalog_size_is_167` in
         `test_recipes.py` and by `test_recipe_count_is_synced.py`; this row is
         the milestone file's own copy and does not need the number twice.
         """
-        assert len(RECIPES) == 165
+        assert len(RECIPES) == 167
 
     def test_list_recipes_matches_dict(self) -> None:
         assert len(list_recipes()) == len(RECIPES)

--- a/tests/test_v07130.py
+++ b/tests/test_v07130.py
@@ -737,10 +737,10 @@ class TestRecipes:
         assert cfg.training.rollout_backend == "openenv"
         assert cfg.training.rollout_func.startswith("soup_cli.envs.")
 
-    def test_catalog_size_is_165(self):
+    def test_catalog_size_is_167(self):
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 165
+        assert len(RECIPES) == 167
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_v07132.py
+++ b/tests/test_v07132.py
@@ -950,7 +950,7 @@ class TestAsrRecipes:
         assert cfg.task == "sft"
         assert cfg.modality == "vision"
 
-    def test_catalog_size_is_165(self):
+    def test_catalog_size_is_167(self):
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 165
+        assert len(RECIPES) == 167


### PR DESCRIPTION
## Summary

Closes #848 (part of #275). Adds `qwen3.5-0.8b-grpo` and `qwen3.5-2b-grpo` to the catalog — `Qwen/Qwen3.5-0.8B` and `Qwen/Qwen3.5-2B` currently ship SFT only. Both are small enough that a contributor might actually run a few steps on their own hardware, which the issue flags as the most useful rows in this part of the tracker.

## Base repos

Checked 2026-09-11 with `huggingface_hub.model_info(..., token=False)`, not an HTTP status (#661): both resolve, are not gated, and report `model_type: qwen3_5` — same as the SFT siblings and the existing `qwen3.5-9b-grpo` template.

## Decisions made explicitly, not inherited silently

- **`lr: 1e-5`** — the majority convention across the 23 existing GRPO recipes (16 use `1e-5`), not the SFT siblings' `2e-4`/`3e-4`. Copying the SFT rate into a GRPO recipe would be an outlier by more than an order of magnitude.
- **LoRA `r=16`/`alpha=32`** — matching the GRPO templates (`qwen3.5-9b-grpo`, `r1-distill-qwen-1.5b-grpo`), not the SFT siblings' `r=8`/`alpha=16`.
- **`max_length: 4096`** — matching the GRPO templates, not the SFT siblings' `2048`. Reasoning completions run long.

## Ratchets covered

- `RecipeMeta` entries with tags following the SFT siblings plus `grpo`/`reasoning`.
- Both added to `EXPECTED_QWEN35_TEXT_RECIPES` (#427's explicit-modality contract) — the family audit fails otherwise.
- Model id pinned on two independent surfaces (`RecipeMeta.model` and YAML `base:`), each by its own test, mirroring `TestDeepSeekV4FlashDpoRecipe`.
- Catalog count bumped 165 → 167 at every site: `catalog.py`'s own comment, all four `test_catalog_size_is_N` milestone checkpoints (renamed to `_167`, new history line added), and all four documentation sites `test_recipe_count_is_synced.py` scans for (`CONTRIBUTING.md`, `docs/commands.md`, `docs/serving-and-export.md` ×2).
- `scripts/generate_recipe_snapshot.py` run last: purely additive diff (22 insertions, 0 deletions) against the delta-encoded fixture.
- `soup recipes show` / `use` run live for both — output below.

## Live output

```
$ soup recipes show qwen3.5-0.8b-grpo
┌─ qwen3.5-0.8b-grpo -- Qwen 3.5 0.8B GRPO reasoning training (Apache-2.0, tiny / mobile) ─┐
│ base: Qwen/Qwen3.5-0.8B                                                                  │
│ task: grpo
│ ...
│ training:
│   lr: 1e-5
│   lora: {r: 16, alpha: 32}
│   grpo_beta: 0.1
│   num_generations: 4
│   reward_fn: accuracy
└───────────────────────────────────────────────────────────────────────────────────────────┘

$ soup recipes use qwen3.5-0.8b-grpo --yes
✓ Recipe qwen3.5-0.8b-grpo written to soup.yaml
Next: soup train --config soup.yaml
```

Same shape for `qwen3.5-2b-grpo`, base swapped to `Qwen/Qwen3.5-2B`.

## Verification

- 678 tests pass across the affected files (`test_recipes.py`, `test_issue427_qwen35_text_modality.py`, `test_recipe_count_is_synced.py`, `test_v07124/07130/07132.py`, `test_issue621_recipe_snapshot.py`), 1 pre-existing unrelated skip.
- `ruff check` and `mypy` both clean.
- **Mutation**: broke `RecipeMeta.model` on one recipe — caught by name by `test_recipe_meta_pins_the_model_id` alone. Reverted, then broke the YAML `base:` line instead — caught by three further tests (the YAML pin, the shape test, and the live show/use test), none of which depend on `RecipeMeta.model`. Reverted after confirming both.
- Live HF Hub check via `huggingface_hub.model_info` for both base repos (not an HTTP ping) — output above.

## A note on mutations, per the issue's own instruction

`grpo_beta: 0.1`, `num_generations: 4`, `reward_fn: accuracy`, `epochs: 3`, `batch_size: auto` all equal their schema defaults — verified directly against `TrainingConfig()`, not assumed. Deleting any of them from the YAML is an equivalent mutation. Reporting them as survivors rather than treating it as a test gap, since it's inherent to a pinned value happening to match the default.

## Not run here

No GPU smoke run — optional per the issue, not required for merge. Happy to add one if useful, but didn't want to present a few local CPU-only steps as a tuned recommendation.
