### PR TITLE
fix(cli): report MLX-unread CUDA-only fields and scope the all-clear

### DIFF
--- a/src/soup_cli/commands/doctor.py
+++ b/src/soup_cli/commands/doctor.py
@@ -322,7 +322,11 @@ def _check_config_support(config_path: str) -> None:
     pre-flight check, and the fields sitting at their schema default are not
     what anyone came here to ask about.
     """
-    from soup_cli.config.backend_support import DEFAULT_BACKEND, check_config
+    from soup_cli.config.backend_support import (
+        DEFAULT_BACKEND,
+        check_config,
+        unsupported_for,
+    )
 
     try:
         from soup_cli.config.loader import load_config
@@ -354,8 +358,10 @@ def _check_config_support(config_path: str) -> None:
         f"backend=[bold]{backend}[/]"
     )
     if not gaps:
+        known = unsupported_for(cfg.task, backend)
         console.print(
-            "  [green]Every setting this config writes is read on this backend.[/]"
+            f"  [green]None of the {len(known)} setting(s) known to be unread "
+            f"on task={cfg.task} backend={backend} is set in this config.[/]"
         )
         return
 

--- a/src/soup_cli/config/backend_support.py
+++ b/src/soup_cli/config/backend_support.py
@@ -118,6 +118,18 @@ _MLX_SFT: tuple[SupportEntry, ...] = (
         "MLX masks the prompt or supervises the whole sequence; no per-field switch",
         trainer_reads=True,
     ),
+    SupportEntry(
+        "training.use_liger",
+        IGNORED,
+        "Liger fused kernels have no MLX implementation",
+        trainer_reads=True,
+    ),
+    SupportEntry(
+        "training.neftune_alpha",
+        IGNORED,
+        "NEFT noise is applied on the transformers training path, not MLX",
+        trainer_reads=True,
+    ),
 )
 
 

--- a/src/soup_cli/trainer/mlx_sft.py
+++ b/src/soup_cli/trainer/mlx_sft.py
@@ -209,6 +209,15 @@ class MLXSFTTrainerWrapper:
             unsupported.append("Ring Attention")
         if tcfg.use_flash_attn:
             unsupported.append("FlashAttention (MLX has its own attention kernels)")
+        if tcfg.use_liger:
+            unsupported.append(
+                "training.use_liger (Liger fused kernels have no MLX implementation)"
+            )
+        if tcfg.neftune_alpha is not None:
+            unsupported.append(
+                "training.neftune_alpha (NEFT noise is applied on the "
+                "transformers training path, not MLX)"
+            )
         # #353's fourth criterion. #381 threaded training.seed through every
         # transformers task wrapper; MLX has its own RNG (mx.random) and reads
         # neither field, so a seeded MLX run is silently unseeded. `is not None`

--- a/tests/test_issue755_backend_support_registry.py
+++ b/tests/test_issue755_backend_support_registry.py
@@ -185,6 +185,20 @@ def test_a_setting_the_backend_ignores_is_reported(config_at):
     assert "training.seed" in reported
 
 
+def test_new_mlx_gaps_use_liger_and_neftune_alpha_are_reported(config_at):
+    """#903: accepted-but-dropped fields must be reported, not all-cleared."""
+    from soup_cli.config.backend_support import check_config
+    from soup_cli.config.loader import load_config
+
+    cfg = load_config(
+        config_at(
+            "sft", "mlx", "  use_liger: true\n              neftune_alpha: 5"
+        )
+    )
+    reported = {e.field for e in check_config(cfg)}
+    assert {"training.use_liger", "training.neftune_alpha"} <= reported
+
+
 def test_only_fields_the_user_actually_set_are_reported(config_at):
     """Not all 275 — and not the other MLX gaps the user never touched."""
     from soup_cli.config.backend_support import check_config
@@ -290,6 +304,23 @@ def test_doctor_exits_non_zero_when_the_config_cannot_be_read(
     # 2 specifically, not merely non-zero: docs/commands.md:218 documents it,
     # and all three unreadable shapes must agree.
     assert excinfo.value.exit_code == 2
+
+
+def test_all_clear_states_what_was_checked(config_at, capsys, monkeypatch):
+    """#903: the all-clear must name its evidence, not claim a universal."""
+    from rich.console import Console
+
+    import soup_cli.commands.doctor as doctor_module
+    from soup_cli.commands.doctor import doctor
+    from soup_cli.config.backend_support import unsupported_for
+
+    monkeypatch.setattr(doctor_module, "console", Console(width=200))
+    path = config_at("sft", "mlx")
+    doctor(nccl=False, disk=False, config=path)
+
+    out = strip_ansi(capsys.readouterr().out)
+    n = len(unsupported_for("sft", "mlx"))
+    assert f"None of the {n} setting(s) known to be unread" in out
 
 
 @pytest.mark.parametrize("width", [35, 60, 200])


### PR DESCRIPTION
## Summary

Fixes #903 — both halves:

1. **Wording:** the `soup doctor --config` all-clear no longer claims universality. It now states what was actually checked: `None of the N setting(s) known to be unread on task=<task> backend=<backend> is set in this config.`
2. **Table:** adds the two repro fields to the declared `_MLX_SFT` table — `training.use_liger` (Liger fused kernels have no MLX implementation) and `training.neftune_alpha` (NEFT noise is applied on the transformers training path, not MLX) — plus matching warning branches in `trainer/mlx_sft.py::_check_unsupported` so the trainer itself reports them.

## Motivation

The v0.75.0 smoke repro (`task=sft backend=mlx` with `use_liger: true, neftune_alpha: 5`) printed "Every setting this config writes is read on this backend." while both fields are accepted and silently dropped — the exact "validated, documented, read by nothing" pattern #755/#756 exists to report. Each added entry was verified by grep to have zero hits in the three MLX modules before adding.

## Changes

- `src/soup_cli/config/backend_support.py`: 2 new `SupportEntry`s (`IGNORED`, `trainer_reads=True`), matching the surrounding entry style.
- `src/soup_cli/trainer/mlx_sft.py`: 2 new `_check_unsupported` branches; the dotted field name is inside the message string (the #756 guard AST-matches on it).
- `src/soup_cli/commands/doctor.py`: all-clear rewritten as a dynamic count via `unsupported_for(task, backend)`.
- `tests/test_issue755_backend_support_registry.py`: 2 new tests — repro fields reported via `check_config` (fails pre-fix), and the all-clear names its evidence count (fails pre-fix on the old wording).

## Testing

- New regression `test_new_mlx_gaps_use_liger_and_neftune_alpha_are_reported`: **passes** locally.
- Registry guard suite (`test_issue755_*`, both directions): **29 passed** locally in a minimal harness (no GPU/MLX/network/model download needed).
- Doctor end-to-end tests (5 pre-existing + 1 new): **not runnable in my minimal harness** — `doctor()` exits 1 because the training stack (torch/transformers/...) is not installed there; I verified the same 5 fail identically on unmodified `main` in that harness, so this is a pre-existing environment gap, not a regression. The new all-clear line was observed rendering correctly in the captured output (`None of the 9 setting(s) known to be unread on task=sft backend=mlx is set in this config.`). Full matrix left to CI.
- `tests/test_issue755_backend_support_registry.py` bidirectional guards still pass, per the issue's acceptance criterion.

## Notes for reviewers

Scope kept to the two repro fields: each table entry must be grep-verified against the MLX modules, and unverified entries would trip the #756 guard in the wrong direction. Happy to extend the table field-by-field in follow-ups.

Signed-off-by: fei <204683769+feiiiiii5@users.noreply.github.com>
