### PR TITLE
fix(doctor): name missing [train] packages on a partial stack

### DIFF
--- a/changelog.d/0.75.0/884.fixed.md
+++ b/changelog.d/0.75.0/884.fixed.md
@@ -1,0 +1,3 @@
+- **`soup doctor` names missing `[train]` packages on a partial stack (#884, #875).**
+  A six-of-seven install no longer prints "Training stack not installed".
+  Contributed by Harsh Raj Singhania.

--- a/src/soup_cli/commands/doctor.py
+++ b/src/soup_cli/commands/doctor.py
@@ -238,10 +238,15 @@ def doctor(
             if extra_name == "train":
                 driver = _nvidia_smi_cuda_version()
                 torch_missing = "torch" in missing_pkgs
+                # Single call site, gated on torch itself being missing.
+                tag = (
+                    _torch_cuda_wheel_tag(driver)
+                    if driver is not None and torch_missing
+                    else None
+                )
+                url = f"https://download.pytorch.org/whl/{tag}" if tag else None
                 if all_missing:
-                    if driver is not None:
-                        tag = _torch_cuda_wheel_tag(driver)
-                        url = f"https://download.pytorch.org/whl/{tag}"
+                    if url is not None:
                         # ``--index-url`` replaces PyPI, so torch must come from the
                         # CUDA wheel index in its own step; the ``[train]`` extra is
                         # then resolved against PyPI with torch already satisfied.
@@ -255,9 +260,7 @@ def doctor(
                         issues.append(
                             'Training stack not installed: pip install "soup-cli[train]"'
                         )
-                elif driver is not None and torch_missing:
-                    tag = _torch_cuda_wheel_tag(driver)
-                    url = f"https://download.pytorch.org/whl/{tag}"
+                elif url is not None:
                     issues.append(
                         f"Training stack incomplete, missing: {missing_list}\n"
                         f"  pip install torch --index-url {url}\n"

--- a/src/soup_cli/commands/doctor.py
+++ b/src/soup_cli/commands/doctor.py
@@ -205,7 +205,7 @@ def doctor(
     # extra, so the suggestion keeps the declared ceilings and the platform
     # torch index instead of bare per-package floors.
     for extra_name, members in EXTRA_GROUPS:
-        group_missing = False
+        missing_pkgs: list[str] = []
         for import_name, pkg_name, min_ver in members:
             version_str = _installed_version_str(import_name, pkg_name)
             if version_str is None:
@@ -216,7 +216,7 @@ def doctor(
                     f">={min_ver}",
                     "[dim]not installed[/]",
                 )
-                group_missing = True
+                missing_pkgs.append(pkg_name)
                 continue
             max_excl = _MAX_EXCLUSIVE.get(pkg_name)
             if max_excl and _version_ge(version_str, max_excl):
@@ -232,28 +232,54 @@ def doctor(
                 issues.append(f'Upgrade {pkg_name}: pip install "{pkg_name}>={min_ver}"')
                 fix_parts.append(f'"{pkg_name}>={min_ver}"')
             table.add_row(pkg_name, escape(f"[{extra_name}]"), version_str, f">={min_ver}", status)
-        if group_missing:
+        if missing_pkgs:
+            all_missing = len(missing_pkgs) == len(members)
+            missing_list = ", ".join(missing_pkgs)
             if extra_name == "train":
                 driver = _nvidia_smi_cuda_version()
-                if driver is not None:
+                torch_missing = "torch" in missing_pkgs
+                if all_missing:
+                    if driver is not None:
+                        tag = _torch_cuda_wheel_tag(driver)
+                        url = f"https://download.pytorch.org/whl/{tag}"
+                        # ``--index-url`` replaces PyPI, so torch must come from the
+                        # CUDA wheel index in its own step; the ``[train]`` extra is
+                        # then resolved against PyPI with torch already satisfied.
+                        issues.append(
+                            "Training stack not installed:\n"
+                            f"  pip install torch --index-url {url}\n"
+                            '  pip install "soup-cli[train]"'
+                        )
+                        fix_pre.append(f"pip install torch --index-url {url}")
+                    else:
+                        issues.append(
+                            'Training stack not installed: pip install "soup-cli[train]"'
+                        )
+                elif driver is not None and torch_missing:
                     tag = _torch_cuda_wheel_tag(driver)
                     url = f"https://download.pytorch.org/whl/{tag}"
-                    # ``--index-url`` replaces PyPI, so torch must come from the
-                    # CUDA wheel index in its own step; the ``[train]`` extra is
-                    # then resolved against PyPI with torch already satisfied.
                     issues.append(
-                        "Training stack not installed:\n"
+                        f"Training stack incomplete, missing: {missing_list}\n"
                         f"  pip install torch --index-url {url}\n"
                         '  pip install "soup-cli[train]"'
                     )
                     fix_pre.append(f"pip install torch --index-url {url}")
                 else:
-                    issues.append('Training stack not installed: pip install "soup-cli[train]"')
+                    issues.append(
+                        f"Training stack incomplete, missing: {missing_list}\n"
+                        '  pip install "soup-cli[train]"'
+                    )
                 fix_parts.append('"soup-cli[train]"')
-            else:
+            elif all_missing:
                 issues.append(
                     f"{extra_name} stack not installed: "
                     f'pip install "soup-cli[{extra_name}]"'
+                )
+                fix_parts.append(f'"soup-cli[{extra_name}]"')
+            else:
+                issues.append(
+                    f"{extra_name} stack incomplete, missing: {missing_list}\n"
+                    f'  pip install "soup-cli[{extra_name}]"'
                 )
                 fix_parts.append(f'"soup-cli[{extra_name}]"')
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -315,6 +315,34 @@ def test_doctor_nvidia_train_suggestion_is_two_step(monkeypatch):
     assert '["soup-cli[train]" --index-url' not in out and '[train]" --index-url' not in out
 
 
+def test_doctor_nvidia_partial_stack_with_torch_missing(monkeypatch):
+    """NVIDIA + partial [train] + torch missing keeps the two-step index URL (#884)."""
+    installed = {
+        "transformers": "5.16.1",
+        "peft": "0.20.0",
+        "trl": "0.29.0",
+        "datasets": "2.14.0",
+        "bitsandbytes": "0.41.0",
+        "accelerate": "0.27.0",
+    }
+
+    def _fake_version(import_name, pkg_name):
+        return installed.get(pkg_name)
+
+    monkeypatch.setattr("soup_cli.commands.doctor._installed_version_str", _fake_version)
+    monkeypatch.setattr(
+        "soup_cli.commands.doctor._nvidia_smi_cuda_version", lambda: (13, 0)
+    )
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 0
+    out = _strip_ansi(result.output)
+    assert "Training stack incomplete, missing: torch" in out
+    assert "pip install torch --index-url https://download.pytorch.org/whl/" in out
+    assert 'pip install "soup-cli[train]"' in out
+    assert "All checks passed!" not in out
+    assert "Training stack not installed" not in out
+
+
 def test_doctor_missing_core_dependency_exits_nonzero(monkeypatch):
     """A missing core dependency makes `soup doctor` exit non-zero (#828)."""
     monkeypatch.setitem(sys.modules, "plotext", None)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -174,6 +174,45 @@ def test_doctor_missing_train_extra_suggests_extra(monkeypatch):
     assert "accelerate>=0.27.0" not in out
 
 
+def test_doctor_partial_train_extra_names_missing_members(monkeypatch):
+    """A partial [train] install names the absent members, not the whole stack (#875)."""
+    installed = {
+        "torch": "2.6.0",
+        "transformers": "5.16.1",
+        "peft": "0.20.0",
+        "trl": "0.29.0",
+        "datasets": "2.14.0",
+        "accelerate": "0.27.0",
+    }
+
+    def _fake_version(import_name, pkg_name):
+        return installed.get(pkg_name)
+
+    monkeypatch.setattr("soup_cli.commands.doctor._installed_version_str", _fake_version)
+    monkeypatch.setattr("soup_cli.commands.doctor._nvidia_smi_cuda_version", lambda: None)
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 0
+    out = _strip_ansi(result.output)
+    assert "Training stack not installed" not in out
+    assert "Training stack incomplete, missing: bitsandbytes" in out
+    assert 'pip install "soup-cli[train]"' in out
+    assert "All checks passed!" not in out
+
+
+def test_doctor_missing_train_extra_message_unchanged_when_none_installed(monkeypatch):
+    """With no [train] members, the existing not-installed message is kept (#875)."""
+    monkeypatch.setattr(
+        "soup_cli.commands.doctor._installed_version_str", lambda import_name, pkg_name: None
+    )
+    monkeypatch.setattr("soup_cli.commands.doctor._nvidia_smi_cuda_version", lambda: None)
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 0
+    out = _strip_ansi(result.output)
+    assert 'Training stack not installed: pip install "soup-cli[train]"' in out
+    assert "Training stack incomplete" not in out
+    assert "All checks passed!" not in out
+
+
 def test_doctor_suggestion_is_colour_safe(monkeypatch):
     """The [train] suggestion survives Rich highlighting (#828 review)."""
     from rich.console import Console


### PR DESCRIPTION
## Summary

`soup doctor` no longer reports the training stack as absent when some `[train]` members are installed. A partial install names the missing packages and still points at `pip install "soup-cli[train]"`.

Fixes #875.

## Motivation

#875: with six of seven `[train]` packages present, doctor printed `Training stack not installed` because `group_missing` flipped on the first absent member. That message is wrong for the usual broken-install case (one wheel missing) and `pip install "soup-cli[train]"` is a no-op for the packages already satisfied.

## Implementation

- Track the missing extra-group members instead of a boolean.
- None present: keep the existing `Training stack not installed` text (including the NVIDIA two-step torch index path).
- Some present: `Training stack incomplete, missing: <packages>` plus the group install line.
- If NVIDIA is detected and `torch` itself is among the missing members of a partial stack, keep the two-step torch index advice.
- Exit code is unchanged: a partial `[train]` group remains exit 0 (#828).

## Testing

Ran:

```
PYTHONPATH=src python3 -m pytest tests/test_doctor.py -q --tb=short -o addopts=
```

Result: 32 passed.

New tests:
- `test_doctor_partial_train_extra_names_missing_members` — bitsandbytes absent, six members present; asserts the incomplete message and no "not installed" / "All checks passed!".
- `test_doctor_missing_train_extra_message_unchanged_when_none_installed` — none present keeps the old message.
