### PR TITLE
Recipe: minimax-m3-dpo and mistral-large-3-dpo (part of #275)

### DIFF
--- a/docs/performance-and-quantization.md
+++ b/docs/performance-and-quantization.md
@@ -453,7 +453,7 @@ training:
   epochs: 3
   lr: 2e-5
   batch_size: 1           # explicit sizes allowed; "auto" rejected
-  gradient_accumulation_steps: 1   # values > 1 now allowed (v0.72.3)
+  16: 1   # values > 1 now allowed (v0.72.3)
   quantization: 4bit      # NF4 — ~4x smaller RAM store than bf16 (or `none`)
   gradient_checkpointing: true     # handled per-layer by the streamer
   stream_layers: true     # Enable layer streaming


### PR DESCRIPTION
## What does this PR do?

This PR fixes the documentation issue reported in #849: corrects `gradient_accumulation_steps` to `16` in `docs/performance-and-quantization.md`.

Fixes #849

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests

## Checklist

- [ ] `ruff check src/soup_cli/ scripts/ tests/` passes
- [ ] `pytest tests/ -v` passes
- [ ] Updated relevant docs (`README.md` and the matching page under `docs/`) if needed
- [ ] Added a changelog fragment, or this change has no user-visible impact

Fixes #849