### PR TITLE
test(config): close the v0.75.0 TDD-review gaps; load_config refuses a non-mapping YAML cleanly

### DIFF
--- a/changelog.d/0.75.0/905.fixed.md
+++ b/changelog.d/0.75.0/905.fixed.md
@@ -1,0 +1,5 @@
+- **`soup train --config` on a YAML document that is a list or a scalar now exits 1 with
+  `Config must be a YAML mapping, got list` instead of a `TypeError` traceback (#905).**
+  `load_config_from_string` had refused that shape for releases; the file call site never
+  did. The unknown-config-key report also no longer claims to be capped when a config has
+  exactly the cap's worth (100) of unknown keys and nothing was dropped.

--- a/src/soup_cli/config/loader.py
+++ b/src/soup_cli/config/loader.py
@@ -67,6 +67,12 @@ def load_config(path: "Path | str") -> SoupConfig:
     if raw is None:
         console.print("[red]Config file is empty[/]")
         raise SystemExit(1)
+    if not isinstance(raw, dict):
+        # A bare list ("- a") or scalar would reach SoupConfig(**raw) and die
+        # with a TypeError traceback; load_config_from_string already refuses
+        # this shape, and the CLI contract here is SystemExit(1).
+        console.print(f"[red]Config must be a YAML mapping, got {type(raw).__name__}[/]")
+        raise SystemExit(1)
 
     unknown_error = _report_unknown_keys(raw)
     if unknown_error is not None:

--- a/src/soup_cli/config/unknown_keys.py
+++ b/src/soup_cli/config/unknown_keys.py
@@ -133,7 +133,9 @@ def _walk(
 
     declared = model.model_fields
     for key, value in raw.items():
-        if len(found) >= _MAX_REPORTED_UNKNOWN_KEYS:
+        # One finding PAST the cap is kept as the overflow marker, so the
+        # report can tell "exactly the cap" from "more than the cap".
+        if len(found) > _MAX_REPORTED_UNKNOWN_KEYS:
             return
         if not isinstance(key, str):
             continue
@@ -165,8 +167,11 @@ def find_unknown_config_keys(raw: dict) -> list[UnknownKey]:
     refuses (v0.75.0, #879). A key present at both levels is left for the
     validator, which raises the precise error for it.
 
-    At most :data:`_MAX_REPORTED_UNKNOWN_KEYS` findings are returned; the
-    report says so when the cap was hit.
+    At most :data:`_MAX_REPORTED_UNKNOWN_KEYS` + 1 findings are returned: the
+    walk keeps one finding past the cap as the overflow marker, and
+    :func:`format_unknown_keys` lists the first cap and says the rest were
+    cut. A config with exactly the cap's worth of unknown keys is reported in
+    full, without the cap sentence.
     """
     try:
         normalised = remap_root_level_misplaced_keys(raw)
@@ -213,8 +218,9 @@ def format_unknown_keys(
     # a deadline are exactly the callers that proceed, so one flag decides both
     # the trailing sentence and the per-key verdict word.
     suffix = "Not applied." if include_deadline else "Refused."
+    overflow = len(unknown) > _MAX_REPORTED_UNKNOWN_KEYS
     lines = []
-    for item in unknown:
+    for item in unknown[:_MAX_REPORTED_UNKNOWN_KEYS]:
         if item.suggestions:
             # After the question mark the suffix starts a new sentence.
             hint = " or ".join(f"'{s}'" for s in item.suggestions)
@@ -222,7 +228,7 @@ def format_unknown_keys(
         else:
             # After " - " it continues the sentence, hence lowercase.
             lines.append(f"unknown config key '{item.path}' - {suffix.lower()}")
-    if len(unknown) >= _MAX_REPORTED_UNKNOWN_KEYS:
+    if overflow:
         lines.append(
             f"(report capped at {_MAX_REPORTED_UNKNOWN_KEYS} unknown keys; "
             "fix these and load again)"

--- a/tests/test_issue627_unknown_config_keys.py
+++ b/tests/test_issue627_unknown_config_keys.py
@@ -172,6 +172,12 @@ class TestTheControl:
             unknown = find_unknown_config_keys(yaml.safe_load(text))
             assert unknown == [], (entry.name, [u.path for u in unknown])
             assert load_config_from_string(text).training.lora.r == 16, entry.name
+            # The remap makes a root-level ``lora:`` LEGAL, so the two checks
+            # above cannot see the canonical-spelling fix; pin the text itself.
+            assert "lora" not in yaml.safe_load(text), (
+                f"{entry.name}: the bundled example spells lora: at the root; "
+                "the canonical spelling is training.lora"
+            )
     def test_non_mapping_values_do_not_crash_the_walk(self) -> None:
         raw = _raw()
         raw["training"] = "not-a-mapping"
@@ -1103,6 +1109,19 @@ class TestTheReportIsSafeForTheTerminal:
         assert for_terminal("\x1b[31m[bold]x[/]\x7f") == "[31m\\[bold]x\\[/]"
         assert for_terminal("tab\tnew\nline") == "tab\tnew\nline"
 
+    @pytest.mark.parametrize("byte", [*range(0x00, 0x20), 0x7F])
+    def test_every_control_byte_is_stripped_except_the_three_whitespace_ones(
+        self, byte: int
+    ) -> None:
+        """ESC and DEL were pinned; BEL, CR and the other 28 were not (TDD review)."""
+        from soup_cli.utils.terminal import for_terminal
+
+        out = for_terminal(f"a{chr(byte)}b")
+        if byte in (0x09, 0x0A, 0x0D):
+            assert out == f"a{chr(byte)}b", f"whitespace byte {byte:#04x} must survive"
+        else:
+            assert out == "ab", f"control byte {byte:#04x} reached the terminal"
+
 
 class TestTheWalkIsBounded:
     """A config string reaches the detector from the Web UI and MCP too.
@@ -1127,10 +1146,33 @@ class TestTheWalkIsBounded:
         started = time.perf_counter()
         unknown = find_unknown_config_keys(raw)
         elapsed = time.perf_counter() - started
-        assert len(unknown) == _MAX_REPORTED_UNKNOWN_KEYS
+        # cap + 1: the extra finding is the overflow marker the report reads.
+        assert len(unknown) == _MAX_REPORTED_UNKNOWN_KEYS + 1
         assert elapsed < 5.0, f"the capped walk took {elapsed:.1f}s"
         message = format_unknown_keys(unknown, include_deadline=False)
         assert f"capped at {_MAX_REPORTED_UNKNOWN_KEYS}" in message
+        assert message.count("unknown config key") == _MAX_REPORTED_UNKNOWN_KEYS
+
+    def test_exactly_the_cap_is_reported_in_full_without_the_cap_sentence(self) -> None:
+        """A boundary the first version got wrong: 100 findings printed 'capped'."""
+        from soup_cli.config.unknown_keys import _MAX_REPORTED_UNKNOWN_KEYS
+
+        def raw(count: int) -> dict:
+            return {
+                "base": "m",
+                "data": {"train": "t.jsonl"},
+                "training": {f"bogus_key_{i}": i for i in range(count)},
+            }
+
+        at_cap = find_unknown_config_keys(raw(_MAX_REPORTED_UNKNOWN_KEYS))
+        assert len(at_cap) == _MAX_REPORTED_UNKNOWN_KEYS
+        at_cap_msg = format_unknown_keys(at_cap, include_deadline=False)
+        assert "capped" not in at_cap_msg
+        assert at_cap_msg.count("unknown config key") == _MAX_REPORTED_UNKNOWN_KEYS
+
+        one_over = find_unknown_config_keys(raw(_MAX_REPORTED_UNKNOWN_KEYS + 1))
+        assert len(one_over) == _MAX_REPORTED_UNKNOWN_KEYS + 1
+        assert "capped" in format_unknown_keys(one_over, include_deadline=False)
 
     def test_a_report_below_the_cap_does_not_claim_to_be_capped(self) -> None:
         unknown = find_unknown_config_keys(
@@ -1180,3 +1222,68 @@ class TestTheWebUiKeepsTheHint:
         assert detail.startswith("Invalid training configuration")
         assert "quantizaton" in detail and "quantization" in detail
         assert "Refused." in detail
+
+
+class TestTheLoaderRefusesANonMappingFile:
+    """``load_config`` on a list-shaped YAML died with a TypeError traceback.
+
+    ``load_config_from_string`` has guarded this shape since v0.40.x (its
+    contract is ValueError-only); the file call site, touched in v0.75.0,
+    never did — found by the post-release TDD review.
+    """
+
+    @pytest.mark.parametrize("text, shape", [("- a\n- b\n", "list"), ("just a string\n", "str")])
+    def test_a_non_mapping_document_is_a_clean_exit_not_a_traceback(
+        self, monkeypatch, tmp_path, text, shape
+    ) -> None:
+        from soup_cli.config import loader
+
+        printed: list[str] = []
+        monkeypatch.setattr(loader.console, "print", lambda *a, **k: printed.append(str(a[0])))
+        path = tmp_path / "soup.yaml"
+        path.write_text(text, encoding="utf-8")
+        with pytest.raises(SystemExit) as excinfo:
+            loader.load_config(path)
+        assert excinfo.value.code == 1
+        assert any("YAML mapping" in line and shape in line for line in printed), printed
+
+
+class TestTheWebUiErrorBranchesAreDistinct:
+    """Both Web UI handlers split ValueError from everything else (TDD review).
+
+    The split is the point of the v0.75.0 change: the loader's ValueError
+    carries the key and the suggestion and is safe to show; anything else
+    (a YAML parser error, an unexpected TypeError) must stay generic.
+    """
+
+    @staticmethod
+    def _client():
+        pytest.importorskip("fastapi")
+        from fastapi.testclient import TestClient
+
+        from soup_cli.ui.app import create_app, get_auth_token
+
+        return TestClient(create_app()), {"Authorization": f"Bearer {get_auth_token()}"}
+
+    def test_from_form_names_the_field_on_a_validation_error(self) -> None:
+        client, headers = self._client()
+        response = client.post(
+            "/api/config/from-form",
+            json={"base": "m", "data": {"train": "./t.jsonl"}, "training": {"epochs": 0}},
+            headers=headers,
+        )
+        assert response.status_code == 200, response.text
+        error = response.json()["error"]
+        assert error.startswith("Invalid configuration:")
+        assert "epochs" in error, error
+
+    def test_train_start_keeps_a_parser_error_generic(self) -> None:
+        client, headers = self._client()
+        response = client.post(
+            "/api/train/start",
+            json={"config_yaml": "base: [unclosed\n  data: {"},
+            headers=headers,
+        )
+        assert response.status_code == 400, response.text
+        detail = response.json()["detail"]
+        assert detail == "Invalid training configuration", detail


### PR DESCRIPTION
Post-release TDD review of v0.75.0 (checklist step 5, run after the tag because the release had run only three of the five reviews). 16 mutations: 3 HIGH / 2 MEDIUM / 2 LOW; every fix here is mutation-checked with a passing baseline.

- **Behaviour:** `load_config` on a list-/scalar-shaped YAML now exits 1 with "Config must be a YAML mapping, got list" instead of a `TypeError` traceback (the string loader already refused this shape).
- **Boundary:** the unknown-key report no longer says "capped at 100" for exactly 100 findings; the walk keeps one finding past the cap as the overflow marker.
- **Tests:** `/api/config/from-form` names the field; `/api/train/start` keeps a parser error generic; `for_terminal` parametrized over all C0 + DEL (BEL/CR were unpinned); fetch examples pin the canonical `training.lora` spelling in the text.
- **Documented, not fixed:** no JS harness exists for `escapeHtml()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)