### PR TITLE
fix: report generated config validation errors

### DIFF
--- a/changelog.d/0.75.0/904.fixed.md
+++ b/changelog.d/0.75.0/904.fixed.md
@@ -1,0 +1,1 @@
+Report generated distill and heal configuration validation failures as concise CLI errors instead of Python tracebacks.

--- a/changelog.d/0.75.0/904.fixed.md
+++ b/changelog.d/0.75.0/904.fixed.md
@@ -1,1 +1,1 @@
-Report generated distill and heal configuration validation failures as concise CLI errors instead of Python tracebacks.
+- **`soup draft distill` and `soup shrink` report a validation failure in their own rendered config as a CLI error rather than a traceback (#895 by @1cbyc in #904).** Both commands validate the YAML they generate before starting a training subprocess and sanitize the validation message for terminal output.

--- a/src/soup_cli/commands/draft.py
+++ b/src/soup_cli/commands/draft.py
@@ -49,6 +49,7 @@ from soup_cli.utils.draft import (
     same_tokenizer,
 )
 from soup_cli.utils.paths import atomic_write_text, enforce_under_cwd_and_no_symlink
+from soup_cli.utils.terminal import for_terminal
 
 if TYPE_CHECKING:  # pragma: no cover — typing only, keeps the CLI import light
     from transformers import PreTrainedModel, PreTrainedTokenizerBase
@@ -396,7 +397,11 @@ def _run_distill(
         data_rows=data_rows,
         uld_strategy=uld_strategy,
     )
-    load_config_from_string(yaml_text)  # validate before spending a subprocess
+    try:
+        load_config_from_string(yaml_text)  # validate before spending a subprocess
+    except ValueError as exc:
+        console.print(f"[red]Invalid rendered distill config:[/] {for_terminal(exc)}")
+        raise typer.Exit(code=1) from exc
 
     # #364 — surface the resolved optimiser-step budget before the run. Epoch
     # granularity can only land NEAR ``--steps``; printing it makes any mismatch

--- a/src/soup_cli/commands/shrink.py
+++ b/src/soup_cli/commands/shrink.py
@@ -41,6 +41,7 @@ from soup_cli.utils.shrink import (
     shrink_arch_of,
     shrink_verdict_to_dict,
 )
+from soup_cli.utils.terminal import for_terminal
 
 console = Console()
 
@@ -563,7 +564,11 @@ def _run_heal(
         out_dir=out_dir,
         heal_rows=heal_rows,
     )
-    load_config_from_string(yaml_text)  # validate before spending a subprocess
+    try:
+        load_config_from_string(yaml_text)  # validate before spending a subprocess
+    except ValueError as exc:
+        console.print(f"[red]Invalid rendered heal config:[/] {for_terminal(exc)}")
+        raise typer.Exit(code=1) from exc
     config_path = Path(pruned_dir).parent / "heal_config.yaml"
     atomic_write_text(yaml_text, str(config_path), field="heal config")
 

--- a/tests/test_v07129.py
+++ b/tests/test_v07129.py
@@ -933,6 +933,35 @@ class TestRunHeal:
         assert exc_info.value.exit_code == 1
         assert messages == ["[red]Invalid rendered heal config:[/] invalid rendered config"]
 
+    def test_run_heal_sanitizes_rendered_config_validation_error(self, tmp_path, monkeypatch):
+        import typer
+
+        import soup_cli.commands.shrink as sc
+
+        messages: list[str] = []
+        monkeypatch.setattr(
+            "soup_cli.config.loader.load_config_from_string",
+            lambda _yaml: (_ for _ in ()).throw(
+                ValueError("bad \x1b[2J[bold red]field[/]")
+            ),
+        )
+        monkeypatch.setattr(sc.console, "print", lambda message: messages.append(message))
+
+        with pytest.raises(typer.Exit) as exc_info:
+            sc._run_heal(
+                pruned_dir="./model",
+                teacher="t",
+                heal_data="./h.jsonl",
+                steps=5,
+                out_dir="./adapter",
+                heal_rows=10,
+            )
+
+        assert exc_info.value.exit_code == 1
+        assert len(messages) == 1
+        assert "\x1b" not in messages[0]
+        assert "bad [2J\\[bold red]field\\[/]" in messages[0]
+
     def test_nonzero_tail_control_bytes_stripped(self, tmp_path, monkeypatch):
         import soup_cli.commands.shrink as sc
 

--- a/tests/test_v07129.py
+++ b/tests/test_v07129.py
@@ -908,6 +908,31 @@ class TestRunHeal:
             sc._run_heal(pruned_dir="./model", teacher="t", heal_data="./h.jsonl",
                          steps=5, out_dir="./adapter", heal_rows=10)
 
+    def test_run_heal_reports_rendered_config_validation_error(self, tmp_path, monkeypatch):
+        import typer
+
+        import soup_cli.commands.shrink as sc
+
+        messages: list[str] = []
+        monkeypatch.setattr(
+            "soup_cli.config.loader.load_config_from_string",
+            lambda _yaml: (_ for _ in ()).throw(ValueError("invalid rendered config")),
+        )
+        monkeypatch.setattr(sc.console, "print", lambda message: messages.append(message))
+
+        with pytest.raises(typer.Exit) as exc_info:
+            sc._run_heal(
+                pruned_dir="./model",
+                teacher="t",
+                heal_data="./h.jsonl",
+                steps=5,
+                out_dir="./adapter",
+                heal_rows=10,
+            )
+
+        assert exc_info.value.exit_code == 1
+        assert messages == ["[red]Invalid rendered heal config:[/] invalid rendered config"]
+
     def test_nonzero_tail_control_bytes_stripped(self, tmp_path, monkeypatch):
         import soup_cli.commands.shrink as sc
 

--- a/tests/test_v07133.py
+++ b/tests/test_v07133.py
@@ -1505,6 +1505,33 @@ class TestDraftDistillCli:
                 out_dir="draftout", steps=100, data_rows=200,
             )
 
+    def test_run_distill_reports_rendered_config_validation_error(
+        self, in_tmp_cwd, monkeypatch
+    ):
+        import typer
+
+        from soup_cli.commands import draft as draft_cmd
+
+        messages: list[str] = []
+        monkeypatch.setattr(
+            "soup_cli.config.loader.load_config_from_string",
+            lambda _yaml: (_ for _ in ()).throw(ValueError("invalid rendered config")),
+        )
+        monkeypatch.setattr(draft_cmd.console, "print", lambda message: messages.append(message))
+
+        with pytest.raises(typer.Exit) as exc_info:
+            draft_cmd._run_distill(
+                draft_base="org/tiny",
+                target="org/target",
+                data="d.jsonl",
+                out_dir="draftout",
+                steps=100,
+                data_rows=200,
+            )
+
+        assert exc_info.value.exit_code == 1
+        assert messages == ["[red]Invalid rendered distill config:[/] invalid rendered config"]
+
     def test_run_distill_timeout_raises_friendly_error(self, in_tmp_cwd, monkeypatch):
         import subprocess as _sp
 

--- a/tests/test_v07133.py
+++ b/tests/test_v07133.py
@@ -1532,6 +1532,37 @@ class TestDraftDistillCli:
         assert exc_info.value.exit_code == 1
         assert messages == ["[red]Invalid rendered distill config:[/] invalid rendered config"]
 
+    def test_run_distill_sanitizes_rendered_config_validation_error(
+        self, in_tmp_cwd, monkeypatch
+    ):
+        import typer
+
+        from soup_cli.commands import draft as draft_cmd
+
+        messages: list[str] = []
+        monkeypatch.setattr(
+            "soup_cli.config.loader.load_config_from_string",
+            lambda _yaml: (_ for _ in ()).throw(
+                ValueError("bad \x1b[2J[bold red]field[/]")
+            ),
+        )
+        monkeypatch.setattr(draft_cmd.console, "print", lambda message: messages.append(message))
+
+        with pytest.raises(typer.Exit) as exc_info:
+            draft_cmd._run_distill(
+                draft_base="org/tiny",
+                target="org/target",
+                data="d.jsonl",
+                out_dir="draftout",
+                steps=100,
+                data_rows=200,
+            )
+
+        assert exc_info.value.exit_code == 1
+        assert len(messages) == 1
+        assert "\x1b" not in messages[0]
+        assert "bad [2J\\[bold red]field\\[/]" in messages[0]
+
     def test_run_distill_timeout_raises_friendly_error(self, in_tmp_cwd, monkeypatch):
         import subprocess as _sp
 


### PR DESCRIPTION
## What does this PR do?

Handles validation failures from the YAML generated by `draft distill` and `shrink` before either command starts its training subprocess. Both paths now print a sanitized project-native error and exit with status 1 instead of exposing a Python traceback.

Focused regressions cover both command boundaries while the existing happy-path tests remain unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Tests

## Checklist

- [x] `ruff check src/soup_cli/ scripts/ tests/ benchmarks/` passes
- [ ] `pytest tests/ -v` passes
- [x] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed
- [x] Added a changelog fragment, or this change has no user-visible impact

Validation:

- 8 focused distill/heal orchestration tests passed
- repository-wide Ruff lint passed
- wheel build passed

Refs #895

Co-authored-by: insisong <emmanuelisaacnsisong@gmail.com>
