### PR TITLE
refactor(ppo): probe the trl KL and epoch renames through _trl_compat

### DIFF
--- a/src/soup_cli/trainer/_trl_compat.py
+++ b/src/soup_cli/trainer/_trl_compat.py
@@ -120,6 +120,20 @@ def prompt_length_kwargs(config_cls: type, max_prompt_length: int) -> dict[str, 
     return {}
 
 
+def kl_penalty_kwargs(config_cls: type, kl_penalty: float) -> dict[str, float]:
+    """``{'kl_coef': x}`` or ``{'init_kl_coef': x}``, whichever this trl's config takes.
+
+    trl 0.29 renamed ``init_kl_coef`` to ``kl_coef`` on ``PPOConfig``. The new
+    name wins when a config accepts both. Returns an empty dict when it accepts
+    neither, so a third rename leaves the coefficient visibly unforwarded
+    rather than passing a keyword the config would reject.
+    """
+    for name in ("kl_coef", "init_kl_coef"):
+        if config_accepts(config_cls, name):
+            return {name: kl_penalty}
+    return {}
+
+
 def _truncate_tokens(tokens: list[int], limit: int, mode: str) -> list[int]:
     """Truncate one token sequence using TRL's preference-side convention."""
     if limit <= 0:

--- a/src/soup_cli/trainer/ppo.py
+++ b/src/soup_cli/trainer/ppo.py
@@ -28,29 +28,29 @@ console = Console()
 
 def _set_ppo_training_kwargs(
     ppo_kwargs: dict[str, object],
-    ppo_params: Mapping[str, object],
+    ppo_config_cls: type,
     tcfg: Any,
 ) -> dict[str, str]:
     """Forward Soup's three PPO schedules across TRL parameter renames."""
+    from soup_cli.trainer._trl_compat import config_accepts, kl_penalty_kwargs
+
     applied: dict[str, str] = {}
 
-    if "num_train_epochs" in ppo_params:
+    if config_accepts(ppo_config_cls, "num_train_epochs"):
         ppo_kwargs["num_train_epochs"] = tcfg.epochs
         applied["train_epochs"] = "num_train_epochs"
 
-    if "num_ppo_epochs" in ppo_params:
+    if config_accepts(ppo_config_cls, "num_ppo_epochs"):
         ppo_kwargs["num_ppo_epochs"] = tcfg.ppo_epochs
         applied["ppo_epochs"] = "num_ppo_epochs"
-    elif "ppo_epochs" in ppo_params:
+    elif config_accepts(ppo_config_cls, "ppo_epochs"):
         ppo_kwargs["ppo_epochs"] = tcfg.ppo_epochs
         applied["ppo_epochs"] = "ppo_epochs"
 
-    if "kl_coef" in ppo_params:
-        ppo_kwargs["kl_coef"] = tcfg.ppo_kl_penalty
-        applied["kl_coef"] = "kl_coef"
-    elif "init_kl_coef" in ppo_params:
-        ppo_kwargs["init_kl_coef"] = tcfg.ppo_kl_penalty
-        applied["kl_coef"] = "init_kl_coef"
+    kl_kwargs = kl_penalty_kwargs(ppo_config_cls, tcfg.ppo_kl_penalty)
+    ppo_kwargs.update(kl_kwargs)
+    for name in kl_kwargs:
+        applied["kl_coef"] = name
 
     return applied
 
@@ -210,7 +210,7 @@ class PPOTrainerWrapper:
         ppo_params = inspect.signature(ppo_config_cls).parameters
 
         applied_ppo_fields = _set_ppo_training_kwargs(
-            ppo_kwargs, ppo_params, tcfg
+            ppo_kwargs, ppo_config_cls, tcfg
         )
 
         if "cliprange" in ppo_params:

--- a/tests/test_issue721_ppo_config_forwarding.py
+++ b/tests/test_issue721_ppo_config_forwarding.py
@@ -8,7 +8,21 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from soup_cli.trainer._trl_compat import kl_penalty_kwargs
 from soup_cli.trainer.ppo import _effective_ppo_setting, _set_ppo_training_kwargs
+
+
+def _config_accepting(*fields: str) -> type:
+    """A config class whose constructor signature accepts exactly ``fields``."""
+
+    class Config:
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+    Config.__signature__ = inspect.Signature(
+        [inspect.Parameter(name, inspect.Parameter.KEYWORD_ONLY, default=None) for name in fields]
+    )
+    return Config
 
 
 @pytest.fixture
@@ -20,7 +34,7 @@ def test_current_trl_parameter_names_receive_non_defaults(training_config) -> No
     kwargs: dict[str, object] = {}
     fields = _set_ppo_training_kwargs(
         kwargs,
-        {"num_train_epochs": None, "num_ppo_epochs": None, "kl_coef": None},
+        _config_accepting("num_train_epochs", "num_ppo_epochs", "kl_coef"),
         training_config,
     )
 
@@ -40,7 +54,7 @@ def test_legacy_trl_parameter_names_remain_supported(training_config) -> None:
     kwargs: dict[str, object] = {}
     fields = _set_ppo_training_kwargs(
         kwargs,
-        {"ppo_epochs": None, "init_kl_coef": None},
+        _config_accepting("ppo_epochs", "init_kl_coef"),
         training_config,
     )
 
@@ -57,13 +71,9 @@ def test_current_names_win_when_a_signature_carries_both(training_config) -> Non
     kwargs: dict[str, object] = {}
     fields = _set_ppo_training_kwargs(
         kwargs,
-        {
-            "num_train_epochs": None,
-            "num_ppo_epochs": None,
-            "ppo_epochs": None,
-            "kl_coef": None,
-            "init_kl_coef": None,
-        },
+        _config_accepting(
+            "num_train_epochs", "num_ppo_epochs", "ppo_epochs", "kl_coef", "init_kl_coef"
+        ),
         training_config,
     )
 
@@ -77,6 +87,29 @@ def test_current_names_win_when_a_signature_carries_both(training_config) -> Non
         "ppo_epochs": "num_ppo_epochs",
         "kl_coef": "kl_coef",
     }
+
+
+@pytest.mark.parametrize(
+    ("fields", "expected"),
+    [
+        (("kl_coef",), {"kl_coef": 0.7}),
+        (("init_kl_coef",), {"init_kl_coef": 0.7}),
+        (("init_kl_coef", "kl_coef"), {"kl_coef": 0.7}),
+        (("cliprange",), {}),
+    ],
+)
+def test_kl_penalty_kwargs_follows_the_rename(fields, expected) -> None:
+    assert kl_penalty_kwargs(_config_accepting(*fields), 0.7) == expected
+
+
+def test_a_config_without_a_kl_field_leaves_it_unforwarded(training_config) -> None:
+    kwargs: dict[str, object] = {}
+    fields = _set_ppo_training_kwargs(
+        kwargs, _config_accepting("num_train_epochs", "num_ppo_epochs"), training_config
+    )
+
+    assert "kl_coef" not in fields
+    assert kwargs == {"num_train_epochs": 7, "num_ppo_epochs": 2}
 
 
 def test_an_unforwarded_setting_is_marked_rather_than_echoed() -> None:
@@ -97,9 +130,8 @@ def test_installed_trl_exposes_and_receives_current_names(training_config) -> No
     pytest.importorskip("trl.experimental.ppo")
     from trl.experimental.ppo import PPOConfig
 
-    params = inspect.signature(PPOConfig).parameters
     kwargs: dict[str, object] = {}
-    _set_ppo_training_kwargs(kwargs, params, training_config)
+    _set_ppo_training_kwargs(kwargs, PPOConfig, training_config)
 
     assert kwargs["num_train_epochs"] == 7
     assert kwargs["num_ppo_epochs"] == 2


### PR DESCRIPTION
## What does this PR do?

The follow-up proposed on #741, after #737 landed.

`init_kl_coef` → `kl_coef` is the fourth trl rename Soup handles, and `trainer/_trl_compat.py` is the module that exists for exactly that. So:

- **`_trl_compat.kl_penalty_kwargs(config_cls, kl_penalty)`** now sits next to `prompt_length_kwargs`, with the same `(config_cls, value) -> dict` shape and built on the same `config_accepts` probe. The new name wins when a config accepts both. An empty dict means it accepts neither, and the setting is then reported as `(not forwarded)` rather than guessed at.
- **`_set_ppo_training_kwargs` takes the config class** and asks `config_accepts` for each field, instead of reading a signature mapping computed in `setup()`. All three PPO renames (`num_train_epochs`, `num_ppo_epochs`/`ppo_epochs`, the KL coefficient) now go through one capability probe.

**No behaviour change.** The constructed kwargs, the `applied` field names and the printed schedule are identical. `test_setup_passes_current_schedule_to_trainer` from #737 passes unchanged.

## Type of change

- [x] Refactor / cleanup
- [x] Tests

## Tests

`tests/test_issue721_ppo_config_forwarding.py` keeps every assertion from #737. The name mappings it passed are replaced by config classes whose signature accepts exactly those fields, since the function now takes a class. New cases:

- `test_kl_penalty_kwargs_follows_the_rename`: modern, legacy, both (the new name wins) and neither (`{}`).
- `test_a_config_without_a_kl_field_leaves_it_unforwarded`: no `kl_coef` in the applied fields, so the summary marks it.

Mutation: preferring `init_kl_coef` in `kl_penalty_kwargs` fails 2 tests, #737's `test_current_names_win_when_a_signature_carries_both` and the new both-names case.

11 passed, 1 skipped. The skip is `test_installed_trl_exposes_and_receives_current_names`, since trl isn't installed here; it is CI's. Across the PPO-touching suites (`test_ppo.py`, `test_trainer_init.py`, `test_bugfixes.py`, `test_code_review_*`, `test_trl_version_compat.py`, …): 399 passed. The 24 failures are identical on unmodified `main` (peft/trl absent locally).

## Checklist

- [x] `ruff check` passes on the touched files (ruff 0.9.4, as pinned)
- [x] `pytest` on the touched and PPO-related suites, as above
- [ ] Updated relevant docs: not needed, internal only
- [x] Added a changelog fragment, or this change has no user-visible impact: no user-visible impact
