### PR TITLE
feat(recipes): add kimi-k2.5-dpo and kimi-k2.5-grpo recipes (#851)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ src/soup_cli/
   experiment/         - SQLite experiment tracking
   eval/               - Eval platform (custom tasks, LLM judge, human eval, leaderboard)
   migrate/            - Config migration (LLaMA-Factory, Axolotl, Unsloth)
-  recipes/            - Ready-made configs for popular models (167 recipes)
+  recipes/            - Ready-made configs for popular models (169 recipes)
   autopilot/          - Zero-config decision engine (v0.25.0)
   registry/           - Model Registry (hashing, store, diff, attach) (v0.26.0 + v0.33.0)
   cans/               - Shareable .can artifact format + run/publish orchestrator (v0.26.0 + v0.33.0)

--- a/changelog.d/0.75.0/872.added.md
+++ b/changelog.d/0.75.0/872.added.md
@@ -1,0 +1,7 @@
+- **Added ready-made `kimi-k2.5-dpo` and `kimi-k2.5-grpo` recipes for moonshotai/Kimi-K2.5
+  (#275 by @Areen-09 in #872).** Completes the task trio for the base model,
+  mirroring the Kimi-K2.6 DPO and GRPO architectures over the ~1T MoE geometry
+  (LoRA r32/a64 for DPO, r16/a32 for GRPO, 4-bit quantization, `moe_lora`,
+  `gradient_checkpointing`, `max_length: 8192`). The recipes are not trained — ~1T MoE
+  requires multi-node DeepSpeed — so hyperparameters are inherited from K2.6 templates
+  rather than tuned for K2.5. Catalog count 167 -> 169.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -152,7 +152,7 @@ soup migrate --from llamafactory config.yaml  Import config from LLaMA-Factory
 soup migrate --from axolotl config.yml        Import config from Axolotl
 soup migrate --from unsloth notebook.ipynb    Import config from Unsloth notebook
 soup migrate --from llamafactory c.yaml --dry-run  Preview without writing
-soup recipes list                             List all 167 ready-made recipes
+soup recipes list                             List all 169 ready-made recipes
 soup recipes show llama3.1-8b-sft            Print recipe YAML
 soup recipes use llama3.1-8b-sft             Copy recipe to soup.yaml
 soup recipes search "reasoning"              Search by keyword/task/size

--- a/docs/serving-and-export.md
+++ b/docs/serving-and-export.md
@@ -546,7 +546,7 @@ soup ui
 
 **Pages:**
 - **Dashboard** — view all experiment runs, loss charts, system info, multi-run comparison
-- **New Training** — create configs from templates or 167 ready-made recipes, validate, start training with live SSE log streaming and progress bar
+- **New Training** — create configs from templates or 169 ready-made recipes, validate, start training with live SSE log streaming and progress bar
 - **Data Explorer** — browse and inspect datasets (JSONL, JSON, CSV, Parquet)
 - **Model Chat** — chat with streaming responses, configurable temperature/top_p/max_tokens, system prompt, adapter selection, markdown rendering, chat export
 
@@ -555,7 +555,7 @@ soup ui
 - **Enhanced Metrics** — 2x2 chart grid (loss, LR, grad_norm, throughput) + GPU memory chart, eval results table
 - **Multi-Run Compare** — overlay loss curves from up to 5 runs side-by-side
 - **Chat Upgrade** — SSE streaming via proxy, typing indicator, cancel button, markdown renderer (bold, italic, code blocks), chat export as JSON
-- **Config Builder** — recipe dropdown (167 recipes), config schema API for dynamic form generation
+- **Config Builder** — recipe dropdown (169 recipes), config schema API for dynamic form generation
 
 **Security:** The Web UI generates a random auth token at startup (printed to console). Every private endpoint — mutating (start/stop training, delete runs, inspect data, validate config) and reading (runs, metrics, system, recipes, SSE streams) — requires an `Authorization: Bearer <token>` header. `/` and `/api/health` stay open so the dashboard can load. CORS is restricted to the served origin. Data inspection is sandboxed to the working directory.
 

--- a/src/soup_cli/recipes/catalog.py
+++ b/src/soup_cli/recipes/catalog.py
@@ -48,7 +48,7 @@ def search_recipes(
 
 
 # ---------------------------------------------------------------------------
-# Recipe catalog (167 recipes)
+# Recipe catalog (169 recipes)
 # ---------------------------------------------------------------------------
 
 RECIPES: Dict[str, RecipeMeta] = {
@@ -4580,6 +4580,79 @@ training:
   quantization: 4bit
   moe_lora: true
   moe_aux_loss_coeff: 0.01
+  gradient_checkpointing: true
+
+output: ./output
+""",
+    ),
+    "kimi-k2.5-dpo": RecipeMeta(
+        model="moonshotai/Kimi-K2.5",
+        task="dpo",
+        size="1T",
+        tags=("kimi", "moonshot", "dpo", "alignment", "preference", "moe", "large", "multi-gpu"),
+        description=(
+            "Kimi K2.5 MoE DPO alignment (Modified MIT, ~1T / 32B active). "
+            "Requires multi-node DeepSpeed."
+        ),
+        yaml_str="""\
+base: moonshotai/Kimi-K2.5
+task: dpo
+
+data:
+  train: ./data/preference_train.jsonl
+  format: dpo
+  max_length: 8192
+
+training:
+  epochs: 1
+  lr: 5e-6
+  batch_size: 1
+  gradient_accumulation_steps: 16
+  lora:
+    r: 32
+    alpha: 64
+    target_modules: auto
+  quantization: 4bit
+  dpo_beta: 0.1
+  moe_lora: true
+  moe_aux_loss_coeff: 0.01
+  gradient_checkpointing: true
+
+output: ./output
+""",
+    ),
+    "kimi-k2.5-grpo": RecipeMeta(
+        model="moonshotai/Kimi-K2.5",
+        task="grpo",
+        size="1T",
+        tags=("kimi", "moonshot", "grpo", "reasoning", "moe", "large", "multi-gpu"),
+        description=(
+            "Kimi K2.5 MoE GRPO reasoning (Modified MIT, ~1T / 32B active). "
+            "Requires multi-node DeepSpeed."
+        ),
+        yaml_str="""\
+base: moonshotai/Kimi-K2.5
+task: grpo
+
+data:
+  train: ./data/reasoning_train.jsonl
+  format: auto
+  max_length: 8192
+
+training:
+  epochs: 3
+  lr: 1e-5
+  batch_size: 1
+  gradient_accumulation_steps: 16
+  lora:
+    r: 16
+    alpha: 32
+    target_modules: auto
+  quantization: 4bit
+  grpo_beta: 0.1
+  num_generations: 4
+  reward_fn: accuracy
+  moe_lora: true
   gradient_checkpointing: true
 
 output: ./output

--- a/tests/fixtures/recipe_config_snapshots.json
+++ b/tests/fixtures/recipe_config_snapshots.json
@@ -799,6 +799,35 @@
       "training.lr": 5e-06,
       "training.verifiable_domain": "math"
     },
+    "kimi-k2.5-dpo": {
+      "base": "moonshotai/Kimi-K2.5",
+      "data.format": "dpo",
+      "data.max_length": 8192,
+      "data.train": "./data/preference_train.jsonl",
+      "task": "dpo",
+      "training.batch_size": 1,
+      "training.epochs": 1,
+      "training.gradient_accumulation_steps": 16,
+      "training.gradient_checkpointing": true,
+      "training.lora.alpha": 64,
+      "training.lora.r": 32,
+      "training.lr": 5e-06,
+      "training.moe_lora": true
+    },
+    "kimi-k2.5-grpo": {
+      "base": "moonshotai/Kimi-K2.5",
+      "data.format": "auto",
+      "data.max_length": 8192,
+      "data.train": "./data/reasoning_train.jsonl",
+      "task": "grpo",
+      "training.batch_size": 1,
+      "training.gradient_accumulation_steps": 16,
+      "training.gradient_checkpointing": true,
+      "training.lora.alpha": 32,
+      "training.lora.r": 16,
+      "training.lr": 1e-05,
+      "training.moe_lora": true
+    },
     "kimi-k2.5-sft": {
       "base": "moonshotai/Kimi-K2.5",
       "data.format": "auto",

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -904,6 +904,192 @@ class TestKimiK26DpoRecipe:
         assert self.MODEL in (tmp_path / "soup.yaml").read_text(encoding="utf-8")
 
 
+class TestKimiK25DpoRecipe:
+    """Coverage for the kimi-k2.5-dpo recipe (#275 / #851 task-variant).
+
+    Kimi-K2.5 shipped SFT (v0.71.24); this adds the direct preference
+    optimization (DPO) shape. The model id is pinned on two independent
+    surfaces — ``RecipeMeta.model`` and the YAML ``base:`` — in two
+    separate tests.
+    """
+
+    RECIPE = "kimi-k2.5-dpo"
+    MODEL = "moonshotai/Kimi-K2.5"
+
+    def test_recipe_meta_pins_the_model_id(self) -> None:
+        """Surface 1: the catalog metadata, read without touching the YAML."""
+        from soup_cli.recipes.catalog import get_recipe
+
+        recipe = get_recipe(self.RECIPE)
+        assert recipe is not None, f"{self.RECIPE} is missing from the catalog"
+        assert recipe.model == self.MODEL
+        assert recipe.task == "dpo"
+        assert recipe.size == "1T"
+        assert "dpo" in recipe.tags
+        assert "Modified MIT" in recipe.description
+
+    def test_yaml_base_pins_the_model_id(self) -> None:
+        """Surface 2: the YAML body, parsed directly rather than via ``.model``."""
+        import yaml
+
+        from soup_cli.recipes.catalog import get_recipe
+
+        recipe = get_recipe(self.RECIPE)
+        assert recipe is not None
+        parsed = yaml.safe_load(recipe.yaml_str)
+        assert parsed["base"] == self.MODEL
+        assert parsed["task"] == "dpo"
+
+    def test_recipe_loads_with_expected_dpo_moe_shape(self) -> None:
+        """The loaded config, verified through schema validation."""
+        from soup_cli.config.loader import load_config_from_string
+        from soup_cli.recipes.catalog import get_recipe
+
+        recipe = get_recipe(self.RECIPE)
+        assert recipe is not None
+        config = load_config_from_string(recipe.yaml_str)
+
+        assert config.base == self.MODEL
+        assert config.task == "dpo"
+        assert config.data.train == "./data/preference_train.jsonl"
+        assert config.data.format == "dpo"
+        assert config.data.max_length == 8192
+        assert config.training.epochs == 1
+        assert config.training.dpo_beta == 0.1
+        assert config.training.lr == 5e-6
+        assert config.training.batch_size == 1
+        assert config.training.gradient_accumulation_steps == 16
+        assert config.training.lora.r == 32
+        assert config.training.lora.alpha == 64
+        assert config.training.quantization == "4bit"
+        assert config.training.moe_lora is True
+        assert config.training.moe_aux_loss_coeff == 0.01
+        assert config.training.gradient_checkpointing is True
+
+    def test_completes_the_task_trio_for_this_base(self) -> None:
+        """#275 is about DPO/GRPO/pretrain variants of the shipped SFT recipes."""
+        from soup_cli.recipes.catalog import RECIPES
+
+        tasks = {r.task for r in RECIPES.values() if r.model == self.MODEL}
+        assert {"sft", "grpo", "dpo"} <= tasks
+
+    def test_shares_base_and_size_with_its_sft_sibling(self) -> None:
+        from soup_cli.recipes.catalog import get_recipe
+
+        dpo, sft = get_recipe(self.RECIPE), get_recipe("kimi-k2.5-sft")
+        assert dpo is not None and sft is not None
+        assert dpo.model == sft.model
+        assert dpo.size == sft.size
+        assert dpo.task != sft.task
+
+    def test_show_and_use_recipe(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        show_result = runner.invoke(app, ["recipes", "show", self.RECIPE])
+        assert show_result.exit_code == 0
+        assert self.MODEL in strip_ansi(show_result.output)
+
+        monkeypatch.chdir(tmp_path)
+        use_result = runner.invoke(app, ["recipes", "use", self.RECIPE, "--yes"])
+        assert use_result.exit_code == 0
+        assert self.MODEL in (tmp_path / "soup.yaml").read_text(encoding="utf-8")
+
+
+class TestKimiK25GrpoRecipe:
+    """Coverage for the kimi-k2.5-grpo recipe (#275 / #851 task-variant).
+
+    Kimi-K2.5 shipped SFT (v0.71.24); this adds the Group Relative Policy
+    Optimization (GRPO) reasoning shape. The model id is pinned on two independent
+    surfaces — ``RecipeMeta.model`` and the YAML ``base:`` — in two separate tests.
+    """
+
+    RECIPE = "kimi-k2.5-grpo"
+    MODEL = "moonshotai/Kimi-K2.5"
+
+    def test_recipe_meta_pins_the_model_id(self) -> None:
+        """Surface 1: the catalog metadata, read without touching the YAML."""
+        from soup_cli.recipes.catalog import get_recipe
+
+        recipe = get_recipe(self.RECIPE)
+        assert recipe is not None, f"{self.RECIPE} is missing from the catalog"
+        assert recipe.model == self.MODEL
+        assert recipe.task == "grpo"
+        assert recipe.size == "1T"
+        assert "grpo" in recipe.tags
+        assert "Modified MIT" in recipe.description
+
+    def test_yaml_base_pins_the_model_id(self) -> None:
+        """Surface 2: the YAML body, parsed directly rather than via ``.model``."""
+        import yaml
+
+        from soup_cli.recipes.catalog import get_recipe
+
+        recipe = get_recipe(self.RECIPE)
+        assert recipe is not None
+        parsed = yaml.safe_load(recipe.yaml_str)
+        assert parsed["base"] == self.MODEL
+        assert parsed["task"] == "grpo"
+
+    def test_recipe_loads_with_expected_grpo_moe_shape(self) -> None:
+        """The loaded config, verified through schema validation."""
+        from soup_cli.config.loader import load_config_from_string
+        from soup_cli.recipes.catalog import get_recipe
+
+        recipe = get_recipe(self.RECIPE)
+        assert recipe is not None
+        config = load_config_from_string(recipe.yaml_str)
+
+        assert config.base == self.MODEL
+        assert config.task == "grpo"
+        assert config.data.train == "./data/reasoning_train.jsonl"
+        assert config.data.format == "auto"
+        assert config.data.max_length == 8192
+        assert config.training.epochs == 3
+        assert config.training.lr == 1e-5
+        assert config.training.batch_size == 1
+        assert config.training.gradient_accumulation_steps == 16
+        assert config.training.lora.r == 16
+        assert config.training.lora.alpha == 32
+        assert config.training.quantization == "4bit"
+        assert config.training.grpo_beta == 0.1
+        assert config.training.num_generations == 4
+        assert config.training.reward_fn == "accuracy"
+        assert config.training.moe_lora is True
+        assert config.training.gradient_checkpointing is True
+
+    def test_completes_the_task_trio_for_this_base(self) -> None:
+        """#275 is about DPO/GRPO/pretrain variants of the shipped SFT recipes."""
+        from soup_cli.recipes.catalog import RECIPES
+
+        tasks = {r.task for r in RECIPES.values() if r.model == self.MODEL}
+        assert {"sft", "grpo", "dpo"} <= tasks
+
+    def test_shares_base_and_size_with_its_sft_sibling(self) -> None:
+        from soup_cli.recipes.catalog import get_recipe
+
+        grpo, sft = get_recipe(self.RECIPE), get_recipe("kimi-k2.5-sft")
+        assert grpo is not None and sft is not None
+        assert grpo.model == sft.model
+        assert grpo.size == sft.size
+        assert grpo.task != sft.task
+
+    def test_show_and_use_recipe(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        show_result = runner.invoke(app, ["recipes", "show", self.RECIPE])
+        assert show_result.exit_code == 0
+        assert self.MODEL in strip_ansi(show_result.output)
+
+        monkeypatch.chdir(tmp_path)
+        use_result = runner.invoke(app, ["recipes", "use", self.RECIPE, "--yes"])
+        assert use_result.exit_code == 0
+        assert self.MODEL in (tmp_path / "soup.yaml").read_text(encoding="utf-8")
+
+
 class TestQwen35NineBDpoRecipe:
     """Coverage for the qwen3.5-9b-dpo recipe (#275 task-variant)."""
 
@@ -1014,7 +1200,7 @@ class TestV025NewRecipes:
             assert cfg.base == recipe.model
             assert cfg.task == recipe.task
 
-    def test_catalog_size_is_167(self):
+    def test_catalog_size_is_169(self):
         """Total catalog size — grew with each release.
 
         v0.25.0 shipped 43 recipes (29 + 9 Part A + 2 Part B tools + 3 Part E MLX).
@@ -1044,10 +1230,11 @@ class TestV025NewRecipes:
         Task-variant for #275 added 1 (deepseek-v4-flash-dpo) -> 164.
         Task-variant for #275 added 1 (kimi-k2.6-dpo) -> 165.
         Task-variant for #275 added 2 (qwen3.5-0.8b-grpo, qwen3.5-2b-grpo) -> 167.
+        Task-variant for #275 / #851 added 2 (kimi-k2.5-dpo, kimi-k2.5-grpo) -> 169.
         """
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 167
+        assert len(RECIPES) == 169
 
     def test_new_recipes_searchable(self):
         """Search returns the new recipes via keyword/task filter."""

--- a/tests/test_v07124.py
+++ b/tests/test_v07124.py
@@ -274,11 +274,11 @@ class TestCatalogCount:
 
         It had drifted through 116 -> 134 -> 137 -> 158 -> 162 without the name
         following, so the one thing a reader saw first was the one thing that
-        was false. The count itself is pinned by `test_catalog_size_is_167` in
+        was false. The count itself is pinned by `test_catalog_size_is_169` in
         `test_recipes.py` and by `test_recipe_count_is_synced.py`; this row is
         the milestone file's own copy and does not need the number twice.
         """
-        assert len(RECIPES) == 167
+        assert len(RECIPES) == 169
 
     def test_list_recipes_matches_dict(self) -> None:
         assert len(list_recipes()) == len(RECIPES)

--- a/tests/test_v07130.py
+++ b/tests/test_v07130.py
@@ -737,10 +737,10 @@ class TestRecipes:
         assert cfg.training.rollout_backend == "openenv"
         assert cfg.training.rollout_func.startswith("soup_cli.envs.")
 
-    def test_catalog_size_is_167(self):
+    def test_catalog_size_is_169(self):
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 167
+        assert len(RECIPES) == 169
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_v07132.py
+++ b/tests/test_v07132.py
@@ -950,7 +950,7 @@ class TestAsrRecipes:
         assert cfg.task == "sft"
         assert cfg.modality == "vision"
 
-    def test_catalog_size_is_167(self):
+    def test_catalog_size_is_169(self):
         from soup_cli.recipes.catalog import RECIPES
 
-        assert len(RECIPES) == 167
+        assert len(RECIPES) == 169


### PR DESCRIPTION
## What does this PR do?

Closes #851 (parent tracking #275).

Adds two ready-made recipes for `moonshotai/Kimi-K2.5` to `src/soup_cli/recipes/catalog.py`:
- `kimi-k2.5-dpo`: Direct preference optimization variant (`task: dpo`, `lr: 5e-6`, `dpo_beta: 0.1`, `moe_aux_loss_coeff: 0.01`, LoRA r=32 / alpha=64).
- `kimi-k2.5-grpo`: Group relative policy optimization reasoning variant (`task: grpo`, `epochs: 3`, `lr: 1e-5`, `grpo_beta: 0.1`, `num_generations: 4`, `reward_fn: accuracy`, LoRA r=16 / alpha=32).

This completes the task trio (`sft`, `dpo`, `grpo`) for the Kimi-K2.5 base model alongside the existing `kimi-k2.5-sft`. Both recipes mirror their Kimi-K2.6 counterparts (`kimi-k2.6-dpo` from #664, `kimi-k2.6-grpo` from #614) over the shared ~1T MoE geometry (`max_length: 8192`, `batch_size: 1`, `gradient_accumulation_steps: 16`, `quantization: 4bit`, `moe_lora: true`, `gradient_checkpointing: true`).

### Key Ratchets & Invariants Passed:
1. **Dual-Surface Model ID Pinning**: In `tests/test_recipes.py`, `TestKimiK25DpoRecipe` and `TestKimiK25GrpoRecipe` pin `RecipeMeta.model` (Surface 1) and YAML `base:` (Surface 2) with independent unit tests. Tested locally: mutating Surface 1 fails only `test_recipe_meta_pins_the_model_id`, and mutating Surface 2 fails only `test_yaml_base_pins_the_model_id`.
2. **Catalog Count Synchronized (165 -> 167)**: Updated across all 9 locations:
   - Documentation & module sites: `src/soup_cli/recipes/catalog.py:51`, `CONTRIBUTING.md:126`, `docs/commands.md:155`, `docs/serving-and-export.md:549`, and `docs/serving-and-export.md:558` (verified by `tests/test_recipe_count_is_synced.py`).
   - Milestone test assertion sites: `tests/test_recipes.py:1120`, `tests/test_v07130.py:740`, `tests/test_v07132.py:953`, and `tests/test_v07124.py:277-281`.
3. **Snapshot Fixture**: Regenerated `tests/fixtures/recipe_config_snapshots.json` with `python scripts/generate_recipe_snapshot.py`; diff is strictly additive (adding only `kimi-k2.5-dpo` and `kimi-k2.5-grpo` deltas). `tests/test_issue621_recipe_snapshot.py` passes 171/171.
4. **Changelog Fragment**: Added `changelog.d/0.74.0/851.added.md`.

---

### Live CLI Invocations

#### `soup recipes show kimi-k2.5-dpo`
```yaml
┌─ kimi-k2.5-dpo -- Kimi K2.5 MoE DPO alignment (Modified MIT, ~1T / 32B acti─┐
│ base: moonshotai/Kimi-K2.5                                                  │
│ task: dpo                                                                   │
│                                                                             │
│ data:                                                                       │
│   train: ./data/preference_train.jsonl                                      │
│   format: dpo                                                               │
│   max_length: 8192                                                          │
│                                                                             │
│ training:                                                                   │
│   epochs: 1                                                                 │
│   lr: 5e-6                                                                  │
│   batch_size: 1                                                             │
│   gradient_accumulation_steps: 16                                           │
│   lora:                                                                     │
│     r: 32                                                                   │
│     alpha: 64                                                               │
│     target_modules: auto                                                    │
│   quantization: 4bit                                                        │
│   dpo_beta: 0.1                                                             │
│   moe_lora: true                                                            │
│   moe_aux_loss_coeff: 0.01                                                  │
│   gradient_checkpointing: true                                              │
│                                                                             │
│ output: ./output                                                            │
│                                                                             │
└─────────────────────────────────────────────────────────────────────────────┘
```

#### `soup recipes show kimi-k2.5-grpo`
```yaml
┌─ kimi-k2.5-grpo -- Kimi K2.5 MoE GRPO reasoning (Modified MIT, ~1T / 32B ac─┐
│ base: moonshotai/Kimi-K2.5                                                  │
│ task: grpo                                                                  │
│                                                                             │
│ data:                                                                       │
│   train: ./data/reasoning_train.jsonl                                       │
│   format: auto                                                              │
│   max_length: 8192                                                          │
│                                                                             │
│ training:                                                                   │
│   epochs: 3                                                                 │
│   lr: 1e-5                                                                  │
│   batch_size: 1                                                             │
│   gradient_accumulation_steps: 16                                           │
│   lora:                                                                     │
│     r: 16                                                                   │
│     alpha: 32                                                               │
│     target_modules: auto                                                    │
│   quantization: 4bit                                                        │
│   grpo_beta: 0.1                                                            │
│   num_generations: 4                                                        │
│   reward_fn: accuracy                                                       │
│   moe_lora: true                                                            │
│   gradient_checkpointing: true                                              │
│                                                                             │
│ output: ./output                                                            │
│                                                                             │
└─────────────────────────────────────────────────────────────────────────────┘
```

#### `soup recipes use`
```bash
$ soup recipes use kimi-k2.5-dpo --yes
✓ Recipe kimi-k2.5-dpo written to soup.yaml
Next: soup train --config soup.yaml

$ soup recipes use kimi-k2.5-grpo --yes
✓ Recipe kimi-k2.5-grpo written to soup.yaml
Next: soup train --config soup.yaml
```

---

### Equivalent Mutation Survivors
The following fields equal their schema defaults, so omitting any of them from the YAML string resolves to byte-identical `SoupConfig` objects (equivalent mutations):
- `dpo_beta: 0.1` (in `kimi-k2.5-dpo`)
- `moe_aux_loss_coeff: 0.01` (in `kimi-k2.5-dpo`)
- `grpo_beta: 0.1` (in `kimi-k2.5-grpo`)
- `num_generations: 4` (in `kimi-k2.5-grpo`)
- `reward_fn: accuracy` (in `kimi-k2.5-grpo`)
- `epochs: 3` (in `kimi-k2.5-grpo`)

They are retained explicitly to mirror the corresponding K2.6 templates.

### Honest Limits
A ~1T parameter MoE model is not trainable on single-machine/CI environments and requires multi-node DeepSpeed. Hyperparameters are inherited from the existing K2.6 templates and have not been independently tuned on K2.5.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests

## Checklist

- [x] `ruff check src/soup_cli/ scripts/ tests/` passes
- [x] `pytest tests/ -v` passes
- [x] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed
- [x] Added a changelog fragment, or this change has no user-visible impact
