### PR TITLE
fix(serve): stop the vLLM backend from sending the engine a doubled BOS (#785 part 2)

### DIFF
--- a/changelog.d/0.74.0/867.fixed.md
+++ b/changelog.d/0.74.0/867.fixed.md
@@ -1,0 +1,15 @@
+- **`soup serve --backend vllm` no longer sends the engine a doubled BOS (#785 part 2 by @abdulwaarith0 in #867).**
+  #782 fixed every path that tokenizes in process, and left the engines that
+  tokenize the prompt string themselves for someone with the hardware to check.
+  Measured on vLLM 0.29.0 with `unsloth/Llama-3.2-1B-Instruct`, whose Llama-3
+  template renders `{{ bos_token }}` (id 128000): for the string Soup sent, the
+  engine reported `prompt_token_ids[:2] == [128000, 128000]` over 37 ids, against
+  the 36 ids `apply_chat_template(tokenize=True)` returns. The vLLM backend now
+  hands the engine `{"prompt_token_ids": [...]}` built with no tokenizer special
+  tokens whenever the chat template rendered the prompt, which reproduced the
+  36-id encoding exactly (`[128000, 128006]`), so the model is prompted with the
+  prefix Soup trains on. `usage.prompt_tokens` drops by one on such templates.
+  Models without a chat template, and templates that fail to render, still send
+  the legacy string and are tokenized by the engine exactly as before. The
+  SGLang and DeepSpeed-MII backends were measured through their own tokenizer
+  paths and are tracked separately in #785.

--- a/changelog.d/0.75.0/867.fixed.md
+++ b/changelog.d/0.75.0/867.fixed.md
@@ -9,6 +9,10 @@
   tokens whenever the chat template rendered the prompt, which reproduced the
   36-id encoding exactly (`[128000, 128006]`), so the model is prompted with the
   prefix Soup trains on. `usage.prompt_tokens` drops by one on such templates.
+  The change is wider than removing a duplicate: for a model whose chat template
+  renders no BOS but whose tokenizer post-processor would add one, the engine
+  previously received one BOS and now receives zero, matching Soup's training
+  path and the in-process fix #782 already shipped for the transformers backend.
   Models without a chat template, and templates that fail to render, still send
   the legacy string and are tokenized by the engine exactly as before. The
   SGLang and DeepSpeed-MII backends were measured through their own tokenizer

--- a/docs/serving-and-export.md
+++ b/docs/serving-and-export.md
@@ -281,9 +281,11 @@ soup serve --model ./output --backend vllm --max-model-len 8192
 > **Tip:** Soup auto-detects vLLM. When installed, you'll see a hint during `soup serve` if you haven't enabled it yet.
 
 The vLLM backend applies the **model's own chat template**, exactly like the
-transformers backend — both call one shared prompt builder. A model that ships
-no chat template falls back to a generic `User:` / `Assistant:` prompt, and the
-server says so at startup. `finish_reason` reports `"length"` when a response
+transformers backend, and encodes the rendered prompt itself so the engine
+receives the same token ids Soup trains on rather than re-tokenizing the string.
+(The SGLang and MII backends still hand the engine the rendered string; see
+#785.) A model that ships no chat template falls back to a generic `User:` /
+`Assistant:` prompt, and the server says so at startup. `finish_reason` reports `"length"` when a response
 hits `max_tokens` and `"stop"` otherwise (`/v1/messages` maps those to
 `max_tokens` / `end_turn`).
 

--- a/src/soup_cli/utils/vllm.py
+++ b/src/soup_cli/utils/vllm.py
@@ -101,8 +101,8 @@ def build_chat_prompt(messages, tokenizer=None) -> str:
     format only when it does not (or when no tokenizer could be loaded).
 
     In-process callers must not hand the result to a bare ``tokenizer(...)``
-    call; use :func:`encode_chat_prompt` (#781). The vLLM engine tokenizes this
-    string itself.
+    call; use :func:`encode_chat_prompt` (#781). Backends whose engine would
+    tokenize this string itself use :func:`build_engine_prompt` (#785).
 
     Args:
         messages: chat messages — pydantic objects or dicts.
@@ -144,6 +144,37 @@ def encode_chat_prompt(
         messages, tokenizer, fallback_on_error=fallback_on_error
     )
     return encode_rendered_prompt(tokenizer, text, templated=templated, **tokenizer_kwargs)
+
+
+def build_engine_prompt(
+    messages: Any, tokenizer: Any = None
+) -> tuple[str, Optional[list[int]]]:
+    """Render chat messages for a backend that tokenizes the prompt itself (#785).
+
+    The vLLM, SGLang and MII backends hand the engine a prompt STRING, and the
+    engine encodes it with its tokenizer's default ``add_special_tokens=True``.
+    A template that renders ``{{ bos_token }}`` therefore reached the model with
+    two of them. Measured on vLLM 0.29.0 + ``unsloth/Llama-3.2-1B-Instruct``
+    (``bos_token_id`` 128000): for the string Soup sends today the engine
+    reported ``prompt_token_ids[:2] == [128000, 128000]`` over 37 ids, against
+    the 36 ids ``apply_chat_template(tokenize=True)`` returns. Handing the
+    engine these ids instead reproduced that 36-id encoding exactly.
+
+    #782 fixed the same defect for every path that tokenizes in process; this is
+    the same rule for the paths that do not, so the chat template stays the
+    single source of the model's special tokens.
+
+    Returns:
+        ``(text, token_ids)``. ``token_ids`` is what to send the engine in place
+        of ``text``, and is None when no template rendered the prompt: the
+        legacy role-prefixed fallback carries no special tokens of its own, so
+        the engine must keep adding its own exactly as it always has.
+    """
+    text, templated = _render_chat_prompt(messages, tokenizer, fallback_on_error=True)
+    if not templated:
+        return text, None
+    encoded = encode_rendered_prompt(tokenizer, text, templated=True)
+    return text, list(encoded["input_ids"])
 
 
 def resolve_finish_reason(output: Any, max_tokens: Optional[int]) -> str:
@@ -392,7 +423,15 @@ def create_vllm_app(
 
         # #332 — the model's OWN chat template, shared with the transformers
         # backend. The pre-fix hand-rolled prompt made chat-tuned models loop.
-        prompt = build_chat_prompt(request.messages, tokenizer)
+        # #785: and send the ids, not the string, whenever that template
+        # rendered the prompt: vLLM tokenizes a string prompt with its own
+        # add_special_tokens=True, which put a second BOS in front of the one
+        # the template had already rendered. A TokensPrompt is a plain
+        # ``{"prompt_token_ids": [...]}`` mapping, so no vLLM import is needed.
+        prompt, prompt_token_ids = build_engine_prompt(request.messages, tokenizer)
+        engine_prompt: Any = (
+            prompt if prompt_token_ids is None else {"prompt_token_ids": prompt_token_ids}
+        )
 
         sampling_params = SamplingParams(
             temperature=request.temperature,
@@ -415,7 +454,7 @@ def create_vllm_app(
             return StreamingResponse(
                 _stream_vllm_response(
                     engine=engine,
-                    prompt=prompt,
+                    prompt=engine_prompt,
                     sampling_params=sampling_params,
                     request_id=request_id,
                     model_name=model_name,
@@ -431,7 +470,7 @@ def create_vllm_app(
             stack.enter_context(metrics.track_request())
             try:
                 results_generator = engine.generate(
-                    prompt, sampling_params, request_id, **generate_kwargs
+                    engine_prompt, sampling_params, request_id, **generate_kwargs
                 )
                 final_output = None
                 async for request_output in results_generator:
@@ -484,7 +523,7 @@ def create_vllm_app(
 
     async def _stream_vllm_response(
         engine,
-        prompt: str,
+        prompt: Any,
         sampling_params,
         request_id: str,
         model_name: str,

--- a/tests/test_issue332_vllm_prompt.py
+++ b/tests/test_issue332_vllm_prompt.py
@@ -287,12 +287,19 @@ class TestVllmAppPrompt:
         return capture, resp.json()
 
     def test_engine_receives_the_templated_prompt(self):
+        """Since #785 the engine gets the templated prompt as token ids rather
+        than text, so vLLM's own tokenizer cannot add a second BOS to it. The
+        #332 invariant is unchanged: those ids encode the model's own template,
+        not the hand-rolled prompt."""
         tok = _tokenizer(_CHATML)
         capture, _ = self._post(tok)
 
-        assert capture["prompt"] == tok.apply_chat_template(
+        templated = tok.apply_chat_template(
             _MESSAGES, tokenize=False, add_generation_prompt=True
         )
+        assert capture["prompt"] == {
+            "prompt_token_ids": tok(templated, add_special_tokens=False)["input_ids"]
+        }
 
     def test_control_engine_receives_legacy_prompt_without_a_template(self):
         capture, _ = self._post(_tokenizer(None))

--- a/tests/test_issue785_engine_bos.py
+++ b/tests/test_issue785_engine_bos.py
@@ -1,0 +1,337 @@
+"""#785 part 2: the backends that let the ENGINE tokenize the rendered prompt.
+
+#782 fixed every path that tokenizes in process: they render the chat template
+and then encode with ``add_special_tokens=False``. It deliberately left the
+backends that hand an inference engine a prompt STRING alone, because nobody had
+the hardware to check what those engines' own tokenizers do with it.
+
+Measured on an RTX 3060 (WSL2) with ``unsloth/Llama-3.2-1B-Instruct``, whose
+Llama-3 template renders ``{{- bos_token }}`` and whose ``bos_token_id`` is
+128000. One request, ``messages=[{"role": "user", "content": "Hi"}]``:
+
+=================  ==========================  ===============================
+engine             what Soup sent              engine ``prompt_token_ids[:2]``
+=================  ==========================  ===============================
+vLLM 0.29.0        the rendered string         ``[128000, 128000]``  (37 ids)
+vLLM 0.29.0        ``{"prompt_token_ids":..}`` ``[128000, 128006]``  (36 ids)
+SGLang 0.5.9 (*)   the rendered string         ``[128000, 128000]``  (37 ids)
+MII 0.3.3 (*)      the rendered string         ``[128000, 128000]``  (37 ids)
+=================  ==========================  ===============================
+
+(*) through the engine's own tokenizer path (SGLang's ``TokenizerManager``
+call, MII's ``HFTokenizer.encode``) on the real tokenizer; the GPU engine
+itself could not be started on that box. The vLLM rows are from a running
+engine's ``RequestOutput.prompt_token_ids``.
+
+36 ids with ``[128000, 128006]`` is exactly what
+``apply_chat_template(tokenize=True)`` returns, and exactly the prefix
+``data/loss_mask.py`` trains on. So the string prompt really did put a second
+BOS in front of the one the template had already rendered, and sending the ids
+really does remove it. This PR fixes the vLLM backend; SGLang and MII are
+measured here and split out, per the issue.
+
+The tokenizers below are real ``transformers`` fast tokenizers built offline
+from an in-memory vocab, so ``apply_chat_template`` is the genuine Jinja
+renderer and the BOS comes from a genuine ``tokenizers`` post-processor. The
+engines are stand-ins that record what they were handed; the GPU measurement
+above is what says a real engine tokenizes a string this way; these tests pin
+that Soup stops handing it one.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_SPECIALS = ["<unk>", "<s>", "</s>", "<|user|>", "<|assistant|>", "<|end|>"]
+_WORDS = ["You", "are", "terse", ".", "What", "is", "the", "capital", "of", "France", "?",
+          "System", "User", "Assistant", ":"]
+_BOS_ID = _SPECIALS.index("<s>")
+
+# The vendor shape this issue is about (Llama-3, Gemma, Mistral): the template
+# renders BOS itself, and the tokenizer's post-processor would add another.
+_BOS_TEMPLATE = (
+    "{{ bos_token }}"
+    "{% for m in messages %}<|{{ m['role'] }}|> {{ m['content'] }} <|end|> {% endfor %}"
+    "{% if add_generation_prompt %}<|assistant|>{% endif %}"
+)
+
+_SYSTEM = {"role": "system", "content": "You are terse."}
+_USER = {"role": "user", "content": "What is the capital of France?"}
+_MESSAGES = [_SYSTEM, _USER]
+
+_LEGACY = "System: You are terse.\nUser: What is the capital of France?\nAssistant:"
+
+
+def _tokenizer(chat_template, *, post_processor="bos"):
+    """A real fast tokenizer whose post-processor prepends ``<s>``."""
+    transformers = pytest.importorskip("transformers")
+    tokenizers = pytest.importorskip("tokenizers")
+    from tokenizers import models, pre_tokenizers, processors
+
+    vocab = {token: index for index, token in enumerate(_SPECIALS + _WORDS)}
+    backend = tokenizers.Tokenizer(models.WordLevel(vocab=vocab, unk_token="<unk>"))
+    backend.pre_tokenizer = pre_tokenizers.Whitespace()
+    backend.add_special_tokens(_SPECIALS)
+    if post_processor == "bos":
+        backend.post_processor = processors.TemplateProcessing(
+            single="<s> $A", special_tokens=[("<s>", _BOS_ID)]
+        )
+    tok = transformers.PreTrainedTokenizerFast(
+        tokenizer_object=backend, unk_token="<unk>", bos_token="<s>", eos_token="</s>"
+    )
+    tok.chat_template = chat_template
+    return tok
+
+
+def _engine_would_send(tok, text):
+    """What an engine that tokenizes the string itself builds from ``text``.
+
+    This is the pre-fix encoding: the engine's tokenizer with its own default
+    ``add_special_tokens=True``, which is what vLLM was measured doing.
+    """
+    return tok(text)["input_ids"]
+
+
+def _hf_prompt_ids(tok, messages):
+    """HF's own one-step encoding, the reference the fix has to reproduce."""
+    return list(
+        tok.apply_chat_template(
+            messages, tokenize=True, add_generation_prompt=True, return_dict=False
+        )
+    )
+
+
+# ============================================================
+# The shared builder
+# ============================================================
+
+
+class TestBuildEnginePrompt:
+    def test_the_fixture_reproduces_the_doubled_bos(self):
+        """CONTROL for this whole file: on this fixture an engine that tokenizes
+        the rendered string really does produce two BOS. Without it, a
+        post-processor that silently added nothing would let every assertion
+        below pass vacuously."""
+        tok = _tokenizer(_BOS_TEMPLATE)
+        text = tok.apply_chat_template(_MESSAGES, tokenize=False, add_generation_prompt=True)
+
+        assert _engine_would_send(tok, text)[:2] == [_BOS_ID, _BOS_ID]
+
+    def test_a_rendered_prompt_yields_ids_with_exactly_one_bos(self):
+        from soup_cli.utils.vllm import build_engine_prompt
+
+        tok = _tokenizer(_BOS_TEMPLATE)
+
+        _, ids = build_engine_prompt(_MESSAGES, tok)
+
+        assert ids[0] == _BOS_ID
+        assert ids.count(_BOS_ID) == 1
+
+    def test_the_ids_equal_hf_apply_chat_template_with_tokenize_true(self):
+        """The same invariant #782 pinned for the in-process paths: what the
+        engine receives must be what HF's one-step encoding produces."""
+        from soup_cli.utils.vllm import build_engine_prompt
+
+        tok = _tokenizer(_BOS_TEMPLATE)
+
+        _, ids = build_engine_prompt(_MESSAGES, tok)
+
+        assert ids == _hf_prompt_ids(tok, _MESSAGES)
+
+    def test_the_text_is_still_exactly_what_build_chat_prompt_renders(self):
+        """The fix changes how the prompt is ENCODED, never how it is rendered.
+        #332's template choice has to survive it untouched."""
+        from soup_cli.utils.vllm import build_chat_prompt, build_engine_prompt
+
+        tok = _tokenizer(_BOS_TEMPLATE)
+
+        text, _ = build_engine_prompt(_MESSAGES, tok)
+
+        assert text == build_chat_prompt(_MESSAGES, tok)
+
+    def test_a_soup_preset_is_prompted_with_no_bos_at_all(self):
+        """Soup's own ``data.chat_template`` presets render no BOS, and training
+        adds none, so an adapter trained under one never saw a BOS. The engine
+        was adding one anyway.
+
+        This is the case that separates the invariant from "drop a duplicate
+        BOS": that rule would leave this prompt with a BOS training never had."""
+        from soup_cli.data.chat_templates import apply_chat_template_override
+        from soup_cli.utils.vllm import build_engine_prompt
+
+        tok = _tokenizer(None)
+        apply_chat_template_override(tok, "llama3")
+        text = tok.apply_chat_template(_MESSAGES, tokenize=False, add_generation_prompt=True)
+        assert not text.startswith("<s>")
+        assert _engine_would_send(tok, text)[0] == _BOS_ID  # the defect, on the preset
+
+        _, ids = build_engine_prompt(_MESSAGES, tok)
+
+        assert _BOS_ID not in ids
+        assert ids == _hf_prompt_ids(tok, _MESSAGES)
+
+    def test_control_a_tokenizer_that_adds_nothing_gets_the_same_ids_as_before(self):
+        """CONTROL: with no post-processor there was never a defect here, so
+        the fix must not move a single id."""
+        from soup_cli.utils.vllm import build_engine_prompt
+
+        tok = _tokenizer(_BOS_TEMPLATE, post_processor=None)
+        text = tok.apply_chat_template(_MESSAGES, tokenize=False, add_generation_prompt=True)
+
+        _, ids = build_engine_prompt(_MESSAGES, tok)
+
+        assert ids == _engine_would_send(tok, text)
+
+    @pytest.mark.parametrize(
+        ("tokenizer_kind", "reason"),
+        [("none", "no tokenizer could be loaded"), ("no_template", "the model ships none")],
+        ids=["no-tokenizer", "no-template"],
+    )
+    def test_control_no_template_sends_the_legacy_string_and_no_ids(
+        self, tokenizer_kind, reason
+    ):
+        """CONTROL: the legacy role-prefixed fallback carries no special tokens
+        of its own, so the engine must go on adding its own. ``None`` ids is how
+        each backend knows to send the string, exactly as it always did."""
+        from soup_cli.utils.vllm import build_engine_prompt
+
+        tok = None if tokenizer_kind == "none" else _tokenizer(None)
+
+        text, ids = build_engine_prompt(_MESSAGES, tok)
+
+        assert text == _LEGACY, reason
+        assert ids is None, reason
+
+    def test_a_broken_template_falls_back_to_the_legacy_string(self):
+        """The flag has to mean "the template rendered this text", not "the
+        tokenizer has a template". The fallback text never went through the
+        template, so the engine's own BOS is the only one it should get."""
+        from soup_cli.utils.vllm import build_engine_prompt
+
+        tok = _tokenizer("{{ this_is_not_defined.boom() }}")
+
+        text, ids = build_engine_prompt(_MESSAGES, tok)
+
+        assert text == _LEGACY
+        assert ids is None
+
+
+# ============================================================
+# The vLLM backend, the engine this was measured on
+# ============================================================
+
+
+class _FakeOutput:
+    def __init__(self, text=" Paris.", token_ids=(1, 2, 3)):
+        self.text = text
+        self.token_ids = list(token_ids)
+        self.finish_reason = "stop"
+
+
+class _FakeRequestOutput:
+    def __init__(self, output, prompt_token_ids=(1, 2, 3)):
+        self.outputs = [output]
+        self.prompt_token_ids = list(prompt_token_ids)
+
+
+def _vllm_client(tokenizer, capture):
+    pytest.importorskip("fastapi", reason="the [serve] extra is optional")
+    from fastapi.testclient import TestClient
+
+    engine = MagicMock()
+
+    def _generate(prompt, sampling_params, request_id, **kwargs):
+        capture["prompt"] = prompt
+
+        async def _gen():
+            yield _FakeRequestOutput(_FakeOutput())
+
+        return _gen()
+
+    engine.generate = _generate
+
+    vllm_stub = MagicMock()
+    vllm_stub.SamplingParams = MagicMock()
+    with patch.dict(
+        sys.modules,
+        {"vllm": vllm_stub, "vllm.lora": MagicMock(), "vllm.lora.request": MagicMock()},
+    ):
+        from soup_cli.utils.vllm import create_vllm_app
+
+        app = create_vllm_app(
+            engine=engine,
+            engine_model_name="test-model",
+            model_name="test-model",
+            max_tokens_default=128,
+            tokenizer=tokenizer,
+        )
+    return TestClient(app)
+
+
+def _post(client, stream=False):
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": _MESSAGES,
+            "max_tokens": 16,
+            "stream": stream,
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response
+
+
+class TestVllmBackend:
+    @pytest.mark.parametrize("stream", [False, True], ids=["non-streaming", "streaming"])
+    def test_the_engine_is_handed_token_ids_not_a_string(self, stream):
+        """Both routes reach the same ``engine.generate``; a fix on one only
+        would leave the other sending the doubled prompt."""
+        tok = _tokenizer(_BOS_TEMPLATE)
+        capture = {}
+
+        _post(_vllm_client(tok, capture), stream=stream)
+
+        assert capture["prompt"] == {"prompt_token_ids": _hf_prompt_ids(tok, _MESSAGES)}
+
+    @pytest.mark.parametrize("stream", [False, True], ids=["non-streaming", "streaming"])
+    def test_what_the_engine_receives_carries_exactly_one_bos(self, stream):
+        tok = _tokenizer(_BOS_TEMPLATE)
+        capture = {}
+
+        _post(_vllm_client(tok, capture), stream=stream)
+
+        ids = capture["prompt"]["prompt_token_ids"]
+
+        assert ids[0] == _BOS_ID
+        assert ids.count(_BOS_ID) == 1
+
+    def test_control_the_string_the_engine_used_to_get_had_two(self):
+        """CONTROL: the assertion above is only a finding because the prompt
+        this backend sent before really did tokenize to two BOS."""
+        tok = _tokenizer(_BOS_TEMPLATE)
+        from soup_cli.utils.vllm import build_chat_prompt
+
+        sent_before = build_chat_prompt(_MESSAGES, tok)
+
+        assert _engine_would_send(tok, sent_before)[:2] == [_BOS_ID, _BOS_ID]
+
+    @pytest.mark.parametrize("stream", [False, True], ids=["non-streaming", "streaming"])
+    def test_control_a_model_with_no_template_still_gets_the_legacy_string(self, stream):
+        """CONTROL: nothing rendered special tokens, so the engine keeps
+        tokenizing the string exactly as it always has."""
+        capture = {}
+
+        _post(_vllm_client(_tokenizer(None), capture), stream=stream)
+
+        assert capture["prompt"] == _LEGACY
+
+    def test_usage_still_reports_the_prompt_length_the_engine_reports(self):
+        """The engine keeps reporting ``prompt_token_ids`` for a tokens prompt,
+        so the token accounting in the response must not change shape."""
+        tok = _tokenizer(_BOS_TEMPLATE)
+
+        body = _post(_vllm_client(tok, {})).json()
+
+        assert body["usage"]["prompt_tokens"] == 3  # len(_FakeRequestOutput ids)


### PR DESCRIPTION
fix(serve): stop the vLLM backend from sending the engine a doubled BOS (#785 part 2)

Part 2 of #785. Part 1 (#788) covers training; #782 covered every path that
tokenizes in process. This is the in-engine backends, which hand the engine a
prompt string and let the engine tokenize it.

## The question, answered by running the engines

Does the engine's own tokenizer add a second BOS on top of the one the chat
template rendered? Measured on an RTX 3060 Laptop (6 GB, WSL2) with
`unsloth/Llama-3.2-1B-Instruct`, whose Llama-3 template renders
`{{- bos_token }}` and whose `bos_token_id` is 128000. One request,
`messages=[{"role": "user", "content": "Hi"}]`. For reference,
`apply_chat_template(tokenize=True)` gives 36 ids starting `[128000, 128006]`.

| engine | what Soup sends | engine `prompt_token_ids[:2]` | ids | verdict |
|---|---|---|---|---|
| vLLM 0.29.0 | rendered string (`build_chat_prompt`) | `[128000, 128000]` | 37 | doubled |
| vLLM 0.29.0 | `{"prompt_token_ids": [...]}` (this PR) | `[128000, 128006]` | 36 | single, equals HF |
| DeepSpeed-MII 0.3.3 | rendered string, via MII's own `HFTokenizer.encode` | `[128000, 128000]` | 37 | doubled |
| SGLang 0.5.9 | rendered string, via SGLang's own `TokenizerManager` tokenize call | `[128000, 128000]` | 37 | doubled |

vLLM numbers come from `RequestOutput.prompt_token_ids` on a real
`vllm.LLM` (the "before" row from `build_chat_prompt`, the "after" row from
the new `build_engine_prompt`, both through the real engine).

MII numbers come from executing `mii.modeling.tokenizers.HFTokenizer.encode`
on the real tokenizer. That is the exact call `MIIPipeline._put_request` makes
for every request (`self.tokenizer.encode(input)` ->
`tokenizer.encode(input, return_tensors="pt")`, default
`add_special_tokens=True`). The full MII engine could not be started on this
box: DeepSpeed's inference ops need a CUDA toolkit to JIT and there is no
`nvcc` here.

SGLang numbers come from executing the call `TokenizerManager._tokenize_texts`
makes for a text request (`self.tokenizer(tokenizer_input, **{})`, default
`add_special_tokens=True`) with SGLang's own `get_tokenizer()` on the real
model. The full SGLang engine could not be started here either: three
attempts (default, `disable_cuda_graph`, `attention_backend=triton` +
`sampling_backend=pytorch`) each stopped on a component needing `nvcc`.

## The fix (vLLM)

`build_engine_prompt(messages, tokenizer)` in `utils/vllm.py` renders the
template exactly as `build_chat_prompt` does, then encodes with
`add_special_tokens=False` through #782's `encode_rendered_prompt`, and
returns `(text, ids)`. `ids` is `None` when no template rendered the prompt
(no tokenizer, no template, or a template that failed to render), so those
cases keep sending the legacy string and the engine keeps tokenizing it
exactly as before.

The vLLM backend now hands `engine.generate` a `{"prompt_token_ids": ids}`
mapping (vLLM's `TokensPrompt` is a plain TypedDict, so no new import) on both
the streaming and non-streaming routes. `usage.prompt_tokens` drops by one on
templates that render BOS, as it did in #782 for the in-process paths.

## SGLang and MII: measured doubled, fix routes checked, split out

#785 offers two fix routes per engine: hand the engine token ids, or its
"no special tokens" option. Both were checked against the installed versions.

**SGLang 0.5.9**
- Token ids: `TokenizerManager._tokenize_one_request` uses `obj.input_ids`
  verbatim when a request carries them, so the ids route exists at the
  `/generate` endpoint. But `sgl.Runtime.generate`, which `utils/sglang.py`
  calls, has no `input_ids` parameter; it posts `{"text": prompt}`. Reaching
  the route means posting to `runtime.url + "/generate"` directly or moving to
  `sgl.Engine` (whose `generate` does take `input_ids`).
- No special tokens: `GenerateReqInput` has no `add_special_tokens` field,
  `ServerArgs` has no such flag, and the text path calls
  `self.tokenizer(tokenizer_input, **{})`. There is no such option.

**DeepSpeed-MII 0.3.3**
- Token ids: `MIIPipeline.__call__(prompts: str | list[str], **generate_kwargs)`
  takes strings only; `GenerateParamsConfig` has no tokenization field.
- No special tokens: `HFTokenizer.encode` hardcodes
  `tokenizer.encode(input, return_tensors="pt")`. `ModelConfig.tokenizer` is
  typed `str | MIITokenizerWrapper`, which looks like the lever, but executing
  it shows `load_tokenizer` re-wraps whatever it is given in `HFTokenizer`, so a
  wrapper overriding `encode(input)` gets called as
  `encode(input, return_tensors="pt")` and raises
  `TypeError: unexpected keyword argument 'return_tensors'`. The route is not
  usable without patching MII's own tokenizer object.

Neither engine could be started on this machine (no CUDA toolkit; vLLM ran
once its flashinfer sampler was switched off, SGLang and MII have no such
switch for the components that need `nvcc`), so a fix for either could not be
verified end to end here the way the vLLM one was. Rather than ship them
unmeasured, this PR records the measurements and the fix routes, and leaves
each engine to a follow-up; the maintainer's "split if hardware is the
blocker" applied one level deeper. If that deferral is acceptable, I can open
one tracking issue per engine carrying the numbers and the route above
(SGLang: post `input_ids` to `/generate` or move to `sgl.Engine`; MII: needs
an upstream change or a patched tokenizer object), so #785 can close on this
PR and #788 with the engine work tracked where someone with the hardware can
pick it up.

## Tests

`tests/test_issue785_engine_bos.py`, in the shape of
`test_issue781_inference_bos.py`: real fast tokenizers built offline from an
in-memory vocab, a template that renders `{{ bos_token }}`, a post-processor
that prepends BOS, and a control proving the fixture really doubles when the
string is tokenized. 17 tests; 12 fail on `main` (`build_engine_prompt` does
not exist, and the vLLM app hands the engine a string).

`test_issue332_vllm_prompt.py::test_engine_receives_the_templated_prompt`
is updated to assert the templated prompt's ids rather than its text; the #332
invariant (the model's own template, not the hand-rolled prompt) is unchanged.

Mutations, each run against this file plus `test_issue332_vllm_prompt.py`
with the function kept but broken (all killed): encoding the rendered text with
the tokenizer's default `add_special_tokens=True` fails 7; the app ignoring the
ids and sending the string fails 5; inverting the `templated` guard (ids for
the legacy fallback, string for the template) fails 15; never returning `None`
so the legacy fallback loses the engine's BOS fails 6; only the streaming route
sending the string fails 2; only the non-streaming route fails 3; dropping the
leading id from what the engine gets fails 5; raising on a broken template
instead of falling back fails 1.

`ruff check` clean. Full `pytest`: 20978 passed, 61 skipped; the only failures
are `test_issue385_stream_dtype.py::TestFloat16StreamingIsBitExact::*[nf4]`,
which fail identically on a clean `main` checkout on this GPU (nf4 stream vs
resident differ by 4.9e-4 / 3.9e-3, unrelated to this change).
