### PR TITLE
fix(data): reject an unknown --format on soup data validate (#866)

### DIFF
--- a/changelog.d/0.74.0/869.fixed.md
+++ b/changelog.d/0.74.0/869.fixed.md
@@ -1,0 +1,9 @@
+- **`soup data validate --format` accepted any string and reported every row valid for it
+  (#866 by @SID-6921 in #869).**
+  `commands/data.py` declared `fmt: str` with help text listing the real formats but never
+  checked the value against `soup_cli.data.formats.VALID_FORMATS` before `validate_and_stats`
+  ran, so `--format bogus` exited 0 and reported "2/2 rows valid for bogus format". Since
+  `soup data validate` is the first step of the PR gate `soup ci init` writes, a typo'd
+  `--format` in a CI workflow silently turned the gate into a pass for any file — the same
+  class of silent pass #811 and #858 just closed for "0 usable rows". An unknown format now
+  exits 1 (input error), not the failed-gate exit code 2.

--- a/src/soup_cli/commands/data.py
+++ b/src/soup_cli/commands/data.py
@@ -96,6 +96,16 @@ def validate(
         console.print(f"[red]File not found: {file_path}[/]")
         raise typer.Exit(1)
 
+    if fmt != "auto":
+        from soup_cli.data.formats import VALID_FORMATS
+
+        if fmt not in VALID_FORMATS:
+            console.print(
+                f"[red]Unknown --format: {fmt!r}[/]\n"
+                f"Accepted: auto, {', '.join(VALID_FORMATS)}"
+            )
+            raise typer.Exit(1)
+
     data = load_raw_data(file_path)
 
     # Auto-detect format if not specified

--- a/tests/test_issue811_data_validate_exit_codes.py
+++ b/tests/test_issue811_data_validate_exit_codes.py
@@ -10,6 +10,7 @@ from click.testing import Result
 from typer.testing import CliRunner
 
 from soup_cli.cli import app
+from soup_cli.data.formats import VALID_FORMATS
 
 from .conftest import strip_ansi
 
@@ -95,3 +96,43 @@ def test_validate_keeps_input_errors_at_exit_one(tmp_path: Path) -> None:
 
     assert undetectable.exit_code == 1
     assert "Cannot detect format" in strip_ansi(undetectable.output)
+
+
+def test_validate_rejects_an_unknown_format(tmp_path: Path) -> None:
+    """#866: --format accepted any string and reported every row valid for
+    it. An unknown format is an input error (exit 1), not the failed-gate
+    exit code (2) #858 settled on for '0 usable rows' -- the two must stay
+    distinguishable so a CI gate can tell a typo'd flag from real bad data."""
+    path = tmp_path / "two_alpaca_rows.jsonl"
+    _write_alpaca(
+        path,
+        [
+            {"instruction": "Summarize this", "output": "A summary long enough"},
+            {"instruction": "Another one", "output": "Another summary here"},
+        ],
+    )
+
+    result = CliRunner().invoke(
+        app, ["data", "validate", str(path), "--format", "bogus"]
+    )
+    output = strip_ansi(result.output)
+
+    assert result.exit_code == 1, output
+    assert "bogus" in output
+    assert "alpaca" in output  # names at least one accepted format
+
+
+@pytest.mark.parametrize("fmt", VALID_FORMATS)
+def test_validate_still_accepts_every_valid_format(tmp_path: Path, fmt: str) -> None:
+    """The guard above must reject unknown values without narrowing what
+    was already accepted. Rows need not be semantically valid for every
+    format here -- only that --format itself is not rejected before
+    validate_and_stats ever runs."""
+    path = tmp_path / "rows.jsonl"
+    path.write_text('{"anything": "goes"}\n', encoding="utf-8")
+
+    result = CliRunner().invoke(
+        app, ["data", "validate", str(path), "--format", fmt]
+    )
+
+    assert "Unknown --format" not in strip_ansi(result.output), result.output


### PR DESCRIPTION
## Summary

Closes #866. `soup data validate` accepted any string for `--format` and reported every row valid in that "format" — exit 0, no error:

```
$ soup data validate two_alpaca_rows.jsonl --format bogus
Issues found:
  ! 2 samples are very short (<10 chars)

2/2 rows valid for bogus format
```

`commands/data.py` declared `fmt: str` with help text listing the real formats but never checked the value against `soup_cli.data.formats.VALID_FORMATS` before `validate_and_stats` ran.

## Why it matters

`soup data validate` is the first step of the PR gate `soup ci init` writes. A typo'd `--format` in a CI workflow (`--format sharegtp`) silently turned the gate into a pass for any file — the same class of silent pass #811 and #858 just closed for "0 usable rows".

## Fix

Validates `--format` against `VALID_FORMATS` (plus `auto`) right after the existing file-exists check, matching the same ordering and message style the `convert` command already uses for `--to` in the same file. A manual check, not `click.Choice`, so an unknown format exits **1** (input error) rather than colliding with the failed-gate exit code **2** that #858 settled on.

```
$ soup data validate two_alpaca_rows.jsonl --format bogus
Unknown --format: 'bogus'
Accepted: auto, chatml, alpaca, sharegpt, dpo, kto, llava, sharegpt4v, plaintext, embedding, audio, tool-calling, prm, pre_tokenized, input_output, video, multimodal, raft, asr
$ echo $?
1
```

## Verification

- `test_validate_rejects_an_unknown_format` — the new failure case, exit 1, message names the bad value and at least one accepted format.
- `test_validate_still_accepts_every_valid_format` — parametrized over every entry in `VALID_FORMATS`, so the guard can't be satisfied by rejecting everything.
- **Mutation**: reverted the guard and confirmed the new test reproduces the exact reported symptom (`exit 0`, `"2/2 rows valid for bogus format"`) before restoring.
- 24 tests pass in `test_issue811_data_validate_exit_codes.py` (18 new parametrized + 6 existing, all still green).
- `ruff check` clean. `mypy`: same 2 pre-existing errors as the unmodified file (confirmed via `git stash`), unrelated to this change and far from the edited lines.

## Not done here

`download_dataset` and `register_data` (same file) have their own, differently-scoped `--format` options with the same unchecked shape. Left alone — out of scope for this issue, which is specifically about `soup data validate`.
