### PR TITLE
docs(changelog): credit @swalla02 for the pipx / PEP 668 install lead (#673)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@ reproducing 70+ versions of notes.
 
 ### Changed
 
-- **The README now leads with `pipx`, and names PEP 668 by its error text (#673, closes #671).**
+- **The README now leads with `pipx`, and names PEP 668 by its error text (#671 by @swalla02 in #673).**
   `pip install soup-cli`, the first command in the README, fails on Debian 12 and
   Ubuntu 23.04 or later:
 


### PR DESCRIPTION
Post-release checklist audit (step 7) on the v0.75.0 CHANGELOG section: 50 entries, every outside one credited inline except this one, which carried the PR number and no author. Docs-only; no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)